### PR TITLE
pscanrulesAlpha: Permissions-Policy scan rule example alerts, etc

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Sub Resource Integrity Attribute Missing scan rule now supports Trusted Domains.
 - The Base64 Disclosure scan rule will now ignore headers which are known to contain irrelevant Base64 like strings or are covered by other rules (ETag, Authorization, X-ChromeLogger-Data, X-ChromePhp-Data) (Issue 6619).
 - Added new Custom Payloads alert tag to the example alerts of the Dangerous JS Function scan rule.
+- Permissions Policy scan rule updated for consistency and documentation purposes (Issue 7458).
 
 ### Fixed
 - False positive condition from Sub Resource Integrity Attribute Missing scan rule when rel=canonical is used (Issue 7040).

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -115,7 +115,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 
 <H2>Permissions Policy Header Not Set</H2>
 This rule checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Permissions-Policy" header, 
-and alerts if one is not found.<br>
+and alerts if one is not found. It also alerts if the deprecated header "Feature-Policy" is found.<br>
 Redirects are ignored except at the Low threshold.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRule.java">PermissionsPolicyScanRule.java</a>

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -14,7 +14,7 @@ pscanalpha.permissionspolicymissing.soln=Ensure that your web server, applicatio
 
 pscanalpha.permissionspolicymissing.deprecated.name=Deprecated Feature Policy Header Set
 pscanalpha.permissionspolicymissing.deprecated.desc=The header has now been renamed to Permissions-Policy. 
-pscanalpha.permissionspolicymissing.deprecated.refs=https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
+pscanalpha.permissionspolicymissing.deprecated.refs=https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy\nhttps://scotthelme.co.uk/goodbye-feature-policy-and-hello-permissions-policy/
 pscanalpha.permissionspolicymissing.deprecated.soln=Ensure that your web server, application server, load balancer, etc. is configured to set the Permissions-Policy header instead of the Feature-Policy header.
 
 pscanalpha.inpagebanner.name=In Page Banner Information Leak

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRuleUnitTest.java
@@ -153,4 +153,12 @@ class PermissionsPolicyScanRuleUnitTest extends PassiveScannerTest<PermissionsPo
                 tags.get(CommonAlertTag.OWASP_2017_A05_BROKEN_AC.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A05_BROKEN_AC.getValue())));
     }
+
+    @Test
+    void shouldReturnExpectedExampleAlerts() {
+        // Given / When
+        int count = rule.getExampleAlerts().size();
+        // Then
+        assertThat(count, is(equalTo(2)));
+    }
 }


### PR DESCRIPTION
- CHANGELOG > Added change note.
- Message.properties > Added reference for Feature-Policy alert.
- PermissionsPolicyScanRule > Updated to facilitate example alerts.
- PermissionsPolicyScanRuleUnitTest > Updated to assert the example alerts.
- pscanalpha.html > Updated help to mention Feature-Policy alerts.

Fixes zaproxy/zaproxy#7458

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>