### PR TITLE
pscanrules: Fix changelog mistake

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added new Custom Payloads alert tag to the example alerts of the Username IDOR and Application Error scan rules.
 - Maintenance changes.
 - The Timestamp Disclosure scan rule is now scoped to a 10 year range with a cap at the Y2038 rollover point (Issue 6741).
-- The Content Security Policy Header Set scan rule will no longer alert if CSP is specified via META tag (Issue 7303).
+- The Content Security Policy Header Not Set scan rule will no longer alert if CSP is specified via META tag (Issue 7303).
 
 ## [42] - 2022-07-15
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,12 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [43] - 2022-09-15
 ### Changed
-
 - Reduce Cache Control scan rule confidence to Low, and add new reference (Issue 6446).
 - Added new Custom Payloads alert tag to the example alerts of the Username IDOR and Application Error scan rules.
 - Maintenance changes.
 - The Timestamp Disclosure scan rule is now scoped to a 10 year range with a cap at the Y2038 rollover point (Issue 6741).
-- THe Content Security Policy Header Set scan rule will no longer alert if CSP is specified via META tag (Issue 7303).
+- The Content Security Policy Header Set scan rule will no longer alert if CSP is specified via META tag (Issue 7303).
 
 ## [42] - 2022-07-15
 ### Changed


### PR DESCRIPTION
Fix "THe" typo and remove a blank line to be more consistent with other recent entries. Insert missing "Not" in the scan rule name. While this is already released, it doesn't need to persist into the future.