### PR TITLE
Increase memory for releases

### DIFF
--- a/.github/workflows/release-add-on.yml
+++ b/.github/workflows/release-add-on.yml
@@ -26,4 +26,4 @@ jobs:
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
         CROWDIN_AUTH_TOKEN: ${{ secrets.ZAPBOT_CROWDIN_TOKEN }}
-      run: ./gradlew :addOns:releaseAddOn
+      run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g :addOns:releaseAddOn


### PR DESCRIPTION
Allow to use more memory to avoid out of memory errors when releasing
several add-ons at the same time.