### PR TITLE
Automation: misc minor fixes

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -147,7 +147,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
     }
 
     @Override
-    public void optionsLoaded() {
+    public void postInit() {
         if (hasView() && this.getParam().isOpenLastPlan()) {
             String path = getParam().getLastPlanPath();
             if (path != null) {

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -113,7 +113,10 @@ public class JobUtils {
             threshold = AlertThreshold.OFF;
         } else {
             progress.warn(
-                    Constant.messages.getString("automation.error.ascan.threshold", jobName, o));
+                    Constant.messages.getString(
+                            "automation.error.ascan.threshold",
+                            jobName,
+                            o.getClass().getCanonicalName()));
         }
         return threshold;
     }
@@ -332,7 +335,7 @@ public class JobUtils {
         if (ignore != null) {
             ignoreList =
                     Arrays.asList(ignore).stream()
-                            .map(e -> "get" + e.toUpperCase().charAt(0) + e.substring(1))
+                            .map(e -> e.toUpperCase().charAt(0) + e.substring(1))
                             .collect(Collectors.toList());
         }
 
@@ -343,16 +346,19 @@ public class JobUtils {
 
                 if ((getterName.startsWith("get") || getterName.startsWith("is"))
                         && m.getParameterCount() == 0
-                        && !getterName.equals("getClass")
-                        && !ignoreList.contains(getterName)) {
+                        && !getterName.equals("getClass")) {
                     // Its a getter so process it
-                    String setterName;
+                    String baseName;
                     if (getterName.startsWith("get")) {
-                        setterName = "s" + getterName.substring(1);
+                        baseName = getterName.substring(3);
                     } else {
                         // is...
-                        setterName = "set" + getterName.substring(2);
+                        baseName = getterName.substring(2);
                     }
+                    if (ignoreList.contains(baseName)) {
+                        continue;
+                    }
+                    String setterName = "set" + baseName;
                     try {
                         Object value = m.invoke(srcObject);
                         if (value == null) {

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJob.java
@@ -75,7 +75,13 @@ public class PassiveScanConfigJob extends AutomationJob {
                 JobUtils.getJobOptions(this, tempProgress),
                 this.originalParameters,
                 this.getName(),
-                IGNORE_PARAMS,
+                new String[] {
+                    "scanFuzzerMessages",
+                    "autoTagScanners",
+                    "passiveScanThreads",
+                    "confirmRemoveAutoTagScanner",
+                    "config"
+                },
                 tempProgress,
                 this.getPlan().getEnv());
     }

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
@@ -67,7 +67,7 @@ class JobUtilsUnitTest {
     @Test
     void shouldApplyObjectToObject() {
         // Given
-        Data source = new Data("A");
+        Data source = new Data("A", Boolean.TRUE);
         Data dest = new Data();
         AutomationProgress progress = mock(AutomationProgress.class);
         AutomationEnvironment env = mock(AutomationEnvironment.class);
@@ -76,21 +76,23 @@ class JobUtilsUnitTest {
         JobUtils.applyObjectToObject(source, dest, "name", new String[] {}, progress, env);
         // Then
         assertThat(dest.getValueString(), is(equalTo("A")));
+        assertThat(dest.isBool(), is(equalTo(Boolean.TRUE)));
     }
 
     @Test
     void shouldApplyObjectToObjectWhileIgnoringSpecifiedPropertyNames() {
         // Given
-        Data source = new Data("A");
+        Data source = new Data("A", Boolean.TRUE);
         Data dest = new Data();
         AutomationProgress progress = mock(AutomationProgress.class);
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         given(env.replaceVars(any())).willAnswer(invocation -> invocation.getArgument(0));
         // When
         JobUtils.applyObjectToObject(
-                source, dest, "name", new String[] {"valueString"}, progress, env);
+                source, dest, "name", new String[] {"valueString", "bool"}, progress, env);
         // Then
         assertThat(dest.getValueString(), is(nullValue()));
+        assertThat(dest.isBool(), is(nullValue()));
     }
 
     @Test
@@ -303,11 +305,13 @@ class JobUtilsUnitTest {
 
     private static class Data {
         private String valueString;
+        private Boolean bool;
 
         Data() {}
 
-        Data(String valueString) {
+        Data(String valueString, Boolean bool) {
             this.valueString = valueString;
+            this.bool = bool;
         }
 
         public String getValueString() {
@@ -318,6 +322,16 @@ class JobUtilsUnitTest {
         // Used by reflection
         public void setValueString(String valueString) {
             this.valueString = valueString;
+        }
+
+        public Boolean isBool() {
+            return bool;
+        }
+
+        @SuppressWarnings("unused")
+        // Used by reflection
+        public void setBool(Boolean bool) {
+            this.bool = bool;
         }
     }
 }


### PR DESCRIPTION
The change to use postInit is to allow other add-ons (like ajaxSpider) to register job types first.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>