### PR TITLE
requester: use versioned param

### DIFF
--- a/addOns/requester/requester.gradle.kts
+++ b/addOns/requester/requester.gradle.kts
@@ -33,3 +33,7 @@ spotless {
         })
     })
 }
+
+dependencies {
+    testImplementation(project(":testutils"))
+}

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/RequesterParam.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/RequesterParam.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.requester;
 
-import org.parosproxy.paros.common.AbstractParam;
+import org.zaproxy.zap.common.VersionedAbstractParam;
 
 /**
  * Manages the requester configurations saved in the configuration file.
@@ -31,9 +31,27 @@ import org.parosproxy.paros.common.AbstractParam;
  *       after creating a new tab.
  * </ul>
  */
-public class RequesterParam extends AbstractParam {
+public class RequesterParam extends VersionedAbstractParam {
 
     private static final String PARAM_BASE_KEY = "requester";
+
+    /**
+     * The current version of the configurations. Used to keep track of configuration changes
+     * between releases, in case changes/updates are needed.
+     *
+     * <p>It only needs to be incremented for configuration changes (not releases of the add-on).
+     *
+     * @see #CONFIG_VERSION_KEY
+     * @see #updateConfigsImpl(int)
+     */
+    private static final int CURRENT_CONFIG_VERSION = 1;
+
+    /**
+     * The key for the version of the configurations.
+     *
+     * @see #CURRENT_CONFIG_VERSION
+     */
+    private static final String CONFIG_VERSION_KEY = PARAM_BASE_KEY + VERSION_ATTRIBUTE;
 
     private static final String PARAM_REQUESTER_AUTO_FOCUS = PARAM_BASE_KEY + ".autoFocus";
 
@@ -44,8 +62,28 @@ public class RequesterParam extends AbstractParam {
     }
 
     @Override
-    protected void parse() {
+    protected int getCurrentVersion() {
+        return CURRENT_CONFIG_VERSION;
+    }
+
+    @Override
+    protected String getConfigVersionKey() {
+        return CONFIG_VERSION_KEY;
+    }
+
+    @Override
+    protected void parseImpl() {
         autoFocus = getConfig().getBoolean(PARAM_REQUESTER_AUTO_FOCUS, true);
+    }
+
+    @Override
+    protected void updateConfigsImpl(int fileVersion) {
+        switch (fileVersion) {
+            case NO_CONFIG_VERSION:
+                // No updates/changes needed.
+                break;
+            default:
+        }
     }
 
     public boolean isAutoFocus() {

--- a/addOns/requester/src/test/java/org/zaproxy/zap/extension/requester/RequesterParamUnitTest.java
+++ b/addOns/requester/src/test/java/org/zaproxy/zap/extension/requester/RequesterParamUnitTest.java
@@ -1,0 +1,107 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.requester;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link RequesterParam}. */
+class RequesterParamUnitTest {
+
+    private static final String AUTO_FOCUS_KEY = "requester.autoFocus";
+
+    private static final boolean DEFAULT_AUTO_FOCUS = true;
+
+    private ZapXmlConfiguration config;
+    private RequesterParam options;
+
+    @BeforeEach
+    void setUp() {
+        options = new RequesterParam();
+        config = new ZapXmlConfiguration();
+        options.load(config);
+    }
+
+    @Test
+    void shouldHaveConfigVersionKey() {
+        assertThat(options.getConfigVersionKey(), is(equalTo("requester[@version]")));
+    }
+
+    @Test
+    void shouldHaveDefaultValues() {
+        // Given
+        options = new RequesterParam();
+        // When / Then
+        assertDefaultValues();
+    }
+
+    private void assertDefaultValues() {
+        assertThat(options.isAutoFocus(), is(equalTo(DEFAULT_AUTO_FOCUS)));
+    }
+
+    @Test
+    void shouldLoadEmptyConfig() {
+        // Given
+        ZapXmlConfiguration emptyConfig = new ZapXmlConfiguration();
+        // When
+        options.load(emptyConfig);
+        // Then
+        assertDefaultValues();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadConfigWithAutoFocus(boolean value) {
+        // Given
+        config.setProperty(AUTO_FOCUS_KEY, value);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isAutoFocus(), is(equalTo(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"not boolean", ""})
+    void shouldUseDefaultWithInvalidAutoFocus(String value) {
+        // Given
+        config.setProperty(AUTO_FOCUS_KEY, value);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isAutoFocus(), is(equalTo(DEFAULT_AUTO_FOCUS)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAndPersistAutoFocus(boolean value) throws Exception {
+        // Given / When
+        options.setAutoFocus(value);
+        // Then
+        assertThat(options.isAutoFocus(), is(equalTo(value)));
+        assertThat(config.getBoolean(AUTO_FOCUS_KEY), is(equalTo(value)));
+    }
+}


### PR DESCRIPTION
Use `VersionedAbstractParam` to make it easier to update the
configurations.