### PR TITLE
Add database add-on

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Depend on `database` add-on.
 
 ## [42] - 2022-09-22
 ### Changed

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -22,6 +22,9 @@ zapAddOn {
                 register("oast") {
                     version.set(">= 0.7.0")
                 }
+                register("database") {
+                    version.set(">= 0.1.0")
+                }
             }
         }
 
@@ -45,6 +48,7 @@ zapAddOn {
 dependencies {
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
+    compileOnly(parent!!.childProjects.get("database")!!)
     compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("oast")!!)
 
@@ -54,6 +58,7 @@ dependencies {
     testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
+    testImplementation(parent!!.childProjects.get("database")!!)
     testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))

--- a/addOns/database/CHANGELOG.md
+++ b/addOns/database/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this add-on will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- Provides the SQLite database engine for other add-ons to use.

--- a/addOns/database/database.gradle.kts
+++ b/addOns/database/database.gradle.kts
@@ -1,0 +1,48 @@
+import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep
+import org.zaproxy.gradle.addon.AddOnStatus
+
+description = "Provides database engines and related infrastructure."
+
+val sqlite by configurations.creating
+configurations.api { extendsFrom(sqlite) }
+
+zapAddOn {
+    addOnName.set("Database")
+    addOnStatus.set(AddOnStatus.ALPHA)
+    zapVersion.set("2.11.1")
+
+    manifest {
+        author.set("ZAP Dev Team")
+        url.set("https://www.zaproxy.org/docs/desktop/addons/database/")
+
+        helpSet {
+            baseName.set("help%LC%.helpset")
+            localeToken.set("%LC%")
+        }
+
+        bundledLibs {
+            libs.from(sqlite)
+        }
+    }
+}
+
+crowdin {
+    configuration {
+        tokens.put("%helpPath%", "")
+    }
+}
+
+spotless {
+    format("help-html", {
+        eclipseWtp(EclipseWtpFormatterStep.HTML)
+        target(fileTree(projectDir) {
+            include("src/**/help/**/*.html")
+        })
+    })
+}
+
+dependencies {
+    sqlite("org.xerial:sqlite-jdbc:3.39.3.0")
+
+    testImplementation(project(":testutils"))
+}

--- a/addOns/database/gradle.properties
+++ b/addOns/database/gradle.properties
@@ -1,0 +1,2 @@
+version=0.1.0
+release=false

--- a/addOns/database/src/main/javahelp/help/contents/database.html
+++ b/addOns/database/src/main/javahelp/help/contents/database.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Database Add-on</TITLE>
+</HEAD>
+<BODY>
+	<H1>Database Add-on</H1>
+	An add-on that provides database engines and other related
+	infrastructure.
+	<p>It provides the following database engines:</p>
+	<ul>
+		<li>SQLite, through <a
+			href="https://github.com/xerial/sqlite-jdbc">SQLite JDBC Driver</a>.
+		</li>
+	</ul>
+
+</BODY>
+</HTML>

--- a/addOns/database/src/main/javahelp/help/helpset.hs
+++ b/addOns/database/src/main/javahelp/help/helpset.hs
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE helpset
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
+         "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
+<helpset version="2.0" xml:lang="en-GB">
+  <title>Database Add-on</title>
+
+  <maps>
+     <homeID>addon.database</homeID>
+     <mapref location="map.jhm"/>
+  </maps>
+
+  <view>
+    <name>TOC</name>
+    <label>Contents</label>
+    <type>org.zaproxy.zap.extension.help.ZapTocView</type>
+    <data>toc.xml</data>
+  </view>
+
+  <view>
+    <name>Index</name>
+    <label>Index</label>
+    <type>javax.help.IndexView</type>
+    <data>index.xml</data>
+  </view>
+
+  <view>
+    <name>Search</name>
+    <label>Search</label>
+    <type>javax.help.SearchView</type>
+    <data engine="com.sun.java.help.search.DefaultSearchEngine">
+      JavaHelpSearch
+    </data>
+  </view>
+
+  <view>
+    <name>Favorites</name>
+    <label>Favorites</label>
+    <type>javax.help.FavoritesView</type>
+  </view>
+</helpset>

--- a/addOns/database/src/main/javahelp/help/index.xml
+++ b/addOns/database/src/main/javahelp/help/index.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE index
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Index Version 1.0//EN"
+         "http://java.sun.com/products/javahelp/index_2_0.dtd">
+
+<index version="2.0">
+    <indexitem text="Database" target="addon.database" />
+</index>

--- a/addOns/database/src/main/javahelp/help/map.jhm
+++ b/addOns/database/src/main/javahelp/help/map.jhm
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE map
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Map Version 1.0//EN"
+         "http://java.sun.com/products/javahelp/map_1_0.dtd">
+
+<map version="1.0">
+    <mapID target="addon.database" url="contents/database.html" />
+</map>

--- a/addOns/database/src/main/javahelp/help/toc.xml
+++ b/addOns/database/src/main/javahelp/help/toc.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE toc
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp TOC Version 2.0//EN"
+         "http://java.sun.com/products/javahelp/toc_2_0.dtd">
+
+<toc version="2.0">
+    <tocitem text="ZAP User Guide" tocid="toplevelitem">
+        <tocitem text="Add Ons" tocid="addons">
+            <tocitem text="Database" target="addon.database" />
+        </tocitem>
+    </tocitem>
+</toc>

--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -11,6 +11,12 @@ zapAddOn {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/spider/")
 
+        dependencies {
+            addOns {
+                register("database")
+            }
+        }
+
         extensions {
             register("org.zaproxy.addon.spider.automation.ExtensionSpiderAutomation") {
                 classnames {
@@ -43,9 +49,11 @@ zapAddOn {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
+    compileOnly(parent!!.childProjects.get("database")!!)
     compileOnly(parent!!.childProjects.get("formhandler")!!)
 
     testImplementation(parent!!.childProjects.get("automation")!!)
+    testImplementation(parent!!.childProjects.get("database")!!)
     testImplementation(parent!!.childProjects.get("formhandler")!!)
     testImplementation(project(":testutils"))
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ var addOns = listOf(
     "commonlib",
     "coreLang",
     "custompayloads",
+    "database",
     "diff",
     "directorylistv1",
     "directorylistv2_3",


### PR DESCRIPTION
Add an add-on that provides database engines, currently SQLite.
Change the `ascanrulesBeta` and `spider` add-ons to depend on it, to no
longer rely on core.

Part of zaproxy/zaproxy#3113

---
Opted to add a new add-on as we could move the scan rule and the spider parser to the add-on instead of having the other two add-ons depend on it.
The add-on can also be used to provide SQLite for the session/permanent database in the future.
Also happy to move it to `commonlib` instead.