### PR TITLE
Use Java version from env var for releases

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -98,10 +98,10 @@ subprojects {
     }
 
     java {
-        // Compile with Java 8 when building ZAP releases.
+        // Compile with appropriate Java version when building ZAP releases.
         if (System.getenv("ZAP_RELEASE") != null) {
             toolchain {
-                languageVersion.set(JavaLanguageVersion.of(8))
+                languageVersion.set(JavaLanguageVersion.of(System.getenv("ZAP_JAVA_VERSION")))
             }
         } else {
             sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Use the Java version defined in the env var when building for ZAP releases.

Part of zaproxy/zaproxy#7478.