### PR TITLE
reports: fix typos in help

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Correct the ID of reports' sections in the help.
+
 ## [0.15.0] - 2022-07-20
 
 ### Fixed

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-html-plus.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-html-plus.html
@@ -30,8 +30,8 @@
 			<td>passingrules</td>
 		</tr>
 		<tr>
-			<td>Alerts Details</td>
-			<td>alertsdetails</td>
+			<td>Alert Details</td>
+			<td>alertdetails</td>
 		</tr>
 		<tr>
 			<td>Statistics</td>

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-html.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-html.html
@@ -22,8 +22,8 @@
 			<td>instancecount</td>
 		</tr>
 		<tr>
-			<td>Alerts Details</td>
-			<td>alertsdetails</td>
+			<td>Alert Details</td>
+			<td>alertdetails</td>
 		</tr>
 	</table>
 

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-pdf.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-pdf.html
@@ -22,8 +22,8 @@
 			<td>instancecount</td>
 		</tr>
 		<tr>
-			<td>Alerts Details</td>
-			<td>alertsdetails</td>
+			<td>Alert Details</td>
+			<td>alertdetails</td>
 		</tr>
 	</table>
 


### PR DESCRIPTION
Correct the ID of reports' sections, adjust the names accordingly.

---
From OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/cX5U-Er1epA/m/5KEnzOY1LwAJ