### PR TITLE
requester: notify persistent connection listeners

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -235,7 +235,8 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                                     new HttpSenderApache(
                                             this::getGlobalCookieStore,
                                             connectionOptions,
-                                            clientCertificatesOptions));
+                                            clientCertificatesOptions,
+                                            () -> legacyProxyListenerHandler));
                 } catch (Exception e) {
                     LOGGER.error("An error occurred while creating the sender:", e);
                 }

--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Manage the send/resend Manual Request Editor dialogues.
   - Add a Tools menu item to open the send Manual Request Editor.
   - Add a context menu item to open the resend Manual Request Editor.
+  - Allow to establish WebSocket connections with the send/resend Manual Request Editor dialogues.
 
 ### Changed
 - Improve reporting of TLS errors (Issue 2699).

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/ManualHttpRequestEditorPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/ManualHttpRequestEditorPanel.java
@@ -48,7 +48,6 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.requester.ExtensionRequester;
 import org.zaproxy.addon.requester.MessageEditorPanel;
-import org.zaproxy.zap.PersistentConnectionListener;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.extension.httppanel.HttpPanel.OptionsLocation;
@@ -613,14 +612,6 @@ public class ManualHttpRequestEditorPanel extends MessageEditorPanel
             }
             return responseSendButton;
         }
-    }
-
-    public void addPersistentConnectionListener(PersistentConnectionListener listener) {
-        sender.addPersistentConnectionListener(listener);
-    }
-
-    public void removePersistentConnectionListener(PersistentConnectionListener listener) {
-        sender.removePersistentConnectionListener(listener);
     }
 
     @Override


### PR DESCRIPTION
Notify the persistent connection listeners when sending the messages to allow other add-ons (e.g. WebSocket) to take over the connection.
Remove code no longer needed.
Change network add-on to allow to notify the persistent connection listeners through the message being sent.