### PR TITLE
domxss: increase allowed requests in tests

### DIFF
--- a/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
+++ b/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
@@ -87,6 +88,14 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionDomXSS());
+    }
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
+        if (strength == AttackStrength.LOW) {
+            return NUMBER_MSGS_ATTACK_STRENGTH_LOW + 1;
+        }
+        return super.getRecommendMaxNumberMessagesPerParam(strength);
     }
 
     @Test


### PR DESCRIPTION
Allow one more request to prevent failures.

---
e.g.: https://github.com/zaproxy/zap-extensions/actions/runs/3184317359/jobs/5193002934#step:7:443