### PR TITLE
Test example alerts

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fix an exception in Bypassing 403 scan rule when creating example alerts.
 
 ## [39] - 2022-09-22
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ForbiddenBypassScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ForbiddenBypassScanRule.java
@@ -187,7 +187,13 @@ public class ForbiddenBypassScanRule extends AbstractAppPlugin {
     @Override
     public List<Alert> getExampleAlerts() {
         List<Alert> alerts = new ArrayList<>();
-        alerts.add(createAlert("", new HttpMessage(), "").build());
+        try {
+            alerts.add(
+                    createAlert("", new HttpMessage(new URI("https://example.com", true)), "")
+                            .build());
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
         return alerts;
     }
 }

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
@@ -20,11 +20,13 @@
 package org.zaproxy.zap.testutils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -196,6 +198,7 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
     Collection<DynamicTest> commonScanRuleTests() {
         List<DynamicTest> commonTests = new ArrayList<>();
         commonTests.add(testScanRuleHasName());
+        commonTests.add(testExampleAlerts());
         addTestsSendReasonableNumberOfMessages(commonTests);
         return commonTests;
     }
@@ -223,6 +226,25 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
                 extensionResourceBundle.keySet().stream()
                         .map(extensionResourceBundle::getString)
                         .anyMatch(str -> str.equals(name)));
+    }
+
+    private DynamicTest testExampleAlerts() {
+        return dynamicTest(
+                "shouldHaveExampleAlerts",
+                () -> {
+                    setUp();
+                    shouldHaveExampleAlerts();
+                });
+    }
+
+    private void shouldHaveExampleAlerts() {
+        // Given / When
+        List<Alert> alerts = assertDoesNotThrow(rule::getExampleAlerts);
+        // Then
+        if (alerts == null) {
+            return;
+        }
+        assertThat(alerts, is(not(empty())));
     }
 
     private void addTestsSendReasonableNumberOfMessages(List<DynamicTest> tests) {


### PR DESCRIPTION
Test that the scan rules create the example alerts without issues.
Fix an exception in `ForbiddenBypassScanRule`.