### PR TITLE
Add Java 18 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11, 17, 18]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Prevent warnings in newer Java versions from being introduced to the codebase.

Related to zaproxy/zaproxy#7389.