### PR TITLE
pscanrulesAlpha and pscanrulesBeta: Add example alerts

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Content Cacheability scan rule now has functionality to generate example alerts for documentation purposes (Issue 7502).
 
 ## [36] - 2022-09-16
 ### Changed

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRuleUnitTest.java
@@ -24,11 +24,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -98,6 +100,14 @@ class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_ATHN_06_CACHE_WEAKNESS.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_ATHN_06_CACHE_WEAKNESS.getValue())));
+    }
+
+    @Test
+    void shouldReturnExampleAlerts() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(3)));
     }
 
     @Test

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The Server Header Information Leak scan rule now has functionality to generate example alerts for documentation purposes (Issue 6119).
 
 ## [30] - 2022-09-15
 ### Changed

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRuleUnitTest.java
@@ -24,10 +24,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -136,5 +138,23 @@ class ServerHeaderInfoLeakScanRuleUnitTest
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_INFO_02_FINGERPRINT_WEB_SERVER.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_INFO_02_FINGERPRINT_WEB_SERVER.getValue())));
+    }
+
+    @Test
+    void shouldReturnExampleAlerts() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        long countLows =
+                rule.getExampleAlerts().stream()
+                        .filter(alert -> Alert.RISK_LOW == alert.getRisk())
+                        .count();
+        long countInfos =
+                rule.getExampleAlerts().stream()
+                        .filter(alert -> Alert.RISK_INFO == alert.getRisk())
+                        .count();
+        // Then
+        assertThat(alerts.size(), is(equalTo(2)));
+        assertThat(countLows, is(equalTo(1L)));
+        assertThat(countInfos, is(equalTo(1L)));
     }
 }


### PR DESCRIPTION
- Rework scan rules to have example alerts and use related alert builder methods.
- Include Unit Test methods to assert the example alert collections.
- Include change note in CHANGELOGs

Part of zaproxy/zaproxy#6119
Fixes zaproxy/zaproxy#7502

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>