### PR TITLE
pscanrulesAlpha & Beta: Remove unnecessary setUri on example alerts

### DIFF
--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
@@ -723,9 +723,8 @@ public class CacheableScanRule extends PluginPassiveScanner {
     @Override
     public List<Alert> getExampleAlerts() {
         List<Alert> alerts = new ArrayList<>();
-        String exampleUri = "https://example.com";
-        alerts.add(alertNonStorable("HEAD ").setUri(exampleUri).build());
-        alerts.add(alertStorableNonCacheable("no-cache").setUri(exampleUri).build());
+        alerts.add(alertNonStorable("HEAD ").build());
+        alerts.add(alertStorableNonCacheable("no-cache").build());
         alerts.add(
                 alertStorableCacheable(
                                 "",

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
@@ -92,11 +92,8 @@ public class ServerHeaderInfoLeakScanRule extends PluginPassiveScanner {
     @Override
     public List<Alert> getExampleAlerts() {
         List<Alert> alerts = new ArrayList<>();
-        alerts.add(buildHeaderPresentAlert("Apache").setUri("https://www.example.com").build());
-        alerts.add(
-                buildVersionLeakAlert("Apache/2.4.1 (Unix)")
-                        .setUri("https://www.example.com")
-                        .build());
+        alerts.add(buildHeaderPresentAlert("Apache").build());
+        alerts.add(buildVersionLeakAlert("Apache/2.4.1 (Unix)").build());
         return alerts;
     }
 


### PR DESCRIPTION
Follow-up to: https://github.com/zaproxy/zap-extensions/pull/4097/

Discussed in: https://github.com/zaproxy/zaproxy-website/pull/1337

CHANGELOGs already have maint note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>