### PR TITLE
encoder: Add Full HTML Entity encoder

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
+### Added
+- A Full HTML Entity encoder (Issue 2222).
+
 ## [0.6.0] - 2021-10-06
 ### Changed
 - Maintenance changes.

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
@@ -32,6 +32,7 @@ import org.zaproxy.addon.encoder.processors.predefined.Base64Decoder;
 import org.zaproxy.addon.encoder.processors.predefined.Base64Encoder;
 import org.zaproxy.addon.encoder.processors.predefined.Base64UrlDecoder;
 import org.zaproxy.addon.encoder.processors.predefined.Base64UrlEncoder;
+import org.zaproxy.addon.encoder.processors.predefined.FullHtmlStringEncoder;
 import org.zaproxy.addon.encoder.processors.predefined.FullUrlDecoder;
 import org.zaproxy.addon.encoder.processors.predefined.FullUrlEncoder;
 import org.zaproxy.addon.encoder.processors.predefined.HexStringDecoder;
@@ -70,6 +71,7 @@ public class EncodeDecodeProcessors {
 
         addPredefined("htmldecode", new HtmlStringDecoder());
         addPredefined("htmlencode", new HtmlStringEncoder());
+        addPredefined("fullhtmlencode", new FullHtmlStringEncoder());
 
         addPredefined("javascriptdecode", new JavaScriptStringDecoder());
         addPredefined("javascriptencode", new JavaScriptStringEncoder());

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/FullHtmlStringEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/FullHtmlStringEncoder.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors.predefined;
+
+public class FullHtmlStringEncoder extends DefaultEncodeDecodeProcessor {
+
+    @Override
+    protected String processInternal(String value) {
+        StringBuilder output = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            output.append("&#").append(value.codePointAt(i)).append(';');
+        }
+        return output.toString();
+    }
+}

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -41,6 +41,7 @@ In its default state the Encode/Decode/Hash dialog displays tabs and output pane
   <li>Full URL Encode</li>
   <li>ASCII Hex Encode</li>
   <li>HTML Encode</li>
+  <li>Full HTML Encode</li>
   <li>JavaScript Encode</li>
 </ul>
 
@@ -112,6 +113,9 @@ Will display escaped Unicode characters. For example, the text
 <H4>HTML Encode</H4>
 Will display the HTML encoding of the text you enter. For example, the text
 <code>&quot;pi&ntilde;ata&quot;</code> would be encoded as <code>&amp;quot;pi&amp;ntilde;ata&amp;quot;</code>.
+
+<H4>Full HTML Encode</H4>
+Will display the full HTML encoding of the text you enter. For example, the text <code>&lt;script&gt;</code> would be encoded as <code>&amp;#60;&amp;#115;&amp;#99;&amp;#114;&amp;#105;&amp;#112;&amp;#116;&amp;#62;</code>
 
 <H4>JavaScript Encode</H4>
 Will display escaped JavaScript literals of the text you enter. For example, the text

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -38,6 +38,7 @@ encoder.predefined.base64decode=Base64 Decode
 encoder.predefined.base64encode=Base64 Encode
 encoder.predefined.base64urldecode=Base64 URL Decode
 encoder.predefined.base64urlencode=Base64 URL Encode
+encoder.predefined.fullhtmlencode=Full HTML Encode
 encoder.predefined.fullurldecode=Full URL Decode
 encoder.predefined.fullurlencode=Full URL Encode
 encoder.predefined.hexdecode=ASCII Hex Decode

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/encoder-default.xml
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/encoder-default.xml
@@ -29,6 +29,10 @@
                 </outputpanel>
                 <outputpanel>
                     <name/>
+                    <processorId>encoder.predefined.fullhtmlencode</processorId>
+                </outputpanel>
+                <outputpanel>
+                    <name/>
                     <processorId>encoder.predefined.javascriptencode</processorId>
                 </outputpanel>
             </outputpanels>


### PR DESCRIPTION
- CHANGELOG > Added note.
- EncodeDecodeProcessors > Accommodate new encoder.
- encoder-default.xml > Accommodate new encoder.
- encoder.html > Added associated help content.
- FullHtmlStringEncoder > Newly added encoder which encodes all characters in a script not just HTML entities.
- Messages.properties > Added support key/value pair for the panel title.

Along with the customizability of the encoder add-on I believe this fixes zaproxy/zaproxy#2222.

Note: No accompanying decoder was added as the existing HTML Decoder already handles this.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>