### PR TITLE
Relocate help and update minimum add-on version

### DIFF
--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-requestor.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-requestor.html
@@ -9,7 +9,7 @@
 <H1>Automation Framework - requestor Job</H1>
 
 This job sends specifically crafted requests to a target url, with a custom request method and body. The user can also specify
-an expected response code, against which the actual response is compared, and the user is warned in case it does not match.
+an expected response code, against which the actual response is compared, and the user is warned in case it does not match. The user can add additional headers to the request e.g. Authorization Tokens, etc.
 
 <H2>YAML</H2>
 
@@ -20,6 +20,8 @@ an expected response code, against which the actual response is compared, and th
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
         method:                        # String: A non-empty request method, default: GET
+        headers:                       # An optional list of additional headers to include in the request
+            - "header1:value1"
         data:                          # String: Optional data to send in the request body
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched
 </pre>

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help_sr_CS/contents/job-requestor.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help_sr_CS/contents/job-requestor.html
@@ -9,7 +9,7 @@
 <H1>Automation Framework - requestor Job</H1>
 
 This job sends specifically crafted requests to a target url, with a custom request method and body. The user can also specify
-an expected response code, against which the actual response is compared, and the user is warned in case it does not match. The user can add additional headers to the request e.g. Authorization Tokens, etc.
+an expected response code, against which the actual response is compared, and the user is warned in case it does not match.
 
 <H2>YAML</H2>
 
@@ -20,8 +20,6 @@ an expected response code, against which the actual response is compared, and th
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
         method:                        # String: A non-empty request method, default: GET
-        headers:                       # An optional list of additional headers to include in the request
-            - "header1:value1"
         data:                          # String: Optional data to send in the request body
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched
 </pre>

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -18,7 +18,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.12.0")
+                            version.set(">=0.18.0")
                         }
                     }
                 }


### PR DESCRIPTION
Relocate help accidentally added to a translation file to the main help file.
Update minimum version of automation in scripts, using newer features.