### PR TITLE
network: close client conn if server closed

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.net.Socket;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -63,6 +64,7 @@ import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.http.io.HttpClientConnection;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
@@ -403,6 +405,13 @@ public class HttpSenderApache
         if (user != null) {
             LegacyUtils.updateHttpState(
                     user.getCorrespondingHttpState(), requestCtx.getCookieStore());
+        }
+
+        HttpClientConnection connection =
+                (HttpClientConnection) requestCtx.getAttribute(ZapHttpRequestExecutor.CONNECTION);
+        if (!connection.isOpen()) {
+            message.setUserObject(Collections.singletonMap("connection.closed", Boolean.TRUE));
+            return;
         }
 
         Socket socket = (Socket) requestCtx.getAttribute(ZapHttpRequestExecutor.CONNECTION_SOCKET);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapHttpRequestExecutor.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapHttpRequestExecutor.java
@@ -47,6 +47,7 @@ import org.apache.hc.core5.io.Closer;
  */
 public class ZapHttpRequestExecutor extends HttpRequestExecutor {
 
+    public static final String CONNECTION = "zap.connection";
     public static final String CONNECTION_SOCKET = "zap.connection.socket";
     public static final String CONNECTION_INPUT_STREAM = "zap.connection.inputstream";
 
@@ -108,6 +109,7 @@ public class ZapHttpRequestExecutor extends HttpRequestExecutor {
             } else if (MessageSupport.canResponseHaveBody(request.getMethod(), response)) {
                 conn.receiveResponseEntity(response);
             }
+            context.setAttribute(CONNECTION, conn);
             return response;
 
         } catch (final HttpException | IOException | RuntimeException ex) {

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainServerHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainServerHandler.java
@@ -25,6 +25,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.ssl.SslClosedEngineException;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -87,6 +88,11 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
 
         writeResponse(ctx, msg);
 
+        if (isClosed(msg)) {
+            close(ctx);
+            return;
+        }
+
         if (postWriteResponse(ctx, msg)) {
             return;
         }
@@ -94,6 +100,15 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
         if (isConnectionClose(msg)) {
             close(ctx);
         }
+    }
+
+    private static boolean isClosed(HttpMessage msg) {
+        Object userObject = msg.getUserObject();
+        if (userObject instanceof Map) {
+            Map<?, ?> properties = (Map<?, ?>) userObject;
+            return Boolean.TRUE.equals(properties.get("connection.closed"));
+        }
+        return false;
     }
 
     protected HandlerResult processMessage(HttpMessage msg) {

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainServerHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainServerHandlerUnitTest.java
@@ -37,6 +37,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -381,6 +382,26 @@ class MainServerHandlerUnitTest {
         assertThat(exceptionsThrown, hasSize(0));
         assertChannelActive(false);
         assertResponse("HTTP/1.1 200\r\n\r\nNot empty body");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.0", "1.1"})
+    void shouldCloseChannelIfUserObjectContainsConnectionClosed(String httpVersion) {
+        // Given
+        String request = "GET / HTTP/" + httpVersion + "\r\nConnection: keep-alive\r\n\r\n";
+        String response = "HTTP/" + httpVersion + " 200\r\nConnection: keep-alive\r\n\r\n";
+        handler1.addAction(
+                0,
+                (ctx, msg) -> {
+                    msg.setResponseHeader(response);
+                    msg.setUserObject(Collections.singletonMap("connection.closed", Boolean.TRUE));
+                });
+        // When
+        written(request);
+        // Then
+        assertThat(exceptionsThrown, hasSize(0));
+        assertChannelActive(false);
+        assertResponse(response);
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
@@ -134,7 +134,11 @@ public class TestHttpServer extends HttpServer {
         }
     }
 
-    /** Gets the messages received by the server. @return the messages received by the server. */
+    /**
+     * Gets the messages received by the server.
+     *
+     * @return the messages received by the server.
+     */
     public List<HttpMessage> getReceivedMessages() {
         return receivedMessages;
     }


### PR DESCRIPTION
Close the client side connection if the server side closed the connection otherwise it could be kept open longer than needed.

Fix zaproxy/zaproxy#7292.