### PR TITLE
ascanrules: Address FP in External Redirect scan rule

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - CVE-2012-1823 Remote Execution and Source Code Disclosure, and Heart Bleed scan rules now include Alert Tags for the applicable CVEs.
 
+### Fixed
+- A false positive that could occur in the External Redirect scan rule if the payload was included in the redirect as a param or portion of the value.
+
 ## [51] - 2023-01-03
 ### Changed
 - Command Injection Scan Rule: Time-based blind detection heuristic has been replaced with linear regression.


### PR DESCRIPTION
Identified via:
https://stackoverflow.com/questions/74025214/owasp-on-liferay7-external-redirect-error

- CHANGELOG > Add fix note.
- ExternalRedirectScanRule > Added validation to ensure it's much more likely that the payload is not a substring of the returned redirect mechanism (ex: part of the path, or an included parameter). 
- ExternalRedirectScanRuleUnitTest > Add a test method to assert the modified behavior. Add utility methods to simplify and reduce verbosity of nano server handlers.

Fixes: zaproxy/zaproxy#7697

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>