### PR TITLE
encoder: Full HTML Entity encoder add unit tests and size string builder

### DIFF
--- a/addOns/encoder/encoder.gradle.kts
+++ b/addOns/encoder/encoder.gradle.kts
@@ -20,3 +20,7 @@ crowdin {
         tokens.put("%helpPath%", resourcesPath)
     }
 }
+
+dependencies {
+    testImplementation(project(":testutils"))
+}

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/FullHtmlStringEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/FullHtmlStringEncoder.java
@@ -23,7 +23,8 @@ public class FullHtmlStringEncoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) {
-        StringBuilder output = new StringBuilder();
+        // Initial size: 3 digits for code point plus 3 appended chars
+        StringBuilder output = new StringBuilder(value.length() * 6);
         for (int i = 0; i < value.length(); i++) {
             output.append("&#").append(value.codePointAt(i)).append(';');
         }

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/FullHtmlStringEncoderUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/FullHtmlStringEncoderUnitTest.java
@@ -1,0 +1,65 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors.predefined;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessor;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
+
+class FullHtmlStringEncoderUnitTest {
+
+    @Test
+    void shouldHandleEmptyInput() throws Exception {
+        // Given
+        EncodeDecodeProcessor encoder = new FullHtmlStringEncoder();
+        // When
+        EncodeDecodeResult result = encoder.process("");
+        // Then
+        assertThat(result.hasError(), is(equalTo(false)));
+        assertThat(result.getResult(), is(equalTo("")));
+    }
+
+    @Test
+    void shouldEncodeSimpleScriptTag() throws Exception {
+        // Given
+        EncodeDecodeProcessor encoder = new FullHtmlStringEncoder();
+        // When
+        EncodeDecodeResult result = encoder.process("<script>");
+        // Then
+        assertThat(result.hasError(), is(equalTo(false)));
+        assertThat(
+                result.getResult(), is(equalTo("&#60;&#115;&#99;&#114;&#105;&#112;&#116;&#62;")));
+    }
+
+    @Test
+    void shouldEncodeStringWithEmoji() throws Exception {
+        // Given
+        EncodeDecodeProcessor encoder = new FullHtmlStringEncoder();
+        // When
+        EncodeDecodeResult result = encoder.process("fred✅");
+        // Then
+        assertThat(result.hasError(), is(equalTo(false)));
+        assertThat(result.getResult(), is(equalTo("&#102;&#114;&#101;&#100;&#9989;")));
+    }
+}


### PR DESCRIPTION
- FullHtmlStringEncoder > Set the string builder's initial size to input length times 6 (assuming code point is 3 digits and we add 3 characters to each).
- FullHtmlStringEncoderUnitTest > Add tests for the new encoder.
- encoder.gradle.kts > Add testutils dependency.

Follow-up to: https://github.com/zaproxy/zap-extensions/pull/4103

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>