### PR TITLE
pscanrules: HashDisclosure correct character class in regex

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - The Server Header Information Leak scan rule now has functionality to generate example alerts for documentation purposes (Issue 6119).
+- Maintenance changes.
 
 ## [43] - 2022-09-15
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
@@ -58,10 +58,10 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
                 Pattern.compile("\\$K4\\$[a-f0-9]{16},", Pattern.CASE_INSENSITIVE),
                 new HashAlert("Kerberos AFS DES", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
         hashPatterns.put(
-                Pattern.compile("\\$2a\\$05\\$[a-zA-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE),
+                Pattern.compile("\\$2a\\$05\\$[a-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE),
                 new HashAlert("OpenBSD Blowfish", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
         hashPatterns.put(
-                Pattern.compile("\\$2y\\$05\\$[a-zA-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE),
+                Pattern.compile("\\$2y\\$05\\$[a-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE),
                 new HashAlert("OpenBSD Blowfish", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
         // MD5 Crypt


### PR DESCRIPTION
- CHANGELOG > Add maintenance note.
- HashDisclosureScanRule > Remove upper case alpha character class in regex since it's case insensitive.

Issue identified by CodeQL
Ex: https://github.com/zaproxy/zap-extensions/pull/4118/commits/28c559b607c8700f1bf7fc77fcf8154b1c876745
![image](https://user-images.githubusercontent.com/7570458/195856509-69153030-cb63-4fc3-a093-1027989cce9b.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>