### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update Zest library to 0.16.0:
+  - Search script engines also by extension not just by name when invoking scripts otherwise it could miss some engines (e.g. Jython).
 - Maintenance changes.
 
 ## [36] - 2022-09-23

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -38,7 +38,7 @@ zapAddOn {
 dependencies {
     compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
-    implementation("org.zaproxy:zest:0.15.0") {
+    implementation("org.zaproxy:zest:0.16.0") {
         // Provided by Selenium add-on.
         exclude(group = "org.seleniumhq.selenium")
         exclude(group = "com.codeborne", module = "phantomjsdriver")


### PR DESCRIPTION
Update Zest library to 0.16.0, addresses:
 - Search script engines also by extension not just by name when invoking scripts otherwise it could miss some engines (e.g. Jython).