### PR TITLE
spider: remove core spider checks

### DIFF
--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
@@ -45,7 +45,6 @@ import org.zaproxy.addon.spider.filters.ParseFilter;
 import org.zaproxy.addon.spider.parser.SpiderParser;
 import org.zaproxy.addon.spider.parser.SvgHrefParser;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
-import org.zaproxy.zap.extension.spider.ExtensionSpider;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.DefaultValueGenerator;
 import org.zaproxy.zap.model.ScanController;
@@ -59,12 +58,6 @@ import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController<SpiderScan> {
     public static final String NAME = "ExtensionSpider2";
-
-    static boolean coreSpiderDisabled;
-
-    static {
-        coreSpiderDisabled = ExtensionSpider.class.getAnnotation(Deprecated.class) != null;
-    }
 
     private ValueGenerator generator = new DefaultValueGenerator();
 
@@ -114,9 +107,7 @@ public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController
 
     @Override
     public void init() {
-        if (coreSpiderDisabled) {
-            SpiderEventPublisher.getPublisher();
-        }
+        SpiderEventPublisher.getPublisher();
     }
 
     public void setValueGenerator(ValueGenerator generator) {
@@ -129,9 +120,6 @@ public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController
 
     @Override
     public void hook(ExtensionHook extensionHook) {
-        if (!coreSpiderDisabled) {
-            return;
-        }
         extensionHook.addSessionListener(new SessionChangedListenerImpl());
 
         // Initialize views
@@ -141,7 +129,7 @@ public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController
             extensionHook.getHookView().addOptionPanel(getOptionsSpiderPanel());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuItemSpiderDialog());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuItemSpiderDialogWithContext());
-            ExtensionHelp.enableHelpKey(getSpiderPanel(), "ui.tabs.spider");
+            ExtensionHelp.enableHelpKey(getSpiderPanel(), "addon.spider.tab");
         }
 
         // Register the params
@@ -162,12 +150,10 @@ public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController
 
     @Override
     public void unload() {
-        if (coreSpiderDisabled) {
-            SpiderEventPublisher.unload();
+        SpiderEventPublisher.unload();
 
-            if (hasView()) {
-                getSpiderPanel().unload();
-            }
+        if (hasView()) {
+            getSpiderPanel().unload();
         }
     }
 
@@ -324,10 +310,6 @@ public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController
 
     @Override
     public void destroy() {
-        if (!coreSpiderDisabled) {
-            return;
-        }
-
         // Shut all of the scans down
         this.stopAllScans();
         if (hasView()) {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/ExtensionSpiderAutomation.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/ExtensionSpiderAutomation.java
@@ -29,7 +29,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.zaproxy.addon.automation.ExtensionAutomation;
 import org.zaproxy.addon.spider.ExtensionSpider2;
-import org.zaproxy.zap.extension.spider.ExtensionSpider;
 
 public class ExtensionSpiderAutomation extends ExtensionAdaptor {
 
@@ -56,10 +55,6 @@ public class ExtensionSpiderAutomation extends ExtensionAdaptor {
 
     @Override
     public void hook(ExtensionHook extensionHook) {
-        if (ExtensionSpider.class.getAnnotation(Deprecated.class) == null) {
-            return;
-        }
-
         job = new SpiderJob();
         getExtension(ExtensionAutomation.class).registerAutomationJob(job);
     }
@@ -75,10 +70,6 @@ public class ExtensionSpiderAutomation extends ExtensionAdaptor {
 
     @Override
     public void unload() {
-        if (job == null) {
-            return;
-        }
-
         getExtension(ExtensionAutomation.class).unregisterAutomationJob(job);
     }
 }

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/ExtensionSpider2UnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/ExtensionSpider2UnitTest.java
@@ -22,9 +22,7 @@ package org.zaproxy.addon.spider;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -40,30 +38,12 @@ class ExtensionSpider2UnitTest {
 
     @BeforeEach
     void setUp() {
-        coreSpiderDeprecated(false);
-
         extension = new ExtensionSpider2();
     }
 
-    private static void coreSpiderDeprecated(boolean deprecated) {
-        ExtensionSpider2.coreSpiderDisabled = deprecated;
-    }
-
     @Test
-    void shouldNotAddSessionChangedListenerOnHookIfCoreSpiderNotDeprecated() {
+    void shouldAddSessionChangedListenerOnHook() {
         // Given
-        coreSpiderDeprecated(false);
-        ExtensionHook extensionHook = mock(ExtensionHook.class);
-        // When
-        extension.hook(extensionHook);
-        // Then
-        verify(extensionHook, times(0)).addSessionListener(any());
-    }
-
-    @Test
-    void shouldAddSessionChangedListenerOnHookIfCoreSpiderDeprecated() {
-        // Given
-        coreSpiderDeprecated(true);
         ExtensionHook extensionHook = mock(ExtensionHook.class);
         // When
         extension.hook(extensionHook);

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SpiderParserTestUtils.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SpiderParserTestUtils.java
@@ -48,7 +48,7 @@ import org.zaproxy.zap.testutils.TestUtils;
  * Class with helper/utility methods to help testing classes involving {@code SpiderParser}
  * implementations.
  *
- * @see org.zaproxy.zap.spider.parser.SpiderParser
+ * @see org.zaproxy.addon.spider.parser.SpiderParser
  */
 abstract class SpiderParserTestUtils<T extends SpiderParser> extends TestUtils {
 


### PR DESCRIPTION
The core checks are no longer needed.
Use the help key of the add-on.

Part of zaproxy/zaproxy#3113.