### PR TITLE
requester: add support for persisting tabs in session database

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add shortcut to Send buttons (Issue 6448).
 - Add button to allow to regenerate Anti-CSRF tokens (Issue 111).
 - Provide the necessary infrastructure for other add-ons (e.g. WebSocket) to send messages.
+- Persist tabs (with name, order and message) in session database
 - On ZAP versions newer than 2.11:
   - Manage the send/resend Manual Request Editor dialogues.
   - Add a Tools menu item to open the send Manual Request Editor.

--- a/addOns/requester/requester.gradle.kts
+++ b/addOns/requester/requester.gradle.kts
@@ -38,5 +38,8 @@ spotless {
 }
 
 dependencies {
+    compileOnly("org.projectlombok:lombok:1.18.24")
+    annotationProcessor("org.projectlombok:lombok:1.18.24")
+
     testImplementation(project(":testutils"))
 }

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/db/RequesterTabRecord.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/db/RequesterTabRecord.java
@@ -1,0 +1,61 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.db;
+
+import lombok.Builder;
+import lombok.Data;
+import net.sf.json.JSONObject;
+import org.zaproxy.zap.extension.httppanel.Message;
+
+import java.util.UUID;
+
+/**
+ * Represents serialized requester tab
+ */
+@Data
+@Builder
+public class RequesterTabRecord {
+
+    /**
+     * Unique identifier of tab record in database
+     */
+    private UUID id;
+
+    /**
+     * Name (title) of the tab
+     */
+    private String name;
+
+    /**
+     * Serialized message using {@link Message#toEventData()}
+     */
+    private JSONObject message;
+
+    /**
+     * Message type {@link Message#getType()}
+     */
+    private String messageType;
+
+    /**
+     * Index of tab (order)
+     */
+    private int index;
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/db/RequesterTabStorage.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/db/RequesterTabStorage.java
@@ -1,0 +1,138 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.db;
+
+import lombok.RequiredArgsConstructor;
+import net.sf.json.JSONObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.zaproxy.addon.requester.exception.RequesterException;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Storage class that wraps table.
+ */
+@RequiredArgsConstructor
+public class RequesterTabStorage {
+
+    private static final Logger LOGGER = LogManager.getLogger(RequesterTabStorage.class);
+
+    private final TableRequesterTab table;
+
+    /**
+     * Creates new tab and stores it in the database
+     * @param name Tab name (title)
+     * @param index Tab index (order)
+     * @param message Serialized message data
+     * @return New tab record
+     */
+    public RequesterTabRecord createNewTab(String name, int index, JSONObject message, String messageType) {
+        try {
+            RequesterTabRecord tabRecord = RequesterTabRecord.builder()
+                    .id(UUID.randomUUID())
+                    .name(name)
+                    .index(index)
+                    .message(message)
+                    .messageType(messageType)
+                    .build();
+            table.insertTab(tabRecord);
+            LOGGER.debug("Created tab with id {}.", tabRecord.getId());
+            return tabRecord;
+        } catch (SQLException e) {
+            LOGGER.error("Could not create tab in database!", e);
+            throw new RequesterException(e);
+        }
+    }
+
+    /**
+     * Obtains all tabs from database ordered by index
+     * @return List of ordered tabs
+     */
+    public List<RequesterTabRecord> getTabs() {
+        try {
+            List<RequesterTabRecord> tabs = table.getAllTabs();
+            LOGGER.debug("Obtained {} request tabs.", tabs.size());
+            return tabs;
+        } catch (SQLException e) {
+            LOGGER.error("Could not create tab in database!", e);
+            throw new RequesterException(e);
+        }
+    }
+
+    /**
+     * Updates tab name in the database
+     * @param tabRecord Tab record to persist (only name will be saved)
+     */
+    public void updateTabName(RequesterTabRecord tabRecord) {
+        try {
+            table.updateTabName(tabRecord);
+            LOGGER.debug("Updated tab name with id {}.", tabRecord.getId());
+        } catch (SQLException e) {
+            LOGGER.error("Could not update tab name in database!", e);
+            throw new RequesterException(e);
+        }
+    }
+
+    /**
+     * Updates tab message in the database
+     * @param tabRecord Tab record to persist (only message will be saved)
+     */
+    public void updateTabMessage(RequesterTabRecord tabRecord) {
+        try {
+            table.updateTabMessage(tabRecord);
+            LOGGER.debug("Updated tab message with id {}.", tabRecord.getId());
+        } catch (SQLException e) {
+            LOGGER.error("Could not update tab message in database!", e);
+            throw new RequesterException(e);
+        }
+    }
+
+    /**
+     * Updates tab index in the database
+     * @param tabRecord Tab record to persist (only index will be saved)
+     */
+    public void updateTabIndex(RequesterTabRecord tabRecord) {
+        try {
+            table.updateTabIndex(tabRecord);
+            LOGGER.debug("Updated tab index with id {}.", tabRecord.getId());
+        } catch (SQLException e) {
+            LOGGER.error("Could not update tab index in database!", e);
+            throw new RequesterException(e);
+        }
+    }
+
+    /**
+     * Deletes tab record from the database
+     * @param tabRecord Tab record to delete
+     */
+    public void deleteTab(RequesterTabRecord tabRecord) {
+        try {
+            table.deleteTab(tabRecord);
+            LOGGER.debug("Deleted tab with id {}.", tabRecord.getId());
+        } catch (SQLException e) {
+            LOGGER.error("Could not delete tab in database!", e);
+            throw new RequesterException(e);
+        }
+    }
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/db/TableRequesterTab.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/db/TableRequesterTab.java
@@ -1,0 +1,192 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.db;
+
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+import org.hsqldb.jdbc.JDBCClob;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.db.DbUtils;
+import org.parosproxy.paros.db.paros.ParosAbstractTable;
+
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Table for persisting Requester tabs
+ */
+public class TableRequesterTab extends ParosAbstractTable {
+
+    private static final String TABLE = "REQUESTER_TAB";
+
+    private PreparedStatement psInsert;
+    private PreparedStatement psSelect;
+    private PreparedStatement psUpdateName;
+    private PreparedStatement psUpdateMessage;
+    private PreparedStatement psUpdateIndex;
+    private PreparedStatement psDelete;
+
+    @Override
+    protected void reconnect(Connection connection) throws DatabaseException {
+        try {
+            if (!DbUtils.hasTable(connection, TABLE)) {
+                DbUtils.execute(
+                        connection,
+                        "CREATE CACHED TABLE " + TABLE + " ("
+                                + "id UUID NOT NULL, "
+                                + "name NVARCHAR(256) NOT NULL, "
+                                + "message CLOB(16M) NOT NULL, "
+                                + "message_type NVARCHAR(256) NOT NULL, "
+                                + "index INT NOT NULL, "
+                                + "PRIMARY KEY (id))"
+                );
+            }
+
+            psInsert = connection.prepareStatement(
+                    "INSERT INTO "
+                            + TABLE
+                            + " (id,  name, message, message_type, index) "
+                            + "VALUES (?, ?, ?, ?, ?)");
+
+            psSelect = connection.prepareStatement(
+                    "SELECT id, name, message, message_type, index FROM " + TABLE + " ORDER BY index");
+
+            psUpdateName = connection.prepareStatement(
+                    "UPDATE "
+                            + TABLE
+                            + " SET name = ? "
+                            + " WHERE id = ?");
+
+            psUpdateMessage = connection.prepareStatement(
+                    "UPDATE "
+                            + TABLE
+                            + " SET message = ?, message_type = ? "
+                            + " WHERE id = ?");
+
+            psUpdateIndex = connection.prepareStatement(
+                    "UPDATE "
+                            + TABLE
+                            + " SET index = ? "
+                            + " WHERE id = ?");
+
+            psDelete = connection.prepareStatement(
+                    "DELETE FROM "
+                            + TABLE
+                            + " WHERE id = ?");
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
+    }
+
+    /**
+     * Inserts tab in the database
+     * @param tabRecord Tab record to persist
+     * @throws SQLException if there is an SQL error
+     */
+    public void insertTab(RequesterTabRecord tabRecord) throws SQLException {
+        psInsert.setObject(1, tabRecord.getId());
+        psInsert.setString(2, tabRecord.getName());
+        psInsert.setClob(3, new JDBCClob(tabRecord.getMessage().toString()));
+        psInsert.setString(4, tabRecord.getMessageType());
+        psInsert.setInt(5, tabRecord.getIndex());
+
+        psInsert.executeUpdate();
+    }
+
+    /**
+     * Obtains all tabs from database ordered by index
+     * @return List of ordered tabs
+     * @throws SQLException if there is an SQL error
+     */
+    public List<RequesterTabRecord> getAllTabs() throws SQLException {
+        List<RequesterTabRecord> tabRecords = new LinkedList<>();
+        try (ResultSet resultSet = psSelect.executeQuery()) {
+            while(resultSet.next()) {
+                tabRecords.add(RequesterTabRecord.builder()
+                        .id((UUID) resultSet.getObject(1))
+                        .name(resultSet.getString(2))
+                        .message(jsonObjectFromClob(resultSet.getClob(3)))
+                        .messageType(resultSet.getString(4))
+                        .index(resultSet.getInt(5))
+                        .build());
+            }
+        }
+        return tabRecords;
+    }
+
+    /**
+     * Updates tab name in the database
+     * @param tabRecord Tab record to persist (only name will be saved)
+     * @throws SQLException if there is an SQL error
+     */
+    public void updateTabName(RequesterTabRecord tabRecord) throws SQLException {
+        psUpdateName.setString(1, tabRecord.getName());
+        psUpdateName.setObject(2, tabRecord.getId());
+
+        psUpdateName.executeUpdate();
+    }
+
+    /**
+     * Updates tab message in the database
+     * @param tabRecord Tab record to persist (only message will be saved)
+     * @throws SQLException if there is an SQL error
+     */
+    public void updateTabIndex(RequesterTabRecord tabRecord) throws SQLException {
+        psUpdateIndex.setInt(1, tabRecord.getIndex());
+        psUpdateIndex.setObject(2, tabRecord.getId());
+
+        psUpdateIndex.executeUpdate();
+    }
+
+    /**
+     * Updates tab index in the database
+     * @param tabRecord Tab record to persist (only index will be saved)
+     * @throws SQLException if there is an SQL error
+     */
+    public void updateTabMessage(RequesterTabRecord tabRecord) throws SQLException {
+        psUpdateMessage.setClob(1, new JDBCClob(tabRecord.getMessage().toString()));
+        psUpdateMessage.setString(2, tabRecord.getMessageType());
+        psUpdateMessage.setObject(3, tabRecord.getId());
+
+        psUpdateMessage.executeUpdate();
+    }
+
+    /**
+     * Deletes tab record from the database
+     * @param tabRecord Tab record to delete
+     * @throws SQLException if there is an SQL error
+     */
+    public void deleteTab(RequesterTabRecord tabRecord) throws SQLException {
+        psDelete.setObject(1, tabRecord.getId());
+
+        psDelete.execute();
+    }
+
+    private JSONObject jsonObjectFromClob(Clob clob) throws SQLException {
+        return (JSONObject) JSONSerializer.toJSON(clob.getSubString(1, (int) clob.length()));
+    }
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/exception/RequesterException.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/exception/RequesterException.java
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.exception;
+
+/**
+ * Requester runtime exception
+ */
+public class RequesterException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public RequesterException(Throwable cause) {
+        super(cause);
+    }
+
+    public RequesterException(String message) {
+        super(message);
+    }
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/ManualHttpRequestEditorPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/ManualHttpRequestEditorPanel.java
@@ -34,20 +34,14 @@ import javax.swing.JTabbedPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
-import org.apache.commons.httpclient.URI;
-import org.apache.commons.httpclient.URIException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
-import org.parosproxy.paros.network.HttpHeader;
-import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.requester.ExtensionRequester;
 import org.zaproxy.addon.requester.MessageEditorPanel;
+import org.zaproxy.addon.requester.util.RequesterUtil;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.extension.httppanel.HttpPanel.OptionsLocation;
@@ -55,12 +49,10 @@ import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
 import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.view.HttpPanelManager;
 
-@SuppressWarnings("serial")
 public class ManualHttpRequestEditorPanel extends MessageEditorPanel
         implements OptionsChangedListener {
 
     private static final long serialVersionUID = -5830450800029295419L;
-    private static final Logger logger = LogManager.getLogger(ManualHttpRequestEditorPanel.class);
     private static final String CONFIG_KEY = "requesterpanel";
     private static final String HELP_KEY = "addon.requester.tab";
 
@@ -271,15 +263,7 @@ public class ManualHttpRequestEditorPanel extends MessageEditorPanel
 
     @Override
     public void setDefaultMessage() {
-        HttpMessage msg = new HttpMessage();
-        try {
-            URI uri = new URI("http://www.any_domain_name.org/path", true);
-            msg.setRequestHeader(
-                    new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP11));
-            setMessage(msg);
-        } catch (HttpMalformedHeaderException | URIException e) {
-            logger.error(e.getMessage(), e);
-        }
+        setMessage(RequesterUtil.createDefaultHttpMessage());
     }
 
     /**

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/RequesterPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/RequesterPanel.java
@@ -19,21 +19,24 @@
  */
 package org.zaproxy.addon.requester.internal;
 
-import java.awt.GridLayout;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.requester.ExtensionRequester;
+import org.zaproxy.addon.requester.db.RequesterTabStorage;
+import org.zaproxy.addon.requester.internal.tab.RequesterNumberedRenamableTabbedPane;
+
+import java.awt.GridLayout;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 
 public class RequesterPanel extends AbstractPanel implements OptionsChangedListener {
 
     private static final long serialVersionUID = 1L;
 
-    private RequesterNumberedRenamableTabbedPane requesterNumberedTabbedPane = null;
+    private RequesterNumberedRenamableTabbedPane tabbedPane = null;
 
     public RequesterPanel(ExtensionRequester extension) {
         super();
@@ -47,26 +50,34 @@ public class RequesterPanel extends AbstractPanel implements OptionsChangedListe
                         .getMenuShortcutKeyStroke(KeyEvent.VK_R, InputEvent.ALT_DOWN_MASK, false));
         this.setMnemonic(Constant.messages.getChar("requester.panel.mnemonic"));
         this.setShowByDefault(true);
-        requesterNumberedTabbedPane = new RequesterNumberedRenamableTabbedPane();
-        this.add(requesterNumberedTabbedPane);
     }
 
-    public RequesterNumberedRenamableTabbedPane getRequesterNumberedTabbedPane() {
-        return requesterNumberedTabbedPane;
+    public RequesterNumberedRenamableTabbedPane getTabbedPane() {
+        return tabbedPane;
     }
 
-    public void newRequester(HttpMessage msg) {
-        ManualHttpRequestEditorPanel requestPane = new ManualHttpRequestEditorPanel();
-        requestPane.setMessage(msg);
-        getRequesterNumberedTabbedPane().addTab(requestPane);
+    public void load(RequesterTabStorage tabStorage) {
+        // If it is already loaded, unload
+        if (tabbedPane != null) {
+            tabbedPane.unload();
+            remove(tabbedPane);
+        }
+
+        // Load tabbed pane
+        tabbedPane = new RequesterNumberedRenamableTabbedPane(tabStorage);
+        this.add(tabbedPane);
+    }
+
+    public void newRequester(HttpMessage message) {
+        getTabbedPane().newRequester(message);
     }
 
     public void unload() {
-        getRequesterNumberedTabbedPane().unload();
+        getTabbedPane().unload();
     }
 
     @Override
     public void optionsChanged(OptionsParam optionsParam) {
-        getRequesterNumberedTabbedPane().optionsChanged(optionsParam);
+        getTabbedPane().optionsChanged(optionsParam);
     }
 }

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/tab/NumberedRenamableTabbedPane.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/tab/NumberedRenamableTabbedPane.java
@@ -1,0 +1,211 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.internal.tab;
+
+import java.awt.Component;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.function.Consumer;
+import javax.swing.Icon;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JTabbedPane;
+
+import org.apache.commons.lang3.StringUtils;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.OptionsChangedListener;
+import org.parosproxy.paros.model.OptionsParam;
+import org.zaproxy.addon.requester.ExtensionRequester;
+import org.zaproxy.addon.requester.MessageEditorPanel;
+import org.zaproxy.addon.requester.internal.tab.close.CloseTabPanel;
+
+/**
+ * Tabbed pane (numbered, renamable)
+ */
+public abstract class NumberedRenamableTabbedPane extends JTabbedPane {
+
+    private static final long serialVersionUID = 1L;
+    private static final Component PLUS_ICON_COMPONENT = new JLabel();
+    private static final Icon PLUS_ICON = ExtensionRequester.createIcon("fugue/plus.png");
+
+    private Integer nextTabNumber = 1;
+
+    protected NumberedRenamableTabbedPane() {
+        super();
+        addPlusTab();
+        addMouseClickListener();
+    }
+
+    /**
+     * Adds default tab to the pane
+     */
+    public abstract void addDefaultTab();
+
+    /**
+     * Notified about tab name change
+     */
+    protected abstract void onTabNameChanged(int index, String newName);
+
+    /**
+     * Notified editor panels about options change
+     * @param optionsParam Changed options
+     */
+    public void optionsChanged(OptionsParam optionsParam) {
+        processEditorPanels(panel -> {
+            if (panel instanceof OptionsChangedListener) {
+                ((OptionsChangedListener) panel).optionsChanged(optionsParam);
+            }
+        });
+    }
+
+    /**
+     * Removes tab from tabeed pane
+     * @param editorPanel Editor panelt o remove
+     */
+    public void removeTab(MessageEditorPanel editorPanel) {
+        int index = indexOfComponent(editorPanel);
+        int editorCount = getEditorPanelCount();
+
+        // Select previous tab if we are at the tab before plus tab (so that we do not select plus tab)
+        if (editorCount > 1 && index == editorCount - 1) {
+            setSelectedIndex(index - 1);
+        }
+
+        editorPanel.unload();
+        editorPanel.saveConfig();
+
+        remove(editorPanel);
+    }
+
+    /**
+     * Adds requester tab to the tabbed pane
+     * @param tabName Tab name (title)
+     * @param editorPanel Editor panel to add to the tabbed pane
+     */
+    public void addRequesterTab(String tabName, MessageEditorPanel editorPanel) {
+        int index = Math.max(getEditorPanelCount(), 0);
+        this.insertTab(tabName, null, editorPanel, null, index);
+        this.setTabComponentAt(index, new CloseTabPanel(tabName, actionEvent -> removeTab(editorPanel)));
+        this.setSelectedIndex(index);
+    }
+
+    /**
+     * Unloads all editor panels.
+     */
+    public void unload() {
+        processEditorPanels(MessageEditorPanel::unload);
+    }
+
+    /**
+     * Generates new tab name
+     * @return Tab name
+     */
+    protected String nextTabName() {
+        return String.valueOf(nextTabNumber++);
+    }
+
+    /**
+     * Processes operation using all message panels
+     * @param action Consumer to process the action using panel
+     */
+    protected void processEditorPanels(Consumer<MessageEditorPanel> action) {
+        int editorPanels = getEditorPanelCount();
+        for (int index = 0; index < editorPanels; ++index) {
+            action.accept((MessageEditorPanel) getComponentAt(index));
+        }
+    }
+
+    /**
+     * Obtains count of editors (does not count PLUS tab)
+     * @return Editor panel count
+     */
+    protected int getEditorPanelCount() {
+        return getTabCount() - 1;
+    }
+
+    /**
+     * Handles single mouse click event
+     * @param event Mouse click event
+     */
+    protected void handleMouseSingleClicked(MouseEvent event) {
+        int index = indexAtLocation(event.getX(), event.getY());
+        if (index == -1) {
+            return;
+        }
+
+        Component component = getComponentAt(index);
+        if (component == PLUS_ICON_COMPONENT) {
+            addDefaultTab();
+        }
+    }
+
+    /**
+     * Handles double mouse click event
+     * @param event Double mouse click event
+     */
+    protected void handleMouseDoubleClicked(MouseEvent event) {
+        int index = indexAtLocation(event.getX(), event.getY());
+        if (index == -1 || index == getTabCount() - 1) {
+            // Index not found or points to plus tab
+            return;
+        }
+
+        Component tabComponent = getTabComponentAt(index);
+
+        String newName = showRenameDialog(tabComponent);
+        if (!StringUtils.isEmpty(newName)) {
+            tabComponent.setName(newName);
+            onTabNameChanged(index, newName);
+        }
+    }
+
+    private void addPlusTab() {
+        this.addTab("", PLUS_ICON, PLUS_ICON_COMPONENT);
+    }
+
+    private void addMouseClickListener() {
+        this.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent event) {
+                handleMouseClicked(event);
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent event) {
+                handleMouseClicked(event);
+            }
+        });
+    }
+
+    private String showRenameDialog(Component tabComponent) {
+        return JOptionPane.showInputDialog(
+                Constant.messages.getString("requester.tab.rename"),
+                tabComponent.getName());
+    }
+
+    private void handleMouseClicked(MouseEvent event) {
+        if (event.getClickCount() == 1) {
+            handleMouseSingleClicked(event);
+        } else if (event.getClickCount() == 2) {
+            handleMouseDoubleClicked(event);
+        }
+    }
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/tab/RequesterNumberedRenamableTabbedPane.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/tab/RequesterNumberedRenamableTabbedPane.java
@@ -1,0 +1,117 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.internal.tab;
+
+import org.zaproxy.addon.requester.MessageEditorPanel;
+import org.zaproxy.addon.requester.db.RequesterTabRecord;
+import org.zaproxy.addon.requester.db.RequesterTabStorage;
+import org.zaproxy.addon.requester.internal.tab.editor.RequestTabHttpEditorWrapper;
+import org.zaproxy.addon.requester.util.RequesterMessageConverter;
+import org.zaproxy.addon.requester.util.RequesterUtil;
+import org.zaproxy.zap.extension.httppanel.Message;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Requester tabbed pane
+ */
+public class RequesterNumberedRenamableTabbedPane extends NumberedRenamableTabbedPane {
+
+    private static final long serialVersionUID = 1L;
+
+    private final RequesterTabStorage tabStorage;
+    private final Map<MessageEditorPanel, RequesterTabRecord> editorPanelMap = new HashMap<>();
+
+    public RequesterNumberedRenamableTabbedPane(RequesterTabStorage tabStorage) {
+        super();
+        this.tabStorage = tabStorage;
+        initializeTabs();
+    }
+
+    /**
+     * Creates new tab for given message
+     * @param message Message to be added
+     */
+    public void newRequester(Message message) {
+        RequesterTabRecord tabRecord = tabStorage.createNewTab(
+                nextTabName(),
+                getEditorPanelCount(),
+                RequesterMessageConverter.toJsonObject(message),
+                message.getType());
+
+        createEditorPanel(message, tabRecord);
+    }
+
+    @Override
+    protected void onTabNameChanged(int index, String newName) {
+        MessageEditorPanel requestPane = (MessageEditorPanel) getComponentAt(index);
+        RequesterTabRecord tabRecord = editorPanelMap.get(requestPane);
+        tabRecord.setName(newName);
+        tabStorage.updateTabName(tabRecord);
+    }
+
+    @Override
+    public void removeTab(MessageEditorPanel tabComponent) {
+        super.removeTab(tabComponent);
+
+        RequesterTabRecord tabRecord = editorPanelMap.remove(tabComponent);
+        tabStorage.deleteTab(tabRecord);
+
+        // Recalculate indexes for all panels from current to the last
+        int editorPanels = getEditorPanelCount();
+        for (int index = tabRecord.getIndex(); index < editorPanels; ++index) {
+            MessageEditorPanel editorPanel = (MessageEditorPanel) getComponentAt(index);
+            RequesterTabRecord panelRecord = editorPanelMap.get(editorPanel);
+            panelRecord.setIndex(index);
+            tabStorage.updateTabIndex(panelRecord);
+        }
+    }
+
+    @Override
+    public void addDefaultTab() {
+        Message message = RequesterUtil.createDefaultHttpMessage();
+        newRequester(message);
+    }
+
+    private void createEditorPanel(Message message, RequesterTabRecord tabRecord) {
+        RequestTabHttpEditorWrapper editorPanel = new RequestTabHttpEditorWrapper(tabStorage, tabRecord);
+        editorPanelMap.put(editorPanel, tabRecord);
+        editorPanel.setUpdateTabRecord(false);
+        editorPanel.setMessage(message);
+        editorPanel.setUpdateTabRecord(true);
+        addRequesterTab(tabRecord.getName(), editorPanel);
+    }
+
+    private void initializeTabs() {
+        List<RequesterTabRecord> tabRecords = tabStorage.getTabs();
+        if (tabRecords.isEmpty()) {
+            addDefaultTab();
+            return;
+        }
+
+        for (RequesterTabRecord tabRecord : tabRecords) {
+            Message message = RequesterMessageConverter.toMessage(tabRecord.getMessage(), tabRecord.getMessageType());
+            createEditorPanel(message, tabRecord);
+        }
+    }
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/tab/close/CloseTabPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/tab/close/CloseTabPanel.java
@@ -1,0 +1,100 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.internal.tab.close;
+
+import java.awt.GridBagConstraints;
+import java.awt.event.ActionListener;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.requester.ExtensionRequester;
+
+public class CloseTabPanel extends JPanel {
+
+    private static final long serialVersionUID = 1L;
+    private static final Icon CLOSE_TAB_GREY_ICON =
+            ExtensionRequester.createIcon("fugue/cross-small-grey.png");
+    private static final Icon CLOSE_TAB_RED_ICON =
+            ExtensionRequester.createIcon("fugue/cross-small-red.png");
+
+    private final JLabel titleLabel;
+
+    public CloseTabPanel(String tabName, ActionListener closeButtonAction) {
+        super();
+        this.setOpaque(false);
+        titleLabel = new JLabel(tabName);
+
+        GridBagConstraints gridConstraints = new GridBagConstraints();
+        gridConstraints.gridx = 0;
+        gridConstraints.gridy = 0;
+        gridConstraints.weightx = 1;
+
+        this.add(titleLabel, gridConstraints);
+
+        gridConstraints.gridx++;
+        gridConstraints.weightx = 0;
+
+        JButton closeButton = createCloseButton(closeButtonAction);
+        this.add(closeButton, gridConstraints);
+    }
+
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+        if (titleLabel != null) {
+            titleLabel.setText(name);
+        }
+    }
+
+    @Override
+    public String getName() {
+        if (titleLabel != null) {
+            return titleLabel.getText();
+        }
+        return super.getName();
+    }
+
+    private static JButton createCloseButton(ActionListener closeButtonAction) {
+        JButton closeButton = new JButton();
+        closeButton.setOpaque(false);
+
+        // Configure icon and rollover icon for button
+        closeButton.setRolloverIcon(CLOSE_TAB_RED_ICON);
+        closeButton.setRolloverEnabled(true);
+        closeButton.setContentAreaFilled(false);
+        closeButton.setToolTipText(Constant.messages.getString("all.button.close"));
+        closeButton.setIcon(CLOSE_TAB_GREY_ICON);
+        // Set a border only on the left side so the button doesn't make the tab too big
+        closeButton.setBorder(new EmptyBorder(0, 6, 0, 0));
+        // This is needed to Macs for some reason
+        closeButton.setBorderPainted(false);
+
+        // Make sure the button can't get focus, otherwise it looks funny
+        closeButton.setFocusable(false);
+
+        // Add action listener
+        closeButton.addActionListener(closeButtonAction);
+        return closeButton;
+    }
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/tab/editor/RequestTabHttpEditorWrapper.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/tab/editor/RequestTabHttpEditorWrapper.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.internal.tab.editor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.zaproxy.addon.requester.db.RequesterTabRecord;
+import org.zaproxy.addon.requester.db.RequesterTabStorage;
+import org.zaproxy.addon.requester.internal.ManualHttpRequestEditorPanel;
+import org.zaproxy.addon.requester.util.RequesterMessageConverter;
+import org.zaproxy.zap.extension.httppanel.Message;
+
+import java.io.IOException;
+
+/**
+ * Wraps {@link ManualHttpRequestEditorPanel} in order to update tabStorage when appropriate methods gets called.
+ */
+@Setter
+@RequiredArgsConstructor
+public class RequestTabHttpEditorWrapper extends ManualHttpRequestEditorPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private final RequesterTabStorage tabStorage;
+    private final RequesterTabRecord tabRecord;
+
+    /**
+     * Should messages be updated?
+     * <p>(prevents updating messages during first load and unload)</p>
+     */
+    private boolean updateTabRecord = true;
+
+    @Override
+    public void setMessage(Message message) {
+        super.setMessage(message);
+
+        updateTabRecordIfNeeded(message);
+    }
+
+    @Override
+    protected void sendMessage(Message message) throws IOException {
+        super.sendMessage(message);
+
+        updateTabRecordIfNeeded(message);
+    }
+
+    @Override
+    public void unload() {
+        updateTabRecord = false;
+        super.unload();
+    }
+
+    private void updateTabRecordIfNeeded(Message message) {
+        if (!updateTabRecord) {
+            return;
+        }
+
+        tabRecord.setMessage(RequesterMessageConverter.toJsonObject(message));
+        tabStorage.updateTabMessage(tabRecord);
+    }
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/util/RequesterMessageConverter.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/util/RequesterMessageConverter.java
@@ -1,0 +1,123 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.util;
+
+import net.sf.json.JSONObject;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.addon.requester.exception.RequesterException;
+import org.zaproxy.zap.extension.httppanel.Message;
+import org.zaproxy.zap.network.HttpRequestBody;
+import org.zaproxy.zap.network.HttpResponseBody;
+
+import java.util.Map;
+
+/**
+ * Requester message converter
+ * <p>Contains utilities for converting between json and message objects.</p>
+ * <p>Used for serialization/deserialization of messages.</p>
+ */
+public class RequesterMessageConverter {
+
+    /**
+     * Converts message to JSON
+     * @param message Message to be converted
+     * @return JSON object
+     */
+    public static JSONObject toJsonObject(Message message) {
+        Map<String, String> eventData = message.toEventData();
+        JSONObject json = new JSONObject();
+        for (Map.Entry<String, String> eventDataEntry : eventData.entrySet()) {
+            json.put(eventDataEntry.getKey(), eventDataEntry.getValue());
+        }
+        return json;
+    }
+
+    /**
+     * Converts JSON to message
+     * @param json JSON json
+     * @param messageType Type of message
+     * @return Message json
+     */
+    public static Message toMessage(JSONObject json, String messageType) {
+        switch (messageType) {
+            case HttpMessage.MESSAGE_TYPE:
+                return toHttpMessage(json);
+            default:
+                throw new RequesterException(String.format("Unsupported message type '%s'!", messageType));
+        }
+    }
+
+    /**
+     * Converts JSON to HTTP message
+     * @param json JSON object
+     * @return HTTP Message object
+     */
+    public static HttpMessage toHttpMessage(JSONObject json) {
+        try {
+            return new HttpMessage(
+                    getHttpRequestHeader(json),
+                    getHttpRequestBody(json),
+                    getHttpResponseHeader(json),
+                    getHttpResponseBody(json)
+            );
+        } catch (org.parosproxy.paros.network.HttpMalformedHeaderException | URIException e) {
+            throw new RequesterException(e);
+        }
+    }
+
+    private static HttpRequestHeader getHttpRequestHeader(JSONObject json) throws HttpMalformedHeaderException, URIException {
+        if (json.containsKey(HttpMessage.EVENT_DATA_REQUEST_HEADER)) {
+            return new HttpRequestHeader(json.getString(HttpMessage.EVENT_DATA_REQUEST_HEADER));
+        }
+        return new HttpRequestHeader(HttpRequestHeader.GET, new URI(RequesterUtil.DEFAULT_URL, true), HttpHeader.HTTP11);
+    }
+
+    private static HttpResponseHeader getHttpResponseHeader(JSONObject json) throws HttpMalformedHeaderException {
+        if (json.containsKey(HttpMessage.EVENT_DATA_RESPONSE_HEADER)) {
+            return new HttpResponseHeader(json.getString(HttpMessage.EVENT_DATA_RESPONSE_HEADER));
+        }
+        return new HttpResponseHeader();
+    }
+
+    private static HttpRequestBody getHttpRequestBody(JSONObject json) {
+        if (json.containsKey(HttpMessage.EVENT_DATA_REQUEST_BODY)) {
+            return new HttpRequestBody(json.getString(HttpMessage.EVENT_DATA_REQUEST_BODY));
+        }
+        return new HttpRequestBody();
+    }
+
+    private static HttpResponseBody getHttpResponseBody(JSONObject json) {
+        if (json.containsKey(HttpMessage.EVENT_DATA_RESPONSE_BODY)) {
+            return new HttpResponseBody(json.getString(HttpMessage.EVENT_DATA_RESPONSE_BODY));
+        }
+        return new HttpResponseBody();
+    }
+
+    private RequesterMessageConverter() {
+
+    }
+
+}

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/util/RequesterUtil.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/util/RequesterUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.util;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.requester.exception.RequesterException;
+
+/**
+ * Requester utilities
+ */
+public class RequesterUtil {
+
+    public static final String DEFAULT_URL = "https://example.com/";
+
+    /**
+     * Creates default HTTP message
+     * @return New {@link HttpMessage}
+     */
+    public static HttpMessage createDefaultHttpMessage() {
+        HttpMessage message = new HttpMessage();
+        try {
+            URI uri = new URI(DEFAULT_URL, true);
+            message.setRequestHeader(new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP11));
+            return message;
+        } catch (HttpMalformedHeaderException | URIException e) {
+            throw new RequesterException(e);
+        }
+    }
+
+    private RequesterUtil() {
+
+    }
+
+}

--- a/addOns/requester/src/test/java/org/zaproxy/addon/requester/util/RequesterMessageConverterUnitTest.java
+++ b/addOns/requester/src/test/java/org/zaproxy/addon/requester/util/RequesterMessageConverterUnitTest.java
@@ -1,0 +1,40 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.requester.util;
+
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+class RequesterMessageConverterUnitTest {
+
+    @Test
+    void conversionTest() {
+        HttpMessage inputMessage = RequesterUtil.createDefaultHttpMessage();
+        JSONObject json = RequesterMessageConverter.toJsonObject(inputMessage);
+        HttpMessage resultMessage = RequesterMessageConverter.toHttpMessage(json);
+        assertThat(resultMessage, is(equalTo(inputMessage)));
+    }
+
+}


### PR DESCRIPTION
Hello, I would like to add support for persisting Requester tabs in session database, so that we do not loose them every time we restart Zaproxy. 

Solution summary:
- Created table "REQUESTER_TAB" for persisting tabs.
- Added support for serializing Message data and storing them as JSON
- Created wrapper to handle persistance logic for ManualHttpRequestEditorPanel
- Refactored tabbed pane (and related classes) to make them more simple and easily integrable with persistence logic.