### PR TITLE
requester: remove core extension checks

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -10,11 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add shortcut to Send buttons (Issue 6448).
 - Add button to allow to regenerate Anti-CSRF tokens (Issue 111).
 - Provide the necessary infrastructure for other add-ons (e.g. WebSocket) to send messages.
-- On ZAP versions newer than 2.11:
-  - Manage the send/resend Manual Request Editor dialogues.
-  - Add a Tools menu item to open the send Manual Request Editor.
-  - Add a context menu item to open the resend Manual Request Editor.
-  - Allow to establish WebSocket connections with the send/resend Manual Request Editor dialogues.
+- Manage the send/resend Manual Request Editor dialogues.
+- Add a Tools menu item to open the send Manual Request Editor.
+- Add a context menu item to open the resend Manual Request Editor.
+- Allow to establish WebSocket connections with the send/resend Manual Request Editor dialogues.
 
 ### Changed
 - Improve reporting of TLS errors (Issue 2699).

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/ExtensionRequester.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/ExtensionRequester.java
@@ -104,13 +104,9 @@ public class ExtensionRequester extends ExtensionAdaptor {
                         hasView() ? getManualIcon() : null));
 
         if (hasView()) {
-            if (isDeprecated(
-                    org.parosproxy.paros.extension.manualrequest.ExtensionManualRequestEditor
-                            .class)) {
-                sendDialog =
-                        new SendHttpMessageEditorDialog(new ManualHttpRequestEditorPanel("manual"));
-                sendDialog.load(extensionHook);
-            }
+            sendDialog =
+                    new SendHttpMessageEditorDialog(new ManualHttpRequestEditorPanel("manual"));
+            sendDialog.load(extensionHook);
 
             extensionHook.addOptionsChangedListener(getRequesterPanel());
 
@@ -123,20 +119,13 @@ public class ExtensionRequester extends ExtensionAdaptor {
             // ToolsMenuItem
             menu.addToolsMenuItem(new ToolsMenuItemRequester(this));
 
-            if (isDeprecated(org.zaproxy.zap.extension.stdmenus.PopupMenuResendMessage.class)) {
-                ManualHttpRequestEditorPanel panel = new ManualHttpRequestEditorPanel("resend");
-                resendDialog = new ResendHttpMessageEditorDialog(panel);
-                resendDialog.load(extensionHook);
-            }
+            ManualHttpRequestEditorPanel panel = new ManualHttpRequestEditorPanel("resend");
+            resendDialog = new ResendHttpMessageEditorDialog(panel);
+            resendDialog.load(extensionHook);
         }
     }
 
     private static void addHrefType(ExtensionHook extensionHook, HrefTypeInfo hrefTypeInfo) {
-        if (!isDeprecated(
-                org.parosproxy.paros.extension.manualrequest.ExtensionManualRequestEditor.class)) {
-            return;
-        }
-
         try {
             Method method =
                     ExtensionHook.class.getDeclaredMethod("addHrefType", HrefTypeInfo.class);
@@ -144,10 +133,6 @@ public class ExtensionRequester extends ExtensionAdaptor {
         } catch (Exception e) {
             LOGGER.error("An error occurred while adding the history type:", e);
         }
-    }
-
-    private static boolean isDeprecated(Class<?> clazz) {
-        return clazz.getAnnotation(Deprecated.class) != null;
     }
 
     private RequesterParam getOptionsParam() {


### PR DESCRIPTION
The core extension checks are no longer needed, the features provided by the add-on should be added always as it's no longer targeting 2.11.
Tweak the changelog to no longer mention 2.11.