### PR TITLE
PScan Rules - move trusted domain help

### DIFF
--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -8,18 +8,6 @@ Passive Scan Rules - Alpha
 <BODY>
 <H1>Passive Scan Rules - Alpha</H1>
 
-<H2>General Configuration</H2>
-
-<H3>Trusted Domains</H3>
-You can specify a comma separated list of URL regex patterns using the <code>rules.domains.trusted</code> parameter via the Options 'Rule configuration' panel.
-Any link URL that matches one of these patterns will be considered to be in a trusted domain and will therefore not be reported.
-Following rules supports <b>Trusted Domains</b> :
-<ul>
- <li>Sub Resource Integrity Attribute Missing</li>
-</ul>
-
-<hr>
-
 The following alpha status passive scan rules are included in this add-on:
 
 <H2>An example passive scan rule which loads data from a file</H2>

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -9,6 +9,18 @@ Passive Scan Rules - Beta
 <BODY>
 <H1>Passive Scan Rules - Beta</H1>
 
+<H2>General Configuration</H2>
+
+<H3>Trusted Domains</H3>
+You can specify a comma separated list of URL regex patterns using the <code>rules.domains.trusted</code> parameter via the Options 'Rule configuration' panel.
+Any link URL that matches one of these patterns will be considered to be in a trusted domain and will therefore not be reported.
+Following rules supports <b>Trusted Domains</b> :
+<ul>
+ <li>Sub Resource Integrity Attribute Missing</li>
+</ul>
+
+<hr>
+
 The following beta status passive scan rules are included in this add-on:
 
 <H2>Content Cacheability</H2>


### PR DESCRIPTION
Missed from https://github.com/zaproxy/zap-extensions/pull/4118

Signed-off-by: Simon Bennetts <psiinon@gmail.com>