### PR TITLE
network: tidy up for newer main release

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Client Certificates management (PKCS#11 and PKCS#12).
+- Connection options, HTTP proxy, and SOCKS proxy.
+- A newer HTTP client implementation.
+
 ### Changed
 - Minor tweaks in help pages for better rendering.
 - Promoted to Beta status.

--- a/addOns/network/src/main/javahelp/help/contents/api.html
+++ b/addOns/network/src/main/javahelp/help/contents/api.html
@@ -11,8 +11,6 @@
 	<h3>Actions</h3>
 	<ul>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			addAlias (name* enabled): Adds an alias for the local servers/proxies.
 			<ul>
 				<li>name: The name of the alias.</li>
@@ -20,8 +18,6 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			addHttpProxyExclusion (host* enabled): Adds a host to be excluded from the HTTP proxy.
 			<ul>
 				<li>host: The value of the host, a regular expression.</li>
@@ -29,8 +25,6 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			addLocalServer (address* port* api proxy behindNat decodeResponse removeAcceptEncoding): Adds a local server/proxy.
 			<ul>
 				<li>address: The address of the local server/proxy.</li>
@@ -43,8 +37,6 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			addPassThrough (authority* enabled): Adds an authority to pass-through the local proxies.
 			<ul>
 				<li>authority: The value of the authority, can be a regular expression.</li>
@@ -52,8 +44,6 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			addPkcs12ClientCertificate (filePath* password* index): Adds a client certificate contained in a PKCS#12 file, the certificate is automatically set as active and used.
 			<ul>
 				<li>filePath: The file path.</li>
@@ -68,24 +58,18 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			removeAlias (name*): Removes an alias.
 			<ul>
 				<li>name: The name of the alias.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			removeHttpProxyExclusion (host*): Removes a HTTP proxy exclusion.
 			<ul>
 				<li>host: The value of the host.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			removeLocalServer (address* port*): Removes a local server/proxy.
 			<ul>
 				<li>address: The address of the local server/proxy.</li>
@@ -93,16 +77,12 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			removePassThrough (authority*):  Removes a pass-through.
 			<ul>
 				<li>authority: The value of the authority.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setAliasEnabled (name* enabled): Sets whether or not an alias is enabled.
 			<ul>
 				<li>name: The name of the alias.</li>
@@ -110,32 +90,24 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setConnectionTimeout (timeout*): Sets the timeout, for reads and connects.
 			<ul>
 				<li>timeout: The timeout, in seconds.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setDefaultUserAgent (userAgent*): Sets the default user-agent.
 			<ul>
 				<li>userAgent: The default user-agent.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setDnsTtlSuccessfulQueries (ttl*): Sets the TTL of successful DNS queries.
 			<ul>
 				<li>ttl: The TTL, in seconds. Negative number, cache forever. Zero, disables caching. Positive number, the number of seconds the successful DNS queries will be cached.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setHttpProxy (host* port* realm username password): Sets the HTTP proxy configuration.
 			<ul>
 				<li>host: The host, name or address.</li>
@@ -146,24 +118,18 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setHttpProxyAuthEnabled (enabled*): Sets whether or not the HTTP proxy authentication is enabled.
 			<ul>
 				<li>enabled: The enabled state, true or false.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setHttpProxyEnabled (enabled*): Sets whether or not the HTTP proxy is enabled.
 			<ul>
 				<li>enabled: The enabled state, true or false.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setHttpProxyExclusionEnabled (host* enabled*): Sets whether or not a HTTP proxy exclusion is enabled.
 			<ul>
 				<li>host: The value of the host.</li>
@@ -171,8 +137,6 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setPassThroughEnabled (authority* enabled): Sets whether or not a pass-through is enabled.
 			<ul>
 				<li>authority: The value of the authority.</li>
@@ -180,24 +144,18 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setRootCaCertValidity (validity*): Sets the Root CA certificate validity. Used when generating a new Root CA certificate.
 			<ul>
 				<li>validity: The number of days that the generated Root CA certificate will be valid for.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setServerCertValidity (validity*): Sets the server certificate validity. Used when generating server certificates.
 			<ul>
 				<li>validity: The number of days that the generated server certificates will be valid for.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setSocksProxy (host* port* version useDns username password): Sets the SOCKS proxy configuration.
 			<ul>
 				<li>host: The host, name or address.</li>
@@ -209,24 +167,18 @@
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setSocksProxyEnabled (enabled*): Sets whether or not the SOCKS proxy is enabled.
 			<ul>
 				<li>enabled: The enabled state, true or false.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setUseClientCertificate (use*): Sets whether or not to use the active client certificate.
 			<ul>
 				<li>use: The use state, true or false.</li>
 			</ul>
 		</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setUseGlobalHttpState (use*): Sets whether or not to use the global HTTP state.
 			<ul>
 				<li>use: The use state, true or false.</li>
@@ -235,7 +187,6 @@
 	</ul>
 
 	<h3>Views</h3>
-	<strong>Note:</strong> These endpoints are only available in weekly releases and versions after 2.11.
 	<ul>
 		<li>getAliases: Gets the aliases used to identify the local servers/proxies.</li>
 		<li>getConnectionTimeout: Gets the connection timeout, in seconds.</li>
@@ -257,14 +208,10 @@
 	<h3>Other</h3>
 	<ul>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			proxy.pac: Provides a PAC file, proxying through the main proxy.
 		</li>
 		<li>rootCaCert: Gets the Root CA certificate used to issue server certificates. Suitable to import into client applications (e.g. browsers).</li>
 		<li>
-			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
-			<br>
 			setProxy (proxy*): Sets the HTTP proxy configuration.
 			<ul>
 				<li>proxy: The JSON object containing the HTTP proxy configuration.</li>
@@ -273,7 +220,6 @@
 	</ul>
 
 	<h3>Shortcuts</h3>
-	<strong>Note:</strong> These endpoints are only available in weekly releases and versions after 2.11.
 	<ul>
 		<li>proxy.pac: Provides a PAC file, proxying through the main proxy.</li>
 		<li>

--- a/addOns/network/src/main/javahelp/help/contents/cmdline.html
+++ b/addOns/network/src/main/javahelp/help/contents/cmdline.html
@@ -6,8 +6,7 @@
 </HEAD>
 <BODY>
 	<H1>Command Line</H1>
-	<strong>Note:</strong> This feature is only available in weekly releases and versions after 2.11.
-	<br>
+
 	The Network add-on supports the following command line options:
 	<table>
 		<tr>

--- a/addOns/network/src/main/javahelp/help/contents/options/clientcertificates.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/clientcertificates.html
@@ -6,8 +6,6 @@
 </HEAD>
 <BODY>
 	<H1>Client Certificates</H1>
-	<strong>Note:</strong> This feature is only available in weekly releases and versions after 2.11.
-	<br>
 	This screen allows you to add a client certificate to use when testing applications protected using mutual SSL.<br>
 	After adding the certificate it can be set as active in the KeyStore tab.<br>
 	Unlike other options screens, the changes done to the keystore are not undone if the Options dialogue is cancelled.

--- a/addOns/network/src/main/javahelp/help/contents/options/connection.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/connection.html
@@ -6,8 +6,6 @@
 </HEAD>
 <BODY>
 	<H1>Connection</H1>
-	<strong>Note:</strong> This feature is only available in weekly releases and versions after 2.11.
-	<br>
 
 	<H2>General</H2>
 	This tab allows you to configure the general connection options.

--- a/addOns/network/src/main/javahelp/help/contents/options/localservers.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/localservers.html
@@ -6,8 +6,6 @@
 </HEAD>
 <BODY>
 	<H1>Local Servers/Proxies</H1>
-	<strong>Note:</strong> This feature is only available in weekly releases and versions after 2.11.
-	<br>
 
 	<H2>Local Servers/Proxies</H2>
 	This tab allows you to configure the addresses and ports on which ZAP accepts incoming connections.

--- a/addOns/network/src/main/javahelp/help/contents/options/options.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/options.html
@@ -6,8 +6,7 @@
 </HEAD>
 <BODY>
 	<H1>Options</H1>
-	<strong>Note:</strong> This feature is only available in weekly releases and versions after 2.11.
-	<br>
+
 	The Network add-on provides the following options screens:
 	<table>
 		<tr>

--- a/addOns/network/src/main/javahelp/help/contents/options/servercertificates.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/servercertificates.html
@@ -6,8 +6,7 @@
 </HEAD>
 <BODY>
 	<H1>Server Certificates</H1>
-	<strong>Note:</strong> This feature is only available in weekly releases and versions after 2.11.
-	<br>
+
 	This screens allows to manage and configure the root CA certificate and issued certificates.
 
 	<p>


### PR DESCRIPTION
Remove references in the help pages to 2.11.
Update changelog with newer additions.