### PR TITLE
ascanrulesAlpha: Text4shell - Add CVE Alert Tag

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The Text4shell scan rule now includes an alert tag for its CVE reference.
 
 ## [40] - 2022-10-19
 ### Added

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Text4ShellScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Text4ShellScanRule.java
@@ -41,6 +41,7 @@ public class Text4ShellScanRule extends AbstractAppParamPlugin {
 
     private static final Logger LOGGER = LogManager.getLogger(Text4ShellScanRule.class);
     private static final String PREFIX = "ascanalpha.text4shell.";
+    private static final String CVE = "CVE-2022-42889";
     private static final String[] ATTACK_PATTERNS = {
         "${url:UTF-8:http://{0}/bingo}", "${url:UTF-8:https://{0}/bingo}"
     };
@@ -95,6 +96,7 @@ public class Text4ShellScanRule extends AbstractAppParamPlugin {
                                 CommonAlertTag.OWASP_2017_A09_VULN_COMP,
                                 CommonAlertTag.WSTG_V42_INPV_11_CODE_INJ));
         alertTags.put(ExtensionOast.OAST_ALERT_TAG_KEY, ExtensionOast.OAST_ALERT_TAG_VALUE);
+        alertTags.put(CVE, "");
         return alertTags;
     }
 

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/Text4ShellScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/Text4ShellScanRuleUnitTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import fi.iki.elonen.NanoHTTPD;
 import java.io.IOException;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.control.Control;
@@ -111,6 +112,14 @@ class Text4ShellScanRuleUnitTest extends ActiveScannerTest<Text4ShellScanRule> {
 
         // Then
         assertThat(httpMessagesSent, hasSize(1));
+    }
+
+    @Test
+    void shouldHaveExpectedNumberOfAlertTags() {
+        // Given / When
+        Map<String, String> alertTags = rule.getAlertTags();
+        // Then
+        assertThat(alertTags.size(), is(equalTo(5)));
     }
 
     private static class Log4ShellServerHandler extends NanoServerHandler {


### PR DESCRIPTION
- CHANGELOG > Add change note.
- Text4ShellScanRule > Add an Alert Tag specifically for the CVE.
- Text4ShellScanRuleUniTest > Add a test to assert the expected number of alert tags.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>