### PR TITLE
retest: fix plan generator

### DIFF
--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Correct the Automation Framework plan generation with localized languages.
 
 ## [0.3.0] - 2022-09-23
 ### Changed

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/RetestPlanGenerator.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/RetestPlanGenerator.java
@@ -121,7 +121,7 @@ public class RetestPlanGenerator {
     private AutomationAlertTest getAlertTest(AlertData alertData, AutomationJob job) {
         AutomationAlertTest alertTest =
                 new AutomationAlertTest(
-                        "alertTest", AbstractAutomationTest.OnFail.WARN.toString(), job);
+                        "alertTest", AbstractAutomationTest.OnFail.WARN.name(), job);
         alertTest.getData().setOnFail(AbstractAutomationTest.OnFail.WARN);
         alertTest.getData().setScanRuleId(alertData.getScanRuleId());
         alertTest.getData().setAlertName(alertData.getAlertName());

--- a/addOns/retest/src/test/java/org/zaproxy/addon/retest/RetestAPIUnitTest.java
+++ b/addOns/retest/src/test/java/org/zaproxy/addon/retest/RetestAPIUnitTest.java
@@ -23,96 +23,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.withSettings;
 
 import net.sf.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.db.RecordAlert;
-import org.parosproxy.paros.db.TableAlert;
-import org.parosproxy.paros.db.TableHistory;
-import org.parosproxy.paros.extension.ExtensionLoader;
-import org.parosproxy.paros.model.HistoryReference;
-import org.parosproxy.paros.model.Model;
-import org.zaproxy.addon.automation.ExtensionAutomation;
 import org.zaproxy.zap.extension.api.ApiException;
-import org.zaproxy.zap.testutils.TestUtils;
 
-class RetestAPIUnitTest extends TestUtils {
+class RetestAPIUnitTest {
 
     private ExtensionRetest extRetest;
-    private ExtensionAutomation extAutomation;
 
     private RetestAPI retestAPI;
     private JSONObject params;
 
     @BeforeEach
     void setUp() throws Exception {
-        mockMessages(new ExtensionRetest());
-        super.setUpZap();
         params = new JSONObject();
-        params.put(RetestAPI.ALERT_IDS, "1,2");
-        Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        Model.setSingletonForTesting(model);
-        ExtensionLoader extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
-        extRetest = mock(ExtensionRetest.class, withSettings().lenient());
-        extAutomation = mock(ExtensionAutomation.class, withSettings().lenient());
-        given(extensionLoader.getExtension(ExtensionAutomation.class)).willReturn(extAutomation);
-        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        extRetest = mock(ExtensionRetest.class);
         retestAPI = new RetestAPI(extRetest);
-
-        RecordAlert recordOne =
-                new RecordAlert(
-                        1,
-                        1,
-                        100,
-                        "Test Alert One",
-                        1,
-                        1,
-                        "Test Description One",
-                        "Test Uri One",
-                        "Test Param One",
-                        "Test Attack One",
-                        "Test OtherInfo One",
-                        "Test Solution One",
-                        "100Test Reference One",
-                        "Test Evidence One",
-                        1,
-                        1,
-                        1,
-                        1,
-                        1,
-                        "100Test Alert Reference");
-        RecordAlert recordTwo =
-                new RecordAlert(
-                        2,
-                        1,
-                        100,
-                        "Test Alert One",
-                        1,
-                        1,
-                        "Test Description One",
-                        "Test Uri One",
-                        "Test Param One",
-                        "Test Attack One",
-                        "Test OtherInfo One",
-                        "Test Solution One",
-                        "100Test Reference One",
-                        "Test Evidence One",
-                        1,
-                        1,
-                        1,
-                        1,
-                        1,
-                        "100Test Alert Reference");
-
-        TableHistory historyTable = mock(TableHistory.class);
-        HistoryReference.setTableHistory(historyTable);
-        TableAlert alertTable = mock(TableAlert.class);
     }
 
     @Test

--- a/addOns/retest/src/test/java/org/zaproxy/addon/retest/RetestPlanGeneratorUnitTest.java
+++ b/addOns/retest/src/test/java/org/zaproxy/addon/retest/RetestPlanGeneratorUnitTest.java
@@ -23,24 +23,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.extension.ExtensionLoader;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationPlan;
 import org.zaproxy.addon.automation.ContextWrapper;
-import org.zaproxy.addon.automation.ExtensionAutomation;
 import org.zaproxy.addon.automation.jobs.ActiveScanJob;
 import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob;
 import org.zaproxy.addon.automation.jobs.PassiveScanWaitJob;
@@ -48,17 +41,13 @@ import org.zaproxy.addon.automation.jobs.RequestorJob;
 import org.zaproxy.addon.automation.tests.AbstractAutomationTest;
 import org.zaproxy.addon.automation.tests.AutomationAlertTest;
 import org.zaproxy.zap.network.HttpRequestBody;
-import org.zaproxy.zap.testutils.TestUtils;
-import org.zaproxy.zap.utils.I18N;
 
-class RetestPlanGeneratorUnitTest extends TestUtils {
+class RetestPlanGeneratorUnitTest {
 
     private static AutomationPlan retestPlan;
 
     @BeforeAll
     static void init() {
-        Constant.messages = mock(I18N.class);
-        mockMessages(new ExtensionAutomation());
         List<AlertData> alertData = new ArrayList<>();
         HttpMessage msgOne = new HttpMessage();
         Alert alertOne = new Alert(100);
@@ -99,14 +88,6 @@ class RetestPlanGeneratorUnitTest extends TestUtils {
         alertData.add(alertTwoData);
 
         retestPlan = new RetestPlanGenerator(alertData).getPlan();
-    }
-
-    @BeforeEach
-    void setUp() throws Exception {
-        mockMessages(new ExtensionAutomation());
-        super.setUpZap();
-        ExtensionLoader extensionLoader = mock(ExtensionLoader.class);
-        Control.initSingletonForTesting(mock(Model.class), extensionLoader);
     }
 
     @Test


### PR DESCRIPTION
Use the name of the enum instead of its localized name, otherwise it would fail for localized languages.
Remove unnecessary test setup code which was also hiding the issue.