### PR TITLE
requester: properly reset manual HTTP editor

### DIFF
--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/ManualHttpRequestEditorPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/ManualHttpRequestEditorPanel.java
@@ -264,9 +264,9 @@ public class ManualHttpRequestEditorPanel extends MessageEditorPanel
 
     @Override
     public void reset() {
-        super.reset();
-
+        getMessagePanel().clearView();
         getResponsePanel().clearView();
+        setDefaultMessage();
     }
 
     @Override


### PR DESCRIPTION
Set the default message after clearing the request and response panels, otherwise the message would not be effectively set into the response panel thus not showing its contents.

---
No changelog update since this does not affect a released version.