### PR TITLE
network: provide exceptions with more info

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/common/ZapSocketTimeoutException.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/common/ZapSocketTimeoutException.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.common;
+
+import java.net.SocketTimeoutException;
+
+/**
+ * A {@code SocketTimeoutException} that provides additional information of ZAP's state.
+ *
+ * @since 0.3.0
+ */
+public class ZapSocketTimeoutException extends SocketTimeoutException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int timeout;
+
+    /**
+     * Constructs a {@code ZapSocketTimeoutException} with the given detail message and the value of
+     * the timeout.
+     *
+     * @param msg the detail message.
+     * @param timeout the value of the timeout.
+     */
+    public ZapSocketTimeoutException(String msg, int timeout) {
+        super(msg);
+
+        this.timeout = timeout;
+    }
+
+    /**
+     * Gets the value of the timeout.
+     *
+     * @return the value of the timeout.
+     */
+    public int getTimeout() {
+        return timeout;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/common/ZapUnknownHostException.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/common/ZapUnknownHostException.java
@@ -1,0 +1,57 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.common;
+
+import java.net.UnknownHostException;
+
+/**
+ * An {@code UnknownHostException} that provides additional information of ZAP's state.
+ *
+ * @since 0.3.0
+ */
+public class ZapUnknownHostException extends UnknownHostException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean fromOutgoingProxy;
+
+    /**
+     * Constructs a {@code ZapUnknownHostException} with the given host and whether the host is the
+     * outgoing proxy.
+     *
+     * @param host the name of the host.
+     * @param fromOutgoingProxy {@code true} if failed to resolve the outgoing proxy's host, {@code
+     *     false} otherwise.
+     */
+    public ZapUnknownHostException(String host, boolean fromOutgoingProxy) {
+        super(host);
+
+        this.fromOutgoingProxy = fromOutgoingProxy;
+    }
+
+    /**
+     * Tells whether or not the failure happened while resolving the outgoing proxy's host.
+     *
+     * @return {@code true} if failed to resolve the outgoing proxy's host, {@code false} otherwise.
+     */
+    public boolean isFromOutgoingProxy() {
+        return fromOutgoingProxy;
+    }
+}


### PR DESCRIPTION
Change network add-on to throw exceptions with more information, for timeouts include its value and for unknown host names whether it was while resolving the proxy's host.