### PR TITLE
portscan: use network add-on for outgoing proxy

### DIFF
--- a/addOns/portscan/CHANGELOG.md
+++ b/addOns/portscan/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Use the Network add-on to obtain the outgoing proxy.
 - Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 

--- a/addOns/portscan/portscan.gradle.kts
+++ b/addOns/portscan/portscan.gradle.kts
@@ -10,5 +10,19 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/port-scan/")
+
+        dependencies {
+            addOns {
+                register("network") {
+                    version.set(">=0.3.0")
+                }
+            }
+        }
     }
+}
+
+dependencies {
+    compileOnly(parent!!.childProjects.get("network")!!)
+
+    testImplementation(parent!!.childProjects.get("network")!!)
 }

--- a/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
+++ b/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.portscan;
 
 import java.awt.EventQueue;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import javax.swing.tree.TreeNode;
@@ -29,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.core.proxy.ProxyListener;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionHookView;
@@ -37,6 +39,7 @@ import org.parosproxy.paros.extension.history.ProxyListenerLog;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.XmlReporterExtension;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.view.SiteMapListener;
@@ -46,6 +49,9 @@ public class ExtensionPortScan extends ExtensionAdaptor
         implements SessionChangedListener, ProxyListener, SiteMapListener, XmlReporterExtension {
 
     private static final Logger logger = LogManager.getLogger(ExtensionPortScan.class);
+
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.singletonList(ExtensionNetwork.class);
 
     // Could be after the last one that saves the HttpMessage, as this ProxyListener doesn't change
     // the HttpMessage.
@@ -62,6 +68,11 @@ public class ExtensionPortScan extends ExtensionAdaptor
         super("ExtensionPortScan");
         this.setI18nPrefix("ports");
         this.setOrder(34);
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
     }
 
     @Override


### PR DESCRIPTION
Use the network add-on to obtain the outgoing proxy instead of core, the latter is deprecated.