### PR TITLE
network: do not allow to dynamically unload

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -1471,7 +1471,8 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
     @Override
     public boolean canUnload() {
-        return true;
+        // Do not allow, the HttpSender implementation is used everywhere.
+        return false;
     }
 
     @Override

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -954,8 +954,8 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldBeUnloadable() {
-        assertThat(extension.canUnload(), is(true));
+    void shouldNotBeUnloadable() {
+        assertThat(extension.canUnload(), is(false));
     }
 
     @Test


### PR DESCRIPTION
The `HttpSender` implementation is used by core and other add-ons.