### PR TITLE
Use network exception in active scan rules

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Rely on Network add-on to obtain more information about socket timeouts.
 
 ## [48] - 2022-09-22
 ### Changed

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -16,6 +16,9 @@ zapAddOn {
                 register("commonlib") {
                     version.set(">= 1.9.0 & < 2.0.0")
                 }
+                register("network") {
+                    version.set(">= 0.3.0")
+                }
                 register("oast") {
                     version.set(">= 0.7.0")
                 }
@@ -42,6 +45,7 @@ zapAddOn {
 dependencies {
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
+    compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("oast")!!)
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     implementation("org.bitbucket.mstrobel:procyon-compilertools:0.5.36")
@@ -49,6 +53,7 @@ dependencies {
     testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
+    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -23,7 +23,6 @@ import static org.zaproxy.zap.extension.ascanrules.utils.Constants.NULL_BYTE_CHA
 
 import java.io.IOException;
 import java.net.SocketException;
-import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -37,9 +36,9 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.network.common.ZapSocketTimeoutException;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
@@ -552,17 +551,13 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
             // request to find the vulnerability
             // but it would be foiled by simple input validation on "..", for instance.
 
-        } catch (SocketTimeoutException ste) {
+        } catch (ZapSocketTimeoutException ste) {
             log.warn(
                     "A timeout occurred while checking [{}] [{}], parameter [{}] for Path Traversal. The currently configured timeout is: {}",
                     msg.getRequestHeader().getMethod(),
                     msg.getRequestHeader().getURI(),
                     param,
-                    Integer.toString(
-                            Model.getSingleton()
-                                    .getOptionsParam()
-                                    .getConnectionParam()
-                                    .getTimeoutInSecs()));
+                    ste.getTimeout());
 
             log.debug("Caught {} {}", ste.getClass().getName(), ste.getMessage());
 

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Depend on `database` add-on.
 - Maintenance changes.
+- Rely on Network add-on to obtain more information about socket timeouts.
 
 ### Added
 - The following scan rules were added, having been promoted to Beta:

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -17,7 +17,7 @@ zapAddOn {
                     version.set(">= 1.10.0 & < 2.0.0")
                 }
                 register("network") {
-                    version.set(">= 0.1.0")
+                    version.set(">= 0.3.0")
                 }
                 register("oast") {
                     version.set(">= 0.7.0")

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
-import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -39,12 +38,12 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.network.common.ZapSocketTimeoutException;
 
 /**
  * Detect and fingerprint forward proxies and reverse proxies configured between the Zap instance
@@ -598,16 +597,12 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin {
 
             try {
                 sendAndReceive(trackmsg, false); // do not follow redirects.
-            } catch (SocketTimeoutException ste) {
+            } catch (ZapSocketTimeoutException ste) {
                 log.warn(
                         "A timeout occurred while checking [{}] [{}] for Proxy Disclosure.\nThe currently configured timeout is: {}",
                         trackmsg.getRequestHeader().getMethod(),
                         trackmsg.getRequestHeader().getURI(),
-                        Integer.toString(
-                                Model.getSingleton()
-                                        .getOptionsParam()
-                                        .getConnectionParam()
-                                        .getTimeoutInSecs()));
+                        ste.getTimeout());
                 log.debug("Caught {} {}", ste.getClass().getName(), ste.getMessage());
                 return;
             }


### PR DESCRIPTION
Catch the exception provided by the network add-on instead of checking the connection options to know the value of the timeout.