### PR TITLE
Network: Custom Bad Host page

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandler.java
@@ -21,7 +21,6 @@ package org.zaproxy.addon.network.internal.server.http.handlers;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import javax.net.ssl.SSLException;
@@ -37,6 +36,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.addon.network.common.ZapUnknownHostException;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.zap.network.HttpRequestConfig;
@@ -140,6 +140,24 @@ public class HttpSenderHandler implements HttpMessageHandler {
                     strBuilder.append(stackTraceFrame).append('\n');
                 }
             }
+        } else if (cause instanceof ZapUnknownHostException) {
+            strBuilder.append(
+                    Constant.messages.getString("network.httpsender.error.badhost.connect"));
+            strBuilder.append(msg.getRequestHeader().getURI().toString()).append('\n');
+            strBuilder
+                    .append(
+                            Constant.messages.getString(
+                                    "network.httpsender.error.badhost.exception"))
+                    .append(cause.getMessage())
+                    .append('\n');
+            strBuilder.append(
+                    Constant.messages.getString(
+                            "network.httpsender.error.badhost.help",
+                            Constant.messages.getString(
+                                    "network.httpsender.error.badhost.help.url")));
+            if (((ZapUnknownHostException) cause).isFromOutgoingProxy()) {
+                strBuilder.append(Constant.messages.getString("network.httpsender.error.proxy"));
+            }
         } else {
             strBuilder
                     .append("ZAP Error")
@@ -148,11 +166,6 @@ public class HttpSenderHandler implements HttpMessageHandler {
                     .append("]: ")
                     .append(cause.getLocalizedMessage())
                     .append("\n");
-            if (cause instanceof UnknownHostException
-                    && connectionParam.isUseProxyChain()
-                    && connectionParam.getProxyChainName().equalsIgnoreCase(cause.getMessage())) {
-                strBuilder.append(Constant.messages.getString("network.httpsender.error.proxy"));
-            }
             strBuilder.append("\n\nStack Trace:\n");
             for (String stackTraceFrame : ExceptionUtils.getRootCauseStackTrace(cause)) {
                 strBuilder.append(stackTraceFrame).append('\n');

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -131,6 +131,11 @@ network.importpem.privkeynobase64 = The private key is not properly base64 encod
 network.importpem.failedkeystore = Failed to create the KeyStore from the .pem file:\n{0}
 network.importpem.failed.title = Error Import Root CA Cert .pem File
 
+network.httpsender.error.badhost.connect = An exception occurred while attempting to connect to: 
+network.httpsender.error.badhost.exception = The exception was: \n
+network.httpsender.error.badhost.help = The following document may be of assistance in resolving this failure:\n{0} 
+network.httpsender.error.badhost.help.url = https://www.zaproxy.org/faq/why-cant-zap-connect-to-my-website/
+
 network.httpsender.error.proxy=\tYour "Options / Network / Connection" proxy settings might be incorrect.
 network.httpsender.error.readtimeout = Failed to read {0} within {1} seconds, check to see if the site is available and if so consider adjusting ZAP''s read time out in the Connection options panel.
 network.httpsender.ssl.error.connect = An exception occurred while attempting to connect to: 


### PR DESCRIPTION
Add a (simple text) custom 'bad host' error page instead of showing the stack trace

![Screenshot 2022-10-24 at 12-04-13 Screenshot](https://user-images.githubusercontent.com/1081115/197502536-3570e05c-d7b6-42be-bb5d-d88831c63115.png)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>