### PR TITLE
spider: use network exception

### DIFF
--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -14,6 +14,9 @@ zapAddOn {
         dependencies {
             addOns {
                 register("database")
+                register("network") {
+                    version.set(">=0.3.0")
+                }
             }
         }
 
@@ -51,10 +54,12 @@ dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
     compileOnly(parent!!.childProjects.get("database")!!)
     compileOnly(parent!!.childProjects.get("formhandler")!!)
+    compileOnly(parent!!.childProjects.get("network")!!)
 
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(parent!!.childProjects.get("database")!!)
     testImplementation(parent!!.childProjects.get("formhandler")!!)
+    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
@@ -24,10 +24,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,12 +57,14 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpSender;
 import org.yaml.snakeyaml.Yaml;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob.Order;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.addon.automation.ContextWrapper;
 import org.zaproxy.addon.automation.tests.AutomationStatisticTest;
+import org.zaproxy.addon.network.common.ZapUnknownHostException;
 import org.zaproxy.addon.spider.ExtensionSpider2;
 import org.zaproxy.addon.spider.SpiderParam;
 import org.zaproxy.addon.spider.SpiderScan;
@@ -522,7 +526,11 @@ class SpiderJobUnitTest extends TestUtils {
         given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
         given(env.replaceVars(url)).willReturn(url);
 
+        HttpSender httpSender = mock(HttpSender.class);
+        doThrow(ZapUnknownHostException.class).when(httpSender).sendAndReceive(any(), anyBoolean());
+
         SpiderJob job = new SpiderJob();
+        job.setUrlRequester(new UrlRequester("", httpSender));
 
         // When
         job.runJob(env, progress);
@@ -533,6 +541,48 @@ class SpiderJobUnitTest extends TestUtils {
         assertThat(progress.getErrors().size(), is(equalTo(1)));
         assertThat(
                 progress.getErrors().get(0), is(equalTo("!spider.automation.error.url.badhost!")));
+    }
+
+    @Test
+    void shouldFailIfInvalidProxyHost() throws Exception {
+        ExtensionHistory extHistory = mock(ExtensionHistory.class, withSettings().lenient());
+        given(extensionLoader.getExtension(ExtensionHistory.class)).willReturn(extHistory);
+
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        String url = "http://null.example.com/";
+        contextWrapper.addUrl(url);
+
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(true);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
+
+        HttpSender httpSender = mock(HttpSender.class);
+        doThrow(new ZapUnknownHostException("", true))
+                .when(httpSender)
+                .sendAndReceive(any(), anyBoolean());
+
+        SpiderJob job = new SpiderJob();
+        job.setUrlRequester(new UrlRequester("", httpSender));
+
+        // When
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(
+                progress.getErrors().get(0),
+                is(equalTo("!spider.automation.error.url.badhost.proxychain!")));
     }
 
     @Test


### PR DESCRIPTION
Rely on network exception to know if it's the proxy's host that was not resolved.