### PR TITLE
network: use exception for timeout value

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -378,7 +378,7 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
         ConnectionParam connectionParam = model.getOptionsParam().getConnectionParam();
         proxyHttpSender = new HttpSender(connectionParam, true, HttpSender.PROXY_INITIATOR);
-        httpSenderHandler = new HttpSenderHandler(connectionParam, proxyHttpSender);
+        httpSenderHandler = new HttpSenderHandler(proxyHttpSender);
     }
 
     private NioEventLoopGroup getMainEventLoopGroup() {
@@ -524,8 +524,7 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                         RemoveAcceptEncodingHandler.getEnabledInstance(),
                         DecodeResponseHandler.getEnabledInstance(),
                         handler,
-                        new HttpSenderHandler(
-                                getModel().getOptionsParam().getConnectionParam(), httpSender));
+                        new HttpSenderHandler(httpSender));
         return createHttpServer(() -> new MainProxyHandler(legacyProxyListenerHandler, handlers));
     }
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandler.java
@@ -20,22 +20,20 @@
 package org.zaproxy.addon.network.internal.server.http.handlers;
 
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import javax.net.ssl.SSLException;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.network.ConnectionParam;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.addon.network.common.ZapSocketTimeoutException;
 import org.zaproxy.addon.network.common.ZapUnknownHostException;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
@@ -53,19 +51,15 @@ public class HttpSenderHandler implements HttpMessageHandler {
     private static final HttpRequestConfig EXCLUDED_REQ_CONFIG =
             HttpRequestConfig.builder().setNotifyListeners(false).build();
 
-    private ConnectionParam connectionParam;
     private HttpSender httpSender;
 
     /**
-     * Constructs a {@code HttpSenderHandler} with the given connection configuration and HTTP
-     * sender.
+     * Constructs a {@code HttpSenderHandler} with the given HTTP sender.
      *
-     * @param connectionParam the connection configuration.
      * @param httpSender the HTTP sender.
-     * @throws NullPointerException if the HTTP sender and given handler are {@code null}.
+     * @throws NullPointerException if the HTTP sender is {@code null}.
      */
-    public HttpSenderHandler(ConnectionParam connectionParam, HttpSender httpSender) {
-        this.connectionParam = Objects.requireNonNull(connectionParam);
+    public HttpSenderHandler(HttpSender httpSender) {
         this.httpSender = Objects.requireNonNull(httpSender);
     }
 
@@ -83,16 +77,12 @@ public class HttpSenderHandler implements HttpMessageHandler {
                 httpSender.sendAndReceive(msg);
             }
 
-        } catch (HttpException e) {
-            LOGGER.error(e.getMessage(), e);
-            ctx.close();
-
-        } catch (SocketTimeoutException e) {
+        } catch (ZapSocketTimeoutException e) {
             String message =
                     Constant.messages.getString(
                             "network.httpsender.error.readtimeout",
                             msg.getRequestHeader().getURI(),
-                            connectionParam.getTimeoutInSecs());
+                            e.getTimeout());
             LOGGER.warn(message);
             setErrorResponse(
                     ctx,
@@ -103,10 +93,13 @@ public class HttpSenderHandler implements HttpMessageHandler {
 
         } catch (IOException e) {
             setErrorResponse(ctx, msg, HttpStatusCode.BAD_GATEWAY, BAD_GATEWAY_REASON_PHRASE, e);
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+            ctx.close();
         }
     }
 
-    private void setErrorResponse(
+    private static void setErrorResponse(
             HttpMessageHandlerContext ctx,
             HttpMessage msg,
             int statusCode,
@@ -132,7 +125,7 @@ public class HttpSenderHandler implements HttpMessageHandler {
                             "network.httpsender.ssl.error.help",
                             Constant.messages.getString("network.httpsender.ssl.error.help.url")));
 
-            LOGGER.warn(strBuilder.toString());
+            LOGGER.warn(strBuilder);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(cause, cause);
                 strBuilder.append("\n\nStack Trace:\n");

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -136,7 +136,7 @@ network.httpsender.error.badhost.exception = The exception was: \n
 network.httpsender.error.badhost.help = The following document may be of assistance in resolving this failure:\n{0} 
 network.httpsender.error.badhost.help.url = https://www.zaproxy.org/faq/why-cant-zap-connect-to-my-website/
 
-network.httpsender.error.proxy=\tYour "Options / Network / Connection" proxy settings might be incorrect.
+network.httpsender.error.proxy=\n\nYour "Options / Network / Connection" proxy settings might be incorrect.
 network.httpsender.error.readtimeout = Failed to read {0} within {1} seconds, check to see if the site is available and if so consider adjusting ZAP''s read time out in the Connection options panel.
 network.httpsender.ssl.error.connect = An exception occurred while attempting to connect to: 
 network.httpsender.ssl.error.exception = The exception was: \n

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandlerUnitTest.java
@@ -36,28 +36,24 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.util.Locale;
-import org.apache.commons.httpclient.HttpException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.network.ConnectionParam;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.common.ZapSocketTimeoutException;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.I18N;
-import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link HttpSenderHandler}. */
 class HttpSenderHandlerUnitTest extends TestUtils {
 
     private HttpMessageHandlerContext ctx;
-    private ConnectionParam connectionParam;
     private HttpSender httpSender;
     private HttpSenderHandler handler;
 
@@ -67,19 +63,15 @@ class HttpSenderHandlerUnitTest extends TestUtils {
 
         ctx = mock(HttpMessageHandlerContext.class);
         httpSender = mock(HttpSender.class);
-        connectionParam = new ConnectionParam();
-        connectionParam.load(new ZapXmlConfiguration());
-        handler = new HttpSenderHandler(connectionParam, httpSender);
+        handler = new HttpSenderHandler(httpSender);
     }
 
     @Test
-    void shouldThrowIfConnectionParamIsNull() {
+    void shouldThrowIfHttpSenderIsNull() {
         // Given
-        ConnectionParam connectionParam = null;
+        HttpSender httpSender = null;
         // When / Then
-        assertThrows(
-                NullPointerException.class,
-                () -> new HttpSenderHandler(connectionParam, httpSender));
+        assertThrows(NullPointerException.class, () -> new HttpSenderHandler(httpSender));
     }
 
     @Test
@@ -128,7 +120,7 @@ class HttpSenderHandlerUnitTest extends TestUtils {
         // Given
         given(ctx.isFromClient()).willReturn(true);
         HttpMessage message = createServerRequest("GET / HTTP/1.1");
-        doThrow(SocketTimeoutException.class).when(httpSender).sendAndReceive(message);
+        doThrow(ZapSocketTimeoutException.class).when(httpSender).sendAndReceive(message);
         // When
         handler.handleMessage(ctx, message);
         verifyMessageSent(message);
@@ -146,7 +138,7 @@ class HttpSenderHandlerUnitTest extends TestUtils {
         // Given
         given(ctx.isFromClient()).willReturn(true);
         HttpMessage message = createServerRequest("HEAD / HTTP/1.1");
-        doThrow(SocketTimeoutException.class).when(httpSender).sendAndReceive(message);
+        doThrow(ZapSocketTimeoutException.class).when(httpSender).sendAndReceive(message);
         // When
         handler.handleMessage(ctx, message);
         verifyMessageSent(message);
@@ -176,11 +168,11 @@ class HttpSenderHandlerUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldCloseWithoutSettingResponseOnHttpProtocolError() throws Exception {
+    void shouldCloseWithoutSettingResponseOnException() throws Exception {
         // Given
         given(ctx.isFromClient()).willReturn(true);
         HttpMessage message = createServerRequest("GET / HTTP/1.1");
-        doThrow(HttpException.class).when(httpSender).sendAndReceive(message);
+        doThrow(RuntimeException.class).when(httpSender).sendAndReceive(message);
         // When
         handler.handleMessage(ctx, message);
         verifyMessageSent(message);


### PR DESCRIPTION
Use the exception timeout value in `HttpSenderHandler` instead of getting it from the options, remove the options which are no longer needed in the class.