### PR TITLE
network: handle server certs always

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
@@ -154,15 +154,13 @@ public class NetworkApi extends ApiImplementor {
         this.addApiAction(
                 new ApiAction(ACTION_IMPORT_ROOT_CA_CERT, Arrays.asList(PARAM_FILE_PATH)));
 
-        if (isHandleServerCerts(extensionNetwork)) {
-            this.addApiAction(
-                    new ApiAction(ACTION_SET_ROOT_CA_CERT_VALIDITY, Arrays.asList(PARAM_VALIDITY)));
-            this.addApiAction(
-                    new ApiAction(ACTION_SET_SERVER_CERT_VALIDITY, Arrays.asList(PARAM_VALIDITY)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_ROOT_CA_CERT_VALIDITY, Arrays.asList(PARAM_VALIDITY)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_SERVER_CERT_VALIDITY, Arrays.asList(PARAM_VALIDITY)));
 
-            this.addApiView(new ApiView(VIEW_GET_ROOT_CA_CERT_VALIDITY));
-            this.addApiView(new ApiView(VIEW_GET_SERVER_CERT_VALIDITY));
-        }
+        this.addApiView(new ApiView(VIEW_GET_ROOT_CA_CERT_VALIDITY));
+        this.addApiView(new ApiView(VIEW_GET_SERVER_CERT_VALIDITY));
 
         if (isHandleLocalServers(extensionNetwork)) {
             this.addApiAction(
@@ -272,10 +270,6 @@ public class NetworkApi extends ApiImplementor {
         }
 
         this.addApiOthers(new ApiOther(OTHER_ROOT_CA_CERT, false));
-    }
-
-    private static boolean isHandleServerCerts(ExtensionNetwork extensionNetwork) {
-        return extensionNetwork == null || extensionNetwork.isHandleServerCerts();
     }
 
     private static boolean isHandleLocalServers(ExtensionNetwork extensionNetwork) {
@@ -566,10 +560,6 @@ public class NetworkApi extends ApiImplementor {
                 }
 
             case ACTION_SET_ROOT_CA_CERT_VALIDITY:
-                if (!isHandleServerCerts(extensionNetwork)) {
-                    throw new ApiException(ApiException.Type.BAD_ACTION);
-                }
-
                 try {
                     Duration validity = Duration.ofDays(params.getInt(PARAM_VALIDITY));
                     extensionNetwork.getServerCertificatesOptions().setRootCaCertValidity(validity);
@@ -579,10 +569,6 @@ public class NetworkApi extends ApiImplementor {
                 }
 
             case ACTION_SET_SERVER_CERT_VALIDITY:
-                if (!isHandleServerCerts(extensionNetwork)) {
-                    throw new ApiException(ApiException.Type.BAD_ACTION);
-                }
-
                 try {
                     Duration validity = Duration.ofDays(params.getInt(PARAM_VALIDITY));
                     extensionNetwork.getServerCertificatesOptions().setServerCertValidity(validity);
@@ -816,10 +802,6 @@ public class NetworkApi extends ApiImplementor {
                 return response;
 
             case VIEW_GET_ROOT_CA_CERT_VALIDITY:
-                if (!isHandleServerCerts(extensionNetwork)) {
-                    throw new ApiException(ApiException.Type.BAD_VIEW);
-                }
-
                 return new ApiResponseElement(
                         name,
                         String.valueOf(
@@ -829,10 +811,6 @@ public class NetworkApi extends ApiImplementor {
                                         .toDays()));
 
             case VIEW_GET_SERVER_CERT_VALIDITY:
-                if (!isHandleServerCerts(extensionNetwork)) {
-                    throw new ApiException(ApiException.Type.BAD_VIEW);
-                }
-
                 return new ApiResponseElement(
                         name,
                         String.valueOf(

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
@@ -21,7 +21,7 @@ package org.zaproxy.addon.network.internal;
 
 import io.netty.util.AttributeKey;
 import java.net.InetSocketAddress;
-import org.parosproxy.paros.security.SslCertificateService;
+import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
 import org.zaproxy.addon.network.internal.handlers.TlsConfig;
 import org.zaproxy.addon.network.internal.server.ServerConfig;
 
@@ -38,8 +38,8 @@ public final class ChannelAttributes {
     public static final AttributeKey<InetSocketAddress> REMOTE_ADDRESS =
             AttributeKey.newInstance("zap.remote-address");
 
-    /** The attribute that contains the {@link SslCertificateService}. */
-    public static final AttributeKey<SslCertificateService> CERTIFICATE_SERVICE =
+    /** The attribute that contains the {@link ServerCertificateService}. */
+    public static final AttributeKey<ServerCertificateService> CERTIFICATE_SERVICE =
             AttributeKey.newInstance("zap.certificate-service");
 
     /** The attribute that contains the {@link TlsConfig}. */

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertData.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertData.java
@@ -1,0 +1,126 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.cert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class CertData {
+
+    private String commonName;
+    private List<Name> subjectAlternativeNames;
+
+    public CertData() {
+        subjectAlternativeNames = new ArrayList<>();
+    }
+
+    public CertData(String commonName) {
+        this();
+        this.commonName = commonName;
+        if (commonName != null) {
+            addSubjectAlternativeName(new Name(Name.DNS, commonName));
+        }
+    }
+
+    public String getCommonName() {
+        return commonName;
+    }
+
+    public void addSubjectAlternativeName(Name subjectAlternativeName) {
+        subjectAlternativeNames.add(subjectAlternativeName);
+    }
+
+    public boolean isSubjectAlternativeNameIsCritical() {
+        return commonName == null;
+    }
+
+    public Name[] getSubjectAlternativeNames() {
+        Name[] subjectAlternativeNamesArray = new Name[subjectAlternativeNames.size()];
+        return subjectAlternativeNames.toArray(subjectAlternativeNamesArray);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(commonName, subjectAlternativeNames);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof CertData)) {
+            return false;
+        }
+        CertData certData = (CertData) obj;
+        return Objects.equals(commonName, certData.commonName)
+                && Objects.equals(subjectAlternativeNames, certData.subjectAlternativeNames);
+    }
+
+    public static class Name {
+        public static final int DNS = 2;
+        public static final int IP_ADDRESS = 7;
+
+        private int type;
+        private String value;
+
+        public Name(int type, String value) {
+            this.type = type;
+            this.value = value;
+        }
+
+        public int getType() {
+            return type;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!(obj instanceof Name)) {
+                return false;
+            }
+
+            Name name = (Name) obj;
+
+            if (getType() != name.getType()) {
+                return false;
+            }
+            return Objects.equals(getValue(), name.getValue());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getType(), getValue());
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
@@ -77,7 +77,6 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemWriter;
-import org.parosproxy.paros.security.CertData;
 
 /** Utilities for certificate generation and manipulation. */
 public final class CertificateUtils {
@@ -126,6 +125,10 @@ public final class CertificateUtils {
     private static final Duration SERVER_CERTIFICATE_START_ADJUSTMENT = Duration.ofDays(30);
 
     private CertificateUtils() {}
+
+    public static char[] getPassphrase() {
+        return PASSPHRASE.clone();
+    }
 
     /**
      * Creates a new Root CA certificate and returns the private and public key in a {@link

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/GenerationException.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/GenerationException.java
@@ -25,6 +25,15 @@ public class GenerationException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     /**
+     * Constructs a {@code GenerationException} with the given message.
+     *
+     * @param message the detail message.
+     */
+    public GenerationException(String message) {
+        super(message);
+    }
+
+    /**
      * Constructs a {@code GenerationException} with the given cause.
      *
      * @param cause the cause of the exception.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/ServerCertificateGenerator.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/ServerCertificateGenerator.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
-import org.parosproxy.paros.security.CertData;
 import org.zaproxy.addon.network.ServerCertificatesOptions;
 
 /** A generator of server certificates. */

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/ServerCertificateService.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/ServerCertificateService.java
@@ -1,0 +1,28 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.cert;
+
+import java.io.IOException;
+import java.security.KeyStore;
+
+public interface ServerCertificateService {
+
+    KeyStore createCertificate(CertData certData) throws IOException;
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
-import org.parosproxy.paros.security.MissingRootCertificateException;
 import org.zaproxy.addon.network.internal.cert.GenerationException;
 
 /**
@@ -105,8 +104,7 @@ public class ServerExceptionHandler extends ChannelInboundHandlerAdapter {
             return;
         }
 
-        if (nestedCause instanceof GenerationException
-                || nestedCause instanceof MissingRootCertificateException) {
+        if (nestedCause instanceof GenerationException) {
             LOGGER.warn("Failed while creating certificate, cause: {}", nestedCause.getMessage());
             return;
         }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
@@ -27,8 +27,8 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.parosproxy.paros.network.ConnectionParam;
-import org.parosproxy.paros.security.SslCertificateService;
 import org.zaproxy.addon.network.internal.ChannelAttributes;
+import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
 import org.zaproxy.addon.network.internal.codec.HttpRequestDecoder;
 import org.zaproxy.addon.network.internal.codec.HttpResponseEncoder;
 import org.zaproxy.addon.network.internal.handlers.ConnectRequestHandler;
@@ -56,7 +56,7 @@ public class HttpServer extends BaseServer {
     private static final TlsConfig DEFAULT_TLS_CONFIG = new TlsConfig();
 
     private final EventExecutorGroup mainHandlerExecutor;
-    private final SslCertificateService sslCertificateService;
+    private final ServerCertificateService certificateService;
     private Supplier<MainServerHandler> handler;
     private DefaultServerConfig serverConfig;
 
@@ -67,16 +67,16 @@ public class HttpServer extends BaseServer {
      *
      * @param group the event loop group.
      * @param mainHandlerExecutor the event executor for the main handler.
-     * @param sslCertificateService the certificate service.
+     * @param certificateService the certificate service.
      * @see #setMainServerHandler(Supplier)
      */
     protected HttpServer(
             NioEventLoopGroup group,
             EventExecutorGroup mainHandlerExecutor,
-            SslCertificateService sslCertificateService) {
+            ServerCertificateService certificateService) {
         super(group);
         this.mainHandlerExecutor = Objects.requireNonNull(mainHandlerExecutor);
-        this.sslCertificateService = Objects.requireNonNull(sslCertificateService);
+        this.certificateService = Objects.requireNonNull(certificateService);
 
         this.serverConfig = new DefaultServerConfig();
         setChannelInitialiser(this::initChannel);
@@ -87,15 +87,15 @@ public class HttpServer extends BaseServer {
      *
      * @param group the event loop group.
      * @param mainHandlerExecutor the event executor for the main handler.
-     * @param sslCertificateService the certificate service.
+     * @param certificateService the certificate service.
      * @param handler the main handler.
      */
     public HttpServer(
             NioEventLoopGroup group,
             EventExecutorGroup mainHandlerExecutor,
-            SslCertificateService sslCertificateService,
+            ServerCertificateService certificateService,
             Supplier<MainServerHandler> handler) {
-        this(group, mainHandlerExecutor, sslCertificateService);
+        this(group, mainHandlerExecutor, certificateService);
 
         setMainServerHandler(handler);
     }
@@ -111,7 +111,7 @@ public class HttpServer extends BaseServer {
     }
 
     protected void initChannel(SocketChannel ch) {
-        ch.attr(ChannelAttributes.CERTIFICATE_SERVICE).set(sslCertificateService);
+        ch.attr(ChannelAttributes.CERTIFICATE_SERVICE).set(certificateService);
         ch.attr(ChannelAttributes.SERVER_CONFIG).set(serverConfig);
         ch.attr(ChannelAttributes.TLS_CONFIG).set(DEFAULT_TLS_CONFIG);
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServer.java
@@ -26,8 +26,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.security.SslCertificateService;
 import org.zaproxy.addon.network.internal.ChannelAttributes;
+import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
 import org.zaproxy.addon.network.internal.handlers.PassThroughHandler;
 import org.zaproxy.addon.network.internal.server.http.LocalServerHandler.SerialiseState;
 import org.zaproxy.addon.network.internal.server.http.handlers.AliasApiRewriteHandler;
@@ -61,7 +61,7 @@ public class LocalServer extends HttpServer {
      *
      * @param group the event loop group.
      * @param mainHandlerExecutor the event executor for the main handler.
-     * @param sslCertificateService the certificate service.
+     * @param certificateService the certificate service.
      * @param legacyHandler the handler for legacy (core) listeners.
      * @param passThroughHandler the pass-through handler.
      * @param httpSenderHandler the HTTP Sender handler.
@@ -72,14 +72,14 @@ public class LocalServer extends HttpServer {
     public LocalServer(
             NioEventLoopGroup group,
             EventExecutorGroup mainHandlerExecutor,
-            SslCertificateService sslCertificateService,
+            ServerCertificateService certificateService,
             LegacyProxyListenerHandler legacyHandler,
             PassThroughHandler passThroughHandler,
             HttpSenderHandler httpSenderHandler,
             LocalServerConfig serverConfig,
             SerialiseState serialiseState,
             Model model) {
-        super(group, mainHandlerExecutor, sslCertificateService);
+        super(group, mainHandlerExecutor, certificateService);
         this.legacyHandler = legacyHandler;
         this.passThroughHandler = Objects.requireNonNull(passThroughHandler);
         this.httpSenderHandler = httpSenderHandler;

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
@@ -133,21 +133,7 @@ class NetworkApiUnitTest extends TestUtils {
 
     @Test
     void shouldAddApiElements() {
-        // Given
-        given(extensionNetwork.isHandleServerCerts()).willReturn(false);
-        // When
-        networkApi = new NetworkApi(extensionNetwork);
-        // Then
-        assertThat(networkApi.getApiActions(), hasSize(2));
-        assertThat(networkApi.getApiViews(), hasSize(0));
-        assertThat(networkApi.getApiOthers(), hasSize(1));
-    }
-
-    @Test
-    void shouldAddAdditionalApiElementsWhenHandlingServerCerts() {
-        // Given
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
-        // When
+        // Given / When
         networkApi = new NetworkApi(extensionNetwork);
         // Then
         assertThat(networkApi.getApiActions(), hasSize(4));
@@ -158,7 +144,6 @@ class NetworkApiUnitTest extends TestUtils {
     @Test
     void shouldAddAdditionalApiElementsWhenHandlingLocalServers() {
         // Given
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         given(extensionNetwork.isHandleLocalServers()).willReturn(true);
         // When
         networkApi = new NetworkApi(extensionNetwork);
@@ -171,7 +156,6 @@ class NetworkApiUnitTest extends TestUtils {
     @Test
     void shouldAddAdditionalApiElementsWhenHandlingConnection() {
         // Given
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         given(extensionNetwork.isHandleLocalServers()).willReturn(true);
         ExtensionNetwork.handleConnection = true;
         // When
@@ -185,7 +169,6 @@ class NetworkApiUnitTest extends TestUtils {
     @Test
     void shouldAddAdditionalApiElementsWhenHandlingClientCertificates() {
         // Given
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         given(extensionNetwork.isHandleLocalServers()).willReturn(true);
         given(extensionNetwork.isHandleClientCerts()).willReturn(true);
         ExtensionNetwork.handleConnection = true;
@@ -345,27 +328,11 @@ class NetworkApiUnitTest extends TestUtils {
         String name = "setRootCaCertValidity";
         JSONObject params = new JSONObject();
         params.put("validity", 123);
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         // When
         ApiResponse response = networkApi.handleApiAction(name, params);
         // Then
         assertThat(response, is(equalTo(ApiResponseElement.OK)));
         verify(serverCertificatesOptions).setRootCaCertValidity(Duration.ofDays(123));
-    }
-
-    @Test
-    void shouldThrowApiExceptionWhenSettingRootCaCertValidityIfNotHandlingServerCerts()
-            throws Exception {
-        // Given
-        String name = "setRootCaCertValidity";
-        JSONObject params = new JSONObject();
-        params.put("validity", 123);
-        given(extensionNetwork.isHandleServerCerts()).willReturn(false);
-        // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> networkApi.handleApiAction(name, params));
-        // Then
-        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_ACTION)));
     }
 
     @Test
@@ -377,7 +344,6 @@ class NetworkApiUnitTest extends TestUtils {
         willThrow(IllegalArgumentException.class)
                 .given(serverCertificatesOptions)
                 .setRootCaCertValidity(any());
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         // When
         ApiException exception =
                 assertThrows(ApiException.class, () -> networkApi.handleApiAction(name, params));
@@ -391,27 +357,11 @@ class NetworkApiUnitTest extends TestUtils {
         String name = "setServerCertValidity";
         JSONObject params = new JSONObject();
         params.put("validity", 123);
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         // When
         ApiResponse response = networkApi.handleApiAction(name, params);
         // Then
         assertThat(response, is(equalTo(ApiResponseElement.OK)));
         verify(serverCertificatesOptions).setServerCertValidity(Duration.ofDays(123));
-    }
-
-    @Test
-    void shouldThrowApiExceptionWhenSettingServerCertValidityIfNotHandlingServerCerts()
-            throws Exception {
-        // Given
-        String name = "setServerCertValidity";
-        JSONObject params = new JSONObject();
-        params.put("validity", 123);
-        given(extensionNetwork.isHandleServerCerts()).willReturn(false);
-        // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> networkApi.handleApiAction(name, params));
-        // Then
-        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_ACTION)));
     }
 
     @Test
@@ -423,7 +373,6 @@ class NetworkApiUnitTest extends TestUtils {
         willThrow(IllegalArgumentException.class)
                 .given(serverCertificatesOptions)
                 .setServerCertValidity(any());
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         // When
         ApiException exception =
                 assertThrows(ApiException.class, () -> networkApi.handleApiAction(name, params));
@@ -662,28 +611,12 @@ class NetworkApiUnitTest extends TestUtils {
         String name = "getRootCaCertValidity";
         JSONObject params = new JSONObject();
         given(serverCertificatesOptions.getRootCaCertValidity()).willReturn(Duration.ofDays(123));
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         // When
         ApiResponse response = networkApi.handleApiView(name, params);
         // Then
         assertThat(response.getName(), is(equalTo(name)));
         assertThat(response, is(instanceOf(ApiResponseElement.class)));
         assertThat(((ApiResponseElement) response).getValue(), is(equalTo("123")));
-    }
-
-    @Test
-    void shouldThrowApiExceptionWhenGettingRootCaCertValidityIfNotHandlingServerCerts()
-            throws Exception {
-        // Given
-        String name = "getRootCaCertValidity";
-        JSONObject params = new JSONObject();
-        given(serverCertificatesOptions.getRootCaCertValidity()).willReturn(Duration.ofDays(123));
-        given(extensionNetwork.isHandleServerCerts()).willReturn(false);
-        // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> networkApi.handleApiView(name, params));
-        // Then
-        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_VIEW)));
     }
 
     @Test
@@ -692,28 +625,12 @@ class NetworkApiUnitTest extends TestUtils {
         String name = "getServerCertValidity";
         JSONObject params = new JSONObject();
         given(serverCertificatesOptions.getServerCertValidity()).willReturn(Duration.ofDays(123));
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         // When
         ApiResponse response = networkApi.handleApiView(name, params);
         // Then
         assertThat(response.getName(), is(equalTo(name)));
         assertThat(response, is(instanceOf(ApiResponseElement.class)));
         assertThat(((ApiResponseElement) response).getValue(), is(equalTo("123")));
-    }
-
-    @Test
-    void shouldThrowApiExceptionWhenGettingServerCertValidityIfNotHandlingServerCerts()
-            throws Exception {
-        // Given
-        String name = "getServerCertValidity";
-        JSONObject params = new JSONObject();
-        given(serverCertificatesOptions.getServerCertValidity()).willReturn(Duration.ofDays(123));
-        given(extensionNetwork.isHandleServerCerts()).willReturn(false);
-        // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> networkApi.handleApiView(name, params));
-        // Then
-        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_VIEW)));
     }
 
     @Test
@@ -1801,7 +1718,6 @@ class NetworkApiUnitTest extends TestUtils {
 
     @Test
     void shouldHaveDescriptionsForAllApiElements() {
-        given(extensionNetwork.isHandleServerCerts()).willReturn(true);
         given(extensionNetwork.isHandleLocalServers()).willReturn(true);
         ExtensionNetwork.handleConnection = true;
         given(extensionNetwork.isHandleClientCerts()).willReturn(true);

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
@@ -43,7 +43,6 @@ import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.parosproxy.paros.security.CertData;
 import org.zaproxy.addon.network.NetworkTestUtils;
 
 /** Unit test for {@link CertificateUtils}. */

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/ServerCertificateGeneratorUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/ServerCertificateGeneratorUnitTest.java
@@ -33,7 +33,6 @@ import java.time.Duration;
 import java.util.Date;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.parosproxy.paros.security.CertData;
 import org.zaproxy.addon.network.NetworkTestUtils;
 import org.zaproxy.addon.network.ServerCertificatesOptions;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
-import org.parosproxy.paros.security.MissingRootCertificateException;
 import org.zaproxy.addon.network.TestLogAppender;
 import org.zaproxy.addon.network.internal.cert.GenerationException;
 
@@ -117,21 +116,6 @@ class ServerExceptionHandlerUnitTest {
                 hasItem(
                         startsWith(
                                 "WARN Failed while creating certificate, cause: java.lang.Exception: Cause")));
-    }
-
-    @Test
-    void shouldLogMissingRootCertificateExceptionAsWarn() throws Exception {
-        // Given
-        Exception cause = new MissingRootCertificateException("No Root CA cert");
-        Exception exception = new DecoderException(cause);
-        // When
-        serverExceptionHandler.exceptionCaught(ctx, exception);
-        // Then
-        assertThat(
-                logEvents,
-                hasItem(
-                        startsWith(
-                                "WARN Failed while creating certificate, cause: No Root CA cert")));
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
@@ -66,12 +66,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.parosproxy.paros.security.SslCertificateService;
 import org.zaproxy.addon.network.internal.ChannelAttributes;
 import org.zaproxy.addon.network.internal.TlsUtils;
+import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
 import org.zaproxy.addon.network.internal.server.BaseServer;
 import org.zaproxy.addon.network.server.Server;
-import org.zaproxy.addon.network.testutils.TestSslCertificateService;
+import org.zaproxy.addon.network.testutils.TestServerCertificateService;
 import org.zaproxy.addon.network.testutils.TextTestClient;
 
 /** Unit test for {@link TlsProtocolHandler}. */
@@ -81,7 +81,7 @@ class TlsProtocolHandlerUnitTest {
 
     private static NioEventLoopGroup eventLoopGroup;
     private static TextTestClient client;
-    private static SslCertificateService sslCertificateService;
+    private static ServerCertificateService certificateService;
     private TextTestClient clientTls;
     private BaseServer server;
     private CountDownLatch serverChannelReady;
@@ -91,7 +91,7 @@ class TlsProtocolHandlerUnitTest {
 
     @BeforeAll
     static void setupAll() throws Exception {
-        sslCertificateService = TestSslCertificateService.createInstance();
+        certificateService = TestServerCertificateService.createInstance();
         eventLoopGroup =
                 new NioEventLoopGroup(
                         NettyRuntime.availableProcessors(),
@@ -159,7 +159,7 @@ class TlsProtocolHandlerUnitTest {
     }
 
     private void initDefaultChannel(SocketChannel ch, TlsProtocolHandler tlsProtocolHandler) {
-        ch.attr(ChannelAttributes.CERTIFICATE_SERVICE).set(sslCertificateService);
+        ch.attr(ChannelAttributes.CERTIFICATE_SERVICE).set(certificateService);
         ch.attr(ChannelAttributes.TLS_CONFIG).set(tlsConfig);
 
         ch.pipeline()

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/HttpServerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/HttpServerUnitTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.parosproxy.paros.security.SslCertificateService;
+import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
 import org.zaproxy.addon.network.server.Server;
 
 /** Unit test for {@link HttpServer}. */
@@ -44,7 +44,7 @@ class HttpServerUnitTest {
 
     private static NioEventLoopGroup group;
     private static EventExecutorGroup mainHandlerExecutor;
-    private SslCertificateService sslCertificateService;
+    private ServerCertificateService certificateService;
     private Supplier<MainServerHandler> handlerSupplier;
 
     @BeforeAll
@@ -70,7 +70,7 @@ class HttpServerUnitTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        sslCertificateService = mock(SslCertificateService.class);
+        certificateService = mock(ServerCertificateService.class);
         handlerSupplier = () -> mock(MainServerHandler.class);
     }
 
@@ -83,10 +83,7 @@ class HttpServerUnitTest {
                 NullPointerException.class,
                 () ->
                         new HttpServer(
-                                group,
-                                mainHandlerExecutor,
-                                sslCertificateService,
-                                handlerSupplier));
+                                group, mainHandlerExecutor, certificateService, handlerSupplier));
     }
 
     @Test
@@ -98,25 +95,19 @@ class HttpServerUnitTest {
                 NullPointerException.class,
                 () ->
                         new HttpServer(
-                                group,
-                                mainHandlerExecutor,
-                                sslCertificateService,
-                                handlerSupplier));
+                                group, mainHandlerExecutor, certificateService, handlerSupplier));
     }
 
     @Test
-    void shouldThrowIfNoSslCertificateService() throws Exception {
+    void shouldThrowIfNoServerCertificateService() throws Exception {
         // Given
-        sslCertificateService = null;
+        certificateService = null;
         // When / Then
         assertThrows(
                 NullPointerException.class,
                 () ->
                         new HttpServer(
-                                group,
-                                mainHandlerExecutor,
-                                sslCertificateService,
-                                handlerSupplier));
+                                group, mainHandlerExecutor, certificateService, handlerSupplier));
     }
 
     @Test
@@ -128,10 +119,7 @@ class HttpServerUnitTest {
                 NullPointerException.class,
                 () ->
                         new HttpServer(
-                                group,
-                                mainHandlerExecutor,
-                                sslCertificateService,
-                                handlerSupplier));
+                                group, mainHandlerExecutor, certificateService, handlerSupplier));
     }
 
     @Test
@@ -139,21 +127,17 @@ class HttpServerUnitTest {
         assertDoesNotThrow(
                 () ->
                         new HttpServer(
-                                group,
-                                mainHandlerExecutor,
-                                sslCertificateService,
-                                handlerSupplier));
+                                group, mainHandlerExecutor, certificateService, handlerSupplier));
     }
 
     @Test
     void shouldCreateWithNoHandler() throws Exception {
-        assertDoesNotThrow(() -> new HttpServer(group, mainHandlerExecutor, sslCertificateService));
+        assertDoesNotThrow(() -> new HttpServer(group, mainHandlerExecutor, certificateService));
     }
 
     @Test
     void shouldFailToStartWithNoHandler() throws Exception {
-        try (HttpServer server =
-                new HttpServer(group, mainHandlerExecutor, sslCertificateService)) {
+        try (HttpServer server = new HttpServer(group, mainHandlerExecutor, certificateService)) {
             IOException exception =
                     assertThrows(IOException.class, () -> server.start(Server.ANY_PORT));
             assertThat(exception.getMessage(), is(equalTo("No main server handler set.")));
@@ -162,8 +146,7 @@ class HttpServerUnitTest {
 
     @Test
     void shouldStartWithHandlerSet() throws Exception {
-        try (HttpServer server =
-                new HttpServer(group, mainHandlerExecutor, sslCertificateService)) {
+        try (HttpServer server = new HttpServer(group, mainHandlerExecutor, certificateService)) {
             server.setMainServerHandler(handlerSupplier);
             assertDoesNotThrow(() -> server.start(Server.ANY_PORT));
         }
@@ -174,8 +157,7 @@ class HttpServerUnitTest {
         // Given
         handlerSupplier = null;
         // When / Then
-        try (HttpServer server =
-                new HttpServer(group, mainHandlerExecutor, sslCertificateService)) {
+        try (HttpServer server = new HttpServer(group, mainHandlerExecutor, certificateService)) {
             assertThrows(
                     NullPointerException.class, () -> server.setMainServerHandler(handlerSupplier));
         }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
-import org.parosproxy.paros.security.SslCertificateService;
+import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
 import org.zaproxy.addon.network.internal.server.http.HttpServer;
 import org.zaproxy.addon.network.internal.server.http.MainServerHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
@@ -41,8 +41,8 @@ import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 /** A HTTP server that allows to receive and send text messages, to help with the tests. */
 public class TestHttpServer extends HttpServer {
 
-    private static final SslCertificateService SSL_CERTIFICATE_SERVICE =
-            TestSslCertificateService.createInstance();
+    private static final ServerCertificateService CERTIFICATE_SERVICE =
+            TestServerCertificateService.createInstance();
 
     private final List<HttpMessage> receivedMessages;
     private HttpMessageHandler handler;
@@ -56,7 +56,7 @@ public class TestHttpServer extends HttpServer {
      * @param mainHandlerExecutor the event executor for the main handler.
      */
     public TestHttpServer(NioEventLoopGroup group, EventExecutorGroup mainHandlerExecutor) {
-        super(group, mainHandlerExecutor, SSL_CERTIFICATE_SERVICE);
+        super(group, mainHandlerExecutor, CERTIFICATE_SERVICE);
 
         receivedMessages = Collections.synchronizedList(new ArrayList<>());
         setMainServerHandler(() -> new MainServerHandler(Collections.singletonList(this::handle)));

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackServiceUnitTest.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackServiceUnitTest.java
@@ -36,6 +36,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.ConnectionParam;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -62,8 +66,10 @@ class CallbackServiceUnitTest extends TestUtils {
     @BeforeAll
     static void setupAll() {
         mockMessages(new ExtensionOast());
+
+        Control.initSingletonForTesting(mock(Model.class), mock(ExtensionLoader.class));
         extensionNetwork = new ExtensionNetwork();
-        extensionNetwork.init();
+        extensionNetwork.hook(mock(ExtensionHook.class));
     }
 
     @AfterAll


### PR DESCRIPTION
Remove core server cert checks that provided compatibility with older core versions, the add-on is now targeting newer versions and should handle server certs always.