### PR TITLE
network: handle client certs always

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -78,7 +78,6 @@ import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionHookView;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.extension.SessionChangedListener;
-import org.parosproxy.paros.extension.option.OptionsParamCertificate;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
@@ -153,7 +152,6 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
     boolean handleClient;
     private HttpSenderNetwork<? extends HttpSenderContext> httpSenderNetwork;
-    boolean handleClientCerts;
     boolean handleLocalServers;
     static Boolean handleConnection;
     private ConnectionParam legacyConnectionOptions;
@@ -264,10 +262,6 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
         return clientCertificatesOptions;
     }
 
-    boolean isHandleClientCerts() {
-        return handleClientCerts;
-    }
-
     boolean isHandleLocalServers() {
         return handleLocalServers;
     }
@@ -310,8 +304,6 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                 }
             }
         }
-
-        handleClientCerts = isDeprecated(OptionsParamCertificate.class);
     }
 
     private static boolean isDeprecated(Class<?> clazz) {
@@ -551,12 +543,10 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
             extensionHook.addOptionsChangedListener(new OptionsChangedListenerImpl());
         }
 
-        if (handleClientCerts) {
-            if (!handleClient) {
-                clientCertificatesOptions = new ClientCertificatesOptions();
-            }
-            extensionHook.addOptionsParamSet(clientCertificatesOptions);
+        if (!handleClient) {
+            clientCertificatesOptions = new ClientCertificatesOptions();
         }
+        extensionHook.addOptionsParamSet(clientCertificatesOptions);
 
         if (hasView()) {
             ExtensionHookView hookView = extensionHook.getHookView();
@@ -586,13 +576,11 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                         new LegacyOptionsPanel("connection", connectionOptionsPanel));
             }
 
-            if (handleClientCerts) {
-                clientCertificatesOptionsPanel =
-                        new ClientCertificatesOptionsPanel(View.getSingleton());
-                optionsDialog.addParamPanel(networkNode, clientCertificatesOptionsPanel, true);
-                hookView.addOptionPanel(
-                        new LegacyOptionsPanel("clientcerts", clientCertificatesOptionsPanel));
-            }
+            clientCertificatesOptionsPanel =
+                    new ClientCertificatesOptionsPanel(View.getSingleton());
+            optionsDialog.addParamPanel(networkNode, clientCertificatesOptionsPanel, true);
+            hookView.addOptionPanel(
+                    new LegacyOptionsPanel("clientcerts", clientCertificatesOptionsPanel));
         }
     }
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
@@ -259,15 +259,12 @@ public class NetworkApi extends ApiImplementor {
             this.addApiView(new ApiView(VIEW_IS_USE_GLOBAL_HTTP_STATE));
         }
 
-        if (isHandleClientCerts(extensionNetwork)) {
-            addApiAction(
-                    new ApiAction(
-                            ACTION_ADD_PKCS12_CLIENT_CERTIFICATE,
-                            Arrays.asList(PARAM_FILE_PATH, PARAM_PASSWORD),
-                            Arrays.asList(PARAM_INDEX)));
-            addApiAction(
-                    new ApiAction(ACTION_SET_USE_CLIENT_CERTIFICATE, Arrays.asList(PARAM_USE)));
-        }
+        addApiAction(
+                new ApiAction(
+                        ACTION_ADD_PKCS12_CLIENT_CERTIFICATE,
+                        Arrays.asList(PARAM_FILE_PATH, PARAM_PASSWORD),
+                        Arrays.asList(PARAM_INDEX)));
+        addApiAction(new ApiAction(ACTION_SET_USE_CLIENT_CERTIFICATE, Arrays.asList(PARAM_USE)));
 
         this.addApiOthers(new ApiOther(OTHER_ROOT_CA_CERT, false));
     }
@@ -278,10 +275,6 @@ public class NetworkApi extends ApiImplementor {
 
     private static boolean isHandleConnection(ExtensionNetwork extensionNetwork) {
         return extensionNetwork == null || ExtensionNetwork.isHandleConnection();
-    }
-
-    private static boolean isHandleClientCerts(ExtensionNetwork extensionNetwork) {
-        return extensionNetwork == null || extensionNetwork.isHandleClientCerts();
     }
 
     @Override
@@ -354,9 +347,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case ACTION_ADD_PKCS12_CLIENT_CERTIFICATE:
                 {
-                    if (!isHandleClientCerts(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     String file = params.getString(PARAM_FILE_PATH);
                     String password = params.getString(PARAM_PASSWORD);
                     int index = ApiUtils.getIntParam(params, PARAM_INDEX);
@@ -628,9 +618,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case ACTION_SET_USE_CLIENT_CERTIFICATE:
                 {
-                    if (!isHandleClientCerts(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     boolean use = getParam(params, PARAM_USE, false);
                     extensionNetwork.getClientCertificatesOptions().setUseCertificate(use);
                     return ApiResponseElement.OK;

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -343,8 +343,8 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook).addOptionsParamSet(argument.capture());
-        assertThat(argument.getAllValues(), contains(instanceOf(ServerCertificatesOptions.class)));
+        verify(extensionHook, times(2)).addOptionsParamSet(argument.capture());
+        assertThat(argument.getAllValues(), hasItem(instanceOf(ServerCertificatesOptions.class)));
         assertThat(
                 extension.getServerCertificatesOptions(),
                 is(equalTo(argument.getAllValues().get(0))));
@@ -418,7 +418,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook, times(2)).addOptionsParamSet(argument.capture());
+        verify(extensionHook, times(3)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), hasItem(instanceOf(LocalServersOptions.class)));
         assertThat(extension.getLocalServersOptions(), is(equalTo(argument.getAllValues().get(1))));
     }
@@ -432,7 +432,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook).addOptionsParamSet(argument.capture());
+        verify(extensionHook, times(2)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), not(contains(instanceOf(LocalServersOptions.class))));
         assertThat(extension.getLocalServersOptions(), is(nullValue()));
     }
@@ -469,7 +469,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook, times(2)).addOptionsParamSet(argument.capture());
+        verify(extensionHook, times(3)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), hasItem(instanceOf(ConnectionOptions.class)));
     }
 
@@ -483,7 +483,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook, times(1)).addOptionsParamSet(argument.capture());
+        verify(extensionHook, times(2)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), not(hasItem(instanceOf(ConnectionOptions.class))));
     }
 
@@ -512,11 +512,10 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldAddClientCertificatesOptionsOnHookIfHandlingClientCerts() {
+    void shouldAddClientCertificatesOptionsOnHook() {
         // Given
         ExtensionHook extensionHook = mock(ExtensionHook.class);
         extension = new ExtensionNetwork();
-        extension.handleClientCerts = true;
         // When
         extension.hook(extensionHook);
         // Then
@@ -524,22 +523,6 @@ class ExtensionNetworkUnitTest extends TestUtils {
         verify(extensionHook, times(2)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), hasItem(instanceOf(ClientCertificatesOptions.class)));
         assertThat(extension.getClientCertificatesOptions(), is(notNullValue()));
-    }
-
-    @Test
-    void shouldNotAddClientCertificatesOptionsOnHookIfNotHandlingClientCerts() {
-        // Given
-        ExtensionHook extensionHook = mock(ExtensionHook.class);
-        extension = new ExtensionNetwork();
-        extension.handleClientCerts = false;
-        // When
-        extension.hook(extensionHook);
-        // Then
-        ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook, times(1)).addOptionsParamSet(argument.capture());
-        assertThat(
-                argument.getAllValues(), not(hasItem(instanceOf(ClientCertificatesOptions.class))));
-        assertThat(extension.getClientCertificatesOptions(), is(nullValue()));
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
@@ -136,7 +136,7 @@ class NetworkApiUnitTest extends TestUtils {
         // Given / When
         networkApi = new NetworkApi(extensionNetwork);
         // Then
-        assertThat(networkApi.getApiActions(), hasSize(4));
+        assertThat(networkApi.getApiActions(), hasSize(6));
         assertThat(networkApi.getApiViews(), hasSize(2));
         assertThat(networkApi.getApiOthers(), hasSize(1));
     }
@@ -148,7 +148,7 @@ class NetworkApiUnitTest extends TestUtils {
         // When
         networkApi = new NetworkApi(extensionNetwork);
         // Then
-        assertThat(networkApi.getApiActions(), hasSize(12));
+        assertThat(networkApi.getApiActions(), hasSize(14));
         assertThat(networkApi.getApiViews(), hasSize(5));
         assertThat(networkApi.getApiOthers(), hasSize(2));
     }
@@ -157,20 +157,6 @@ class NetworkApiUnitTest extends TestUtils {
     void shouldAddAdditionalApiElementsWhenHandlingConnection() {
         // Given
         given(extensionNetwork.isHandleLocalServers()).willReturn(true);
-        ExtensionNetwork.handleConnection = true;
-        // When
-        networkApi = new NetworkApi(extensionNetwork);
-        // Then
-        assertThat(networkApi.getApiActions(), hasSize(24));
-        assertThat(networkApi.getApiViews(), hasSize(15));
-        assertThat(networkApi.getApiOthers(), hasSize(3));
-    }
-
-    @Test
-    void shouldAddAdditionalApiElementsWhenHandlingClientCertificates() {
-        // Given
-        given(extensionNetwork.isHandleLocalServers()).willReturn(true);
-        given(extensionNetwork.isHandleClientCerts()).willReturn(true);
         ExtensionNetwork.handleConnection = true;
         // When
         networkApi = new NetworkApi(extensionNetwork);
@@ -1649,7 +1635,6 @@ class NetworkApiUnitTest extends TestUtils {
         params.put("password", password);
         int index = 1234;
         params.put("index", index);
-        given(extensionNetwork.isHandleClientCerts()).willReturn(true);
         given(clientCertificatesOptions.addPkcs12Certificate()).willReturn(true);
         // When
         ApiResponse response = networkApi.handleApiAction(name, params);
@@ -1673,7 +1658,6 @@ class NetworkApiUnitTest extends TestUtils {
         params.put("password", password);
         int index = 1234;
         params.put("index", index);
-        given(extensionNetwork.isHandleClientCerts()).willReturn(true);
         given(clientCertificatesOptions.addPkcs12Certificate()).willReturn(false);
         // When
         ApiException exception =
@@ -1694,7 +1678,6 @@ class NetworkApiUnitTest extends TestUtils {
         String name = "setUseClientCertificate";
         JSONObject params = new JSONObject();
         params.put("use", use);
-        given(extensionNetwork.isHandleClientCerts()).willReturn(true);
         // When
         ApiResponse response = networkApi.handleApiAction(name, params);
         // Then
@@ -1702,25 +1685,10 @@ class NetworkApiUnitTest extends TestUtils {
         verify(clientCertificatesOptions).setUseCertificate(use);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"addPkcs12ClientCertificate", "setUseClientCertificate"})
-    void shouldThrowApiExceptionForUnsupportedActionsIfNotHandlingClientCertificates(String name)
-            throws Exception {
-        // Given
-        JSONObject params = new JSONObject();
-        given(extensionNetwork.isHandleClientCerts()).willReturn(false);
-        // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> networkApi.handleApiAction(name, params));
-        // Then
-        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_ACTION)));
-    }
-
     @Test
     void shouldHaveDescriptionsForAllApiElements() {
         given(extensionNetwork.isHandleLocalServers()).willReturn(true);
         ExtensionNetwork.handleConnection = true;
-        given(extensionNetwork.isHandleClientCerts()).willReturn(true);
         networkApi = new NetworkApi(extensionNetwork);
         List<String> missingKeys = new ArrayList<>();
         checkKey(networkApi.getDescriptionKey(), missingKeys);


### PR DESCRIPTION
Remove core client cert checks that provided compatibility with older core versions, the add-on is now targeting newer versions and should handle client certs always.