### PR TITLE
network: handle client connection options always

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptions.java
@@ -32,7 +32,6 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpRequestHeader;
-import org.parosproxy.paros.network.SSLConnector;
 import org.zaproxy.addon.network.internal.TlsUtils;
 import org.zaproxy.addon.network.internal.client.HttpProxy;
 import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
@@ -207,7 +206,6 @@ public class ConnectionOptions extends VersionedAbstractParam {
             }
         }
         tlsProtocols = protocols;
-        applyTlsProtocols();
         allowUnsafeRenegotiation = getBoolean(TLS_ALLOW_UNSAFE_RENEGOTIATION, false);
         setAllowUnsafeRenegotiationSystemProperty(allowUnsafeRenegotiation);
 
@@ -409,7 +407,6 @@ public class ConnectionOptions extends VersionedAbstractParam {
     public void setTlsProtocols(List<String> tlsProtocols) {
         this.tlsProtocols = TlsUtils.filterUnsupportedProtocols(tlsProtocols);
         persistTlsProtocols(tlsProtocols);
-        applyTlsProtocols();
 
         notifyChangesListeners();
     }
@@ -419,20 +416,6 @@ public class ConnectionOptions extends VersionedAbstractParam {
         for (int i = 0; i < tlsProtocols.size(); ++i) {
             String elementBaseKey = TLS_PROTOCOL_KEY + "(" + i + ")";
             getConfig().setProperty(elementBaseKey, tlsProtocols.get(i));
-        }
-    }
-
-    private void applyTlsProtocols() {
-        try {
-            SSLConnector.setClientEnabledProtocols(tlsProtocols.toArray(new String[0]));
-        } catch (IllegalArgumentException e) {
-            LOGGER.warn(
-                    "Failed to apply protocols {} falling back to {} caused by: {}",
-                    tlsProtocols,
-                    TlsUtils.getSupportedProtocols(),
-                    e.getMessage());
-            tlsProtocols = TlsUtils.getSupportedProtocols();
-            SSLConnector.setClientEnabledProtocols(tlsProtocols.toArray(new String[0]));
         }
     }
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptionsPanel.java
@@ -39,7 +39,6 @@ import javax.swing.JTabbedPane;
 import javax.swing.border.TitledBorder;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
-import org.parosproxy.paros.network.ConnectionParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.addon.network.internal.client.CommonUserAgents;
 import org.zaproxy.addon.network.internal.client.HttpProxy;
@@ -331,7 +330,7 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
             layout.setAutoCreateContainerGaps(true);
 
             hostTextField = new ZapTextField();
-            hostTextField.setText(ConnectionParam.DEFAULT_SOCKS_PROXY.getHost());
+            hostTextField.setText(ConnectionOptions.DEFAULT_HTTP_PROXY.getHost());
             JLabel hostLabel =
                     new JLabel(
                             Constant.messages.getString(
@@ -339,7 +338,7 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
             hostLabel.setLabelFor(hostTextField);
 
             portNumberSpinner =
-                    new ZapPortNumberSpinner(ConnectionParam.DEFAULT_SOCKS_PROXY.getPort());
+                    new ZapPortNumberSpinner(ConnectionOptions.DEFAULT_HTTP_PROXY.getPort());
             JLabel portLabel =
                     new JLabel(
                             Constant.messages.getString(
@@ -581,7 +580,7 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
             layout.setAutoCreateContainerGaps(true);
 
             hostTextField = new ZapTextField();
-            hostTextField.setText(ConnectionParam.DEFAULT_SOCKS_PROXY.getHost());
+            hostTextField.setText(ConnectionOptions.DEFAULT_SOCKS_PROXY.getHost());
             JLabel hostLabel =
                     new JLabel(
                             Constant.messages.getString(
@@ -589,7 +588,7 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
             hostLabel.setLabelFor(hostTextField);
 
             portNumberSpinner =
-                    new ZapPortNumberSpinner(ConnectionParam.DEFAULT_SOCKS_PROXY.getPort());
+                    new ZapPortNumberSpinner(ConnectionOptions.DEFAULT_SOCKS_PROXY.getPort());
             JLabel portLabel =
                     new JLabel(
                             Constant.messages.getString(

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
@@ -205,59 +205,56 @@ public class NetworkApi extends ApiImplementor {
             this.addApiShortcut(OTHER_PROXY_PAC);
         }
 
-        if (isHandleConnection(extensionNetwork)) {
-            this.addApiOthers(new ApiOther(OTHER_SET_PROXY, Arrays.asList(PARAM_PROXY)));
-            this.addApiShortcut(SHORTCUT_SET_PROXY);
+        this.addApiOthers(new ApiOther(OTHER_SET_PROXY, Arrays.asList(PARAM_PROXY)));
+        this.addApiShortcut(SHORTCUT_SET_PROXY);
 
-            this.addApiAction(
-                    new ApiAction(ACTION_SET_CONNECTION_TIMEOUT, Arrays.asList(PARAM_TIMEOUT)));
-            this.addApiAction(
-                    new ApiAction(ACTION_SET_DEFAULT_USER_AGENT, Arrays.asList(PARAM_USER_AGENT)));
-            this.addApiAction(
-                    new ApiAction(ACTION_SET_DNS_TTL_SUCCESSFUL_QUERIES, Arrays.asList(PARAM_TTL)));
-            this.addApiAction(
-                    new ApiAction(
-                            ACTION_ADD_HTTP_PROXY_EXCLUSION,
-                            Arrays.asList(PARAM_HOST),
-                            Arrays.asList(PARAM_ENABLED)));
-            this.addApiAction(
-                    new ApiAction(ACTION_REMOVE_HTTP_PROXY_EXCLUSION, Arrays.asList(PARAM_HOST)));
-            this.addApiAction(
-                    new ApiAction(
-                            ACTION_SET_HTTP_PROXY,
-                            Arrays.asList(PARAM_HOST, PARAM_PORT),
-                            Arrays.asList(PARAM_REALM, PARAM_USERNAME, PARAM_PASSWORD)));
-            this.addApiAction(
-                    new ApiAction(
-                            ACTION_SET_HTTP_PROXY_AUTH_ENABLED, Arrays.asList(PARAM_ENABLED)));
-            this.addApiAction(
-                    new ApiAction(ACTION_SET_HTTP_PROXY_ENABLED, Arrays.asList(PARAM_ENABLED)));
-            this.addApiAction(
-                    new ApiAction(
-                            ACTION_SET_HTTP_PROXY_EXCLUSION_ENABLED,
-                            Arrays.asList(PARAM_HOST, PARAM_ENABLED)));
-            this.addApiAction(
-                    new ApiAction(
-                            ACTION_SET_SOCKS_PROXY,
-                            Arrays.asList(PARAM_HOST, PARAM_PORT),
-                            Arrays.asList(
-                                    PARAM_VERSION, PARAM_USE_DNS, PARAM_USERNAME, PARAM_PASSWORD)));
-            this.addApiAction(
-                    new ApiAction(ACTION_SET_SOCKS_PROXY_ENABLED, Arrays.asList(PARAM_ENABLED)));
-            this.addApiAction(
-                    new ApiAction(ACTION_SET_USE_GLOBAL_HTTP_STATE, Arrays.asList(PARAM_USE)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_CONNECTION_TIMEOUT, Arrays.asList(PARAM_TIMEOUT)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_DEFAULT_USER_AGENT, Arrays.asList(PARAM_USER_AGENT)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_DNS_TTL_SUCCESSFUL_QUERIES, Arrays.asList(PARAM_TTL)));
+        this.addApiAction(
+                new ApiAction(
+                        ACTION_ADD_HTTP_PROXY_EXCLUSION,
+                        Arrays.asList(PARAM_HOST),
+                        Arrays.asList(PARAM_ENABLED)));
+        this.addApiAction(
+                new ApiAction(ACTION_REMOVE_HTTP_PROXY_EXCLUSION, Arrays.asList(PARAM_HOST)));
+        this.addApiAction(
+                new ApiAction(
+                        ACTION_SET_HTTP_PROXY,
+                        Arrays.asList(PARAM_HOST, PARAM_PORT),
+                        Arrays.asList(PARAM_REALM, PARAM_USERNAME, PARAM_PASSWORD)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_HTTP_PROXY_AUTH_ENABLED, Arrays.asList(PARAM_ENABLED)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_HTTP_PROXY_ENABLED, Arrays.asList(PARAM_ENABLED)));
+        this.addApiAction(
+                new ApiAction(
+                        ACTION_SET_HTTP_PROXY_EXCLUSION_ENABLED,
+                        Arrays.asList(PARAM_HOST, PARAM_ENABLED)));
+        this.addApiAction(
+                new ApiAction(
+                        ACTION_SET_SOCKS_PROXY,
+                        Arrays.asList(PARAM_HOST, PARAM_PORT),
+                        Arrays.asList(
+                                PARAM_VERSION, PARAM_USE_DNS, PARAM_USERNAME, PARAM_PASSWORD)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_SOCKS_PROXY_ENABLED, Arrays.asList(PARAM_ENABLED)));
+        this.addApiAction(
+                new ApiAction(ACTION_SET_USE_GLOBAL_HTTP_STATE, Arrays.asList(PARAM_USE)));
 
-            this.addApiView(new ApiView(VIEW_GET_CONNECTION_TIMEOUT));
-            this.addApiView(new ApiView(VIEW_GET_DEFAULT_USER_AGENT));
-            this.addApiView(new ApiView(VIEW_GET_DNS_TTL_SUCCESSFUL_QUERIES));
-            this.addApiView(new ApiView(VIEW_GET_HTTP_PROXY));
-            this.addApiView(new ApiView(VIEW_GET_HTTP_PROXY_EXCLUSIONS));
-            this.addApiView(new ApiView(VIEW_GET_SOCKS_PROXY));
-            this.addApiView(new ApiView(VIEW_IS_HTTP_PROXY_AUTH_ENABLED));
-            this.addApiView(new ApiView(VIEW_IS_HTTP_PROXY_ENABLED));
-            this.addApiView(new ApiView(VIEW_IS_SOCKS_PROXY_ENABLED));
-            this.addApiView(new ApiView(VIEW_IS_USE_GLOBAL_HTTP_STATE));
-        }
+        this.addApiView(new ApiView(VIEW_GET_CONNECTION_TIMEOUT));
+        this.addApiView(new ApiView(VIEW_GET_DEFAULT_USER_AGENT));
+        this.addApiView(new ApiView(VIEW_GET_DNS_TTL_SUCCESSFUL_QUERIES));
+        this.addApiView(new ApiView(VIEW_GET_HTTP_PROXY));
+        this.addApiView(new ApiView(VIEW_GET_HTTP_PROXY_EXCLUSIONS));
+        this.addApiView(new ApiView(VIEW_GET_SOCKS_PROXY));
+        this.addApiView(new ApiView(VIEW_IS_HTTP_PROXY_AUTH_ENABLED));
+        this.addApiView(new ApiView(VIEW_IS_HTTP_PROXY_ENABLED));
+        this.addApiView(new ApiView(VIEW_IS_SOCKS_PROXY_ENABLED));
+        this.addApiView(new ApiView(VIEW_IS_USE_GLOBAL_HTTP_STATE));
 
         addApiAction(
                 new ApiAction(
@@ -271,10 +268,6 @@ public class NetworkApi extends ApiImplementor {
 
     private static boolean isHandleLocalServers(ExtensionNetwork extensionNetwork) {
         return extensionNetwork == null || extensionNetwork.isHandleLocalServers();
-    }
-
-    private static boolean isHandleConnection(ExtensionNetwork extensionNetwork) {
-        return extensionNetwork == null || ExtensionNetwork.isHandleConnection();
     }
 
     @Override
@@ -298,9 +291,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case ACTION_ADD_HTTP_PROXY_EXCLUSION:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     Pattern host = createHostPattern(params.getString(PARAM_HOST));
                     boolean enabled = getParam(params, PARAM_ENABLED, true);
                     HttpProxyExclusion exclusion = new HttpProxyExclusion(host, enabled);
@@ -392,9 +382,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case ACTION_REMOVE_HTTP_PROXY_EXCLUSION:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     String host = params.getString(PARAM_HOST);
                     boolean removed =
                             extensionNetwork.getConnectionOptions().removeHttpProxyExclusion(host);
@@ -448,36 +435,24 @@ public class NetworkApi extends ApiImplementor {
                 }
             case ACTION_SET_CONNECTION_TIMEOUT:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     int timeout = ApiUtils.getIntParam(params, PARAM_TIMEOUT);
                     extensionNetwork.getConnectionOptions().setTimeoutInSecs(timeout);
                     return ApiResponseElement.OK;
                 }
             case ACTION_SET_DEFAULT_USER_AGENT:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     String userAgent = params.getString(PARAM_USER_AGENT);
                     extensionNetwork.getConnectionOptions().setDefaultUserAgent(userAgent);
                     return ApiResponseElement.OK;
                 }
             case ACTION_SET_DNS_TTL_SUCCESSFUL_QUERIES:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     int ttl = ApiUtils.getIntParam(params, PARAM_TTL);
                     extensionNetwork.getConnectionOptions().setDnsTtlSuccessfulQueries(ttl);
                     return ApiResponseElement.OK;
                 }
             case ACTION_SET_HTTP_PROXY:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     String host = params.getString(PARAM_HOST);
                     int port = getParam(params, PARAM_PORT, -1);
                     if (!isValidPort(port)) {
@@ -500,27 +475,18 @@ public class NetworkApi extends ApiImplementor {
                 }
             case ACTION_SET_HTTP_PROXY_AUTH_ENABLED:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     boolean enabled = getParam(params, PARAM_ENABLED, false);
                     extensionNetwork.getConnectionOptions().setHttpProxyAuthEnabled(enabled);
                     return ApiResponseElement.OK;
                 }
             case ACTION_SET_HTTP_PROXY_ENABLED:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     boolean enabled = getParam(params, PARAM_ENABLED, false);
                     extensionNetwork.getConnectionOptions().setHttpProxyEnabled(enabled);
                     return ApiResponseElement.OK;
                 }
             case ACTION_SET_HTTP_PROXY_EXCLUSION_ENABLED:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     String host = params.getString(PARAM_HOST);
                     boolean enabled = getParam(params, PARAM_ENABLED, true);
                     boolean changed =
@@ -568,9 +534,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case ACTION_SET_SOCKS_PROXY:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     String host = params.getString(PARAM_HOST);
                     int port = getParam(params, PARAM_PORT, -1);
                     if (!isValidPort(port)) {
@@ -600,18 +563,12 @@ public class NetworkApi extends ApiImplementor {
                 }
             case ACTION_SET_SOCKS_PROXY_ENABLED:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     boolean enabled = getParam(params, PARAM_ENABLED, false);
                     extensionNetwork.getConnectionOptions().setSocksProxyEnabled(enabled);
                     return ApiResponseElement.OK;
                 }
             case ACTION_SET_USE_GLOBAL_HTTP_STATE:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_ACTION);
-                    }
                     boolean use = getParam(params, PARAM_USE, false);
                     extensionNetwork.getConnectionOptions().setUseGlobalHttpState(use);
                     return ApiResponseElement.OK;
@@ -700,34 +657,22 @@ public class NetworkApi extends ApiImplementor {
                 }
             case VIEW_GET_CONNECTION_TIMEOUT:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     int timeout = extensionNetwork.getConnectionOptions().getTimeoutInSecs();
                     return new ApiResponseElement(name, String.valueOf(timeout));
                 }
             case VIEW_GET_DEFAULT_USER_AGENT:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     String userAgent =
                             extensionNetwork.getConnectionOptions().getDefaultUserAgent();
                     return new ApiResponseElement(name, userAgent);
                 }
             case VIEW_GET_DNS_TTL_SUCCESSFUL_QUERIES:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     int ttl = extensionNetwork.getConnectionOptions().getDnsTtlSuccessfulQueries();
                     return new ApiResponseElement(name, String.valueOf(ttl));
                 }
             case VIEW_GET_HTTP_PROXY:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     HttpProxy proxy = extensionNetwork.getConnectionOptions().getHttpProxy();
                     Map<String, Object> proxyData = new LinkedHashMap<>();
                     proxyData.put("host", proxy.getHost());
@@ -740,9 +685,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case VIEW_GET_HTTP_PROXY_EXCLUSIONS:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     ApiResponseList response = new ApiResponseList(name);
                     for (HttpProxyExclusion exclusion :
                             extensionNetwork.getConnectionOptions().getHttpProxyExclusions()) {
@@ -807,9 +749,6 @@ public class NetworkApi extends ApiImplementor {
                                         .toDays()));
             case VIEW_GET_SOCKS_PROXY:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     SocksProxy proxy = extensionNetwork.getConnectionOptions().getSocksProxy();
                     Map<String, Object> proxyData = new LinkedHashMap<>();
                     proxyData.put("host", proxy.getHost());
@@ -823,9 +762,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case VIEW_IS_HTTP_PROXY_AUTH_ENABLED:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     return new ApiResponseElement(
                             name,
                             String.valueOf(
@@ -835,9 +771,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case VIEW_IS_HTTP_PROXY_ENABLED:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     return new ApiResponseElement(
                             name,
                             String.valueOf(
@@ -845,9 +778,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case VIEW_IS_SOCKS_PROXY_ENABLED:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     return new ApiResponseElement(
                             name,
                             String.valueOf(
@@ -855,9 +785,6 @@ public class NetworkApi extends ApiImplementor {
                 }
             case VIEW_IS_USE_GLOBAL_HTTP_STATE:
                 {
-                    if (!isHandleConnection(extensionNetwork)) {
-                        throw new ApiException(ApiException.Type.BAD_VIEW);
-                    }
                     return new ApiResponseElement(
                             name,
                             String.valueOf(
@@ -915,9 +842,6 @@ public class NetworkApi extends ApiImplementor {
                 return msg;
 
             case OTHER_SET_PROXY:
-                if (!isHandleConnection(extensionNetwork)) {
-                    throw new ApiException(ApiException.Type.BAD_OTHER);
-                }
 
                 /* JSON string:
                  *  {"type":1,
@@ -982,11 +906,7 @@ public class NetworkApi extends ApiImplementor {
             return handleApiOther(msg, OTHER_PROXY_PAC, new JSONObject());
         }
 
-        if (isHandleConnection(extensionNetwork)
-                && msg.getRequestHeader()
-                        .getURI()
-                        .getEscapedPath()
-                        .startsWith("/" + SHORTCUT_SET_PROXY)) {
+        if (msg.getRequestHeader().getURI().getEscapedPath().startsWith("/" + SHORTCUT_SET_PROXY)) {
             JSONObject params = new JSONObject();
             params.put(PARAM_PROXY, msg.getRequestBody().toString());
             return this.handleApiOther(msg, OTHER_SET_PROXY, params);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import org.parosproxy.paros.network.ConnectionParam;
+import org.zaproxy.addon.network.ConnectionOptions;
 import org.zaproxy.addon.network.internal.ChannelAttributes;
 import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
 import org.zaproxy.addon.network.internal.codec.HttpRequestDecoder;
@@ -118,7 +118,7 @@ public class HttpServer extends BaseServer {
         ch.pipeline()
                 .addLast(
                         "timeout",
-                        new ReadTimeoutHandler(ConnectionParam.DEFAULT_TIMEOUT, TimeUnit.SECONDS))
+                        new ReadTimeoutHandler(ConnectionOptions.DEFAULT_TIMEOUT, TimeUnit.SECONDS))
                 .addLast("tls.upgrade", new TlsProtocolHandler())
                 .addLast("http.decoder", new HttpRequestDecoder())
                 .addLast("http.encoder", HttpResponseEncoder.getInstance())


### PR DESCRIPTION
Remove core client connection options checks that provided compatibility with older core versions.