### PR TITLE
bugtracker: address warnings

### DIFF
--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.12.0.
+- Maintenance changes.
 
 ## [4] - 2022-09-23
 ### Changed

--- a/addOns/bugtracker/bugtracker.gradle.kts
+++ b/addOns/bugtracker/bugtracker.gradle.kts
@@ -1,9 +1,5 @@
 description = "Bug Tracker extension."
 
-tasks.withType<JavaCompile> {
-    options.compilerArgs = options.compilerArgs - "-Werror" + "-proc:none"
-}
-
 zapAddOn {
     addOnName.set("Bug Tracker")
     zapVersion.set("2.12.0")
@@ -15,6 +11,10 @@ zapAddOn {
 }
 
 dependencies {
+    compileOnly("com.infradna.tool:bridge-method-annotation:1.18") {
+        exclude(group = "org.jenkins-ci")
+    }
+    compileOnly("com.github.spotbugs:spotbugs-annotations:3.1.12")
     implementation("com.j2bugzilla:j2bugzilla:2.2.1") {
         // Not needed.
         exclude(group = "junit")

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzillaTableModel.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzillaTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class BugTrackerBugzillaTableModel
         extends AbstractMultipleOptionsTableModel<BugTrackerBugzillaConfigParams> {
 

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubTableModel.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class BugTrackerGithubTableModel
         extends AbstractMultipleOptionsTableModel<BugTrackerGithubConfigParams> {
 

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/DialogAddBugzillaConfig.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/DialogAddBugzillaConfig.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddBugzillaConfig extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/DialogAddGithubConfig.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/DialogAddGithubConfig.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddGithubConfig extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/PopupMenuItemAlert.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/PopupMenuItemAlert.java
@@ -42,9 +42,9 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
  * An {@link ExtensionPopupMenuItem} that exposes the selected {@link Alert alerts} of the Alerts
  * tree.
  *
- * @since TODO add version
  * @see #performAction(Alert)
  */
+@SuppressWarnings("serial")
 public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/PopupSemiAutoIssue.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/PopupSemiAutoIssue.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class PopupSemiAutoIssue extends PopupMenuItemAlert {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/RaiseSemiAutoIssueDialog.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/RaiseSemiAutoIssueDialog.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class RaiseSemiAutoIssueDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = -3223449799557586758L;


### PR DESCRIPTION
Address remaining warnings and remove compiler flags that were suppressing them.