### PR TITLE
domxss: increase again allowed requests in tests

### DIFF
--- a/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
+++ b/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
@@ -93,7 +93,7 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
     @Override
     protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
         if (strength == AttackStrength.LOW) {
-            return NUMBER_MSGS_ATTACK_STRENGTH_LOW + 1;
+            return NUMBER_MSGS_ATTACK_STRENGTH_LOW + 3;
         }
         return super.getRecommendMaxNumberMessagesPerParam(strength);
     }


### PR DESCRIPTION
Allow 3 more requests to prevent intermittent failures.

---
e.g. https://github.com/zaproxy/zap-extensions/actions/runs/3339561777/jobs/5528661644#step:7:485
It also caused the weekly to fail earlier https://github.com/zaproxy/zaproxy/actions/runs/3338047891/jobs/5525190759#step:4:67