### PR TITLE
exim: correct messages keys and add API config

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Show missing API endpoints' descriptions.
 
 ## [0.3.0] - 2022-10-27
 ### Changed

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -37,6 +37,11 @@ zapAddOn {
             }
         }
     }
+
+    apiClientGen {
+        api.set("org.zaproxy.addon.exim.ImportExportApi")
+        messages.set(file("src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties"))
+    }
 }
 
 crowdin {

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -21,7 +21,8 @@ exim.har.file.import.error = Could not import the file {0}
 exim.har.topmenu.import.importhar = Import HAR (HTTP Archive File)
 exim.har.topmenu.import.importhar.tooltip = Import a HTTP Archive File and add the messages to the sites tree and history panel.
 
-exim.api.action.importurls = Imports URLs (one per line) from the file with the given file system path.
+exim.api.action.importHar = Imports a HAR file.
+exim.api.action.importUrls = Imports URLs (one per line) from the file with the given file system path.
 
 exim.api.desc = Export/Import functionality.
 
@@ -39,8 +40,8 @@ exim.importurls.topmenu.import = Import a File Containing URLs
 exim.importurls.topmenu.import.tooltip = The file must be plain text with one URL per line.\nBlank lines and lines starting with a # are ignored.
 exim.importurls.warn.scheme = \"{0}\" does not have a scheme.
 
-exim.api.action.importzaplogs = Imports previously exported ZAP messages from the file with the given file system path.
-exim.api.action.importmodsec2logs = Imports ModSecurity2 logs from the file with the given file system path.
+exim.api.action.importZapLogs = Imports previously exported ZAP messages from the file with the given file system path.
+exim.api.action.importModsec2Logs = Imports ModSecurity2 logs from the file with the given file system path.
 exim.importLogFiles.import.menu.label=Import URLs from Logs or raw Files...
 exim.importLogFiles.choosefile.filter.txt.description = Text File (*.txt)
 exim.importLogFiles.choosefile.filter.log.description = Log File (*.log)


### PR DESCRIPTION
Correct the case of API endpoints' messages keys.
Add a missing API endpoint description.
Add API configuration for client generation.