### PR TITLE
encoder: Simplify script use

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Allow script processors to return strings without requiring an "EncodeDecodeResult" wrapper.
 
 ## [0.7.0] - 2022-10-27
 ### Changed

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/script/EncodeDecodeScript.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/script/EncodeDecodeScript.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.encoder.processors.script;
 
-import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
-
 public interface EncodeDecodeScript {
-    EncodeDecodeResult process(String value) throws Exception;
+    Object process(String value) throws Exception;
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/script/ScriptBasedEncodeDecodeProcessor.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/script/ScriptBasedEncodeDecodeProcessor.java
@@ -75,7 +75,10 @@ public class ScriptBasedEncodeDecodeProcessor implements EncodeDecodeProcessor {
             EncodeDecodeScript script = evaluateScript(scriptWrapper);
             if (script != null) {
                 LOGGER.debug("Calling encode/decode script {}", scriptWrapper.getName());
-                return script.process(value);
+                Object result = script.process(value);
+                return result instanceof EncodeDecodeResult
+                        ? (EncodeDecodeResult) result
+                        : new EncodeDecodeResult(result == null ? null : result.toString());
             } else {
                 String errorMsg =
                         Constant.messages.getString(
@@ -92,10 +95,12 @@ public class ScriptBasedEncodeDecodeProcessor implements EncodeDecodeProcessor {
 
     private EncodeDecodeScript evaluateScript(ScriptWrapper scriptWrapper)
             throws javax.script.ScriptException, java.io.IOException {
-
-        String md5AsHex = getMd5HashAsHex(scriptWrapper.getContents());
-        if (StringUtils.equals(cachedScriptHash, md5AsHex)) {
-            return cachedScript;
+        String md5AsHex = null;
+        if (cachedScript != null) {
+            md5AsHex = getMd5HashAsHex(scriptWrapper.getContents());
+            if (StringUtils.equals(cachedScriptHash, md5AsHex)) {
+                return cachedScript;
+            }
         }
 
         ExtensionScript extensionScript = ExtensionEncoder.getExtensionScript();

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -172,7 +172,8 @@ Will display the SHA1 hash of the text you enter.
 Will display the SHA256 hash of the text you enter.
 
 <H3>Custom</H3>
-Custom "Encode/Decode" scripts can be created/added to the Scripts Tree and used by custom Output Panels.
+Custom "Encode/Decode" scripts can be created/added to the Scripts Tree and used by custom Output Panels. They should return <code>EncodeDecodeResult</code> objects as indicated by the templates. However,
+in the event that users aren't careful in doing so will return other data types leveraging their <code>toString()</code> implementation (which may or may not be useful/obvious at first glance).
 
 <H2>Accessed via</H2>
 <table>

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/script/EncodeDecodeScriptUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/script/EncodeDecodeScriptUnitTest.java
@@ -1,0 +1,112 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors.predefined.script;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.IOException;
+import java.util.List;
+import javax.script.ScriptException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.encoder.ExtensionEncoder;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
+import org.zaproxy.addon.encoder.processors.script.EncodeDecodeScript;
+import org.zaproxy.addon.encoder.processors.script.ScriptBasedEncodeDecodeProcessor;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+public class EncodeDecodeScriptUnitTest {
+
+    private EncodeDecodeScript script;
+    private ScriptBasedEncodeDecodeProcessor processor;
+
+    @BeforeEach
+    void setup() throws ScriptException, IOException {
+        Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        Model.setSingletonForTesting(model);
+        ExtensionLoader extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+        ExtensionScript extScript = mock(ExtensionScript.class, withSettings().lenient());
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extScript);
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.isEnabled()).willReturn(true);
+        given(extScript.getScripts(ExtensionEncoder.SCRIPT_TYPE_ENCODE_DECODE))
+                .willReturn(List.of(scriptWrapper));
+        script = mock(EncodeDecodeScript.class);
+        given(extScript.getInterface(scriptWrapper, EncodeDecodeScript.class)).willReturn(script);
+        processor = new ScriptBasedEncodeDecodeProcessor("testScript");
+        given(scriptWrapper.getName()).willReturn("testScript");
+    }
+
+    @Test
+    void shouldHandleExpectedResultObject() throws Exception {
+        // Given
+        String admin = "admin";
+        EncodeDecodeResult expected = new EncodeDecodeResult(admin);
+        given(script.process(admin)).willReturn(expected);
+        // When
+        EncodeDecodeResult result = processor.process(admin);
+        // Then
+        assertThat(result, is(equalTo(expected)));
+    }
+
+    @Test
+    void shouldHandleStringResultObject() throws Exception {
+        // Given
+        String admin = "admin";
+        given(script.process(admin)).willReturn(admin);
+        // When
+        EncodeDecodeResult result = processor.process(admin);
+        // Then
+        assertThat(result.getResult(), is(equalTo(admin)));
+    }
+
+    @Test
+    void shouldHandleUnexpectedReturnType() throws Exception {
+        // Given
+        String admin = "admin";
+        given(script.process(admin)).willReturn(6667);
+        // When
+        EncodeDecodeResult result = processor.process(admin);
+        // Then
+        assertThat(result.getResult(), is(equalTo("6667")));
+    }
+
+    @Test
+    void shouldHandleNullReturnType() throws Exception {
+        // Given
+        String admin = "admin";
+        given(script.process(admin)).willReturn(null);
+        // When
+        EncodeDecodeResult result = processor.process(admin);
+        // Then
+        assertThat(result.getResult(), is(equalTo(null)));
+    }
+}


### PR DESCRIPTION
- CHANGELOG > Add change note.
- EncodeDecodeScript > Update handling: If the script returns an EncodeDecodeResult then just use it, if String then use it to instantiate a new EncodeDecodeResult.
- ScriptBasedEncodeDecodeProcessor > Return Object generically in the process method.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>