### PR TITLE
openapi: Use latest version of parsing library

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [29] - 2022-10-27
 ### Changed

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -77,8 +77,8 @@ dependencies {
     compileOnly(parent!!.childProjects.get("formhandler")!!)
     compileOnly(parent!!.childProjects.get("spider")!!)
 
-    implementation("io.swagger.parser.v3:swagger-parser:2.0.28")
-    implementation("io.swagger:swagger-compat-spec-parser:1.0.56") {
+    implementation("io.swagger.parser.v3:swagger-parser:2.1.7")
+    implementation("io.swagger:swagger-compat-spec-parser:1.0.63") {
         // Not needed:
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
@@ -51,7 +51,6 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -401,17 +400,7 @@ public class SwaggerConverter implements Converter {
             String url = server.getUrl();
             if (server.getVariables() != null) {
                 for (Map.Entry<String, ServerVariable> entry : server.getVariables().entrySet()) {
-                    // TODO: Remove the null check in the code below.
-                    // The following code is a workaround for a bug in Swagger-Parser where empty
-                    // strings were converted to null values.
-                    // It was fixed in Swagger-Parser version 2.0.29, but a different bug was
-                    // introduced where malformed schemas (e.g. in our unit tests) end up throwing
-                    // NPEs instead of returning a list of errors.
-                    // See https://github.com/swagger-api/swagger-parser/issues/1685.
-                    url =
-                            url.replace(
-                                    "{" + entry.getKey() + "}",
-                                    ObjectUtils.firstNonNull(entry.getValue().getDefault(), ""));
+                    url = url.replace("{" + entry.getKey() + "}", entry.getValue().getDefault());
                 }
             }
             try {

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
@@ -316,7 +316,7 @@ class OpenApiUnitTest extends AbstractServerTest {
         // Then
         assertThat(converter.getErrorMessages(), is(empty()));
         assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\",\"x\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\",\"x\":{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\",\"x\":\"John Doe\"}],\"status\":\"available\"}}],\"status\":\"available\"}",
                 accessedUrls.get("POST http://" + host + "/PetStore/pet"));
     }
 


### PR DESCRIPTION
Update `io.swagger.parser.v3:swagger-parser` to version 2.1.7.

Signed-off-by: ricekot <github@ricekot.com>