### PR TITLE
reports: XML & JSON Include Program Name metadata

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+# Changed
+- The XML and JSON reports now include programName metadata elements (Issue 6640).
 
 ## [0.16.0] - 2022-10-27
 ### Added

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -392,6 +392,7 @@ public class ExtensionReports extends ExtensionAdaptor {
                         "generatedString", SIMPLE_DATE_FORMAT.format(System.currentTimeMillis()));
             }
             context.setVariable("zapVersion", Constant.PROGRAM_VERSION);
+            context.setVariable("programName", Constant.PROGRAM_NAME);
 
             if (reportDataHandler != null) {
                 reportDataHandler.handle(reportData);

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
@@ -1,4 +1,5 @@
 {
+    "@programName": [[${programName}]],
     "@version": [[${zapVersion}]],
     "@generated": [[${generatedString}]],
     "site":[ [#th:block th:each="site, siteState: ${reportData.sites}"][#th:block th:if="${! siteState.first}"],[/th:block]

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json/report.json
@@ -1,4 +1,5 @@
 {
+	"@programName": [[${programName}]],
 	"@version": [[${zapVersion}]],
 	"@generated": [[${generatedString}]],
 	"site":[ [#th:block th:each="site, siteState: ${reportData.sites}"][#th:block th:if="${! siteState.first}"],[/th:block]

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml-plus/report.xml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml-plus/report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <OWASPZAPReport
-	th:attr="version=${zapVersion}, generated=${generatedString}">
+	th:attr="programName=${programName}, version=${zapVersion}, generated=${generatedString}">
 	<th:block th:each="site: ${reportData.sites}">
 		<site th:name="${site}"
 			th:attr="host=${helper.getHostForSite(site)}, port=${helper.getPortForSite(site)}, ssl=${helper.isSslSite(site)}">

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <OWASPZAPReport
-	th:attr="version=${zapVersion}, generated=${generatedString}">
+	th:attr="programName=${programName}, version=${zapVersion}, generated=${generatedString}">
 	<th:block th:each="site: ${reportData.sites}">
 		<site th:name="${site}"
 			th:attr="host=${helper.getHostForSite(site)}, port=${helper.getPortForSite(site)}, ssl=${helper.isSslSite(site)}">

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json-plus.json
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json-plus.json
@@ -1,4 +1,5 @@
 {
+    "@programName": "OWASP ZAP",
     "@version": "Dev Build",
     "@generated": "Thu, 20 Oct 2022 17:10:46",
     "site":[ 

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json.json
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json.json
@@ -1,4 +1,5 @@
 {
+	"@programName": "OWASP ZAP",
 	"@version": "Dev Build",
 	"@generated": "Thu, 17 Jun 2021 16:04:28",
 	"site":[ 

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml-plus.xml
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml-plus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<OWASPZAPReport version="Dev Build" generated="Thu, 20 Oct 2022 17:11:39">
+<OWASPZAPReport programName="OWASP ZAP" version="Dev Build" generated="Thu, 20 Oct 2022 17:11:39">
 	
 		<site name="http://example.com" host="example.com" port="80" ssl="false">
 			<alerts>

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml.xml
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<OWASPZAPReport version="Dev Build" generated="Tue, 22 Jun 2021 15:11:26">
+<OWASPZAPReport programName="OWASP ZAP" version="Dev Build" generated="Tue, 22 Jun 2021 15:11:26">
 	
 		<site name="http://example.com" host="example.com" port="80" ssl="false">
 			<alerts>


### PR DESCRIPTION
- CHANGELOG > Add change note.
- ExtensionReports > Set a variable to be available for report metadata "programName".
- json and xml templates > Include the new metadata element.
- UnitTest samples > Updated with the new metadata element.

Fixes zaproxy/zaproxy#6640

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>