### PR TITLE
encoder: Add hasher lower case option and new default

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show help and options buttons in the main dialog.
 - The Base64 decoder now uses a Mime decoder and handles line wrapped input.
 
+### Added
+- Add an option which controls whether or not Hash output panels use full caps or lower case (Issue 7503).
+
 ## [0.7.0] - 2022-10-27
 ### Changed
 - Maintenance changes.

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/EncodeDecodeOptions.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/EncodeDecodeOptions.java
@@ -35,6 +35,7 @@ public class EncodeDecodeOptions extends VersionedAbstractParam {
 
     private static final String PARAM_BASE64_CHARSET = "encoder.base64charset";
     private static final String PARAM_BASE64_DO_BREAK_LINES = "encoder.base64dobreaklines";
+    private static final String PARAM_HASHERS_DO_LOWERCASE = "encoder.hashers.lowercase";
 
     private static final String CORE_PARAM_BASE64_CHARSET = "encode.param.base64charset";
     private static final String CORE_PARAM_BASE64_DO_BREAK_LINES =
@@ -42,9 +43,11 @@ public class EncodeDecodeOptions extends VersionedAbstractParam {
 
     public static final String DEFAULT_CHARSET = "UTF-8";
     public static final boolean DEFAULT_DO_BREAK_LINES = true;
+    public static final boolean DEFAULT_DO_LOWERCASE = true;
 
     private String base64Charset;
     private boolean base64DoBreakLines;
+    private boolean hashersLowerCase;
 
     public EncodeDecodeOptions() {
         base64Charset = DEFAULT_CHARSET;
@@ -69,10 +72,20 @@ public class EncodeDecodeOptions extends VersionedAbstractParam {
         getConfig().setProperty(PARAM_BASE64_DO_BREAK_LINES, base64OuputBreak);
     }
 
+    public boolean isHashersLowerCase() {
+        return hashersLowerCase;
+    }
+
+    public void setHashersLowerCase(boolean hashersLowerCase) {
+        this.hashersLowerCase = hashersLowerCase;
+        getConfig().setProperty(PARAM_HASHERS_DO_LOWERCASE, hashersLowerCase);
+    }
+
     @Override
     protected void parseImpl() {
         base64DoBreakLines = getBoolean(PARAM_BASE64_DO_BREAK_LINES, DEFAULT_DO_BREAK_LINES);
         base64Charset = getString(PARAM_BASE64_CHARSET, DEFAULT_CHARSET);
+        hashersLowerCase = getBoolean(PARAM_HASHERS_DO_LOWERCASE, DEFAULT_DO_LOWERCASE);
     }
 
     @Override

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/EncodeDecodeOptionsPanel.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/EncodeDecodeOptionsPanel.java
@@ -46,14 +46,20 @@ public class EncodeDecodeOptionsPanel extends AbstractParamPanel {
             Constant.messages.getString("encoder.optionspanel.base64.charset");
     private static final String BREAK_LINES_LABEL =
             Constant.messages.getString("encoder.optionspanel.base64.breaklines");
+    private static final String NAME_HASHERS =
+            Constant.messages.getString("encoder.optionspanel.hashers");
+    private static final String HASHERS_LOWERCASE_LABEL =
+            Constant.messages.getString("encoder.optionspanel.hashers.output.lowercase");
 
     private static final String[] CHARSETS = {"ISO-8859-1", "US-ASCII", "UTF-8"};
 
     private JComboBox<String> comboBoxBase64Charset;
 
     private JCheckBox checkBoxBase64DoBreakLines;
+    private JCheckBox checkBoxHashersLowerCase;
 
     private JPanel base64Panel;
+    private JPanel hashersPanel;
 
     public EncodeDecodeOptionsPanel() {
         super();
@@ -61,12 +67,22 @@ public class EncodeDecodeOptionsPanel extends AbstractParamPanel {
 
         setLayout(new BorderLayout(0, 0));
 
-        final JPanel panel = new JPanel(new BorderLayout());
+        final JPanel panel = new JPanel(new GridBagLayout());
         panel.setBorder(new EmptyBorder(2, 2, 2, 2));
 
-        panel.add(getBase64Panel(), BorderLayout.NORTH);
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.insets = new java.awt.Insets(2, 2, 2, 2);
+        gbc.anchor = GridBagConstraints.NORTH;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weighty = 0.0D;
+        gbc.weightx = 1.0D;
+        panel.add(getBase64Panel(), gbc);
+        gbc.gridy = 1;
+        panel.add(getHashersPanel(), gbc);
 
-        add(panel);
+        add(panel, BorderLayout.NORTH);
     }
 
     private JPanel getBase64Panel() {
@@ -124,6 +140,41 @@ public class EncodeDecodeOptionsPanel extends AbstractParamPanel {
         return checkBoxBase64DoBreakLines;
     }
 
+    private JPanel getHashersPanel() {
+        if (hashersPanel == null) {
+            hashersPanel = new JPanel();
+            hashersPanel.setLayout(new GridBagLayout());
+
+            GridBagConstraints gbc = new GridBagConstraints();
+
+            hashersPanel.setBorder(
+                    BorderFactory.createTitledBorder(
+                            null,
+                            NAME_HASHERS,
+                            TitledBorder.DEFAULT_JUSTIFICATION,
+                            TitledBorder.DEFAULT_POSITION,
+                            FontUtils.getFont(FontUtils.Size.standard)));
+
+            gbc.anchor = GridBagConstraints.NORTHWEST;
+            gbc.gridx = 0;
+            gbc.gridy = 1;
+            gbc.weightx = 1.0D;
+            hashersPanel.add(new JLabel(HASHERS_LOWERCASE_LABEL), gbc);
+
+            gbc.gridx = 1;
+            gbc.gridy = 1;
+            hashersPanel.add(getCheckBoxHashersLowerCase(), gbc);
+        }
+        return hashersPanel;
+    }
+
+    private JCheckBox getCheckBoxHashersLowerCase() {
+        if (checkBoxHashersLowerCase == null) {
+            checkBoxHashersLowerCase = new JCheckBox();
+        }
+        return checkBoxHashersLowerCase;
+    }
+
     @Override
     public void initParam(Object obj) {
         final OptionsParam options = (OptionsParam) obj;
@@ -132,6 +183,7 @@ public class EncodeDecodeOptionsPanel extends AbstractParamPanel {
         comboBoxBase64Charset.setSelectedItem(param.getBase64Charset());
 
         checkBoxBase64DoBreakLines.setSelected(param.isBase64DoBreakLines());
+        checkBoxHashersLowerCase.setSelected(param.isHashersLowerCase());
     }
 
     @Override
@@ -142,6 +194,7 @@ public class EncodeDecodeOptionsPanel extends AbstractParamPanel {
         param.setBase64Charset((String) comboBoxBase64Charset.getSelectedItem());
 
         param.setBase64DoBreakLines(checkBoxBase64DoBreakLines.isSelected());
+        param.setHashersLowerCase(checkBoxHashersLowerCase.isSelected());
     }
 
     @Override

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HashProcessor.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HashProcessor.java
@@ -21,6 +21,9 @@ package org.zaproxy.addon.encoder.processors.predefined;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import org.parosproxy.paros.control.Control;
+import org.zaproxy.addon.encoder.EncodeDecodeOptions;
+import org.zaproxy.addon.encoder.ExtensionEncoder;
 
 public class HashProcessor extends DefaultEncodeDecodeProcessor {
 
@@ -32,7 +35,13 @@ public class HashProcessor extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws NoSuchAlgorithmException {
-        return HexStringEncoder.getHexString(getHash(value.getBytes()));
+        EncodeDecodeOptions encDecOpts =
+                Control.getSingleton()
+                        .getExtensionLoader()
+                        .getExtension(ExtensionEncoder.class)
+                        .getOptions();
+        String output = HexStringEncoder.getHexString(getHash(value.getBytes()));
+        return encDecOpts.isHashersLowerCase() ? output.toLowerCase() : output;
     }
 
     private byte[] getHash(byte[] buf) throws NoSuchAlgorithmException {

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/options.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/options.html
@@ -15,5 +15,8 @@ Allows the user to select which character set should be used for Base64 conversi
 <H3>Base64 - Break Lines</H3>
 Indicates whether or not Base64 encoding should break lines at 76 characters (MIME standard).
 
+<H3>Hashers - Always output lower case?</H3>
+Indicates whether or not the output of predefined Hash processors should always be lower case or not (upper case).
+
 </BODY>
 </HTML>

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -32,6 +32,8 @@ encoder.optionspanel.name=Encode/Decode
 encoder.optionspanel.base64=Base64
 encoder.optionspanel.base64.charset=Charset:
 encoder.optionspanel.base64.breaklines=Break Lines:
+encoder.optionspanel.hashers=Hashers
+encoder.optionspanel.hashers.output.lowercase=Always output lower case?
 
 encoder.popup.title=Encode/Decode/Hash...
 encoder.popup.delete=Delete Output Panel


### PR DESCRIPTION
- CHANGELOG > Add change note.
- EncodeDecodeOptions > Handle setting and getting the new option value (default true, lower case).
- EncodeDecodeOptionsPanel > Handle displaying the new option value.
- HashProcessor > Handle processing per the new option.
- Messages.properties > Add supporting name/value pairs.
- options.html > Updated with the new option.

Fixes zaproxy/zaproxy#7503

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>