### PR TITLE
network: update dependencies

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update dependencies.
 
 ## [0.3.0] - 2022-10-27
 ### Added

--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -49,7 +49,7 @@ spotless {
 }
 
 dependencies {
-    val nettyVersion = "4.1.81.Final"
+    val nettyVersion = "4.1.84.Final"
     implementation("io.netty:netty-codec:$nettyVersion")
     implementation("io.netty:netty-handler:$nettyVersion")
 
@@ -59,10 +59,11 @@ dependencies {
         exclude(group = "org.apache.logging.log4j")
     }
 
-    val bcVersion = "1.70"
-    bouncyCastle("org.bouncycastle:bcmail-jdk15on:$bcVersion")
-    bouncyCastle("org.bouncycastle:bcprov-jdk15on:$bcVersion")
-    bouncyCastle("org.bouncycastle:bcpkix-jdk15on:$bcVersion")
+    val bcVersion = "1.72"
+    val bcJava = "jdk18on"
+    bouncyCastle("org.bouncycastle:bcmail-$bcJava:$bcVersion")
+    bouncyCastle("org.bouncycastle:bcprov-$bcJava:$bcVersion")
+    bouncyCastle("org.bouncycastle:bcpkix-$bcJava:$bcVersion")
 
     implementation("org.jitsi:ice4j:3.0-24-g34c2ce5") {
         // Don't need its dependencies, for now.


### PR DESCRIPTION
Update the following dependencies:
 - Netty, 4.1.81.Final → 4.1.84.Final;
 - Bouncy Castle, 1.70 → 1.72.