### PR TITLE
network: correct HTTP/NTLM proxy reauthentication

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Allow to send TRACE requests with payload and with an outgoing proxy (Issue 7578).
+- Correct HTTP/NTLM reauthentication to target and proxy (Issue 7566).
 
 ## [0.3.0] - 2022-10-27
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyCredentialsProvider.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyCredentialsProvider.java
@@ -42,7 +42,7 @@ public class ProxyCredentialsProvider implements CredentialsProvider {
     @Override
     public Credentials getCredentials(AuthScope authScope, HttpContext context) {
         HttpProxy proxy = options.getHttpProxy();
-        if (!options.isHttpProxyEnabled() || !options.isHttpProxyAuthEnabled()) {
+        if (!hasProxyAuth()) {
             return null;
         }
 
@@ -69,5 +69,9 @@ public class ProxyCredentialsProvider implements CredentialsProvider {
 
         return new NTCredentials(
                 credentials.getUserName(), credentials.getPassword(), "", proxy.getRealm());
+    }
+
+    public boolean hasProxyAuth() {
+        return options.isHttpProxyEnabled() && options.isHttpProxyAuthEnabled();
     }
 }


### PR DESCRIPTION
Retry the proxy authentication using the credentials available if it failed with the header already present.

Part of zaproxy/zaproxy#7566.