### PR TITLE
Preserve HTTP version in active scan rules

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Preserve the HTTP version in the scan rules:
+  - Remote Code Execution - CVE-2012-1823
+  - Source Code Disclosure - CVE-2012-1823
+  - Source Code Disclosure - /WEB-INF folder
 
 ## [49] - 2022-10-27
 ### Added

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRule.java
@@ -157,7 +157,9 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin {
             // send it as a POST request, unauthorised, with the payload as the POST body.
             HttpRequestHeader requestHeader =
                     new HttpRequestHeader(
-                            HttpRequestHeader.POST, attackURI, HttpRequestHeader.HTTP11);
+                            HttpRequestHeader.POST,
+                            attackURI,
+                            getBaseMsg().getRequestHeader().getVersion());
             HttpMessage attackmsg = new HttpMessage(requestHeader);
             attackmsg.setRequestBody(payload);
             requestHeader.setContentLength(attackmsg.getRequestBody().length());

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRule.java
@@ -151,6 +151,7 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin {
             }
             // and send it as a GET, unauthorised.
             HttpMessage attackmsg = new HttpMessage(attackURI);
+            attackmsg.getRequestHeader().setVersion(getBaseMsg().getRequestHeader().getVersion());
             sendAndReceive(attackmsg, false); // do not follow redirects
 
             if (isPage200(attackmsg)) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -39,6 +39,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.model.Vulnerabilities;
@@ -151,7 +152,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
             for (String filename : WEBINF_FILES) {
 
                 HttpMessage webinffilemsg =
-                        new HttpMessage(
+                        createHttpMessage(
                                 new URI(
                                         originalURI.getScheme()
                                                 + "://"
@@ -183,7 +184,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
                 URI classURI = getClassURI(originalURI, classname);
                 log.debug("Looking for Class file: {}", classURI);
 
-                HttpMessage classfilemsg = new HttpMessage(classURI);
+                HttpMessage classfilemsg = createHttpMessage(classURI);
                 sendAndReceive(classfilemsg, false); // do not follow redirects
                 if (isPage200(classfilemsg)) {
                     // to decompile the class file, we need to write it to disk..
@@ -256,7 +257,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
                             log.debug("Found props file: {}", propsFilename);
 
                             URI propsFileURI = getPropsFileURI(originalURI, propsFilename);
-                            HttpMessage propsfilemsg = new HttpMessage(propsFileURI);
+                            HttpMessage propsfilemsg = createHttpMessage(propsFileURI);
                             sendAndReceive(propsfilemsg, false); // do not follow redirects
                             if (isPage200(propsfilemsg)) {
                                 // Holy sheet.. we found a properties file
@@ -302,6 +303,12 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
                     e.getMessage(),
                     e);
         }
+    }
+
+    private HttpMessage createHttpMessage(URI uri) throws HttpMalformedHeaderException {
+        HttpMessage msg = new HttpMessage(uri);
+        msg.getRequestHeader().setVersion(getBaseMsg().getRequestHeader().getVersion());
+        return msg;
     }
 
     /**

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Preserve the HTTP version in Web Cache Deception scan rule.
 
 ## [41] - 2022-10-27
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRule.java
@@ -134,6 +134,9 @@ public class WebCacheDeceptionScanRule extends AbstractAppPlugin {
 
         HttpMessage unauthorisedMessage = new HttpMessage(uri);
         unauthorisedMessage.getRequestHeader().setMethod(method);
+        unauthorisedMessage
+                .getRequestHeader()
+                .setVersion(getBaseMsg().getRequestHeader().getVersion());
         HttpSender sender = new HttpSender(HttpSender.ACTIVE_SCANNER_INITIATOR);
         sender.setUseGlobalState(false);
         sender.sendAndReceive(unauthorisedMessage);

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Preserve the HTTP version in the scan rules:
+  - Backup File Disclosure
+  - Bypassing 403
+  - Cross-Domain Misconfiguration
+  - Relative Path Confusion
+  - Source Code Disclosure - Git
+  - Source Code Disclosure - SVN
+  - Possible Username Enumeration
 
 ## [43] - 2022-10-27
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
@@ -447,6 +447,9 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                                     randomfilepath,
                                     null,
                                     null));
+            nonexistfilemsg
+                    .getRequestHeader()
+                    .setVersion(getBaseMsg().getRequestHeader().getVersion());
             setMessageCookies(nonexistfilemsg, originalMessage);
             sendAndReceive(nonexistfilemsg, false);
             byte[] nonexistfilemsgdata = nonexistfilemsg.getResponseBody().getBytes();
@@ -494,6 +497,9 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                                         randomparentpath,
                                         null,
                                         null));
+                nonexistparentmsg
+                        .getRequestHeader()
+                        .setVersion(getBaseMsg().getRequestHeader().getVersion());
                 setMessageCookies(nonexistparentmsg, originalMessage);
                 sendAndReceive(nonexistparentmsg, false);
                 nonexistparentmsgdata = nonexistparentmsg.getResponseBody().getBytes();

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java
@@ -162,6 +162,9 @@ public class CrossDomainScanRule extends AbstractHostPlugin {
                                 "/" + ADOBE_CROSS_DOMAIN_POLICY_FILE,
                                 null,
                                 null));
+        crossdomainmessage
+                .getRequestHeader()
+                .setVersion(getBaseMsg().getRequestHeader().getVersion());
         sendAndReceive(crossdomainmessage, false);
 
         if (crossdomainmessage.getResponseBody().length() == 0) {
@@ -257,6 +260,9 @@ public class CrossDomainScanRule extends AbstractHostPlugin {
                                 "/" + SILVERLIGHT_CROSS_DOMAIN_POLICY_FILE,
                                 null,
                                 null));
+        clientaccesspolicymessage
+                .getRequestHeader()
+                .setVersion(getBaseMsg().getRequestHeader().getVersion());
         sendAndReceive(clientaccesspolicymessage, false);
 
         if (clientaccesspolicymessage.getResponseBody().length() == 0) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ForbiddenBypassScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ForbiddenBypassScanRule.java
@@ -110,6 +110,9 @@ public class ForbiddenBypassScanRule extends AbstractAppPlugin {
         for (String pathPayload : pathPayloads) {
             HttpMessage reqWithPayload =
                     new HttpMessage(new URI(schema + "://" + host + "" + pathPayload, true));
+            reqWithPayload
+                    .getRequestHeader()
+                    .setVersion(getBaseMsg().getRequestHeader().getVersion());
             sendAndReceive(reqWithPayload);
             if (reqWithPayload.getResponseHeader().getStatusCode() == HttpStatusCode.OK) {
                 createAlert(uri.toString(), reqWithPayload, pathPayload).raise();
@@ -146,6 +149,9 @@ public class ForbiddenBypassScanRule extends AbstractAppPlugin {
             }
 
             HttpMessage reqWithPayload = new HttpMessage(new URI(tmpUri, true));
+            reqWithPayload
+                    .getRequestHeader()
+                    .setVersion(getBaseMsg().getRequestHeader().getVersion());
 
             String[] headerPayload = header.split(":");
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/MessageCache.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/MessageCache.java
@@ -87,6 +87,7 @@ public class MessageCache {
             // request the file, then add the file to the cache
             // use the cookies from an original request, in case authorisation is required
             HttpMessage requestmsg = new HttpMessage(uri);
+            requestmsg.getRequestHeader().setVersion(basemsg.getRequestHeader().getVersion());
             try {
                 requestmsg.setCookieParams(basemsg.getCookieParams());
             } catch (Exception e) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -244,6 +244,9 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin {
                                 null,
                                 null);
                 HttpMessage hackedMessage = new HttpMessage(hackedUri);
+                hackedMessage
+                        .getRequestHeader()
+                        .setVersion(getBaseMsg().getRequestHeader().getVersion());
                 try {
                     hackedMessage.setCookieParams(originalMsg.getCookieParams());
                 } catch (Exception e) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
@@ -320,6 +320,9 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
                                             + ".svn-base",
                                     null,
                                     null));
+            svnsourcefileattackmsg
+                    .getRequestHeader()
+                    .setVersion(getBaseMsg().getRequestHeader().getVersion());
             svnsourcefileattackmsg.setCookieParams(this.getBaseMsg().getCookieParams());
             // svnsourcefileattackmsg.setRequestHeader(this.getBaseMsg().getRequestHeader());
             sendAndReceive(svnsourcefileattackmsg, false); // do not follow redirects
@@ -425,6 +428,9 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
                                         pathminusfilename + ".svn/wc.db",
                                         null,
                                         null));
+                svnWCDBAttackMsg
+                        .getRequestHeader()
+                        .setVersion(getBaseMsg().getRequestHeader().getVersion());
                 svnWCDBAttackMsg.setCookieParams(this.getBaseMsg().getCookieParams());
                 // svnsourcefileattackmsg.setRequestHeader(this.getBaseMsg().getRequestHeader());
                 sendAndReceive(svnWCDBAttackMsg, false); // do not follow redirects
@@ -554,6 +560,12 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
                                                                         + svnFilename,
                                                                 null,
                                                                 null));
+                                        svnSourceFileAttackMsg
+                                                .getRequestHeader()
+                                                .setVersion(
+                                                        getBaseMsg()
+                                                                .getRequestHeader()
+                                                                .getVersion());
                                         svnSourceFileAttackMsg.setCookieParams(
                                                 this.getBaseMsg().getCookieParams());
                                         // svnsourcefileattackmsg.setRequestHeader(this.getBaseMsg().getRequestHeader());

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
@@ -259,6 +259,9 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin {
                             .setMethod(HttpRequestHeader.GET); // it's always a GET for a redirect
                     msgRedirect
                             .getRequestHeader()
+                            .setVersion(getBaseMsg().getRequestHeader().getVersion());
+                    msgRedirect
+                            .getRequestHeader()
                             .setContentLength(0); // since we send a GET, the body will be 0 long
                     if (!cookies.isEmpty()) {
                         // if a previous request sent back a cookie that has not since been
@@ -487,6 +490,9 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin {
                             msgRedirect.getRequestHeader().setURI(newLocationWorkaround);
                         }
                         msgRedirect.getRequestHeader().setMethod(HttpRequestHeader.GET);
+                        msgRedirect
+                                .getRequestHeader()
+                                .setVersion(getBaseMsg().getRequestHeader().getVersion());
                         msgRedirect
                                 .getRequestHeader()
                                 .setContentLength(


### PR DESCRIPTION
Use the HTTP version of the message being scanned when creating new HTTP messages to keep scanning with same version.