### PR TITLE
network: do not change the case of Content-Length

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Use always a plain connection to the outgoing HTTP proxy (Issue 7594).
+- Do not change the case of the Content-Length header.
 
 ## [0.5.0] - 2022-11-09
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -698,15 +698,18 @@ public class HttpSenderApache
     private static void copyHeaders(MessageHeaders from, HttpHeader to) {
         for (Iterator<Header> it = from.headerIterator(); it.hasNext(); ) {
             Header header = it.next();
-            to.addHeader(header.getName(), header.getValue());
-        }
-
-        String contentLength = to.getHeader(HttpHeader.CONTENT_LENGTH);
-        if (contentLength != null) {
-            try {
-                to.setContentLength(Integer.parseInt(contentLength));
-            } catch (NumberFormatException e) {
-                LOGGER.debug("Invalid content-length value: {}", contentLength);
+            String name = header.getName();
+            if (HttpHeader.CONTENT_LENGTH.equalsIgnoreCase(name)) {
+                String contentLength = header.getValue();
+                try {
+                    to.setContentLength(Integer.parseInt(contentLength));
+                } catch (NumberFormatException e) {
+                    LOGGER.debug("Invalid content-length value: {}", contentLength);
+                }
+                // Set it again to keep the exact case.
+                to.setHeader(name, contentLength);
+            } else {
+                to.addHeader(name, header.getValue());
             }
         }
     }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
@@ -467,6 +467,37 @@ class HttpSenderImplUnitTest {
         @ParameterizedTest
         @MethodSource(
                 "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#requestMethodsAndSendAndReceiveMethods")
+        void shouldBeUpdatedWithExactContentLengthHeaderCase(
+                String requestMethod, SenderMethod method) throws Exception {
+            // Given
+            message.getRequestHeader().setHeader("Host", "localhost:" + serverPort);
+            message.getRequestHeader().addHeader("content-length", "0");
+            message.getRequestHeader().addHeader("OtherHeader", "SomeValue");
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            String expectedRequestHeader =
+                    "GET "
+                            + getServerUri("/")
+                            + " HTTP/1.1\r\n"
+                            + "Host: localhost:"
+                            + serverPort
+                            + "\r\n"
+                            + "content-length: 0\r\n"
+                            + "OtherHeader: SomeValue\r\n"
+                            + "\r\n";
+            assertThat(message.getRequestHeader().toString(), is(equalTo(expectedRequestHeader)));
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            HttpMessage receivedMessage = server.getReceivedMessages().get(0);
+            assertThat(
+                    receivedMessage.getRequestHeader().toString(),
+                    is(equalTo(expectedRequestHeader)));
+            assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#requestMethodsAndSendAndReceiveMethods")
         void shouldBeSentWithRetriesOnIoError(String requestMethod, SenderMethod method)
                 throws Exception {
             // Given


### PR DESCRIPTION
Set the header with the original case when updating the request sent.