### PR TITLE
network: use plain connection to outgoing proxy

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Use always a plain connection to the outgoing HTTP proxy (Issue 7594).
 
 ## [0.5.0] - 2022-11-09
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyRoutePlanner.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyRoutePlanner.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.network.internal.client.apachev5;
 import org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.parosproxy.paros.network.HttpHeader;
 import org.zaproxy.addon.network.ConnectionOptions;
 import org.zaproxy.addon.network.internal.client.HttpProxy;
 
@@ -42,6 +43,6 @@ public class ProxyRoutePlanner extends DefaultRoutePlanner {
         if (!options.isUseHttpProxy(target.getHostName())) {
             return null;
         }
-        return new HttpHost(target.getSchemeName(), proxy.getHost(), proxy.getPort());
+        return new HttpHost(HttpHeader.HTTP, proxy.getHost(), proxy.getPort());
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyRoutePlannerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyRoutePlannerUnitTest.java
@@ -30,7 +30,9 @@ import static org.mockito.Mockito.mock;
 import java.net.PasswordAuthentication;
 import org.apache.hc.core5.http.HttpHost;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpHeader;
 import org.zaproxy.addon.network.ConnectionOptions;
 import org.zaproxy.addon.network.internal.client.HttpProxy;
 
@@ -54,10 +56,10 @@ class ProxyRoutePlannerUnitTest {
         proxyRoutePlanner = new ProxyRoutePlanner(connectionOptions);
     }
 
-    @Test
-    void shouldProxyIfEnabledForHost() {
+    @ParameterizedTest
+    @ValueSource(strings = {HttpHeader.HTTP, HttpHeader.HTTPS})
+    void shouldProxyIfEnabledForHost(String schemeName) {
         // Given
-        String schemeName = "http";
         String hostName = "localhost";
         HttpHost host = new HttpHost(schemeName, hostName, 8080);
         given(connectionOptions.isUseHttpProxy(hostName)).willReturn(true);
@@ -65,15 +67,15 @@ class ProxyRoutePlannerUnitTest {
         HttpHost proxy = proxyRoutePlanner.determineProxy(host, null);
         // Then
         assertThat(proxy, is(notNullValue()));
-        assertThat(proxy.getSchemeName(), is(equalTo(schemeName)));
+        assertThat(proxy.getSchemeName(), is(equalTo(HttpHeader.HTTP)));
         assertThat(proxy.getHostName(), is(equalTo(HTTP_PROXY.getHost())));
         assertThat(proxy.getPort(), is(equalTo(HTTP_PROXY.getPort())));
     }
 
-    @Test
-    void shouldNotProxyIfNotEnabledForHost() {
+    @ParameterizedTest
+    @ValueSource(strings = {HttpHeader.HTTP, HttpHeader.HTTPS})
+    void shouldNotProxyIfNotEnabledForHost(String schemeName) {
         // Given
-        String schemeName = "http";
         String hostName = "localhost";
         HttpHost host = new HttpHost(schemeName, hostName, 8080);
         given(connectionOptions.isUseHttpProxy(hostName)).willReturn(false);


### PR DESCRIPTION
Use always a plain connection to the outgoing proxy.

Fix zaproxy/zaproxy#7594.