### PR TITLE
network: use available response content

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Use always a plain connection to the outgoing HTTP proxy (Issue 7594).
 - Do not change the case of the Content-Length header.
+- Use the available response content when the Content-Length is more than what is available.
 
 ## [0.5.0] - 2022-11-09
 ### Fixed

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
@@ -558,6 +558,28 @@ class HttpSenderImplUnitTest {
         @ParameterizedTest
         @MethodSource(
                 "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeReceivedEvenWithLessContentThanContentLength(SenderMethod method)
+                throws Exception {
+            // Given
+            String responseHeader =
+                    "HTTP/1.1 200 OK\r\nContent-Length: 420\r\nConnection: close\r\n\r\n";
+            String responseBody = "Response Body";
+            server.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        msg.setResponseHeader(responseHeader);
+                        msg.setResponseBody(responseBody);
+                    });
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            assertThat(message.getResponseHeader().toString(), is(equalTo(responseHeader)));
+            assertThat(message.getResponseBody().toString(), is(equalTo(responseBody)));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
         void shouldPreserveNonAsciiCharactersInHeader(SenderMethod method) throws Exception {
             // Given
             String responseHeader = "HTTP/1.1 200 OK\r\nJ/ψ:  → VP\r\nContent-Length: 0\r\n\r\n";


### PR DESCRIPTION
Use the available response content instead of throwing an exception when the Content-Length is more than what's available.

---
Reported in https://twitter.com/jonnwu/status/1591980559471112192