### PR TITLE
network: properly persist proxy error responses

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use always a plain connection to the outgoing HTTP proxy (Issue 7594).
 - Do not change the case of the Content-Length header.
 - Use the available response content when the Content-Length is more than what is available.
+- Properly persist proxy error responses.
 
 ## [0.5.0] - 2022-11-09
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandler.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
@@ -174,10 +175,15 @@ public class HttpSenderHandler implements HttpMessageHandler {
             int statusCode,
             String reasonPhrase,
             String message) {
-        HttpResponseHeader responseHeader = new HttpResponseHeader();
-        responseHeader.setVersion(HttpHeader.HTTP11);
-        responseHeader.setStatusCode(statusCode);
-        responseHeader.setReasonPhrase(reasonPhrase);
+        HttpResponseHeader responseHeader;
+        try {
+            responseHeader =
+                    new HttpResponseHeader(
+                            HttpHeader.HTTP11 + " " + statusCode + " " + reasonPhrase);
+        } catch (HttpMalformedHeaderException e) {
+            LOGGER.error("Failed to create valid header.", e);
+            return;
+        }
         responseHeader.setHeader(HttpHeader.CONTENT_TYPE, "text/plain; charset=UTF-8");
         responseHeader.setHeader(
                 HttpHeader.CONTENT_LENGTH,

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandlerUnitTest.java
@@ -127,6 +127,7 @@ class HttpSenderHandlerUnitTest {
         verifyMessageSent(message);
         verify(ctx, times(0)).overridden();
         verify(ctx, times(0)).close();
+        assertThat(message.getResponseHeader().isEmpty(), is(equalTo(false)));
         assertThat(
                 message.getResponseHeader().toString(), startsWith("HTTP/1.1 504 Gateway Timeout"));
         assertThat(
@@ -145,6 +146,7 @@ class HttpSenderHandlerUnitTest {
         verifyMessageSent(message);
         verify(ctx, times(0)).overridden();
         verify(ctx, times(0)).close();
+        assertThat(message.getResponseHeader().isEmpty(), is(equalTo(false)));
         assertThat(
                 message.getResponseHeader().toString(), startsWith("HTTP/1.1 504 Gateway Timeout"));
         assertThat(message.getResponseBody().toString(), is(equalTo("")));
@@ -162,6 +164,7 @@ class HttpSenderHandlerUnitTest {
         verifyMessageSent(message);
         verify(ctx, times(0)).overridden();
         verify(ctx, times(0)).close();
+        assertThat(message.getResponseHeader().isEmpty(), is(equalTo(false)));
         assertThat(message.getResponseHeader().toString(), startsWith("HTTP/1.1 502 Bad Gateway"));
         assertThat(
                 message.getResponseBody().toString(),


### PR DESCRIPTION
Set the status line into the response header so the response is marked as non-empty and thus persisted to the session.