### PR TITLE
encoder: Base64 decode handle wrapped lines

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintenance changes.
 - Allow script processors to return strings without requiring an "EncodeDecodeResult" wrapper.
 - Show help and options buttons in the main dialog.
+- The Base64 decoder now uses a Mime decoder and handles line wrapped input.
 
 ## [0.7.0] - 2022-10-27
 ### Changed

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64Decoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64Decoder.java
@@ -36,7 +36,7 @@ public class Base64Decoder extends DefaultEncodeDecodeProcessor {
                         .getExtensionLoader()
                         .getExtension(ExtensionEncoder.class)
                         .getOptions();
-        return new String(Base64.getDecoder().decode(value), encDecOpts.getBase64Charset());
+        return new String(Base64.getMimeDecoder().decode(value), encDecOpts.getBase64Charset());
     }
 
     public static Base64Decoder getSingleton() {

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -141,6 +141,7 @@ If there is no valid decoding then the field will be disabled.
 
 <H4>Base 64 Decode</H4>
 Will display the base 64 decoding of the text you enter.<br/>
+Leveraging a <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Base64.html#getMimeDecoder()">Mime decoder</a> to handle wrapped lines.
 
 <H4>Base 64 URL Decode</H4>
 Will display the base 64 URL decoding of the text you enter. Base64URL is a modification to the primary base 64 standard 

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/Base64DecoderUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/Base64DecoderUnitTest.java
@@ -57,17 +57,15 @@ public class Base64DecoderUnitTest extends ProcessorTests<Base64Decoder> {
     }
 
     @Test
-    void shouldFailToDecodeWhenInputIsWrapped() throws Exception {
+    void shouldNotFailToDecodeWhenInputIsWrapped() throws Exception {
         // Given / When
         EncodeDecodeResult result =
                 processor.process(
                         "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4g\r\n"
                                 + "TnVsbGFtIHRyaXN0aXF1ZSBtb3JiaS4=");
         // Then
-        assertThat(result.hasError(), is(equalTo(true)));
-        assertThat(
-                result.getResult(),
-                is(equalTo("IllegalArgumentException: Illegal base64 character d")));
+        assertThat(result.hasError(), is(equalTo(false)));
+        assertThat(result.getResult(), is(equalTo(EIGHTY_CHARS_LOREM)));
     }
 
     @Test


### PR DESCRIPTION
- CHANGELOG > Added change note.
- Bse64Decoder > Use mime decoder.
- Base64DecoderUnitTest > Update previous failure case to be a success case.
- encoder.html > Added reference to Mime decoder and related javadocs.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>