### PR TITLE
pscanrulesAlpha: correct HTTP field name check

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Use case insensitive HTTP field name check in Insufficient Site Isolation Against Spectre Vulnerability scan rule.
 
 ## [37] - 2022-10-27
 ### Changed

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -158,7 +159,7 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
     static class CorpHeaderScanRule extends SiteIsolationHeaderScanRule {
         public static final String HEADER = "Cross-Origin-Resource-Policy";
         private static final String CORP_MESSAGE_PREFIX = SITE_ISOLATION_MESSAGE_PREFIX + "corp.";
-        public static final String CORS_PREFIX = "Access-Control-Allow-";
+        public static final String CORS_PREFIX = "access-control-allow-";
 
         CorpHeaderScanRule(Supplier<AlertBuilder> newAlert) {
             super(newAlert);
@@ -168,7 +169,11 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
         List<AlertBuilder> build(HttpResponseHeader responseHeader) {
             boolean hasCorsHeader =
                     responseHeader.getHeaders().stream()
-                            .anyMatch(header -> header.getName().startsWith(CORS_PREFIX));
+                            .anyMatch(
+                                    header ->
+                                            header.getName()
+                                                    .toLowerCase(Locale.ROOT)
+                                                    .startsWith(CORS_PREFIX));
             if (hasCorsHeader) {
                 return Collections.emptyList();
             }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRuleTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRuleTest.java
@@ -28,6 +28,8 @@ import static org.mockito.BDDMockito.given;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 
@@ -216,14 +218,16 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         assertThat(alertsRaised, hasSize(0));
     }
 
-    @Test
-    void shouldNotRaiseCorpAlertGivenCorsHeaderIsSet() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"Access-Control-Allow-Origin", "access-control-allow-origin"})
+    void shouldNotRaiseCorpAlertGivenCorsHeaderIsSet(String corsFieldName) throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"
-                        + "Access-Control-Allow-Origin: *\r\n"
+                        + corsFieldName
+                        + ": *\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
         given(passiveScanData.isPage200(any())).willReturn(false);


### PR DESCRIPTION
Use case insensitive HTTP field name check in Insufficient Site Isolation Against Spectre Vulnerability scan rule.