### PR TITLE
Address issues related to HTTP/2

### DIFF
--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -5,6 +5,9 @@ description = "Provides core networking capabilities."
 val bouncyCastle by configurations.creating
 configurations.api { extendsFrom(bouncyCastle) }
 
+val hc by configurations.creating
+configurations.implementation { extendsFrom(hc) }
+
 zapAddOn {
     addOnName.set("Network")
     addOnStatus.set(AddOnStatus.BETA)
@@ -21,6 +24,7 @@ zapAddOn {
 
         bundledLibs {
             libs.from(bouncyCastle)
+            libs.from(hc)
         }
     }
 
@@ -43,6 +47,7 @@ spotless {
             fileTree(projectDir) {
                 include("src/**/*.java")
                 exclude("src/main/java/org/apache/hc/client5/**/Zap*.java")
+                exclude("src/main/java/org/apache/hc/core5/**/*.java")
                 exclude("src/main/java/org/zaproxy/addon/network/internal/codec/netty/*.java")
             }
         )
@@ -55,7 +60,7 @@ dependencies {
     implementation("io.netty:netty-handler:$nettyVersion")
     implementation("io.netty:netty-codec-http2:$nettyVersion")
 
-    implementation("org.apache.httpcomponents.client5:httpclient5:5.2")
+    hc("org.apache.httpcomponents.client5:httpclient5:5.2")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.19.0") {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")

--- a/addOns/network/src/main/java/org/apache/hc/core5/http2/impl/DefaultH2RequestConverter.java
+++ b/addOns/network/src/main/java/org/apache/hc/core5/http2/impl/DefaultH2RequestConverter.java
@@ -1,0 +1,135 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.http2.impl;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http2.H2MessageConverter;
+import org.apache.hc.core5.http2.H2PseudoRequestHeaders;
+import org.apache.hc.core5.net.URIAuthority;
+
+/**
+ * HTTP/2 request converter, that does not validate the fields.
+ */
+public final class DefaultH2RequestConverter implements H2MessageConverter<HttpRequest> {
+
+    public final static DefaultH2RequestConverter INSTANCE = new DefaultH2RequestConverter();
+
+    @Override
+    public HttpRequest convert(final List<Header> headers) throws HttpException {
+        String method = null;
+        String scheme = null;
+        String authority = null;
+        String path = null;
+        final List<Header> messageHeaders = new ArrayList<>();
+
+        for (int i = 0; i < headers.size(); i++) {
+            final Header header = headers.get(i);
+            final String name = header.getName();
+            final String value = header.getValue();
+
+            if (name.startsWith(":")) {
+                switch (name) {
+                    case H2PseudoRequestHeaders.METHOD:
+                        if (method == null) {
+                            method = value;
+                        }
+                        break;
+                    case H2PseudoRequestHeaders.SCHEME:
+                        if (scheme == null) {
+                            scheme = value;
+                        }
+                        break;
+                    case H2PseudoRequestHeaders.PATH:
+                        if (path == null) {
+                            path = value;
+                        }
+                        break;
+                    case H2PseudoRequestHeaders.AUTHORITY:
+                        if (authority == null) {
+                            authority = value;
+                        }
+                        break;
+                    default:
+                }
+            } else {
+                messageHeaders.add(header);
+            }
+        }
+        final HttpRequest httpRequest = new BasicHttpRequest(method, path);
+        httpRequest.setVersion(HttpVersion.HTTP_2);
+        httpRequest.setScheme(scheme);
+        try {
+            httpRequest.setAuthority(URIAuthority.create(authority));
+        } catch (final URISyntaxException ex) {
+            throw new ProtocolException(ex.getMessage(), ex);
+        }
+        httpRequest.setPath(path);
+        for (int i = 0; i < messageHeaders.size(); i++) {
+            httpRequest.addHeader(messageHeaders.get(i));
+        }
+        return httpRequest;
+    }
+
+    @Override
+    public List<Header> convert(final HttpRequest message) throws HttpException {
+        final boolean optionMethod = Method.CONNECT.name().equalsIgnoreCase(message.getMethod());
+        final List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(H2PseudoRequestHeaders.METHOD, message.getMethod(), false));
+        if (optionMethod) {
+            headers.add(new BasicHeader(H2PseudoRequestHeaders.AUTHORITY, message.getAuthority(), false));
+        }  else {
+            headers.add(new BasicHeader(H2PseudoRequestHeaders.SCHEME, message.getScheme(), false));
+            if (message.getAuthority() != null) {
+                headers.add(new BasicHeader(H2PseudoRequestHeaders.AUTHORITY, message.getAuthority(), false));
+            }
+            headers.add(new BasicHeader(H2PseudoRequestHeaders.PATH, message.getPath(), false));
+        }
+
+        for (final Iterator<Header> it = message.headerIterator(); it.hasNext(); ) {
+            final Header header = it.next();
+            final String name = header.getName();
+            final String value = header.getValue();
+            headers.add(new BasicHeader(name, value));
+        }
+
+        return headers;
+    }
+
+}

--- a/addOns/network/src/main/java/org/apache/hc/core5/http2/impl/DefaultH2ResponseConverter.java
+++ b/addOns/network/src/main/java/org/apache/hc/core5/http2/impl/DefaultH2ResponseConverter.java
@@ -1,0 +1,106 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.core5.http2.impl;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http2.H2MessageConverter;
+import org.apache.hc.core5.http2.H2PseudoResponseHeaders;
+
+/**
+ * HTTP/2 response converter, that does not validate the fields
+ */
+public class DefaultH2ResponseConverter implements H2MessageConverter<HttpResponse> {
+
+    public final static DefaultH2ResponseConverter INSTANCE = new DefaultH2ResponseConverter();
+
+    @Override
+    public HttpResponse convert(final List<Header> headers) throws HttpException {
+        String statusText = null;
+        final List<Header> messageHeaders = new ArrayList<>();
+
+        for (int i = 0; i < headers.size(); i++) {
+            final Header header = headers.get(i);
+            final String name = header.getName();
+            final String value = header.getValue();
+
+            if (name.startsWith(":")) {
+                if (name.equals(H2PseudoResponseHeaders.STATUS) && statusText == null) {
+                    statusText = value;
+                }
+            } else {
+                messageHeaders.add(header);
+            }
+
+        }
+
+        if (statusText == null) {
+            throw new ProtocolException("Mandatory response header '%s' not found", H2PseudoResponseHeaders.STATUS);
+        }
+        final int statusCode;
+        try {
+            statusCode = Integer.parseInt(statusText);
+        } catch (final NumberFormatException ex) {
+            throw new ProtocolException("Invalid response status: " + statusText);
+        }
+        final HttpResponse response = new BasicHttpResponse(statusCode, null);
+        response.setVersion(HttpVersion.HTTP_2);
+        for (int i = 0; i < messageHeaders.size(); i++) {
+            response.addHeader(messageHeaders.get(i));
+        }
+        return response;
+    }
+
+    @Override
+    public List<Header> convert(final HttpResponse message) throws HttpException {
+        final int code = message.getCode();
+        if (code < 100 || code >= 600) {
+            throw new ProtocolException("Response status %s is invalid", code);
+        }
+        final List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader(H2PseudoResponseHeaders.STATUS, Integer.toString(code), false));
+
+        for (final Iterator<Header> it = message.headerIterator(); it.hasNext(); ) {
+            final Header header = it.next();
+            final String name = header.getName();
+            final String value = header.getValue();
+            headers.add(new BasicHeader(name, value));
+        }
+        return headers;
+    }
+
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/Http2MessageHelper.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/Http2MessageHelper.java
@@ -42,7 +42,6 @@ import org.parosproxy.paros.network.HttpResponseHeader;
 /** Helper class to map between {@link HttpMessage} and {@link Http2Headers}. */
 public class Http2MessageHelper {
 
-    private static final AsciiString AUTHORITY_PSEUDO_HEADER = AsciiString.cached(":authority");
     private static final String HOST = HttpRequestHeader.HOST.toLowerCase(Locale.ROOT);
 
     private Http2MessageHelper() {}
@@ -136,9 +135,7 @@ public class Http2MessageHelper {
                 CharSequence name = entry.getKey();
                 CharSequence value = entry.getValue();
 
-                if (AUTHORITY_PSEUDO_HEADER.contentEqualsIgnoreCase(name)) {
-                    toHeader.addHeader(HOST, value.toString());
-                } else if (!Http2Headers.PseudoHeaderName.isPseudoHeader(name)) {
+                if (!Http2Headers.PseudoHeaderName.isPseudoHeader(name)) {
                     if (COOKIE.contentEqualsIgnoreCase(name)) {
                         if (cookies == null) {
                             cookies = InternalThreadLocalMap.get().stringBuilder();

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoder.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.addon.network.internal.codec;
 
-import java.net.InetSocketAddress;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.network.internal.ChannelAttributes;
@@ -35,9 +34,6 @@ public class HttpRequestDecoder extends HttpMessageDecoder {
                     HttpRequestHeader header = msg.getRequestHeader();
                     boolean secure = ctx.channel().attr(ChannelAttributes.TLS_UPGRADED).get();
                     header.setMessage(content, secure);
-                    InetSocketAddress remoteAddress =
-                            ctx.channel().attr(ChannelAttributes.REMOTE_ADDRESS).get();
-                    header.setSenderAddress(remoteAddress.getAddress());
                     return header;
                 },
                 HttpMessage::getRequestBody);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/CommonMessagePropertiesHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/CommonMessagePropertiesHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import java.net.InetSocketAddress;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.internal.ChannelAttributes;
+
+/**
+ * Sets common properties to the {@code HttpMessage}.
+ *
+ * <ul>
+ *   <li>The sender address, obtained from the channel attribute {@link
+ *       ChannelAttributes#REMOTE_ADDRESS}.
+ * </ul>
+ */
+@Sharable
+public class CommonMessagePropertiesHandler extends SimpleChannelInboundHandler<HttpMessage> {
+
+    private static final CommonMessagePropertiesHandler INSTANCE =
+            new CommonMessagePropertiesHandler();
+
+    /**
+     * Gets the instance of this handler.
+     *
+     * @return the instance, never {@code null}.
+     */
+    public static CommonMessagePropertiesHandler getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, HttpMessage msg) throws Exception {
+        InetSocketAddress remoteAddress =
+                ctx.channel().attr(ChannelAttributes.REMOTE_ADDRESS).get();
+        if (remoteAddress != null) {
+            msg.getRequestHeader().setSenderAddress(remoteAddress.getAddress());
+        }
+
+        ctx.fireChannelRead(msg);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandler.java
@@ -82,11 +82,11 @@ public class TlsProtocolHandler extends ByteToMessageDecoder {
     }
 
     @Override
-    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        super.handlerAdded(ctx);
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        super.channelActive(ctx);
 
         TlsConfig config = ctx.channel().attr(ChannelAttributes.TLS_CONFIG).get();
-        if (!config.isAlpnEnabled()) {
+        if (config != null && !config.isAlpnEnabled()) {
             ctx.pipeline().addAfter(ctx.name(), "http2.preface", new Http2PrefaceHandler());
         }
     }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
@@ -40,6 +40,7 @@ import org.zaproxy.addon.network.internal.codec.HttpRequestDecoder;
 import org.zaproxy.addon.network.internal.codec.HttpResponseEncoder;
 import org.zaproxy.addon.network.internal.codec.HttpToHttp2ConnectionHandler;
 import org.zaproxy.addon.network.internal.codec.InboundHttp2ToHttpAdapter;
+import org.zaproxy.addon.network.internal.handlers.CommonMessagePropertiesHandler;
 import org.zaproxy.addon.network.internal.handlers.ConnectRequestHandler;
 import org.zaproxy.addon.network.internal.handlers.ReadTimeoutHandler;
 import org.zaproxy.addon.network.internal.handlers.RecursiveRequestHandler;
@@ -140,6 +141,7 @@ public class HttpServer extends BaseServer {
                 .addLast("tls.upgrade", new TlsProtocolHandler())
                 .addLast(HTTP_DECODER_HANDLER_NAME, new HttpRequestDecoder())
                 .addLast(HTTP_ENCODER_HANDLER_NAME, HttpResponseEncoder.getInstance())
+                .addLast(CommonMessagePropertiesHandler.getInstance())
                 .addLast("http.connect", ConnectRequestHandler.getInstance())
                 .addLast("http.recursive", RecursiveRequestHandler.getInstance())
                 .addLast(mainHandlerExecutor, "http.main-handler", handler.get())

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/Http2MessageHelperUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/Http2MessageHelperUnitTest.java
@@ -90,7 +90,6 @@ class Http2MessageHelperUnitTest {
         // Then
         assertRequestHeader(
                 "METHOD " + scheme + "://127.0.0.1:8080/path?query=a HTTP/2",
-                "host: 127.0.0.1:8080",
                 "header-a: value-a",
                 "header-b: value-b");
         assertRequestBody("");
@@ -169,10 +168,7 @@ class Http2MessageHelperUnitTest {
         setHttpRequest(STREAM_ID, headers, msg);
         // Then
         assertRequestHeader(
-                "METHOD https://127.0.0.1:8080/ HTTP/2",
-                "host: 127.0.0.1:8080",
-                "header-a: value-a",
-                "header-b: value-b");
+                "METHOD https://127.0.0.1:8080/ HTTP/2", "header-a: value-a", "header-b: value-b");
         assertRequestBody("");
     }
 
@@ -193,7 +189,6 @@ class Http2MessageHelperUnitTest {
         // Then
         assertRequestHeader(
                 "METHOD " + scheme + "://127.0.0.1:8080/path?query=a HTTP/2",
-                "host: 127.0.0.1:8080",
                 ":invalid-1: value-1",
                 ":invalid-2: value-2",
                 "header-a: value-a",
@@ -219,7 +214,6 @@ class Http2MessageHelperUnitTest {
         // Then
         assertRequestHeader(
                 "METHOD " + scheme + "://127.0.0.1:8080/path?query=a HTTP/2",
-                "host: 127.0.0.1:8080",
                 "header-a: value-a",
                 "header-b: value-b",
                 "cookie: sid=B; csrftoken=A; a=2");
@@ -243,7 +237,6 @@ class Http2MessageHelperUnitTest {
         // Then
         assertRequestHeader(
                 "METHOD " + scheme + "://127.0.0.1:8080/path?query=a HTTP/2",
-                "host: 127.0.0.1:8080",
                 "header-a: value-a",
                 "header-b: value-b",
                 "cookie: sid=B; csrftoken=A; a=2");
@@ -265,8 +258,7 @@ class Http2MessageHelperUnitTest {
         // When
         setHttpRequest(STREAM_ID, headers, msg);
         // Then
-        assertRequestHeader(
-                "CONNECT 127.0.0.1:8080 HTTP/2", "host: 127.0.0.1:8080", "header: value");
+        assertRequestHeader("CONNECT 127.0.0.1:8080 HTTP/2", "header: value");
         assertRequestBody("");
     }
 
@@ -281,8 +273,7 @@ class Http2MessageHelperUnitTest {
         // When
         setHttpRequest(STREAM_ID, headers, msg);
         // Then
-        assertRequestHeader(
-                "OPTIONS " + scheme + "://127.0.0.1:8080/path HTTP/2", "host: 127.0.0.1:8080");
+        assertRequestHeader("OPTIONS " + scheme + "://127.0.0.1:8080/path HTTP/2");
         assertRequestBody("");
     }
 
@@ -297,8 +288,8 @@ class Http2MessageHelperUnitTest {
         // When / Then
         setHttpRequest(STREAM_ID, headers, msg);
         // XXX Not supported by core, should result in e.g.:
-        // assertRequestHeader("OPTIONS * HTTP/2", "host: 127.0.0.1:8080");
-        assertRequestHeader("OPTIONS " + scheme + "://null* HTTP/2", "host: 127.0.0.1:8080");
+        // assertRequestHeader("OPTIONS * HTTP/2");
+        assertRequestHeader("OPTIONS " + scheme + "://null* HTTP/2");
         assertRequestBody("");
     }
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoderUnitTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.net.InetSocketAddress;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,12 +38,8 @@ import org.zaproxy.addon.network.internal.ChannelAttributes;
 /** Unit test for {@link HttpRequestDecoder}. */
 class HttpRequestDecoderUnitTest extends HttpMessageDecoderUnitTest {
 
-    private static final InetSocketAddress SENDER_ADDRESS =
-            new InetSocketAddress("127.0.0.1", 1234);
-
     @BeforeEach
     void setUpAttributes() {
-        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(SENDER_ADDRESS);
         channel.attr(ChannelAttributes.TLS_UPGRADED).set(Boolean.FALSE);
     }
 
@@ -147,37 +142,6 @@ class HttpRequestDecoderUnitTest extends HttpMessageDecoderUnitTest {
     void shouldProduceMessageWithExceptionForNullTlsUpgraded() {
         // Given
         channel.attr(ChannelAttributes.TLS_UPGRADED).set(null);
-        String content = "GET / HTTP/1.1\r\n\r\n";
-        // When
-        written(content, true);
-        // Then
-        HttpMessage message = channel.readInbound();
-        assertThat(message, is(notNullValue()));
-        assertThat(message.getUserObject(), is(instanceOf(NullPointerException.class)));
-        assertChannelState();
-    }
-
-    @Test
-    void shouldHaveSenderAddress() {
-        // Given
-        InetSocketAddress senderAddress = new InetSocketAddress("127.0.0.3", 1234);
-        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(senderAddress);
-        String content = "GET / HTTP/1.1\r\n\r\n";
-        // When
-        written(content, true);
-        // Then
-        HttpMessage message = channel.readInbound();
-        assertThat(message, is(notNullValue()));
-        assertThat(
-                message.getRequestHeader().getSenderAddress(),
-                is(equalTo(senderAddress.getAddress())));
-        assertChannelState();
-    }
-
-    @Test
-    void shouldProduceMessageWithExceptionForNullRemoteAddress() {
-        // Given
-        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(null);
         String content = "GET / HTTP/1.1\r\n\r\n";
         // When
         written(content, true);

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpToHttp2ConnectionHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpToHttp2ConnectionHandlerUnitTest.java
@@ -180,7 +180,6 @@ class HttpToHttp2ConnectionHandlerUnitTest {
         assertRequestHeader(
                 receivedRequest,
                 "METHOD http://127.0.0.1:" + port + "/path?a=b HTTP/2",
-                "host: 127.0.0.1:" + port,
                 "header-a: 1",
                 "header-b: 2",
                 "content-length: 12");
@@ -208,7 +207,6 @@ class HttpToHttp2ConnectionHandlerUnitTest {
         assertRequestHeader(
                 receivedRequest,
                 "METHOD http://127.0.0.1:" + port + "/path?a=b HTTP/2",
-                "host: 127.0.0.1:" + port,
                 "header-a: 1",
                 "header-b: 2",
                 "content-length: 12");
@@ -233,7 +231,6 @@ class HttpToHttp2ConnectionHandlerUnitTest {
         assertRequestHeader(
                 receivedRequest,
                 "METHOD http://127.0.0.1:" + port + "/path?a=b HTTP/2",
-                "host: 127.0.0.1:" + port,
                 "header-a: 1",
                 "header-b: 2",
                 "content-length: 0");

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/CommonMessagePropertiesHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/CommonMessagePropertiesHandlerUnitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.net.InetSocketAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.internal.ChannelAttributes;
+
+/** Unit test for {@link CommonMessagePropertiesHandler}. */
+class CommonMessagePropertiesHandlerUnitTest {
+
+    private static final InetSocketAddress SENDER_ADDRESS =
+            new InetSocketAddress("127.0.0.1", 1234);
+
+    protected EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        channel = new EmbeddedChannel(CommonMessagePropertiesHandler.getInstance());
+        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(SENDER_ADDRESS);
+    }
+
+    @Test
+    void shouldSetSenderAddress() {
+        // Given
+        InetSocketAddress senderAddress = new InetSocketAddress("127.0.0.3", 1234);
+        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(senderAddress);
+        HttpMessage msg = new HttpMessage();
+        // When
+        written(msg);
+        // Then
+        assertThat(
+                msg.getRequestHeader().getSenderAddress(), is(equalTo(senderAddress.getAddress())));
+        assertChannelState(msg);
+    }
+
+    @Test
+    void shouldNotSetSenderAddressIfNotPresent() {
+        // Given
+        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(null);
+        HttpMessage msg = new HttpMessage();
+        // When
+        written(msg);
+        // Then
+        assertThat(msg.getRequestHeader().getSenderAddress(), is(nullValue()));
+        assertThat(msg.getUserObject(), is(nullValue()));
+        assertChannelState(msg);
+    }
+
+    protected void written(HttpMessage message) {
+        assertThat(channel.writeInbound(message), is(equalTo(true)));
+    }
+
+    protected void assertChannelState(HttpMessage msg) {
+        assertThat(channel.finish(), is(equalTo(true)));
+        assertThat(channel.readInbound(), is(equalTo(msg)));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
@@ -242,7 +242,7 @@ class TlsProtocolHandlerUnitTest {
         ChannelPipeline pipeline = mock(ChannelPipeline.class);
         withAlpnEnabled(ctx, pipeline, false);
         // When
-        handler.handlerAdded(ctx);
+        handler.channelActive(ctx);
         // Then
         verify(pipeline).addAfter(any(), eq("http2.preface"), any());
         verifyNoMoreInteractions(pipeline);
@@ -256,7 +256,7 @@ class TlsProtocolHandlerUnitTest {
         ChannelPipeline pipeline = mock(ChannelPipeline.class);
         withAlpnEnabled(ctx, pipeline, true);
         // When
-        handler.handlerAdded(ctx);
+        handler.channelActive(ctx);
         // Then
         verifyNoInteractions(pipeline);
     }

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Do not include the Connection header in Callback responses for HTTP/2.
 
 ## [0.13.0] - 2022-10-27
 ### Changed

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListener.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListener.java
@@ -70,6 +70,9 @@ class CallbackProxyListener implements HttpMessageHandler {
                     path,
                     msg.getRequestHeader().getSenderAddress());
             msg.setResponseHeader(RESPONSE_HEADER);
+            if ("HTTP/2".equalsIgnoreCase(msg.getRequestHeader().getVersion())) {
+                msg.getResponseHeader().setHeader(HttpHeader.CONNECTION, null);
+            }
             String uuid = path.substring(1);
             String handler = callbackService.getHandlers().get(uuid);
             if (handler != null) {

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListenerUnitTest.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListenerUnitTest.java
@@ -132,6 +132,19 @@ class CallbackProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldRemoveConnectionHeaderIfHttp2Request() throws Exception {
+        // Given
+        given(ctx.isFromClient()).willReturn(true);
+        message.getRequestHeader().setVersion("HTTP/2");
+        // When
+        listener.handleMessage(ctx, message);
+        // Then
+        assertThat(
+                message.getResponseHeader().toString(),
+                is(equalTo("HTTP/1.1 200\r\nContent-Length: 0\r\n\r\n")));
+    }
+
+    @Test
     void shouldNotNotifyOfResponse() throws Exception {
         // Given
         given(ctx.isFromClient()).willReturn(false);


### PR DESCRIPTION
Network:
 - Flag responses from the target host, this could lead to responses not being passively scanned.
 - Add the source address to all messages received by the local servers, regardless of the HTTP version.
 - Allow (semantically) malformed messages (e.g. names with mixed/upper case, invalid pseudo-headers).
 - Correct the order when HTTP/2 preface handler is added.
 - Reduce the changes done to the messages received and forwarded.

OAST:
 - Do not include the Connection header in Callback responses for HTTP/2.