### PR TITLE
quickstart: correctly unload the add-on

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correctly unload the add-on.
 
 ## [35] - 2022-10-27
 ### Changed

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -122,6 +122,7 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
     public void unload() {
         if (hasView()) {
             this.getExtQuickStart().setLaunchPanel(null);
+            launchPanel.unload();
         }
     }
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
@@ -438,4 +438,8 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
             this.canLaunch = canLaunchNow;
         }
     }
+
+    void unload() {
+        ZAP.getEventBus().unregisterConsumer(this);
+    }
 }


### PR DESCRIPTION
Unregister the event consumer when the add-on is unloaded.