### PR TITLE
network: differentiate trailer headers

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/h2/HttpMessageResponseConsumer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/h2/HttpMessageResponseConsumer.java
@@ -20,31 +20,137 @@
 package org.zaproxy.addon.network.internal.client.apachev5.h2;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.apache.hc.core5.concurrent.CallbackContribution;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.function.Supplier;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpResponse;
-import org.apache.hc.core5.http.nio.support.AbstractAsyncResponseConsumer;
+import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.AsyncResponseConsumer;
+import org.apache.hc.core5.http.nio.CapacityChannel;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeaderField;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 
-public class HttpMessageResponseConsumer
-        extends AbstractAsyncResponseConsumer<HttpMessage, byte[]> {
+public class HttpMessageResponseConsumer implements AsyncResponseConsumer<HttpMessage> {
 
     private static final Logger LOGGER = LogManager.getLogger(HttpMessageResponseConsumer.class);
 
     private static final byte[] EMPTY_BODY = {};
 
-    private HttpMessage message;
+    private final Supplier<AsyncEntityConsumer<byte[]>> dataConsumerSupplier;
+    private final AtomicReference<AsyncEntityConsumer<byte[]>> dataConsumerRef;
+    private final HttpMessage message;
 
     public HttpMessageResponseConsumer(HttpMessage message) {
-        super(new SimpleAsyncEntityConsumer());
-
         this.message = message;
+        this.dataConsumerSupplier = SimpleAsyncEntityConsumer::new;
+        this.dataConsumerRef = new AtomicReference<>();
+    }
+
+    @Override
+    public final void consumeResponse(
+            final HttpResponse response,
+            final EntityDetails entityDetails,
+            final HttpContext httpContext,
+            final FutureCallback<HttpMessage> resultCallback)
+            throws HttpException, IOException {
+        if (entityDetails != null) {
+            final AsyncEntityConsumer<byte[]> dataConsumer = dataConsumerSupplier.get();
+            if (dataConsumer == null) {
+                throw new HttpException("Supplied data consumer is null");
+            }
+            dataConsumerRef.set(dataConsumer);
+            dataConsumer.streamStart(
+                    entityDetails,
+                    new CallbackContribution<byte[]>(resultCallback) {
+
+                        @Override
+                        public void completed(final byte[] entity) {
+                            final ContentType contentType;
+                            try {
+                                contentType = ContentType.parse(entityDetails.getContentType());
+                                final HttpMessage result =
+                                        buildResult(response, entity, contentType);
+                                if (resultCallback != null) {
+                                    resultCallback.completed(result);
+                                }
+                            } catch (final UnsupportedCharsetException ex) {
+                                if (resultCallback != null) {
+                                    resultCallback.failed(ex);
+                                }
+                            }
+                        }
+                    });
+        } else {
+            final HttpMessage result = buildResult(response, null, null);
+            if (resultCallback != null) {
+                resultCallback.completed(result);
+            }
+        }
+    }
+
+    @Override
+    public final void updateCapacity(final CapacityChannel capacityChannel) throws IOException {
+        final AsyncEntityConsumer<byte[]> dataConsumer = dataConsumerRef.get();
+        if (dataConsumer != null) {
+            dataConsumer.updateCapacity(capacityChannel);
+        } else {
+            capacityChannel.update(Integer.MAX_VALUE);
+        }
+    }
+
+    @Override
+    public final void consume(final ByteBuffer src) throws IOException {
+        final AsyncEntityConsumer<byte[]> dataConsumer = dataConsumerRef.get();
+        if (dataConsumer != null) {
+            dataConsumer.consume(src);
+        }
+    }
+
+    @Override
+    public void streamEnd(final List<? extends Header> trailers) throws HttpException, IOException {
+        if (trailers != null) {
+            getProperties(message)
+                    .put(
+                            "zap.h2.trailers.resp",
+                            trailers.stream()
+                                    .map(e -> new HttpHeaderField(e.getName(), e.getValue()))
+                                    .collect(Collectors.toCollection(ArrayList::new)));
+        }
+
+        final AsyncEntityConsumer<byte[]> dataConsumer = dataConsumerRef.get();
+        if (dataConsumer != null) {
+            dataConsumer.streamEnd(trailers);
+        }
+    }
+
+    @Override
+    public final void failed(final Exception cause) {
+        releaseResources();
+    }
+
+    @Override
+    public final void releaseResources() {
+        final AsyncEntityConsumer<byte[]> dataConsumer = dataConsumerRef.getAndSet(null);
+        if (dataConsumer != null) {
+            dataConsumer.releaseResources();
+        }
     }
 
     @Override
@@ -53,9 +159,7 @@ public class HttpMessageResponseConsumer
         // Nothing to do.
     }
 
-    @Override
-    protected HttpMessage buildResult(
-            HttpResponse response, byte[] entity, ContentType contentType) {
+    HttpMessage buildResult(HttpResponse response, byte[] entity, ContentType contentType) {
         HttpResponseHeader header = message.getResponseHeader();
         try {
             header.setMessage("HTTP/2 " + response.getCode());
@@ -67,5 +171,15 @@ public class HttpMessageResponseConsumer
         }
         message.setResponseBody(entity == null ? EMPTY_BODY : entity);
         return message;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getProperties(HttpMessage message) {
+        Object userObject = message.getUserObject();
+        if (!(userObject instanceof Map)) {
+            userObject = new HashMap<>();
+            message.setUserObject(userObject);
+        }
+        return (Map<String, Object>) userObject;
     }
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpToHttp2ConnectionHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpToHttp2ConnectionHandler.java
@@ -204,8 +204,28 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
 
             if (!endStream) {
                 ByteBuf content = Unpooled.wrappedBuffer(body.getBytes());
+                Http2Headers trailers =
+                        Http2MessageHelper.createTrailerHttp2Headers(msg, encodeRequest);
                 encoder.writeData(
-                        ctx, currentStreamId, content, 0, true, promiseAggregator.newPromise());
+                        ctx,
+                        currentStreamId,
+                        content,
+                        0,
+                        trailers.isEmpty(),
+                        promiseAggregator.newPromise());
+
+                if (!trailers.isEmpty()) {
+                    encoder.writeHeaders(
+                            ctx,
+                            currentStreamId,
+                            trailers,
+                            dependencyId,
+                            weight,
+                            false,
+                            0,
+                            true,
+                            promiseAggregator.newPromise());
+                }
             }
         } catch (Throwable t) {
             onError(ctx, true, t);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/InboundHttp2ToHttpAdapter.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/InboundHttp2ToHttpAdapter.java
@@ -142,7 +142,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         if (msg == null) {
             msg = newMessage(server, stream, headers);
         } else {
-            Http2MessageHelper.copyHeaders(stream.id(), headers, msg, server);
+            Http2MessageHelper.addTrailerHeaders(stream.id(), headers, msg, server);
         }
 
         if (mustSendImmediately(server, msg)) {

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/InboundHttp2ToHttpAdapterUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/InboundHttp2ToHttpAdapterUnitTest.java
@@ -199,7 +199,7 @@ class InboundHttp2ToHttpAdapterUnitTest {
         // When
         adapter.onHeadersRead(ctx, streamId, headers, padding, endOfStream);
         // Then
-        helper.verify(() -> Http2MessageHelper.copyHeaders(streamId, headers, msg, server));
+        helper.verify(() -> Http2MessageHelper.addTrailerHeaders(streamId, headers, msg, server));
         verifyNoInteractions(ctx);
     }
 
@@ -272,7 +272,7 @@ class InboundHttp2ToHttpAdapterUnitTest {
         // When
         adapter.onHeadersRead(ctx, streamId, headers, padding, endOfStream);
         // Then
-        helper.verify(() -> Http2MessageHelper.copyHeaders(streamId, headers, msg, server));
+        helper.verify(() -> Http2MessageHelper.addTrailerHeaders(streamId, headers, msg, server));
         verifyNoInteractions(ctx);
     }
 
@@ -318,7 +318,7 @@ class InboundHttp2ToHttpAdapterUnitTest {
         adapter.onHeadersRead(
                 ctx, streamId, headers, streamDependency, weight, false, padding, endOfStream);
         // Then
-        helper.verify(() -> Http2MessageHelper.copyHeaders(streamId, headers, msg, server));
+        helper.verify(() -> Http2MessageHelper.addTrailerHeaders(streamId, headers, msg, server));
         verifyNoInteractions(ctx);
     }
 
@@ -396,7 +396,7 @@ class InboundHttp2ToHttpAdapterUnitTest {
         adapter.onHeadersRead(
                 ctx, streamId, headers, streamDependency, weight, false, padding, endOfStream);
         // Then
-        helper.verify(() -> Http2MessageHelper.copyHeaders(streamId, headers, msg, server));
+        helper.verify(() -> Http2MessageHelper.addTrailerHeaders(streamId, headers, msg, server));
         verifyNoInteractions(ctx);
     }
 


### PR DESCRIPTION
Allow to forward the trailer headers separately from the main headers, to keep the expected content/data.