### PR TITLE
pscanrules: ignore non-HTML files in ModernAppDetectionScanRule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - The Private Address Disclosure and Session ID in URL Rewrite scan rules now include example alert functionality for documentation generation purposes (Issue 6119 and 7100).
 
+### Fixed
+- The Modern App Detection scan rule now ignores non-HTML files (Issue 7617).
+
 ## [44] - 2022-10-27
 ### Added
 - The following scan rules were added, having been promoted from Beta:
@@ -28,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - User Controlled Javascript Event
   - User Controlled Open Redirect
   - X-Backend-Server Information Leak
-  - X-ChromeLogger-Data Info Leak   
+  - X-ChromeLogger-Data Info Leak
 
 ### Changed
 - Update minimum ZAP version to 2.12.0.
@@ -234,7 +237,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Maintenance changes.
 - Migrate CSP Scanner into the main passive scan release package (promoting it to Release). Upgrade Salvation (dependency) to 2.6.0.
-- Application Error scanner change for HTTP 500. Alert changed to low risk for HTTP 500, and not raised at all when Threshold is High.  
+- Application Error scanner change for HTTP 500. Alert changed to low risk for HTTP 500, and not raised at all when Threshold is High.
 - Updated the reference link for the alert: Web Browser XSS Protection Not Enabled.
 - Promote Charset Mismatch Scanner to release (Issue 4460).
 - Promote ViewState Scanner to release (Issue 4453).

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java
@@ -43,6 +43,7 @@ public class ModernAppDetectionScanRule extends PluginPassiveScanner {
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!msg.getResponseHeader().isHtml()) {
             // Only check HTML responses
+            return;
         }
         String evidence = null;
         String otherInfo = null;

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRuleUnitTest.java
@@ -38,6 +38,19 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
     }
 
     @Test
+    void shouldNotRaiseAlertWithNonHtmlContentType() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200\r\n" + "Content-Type: application/foo\r\n");
+        msg.setResponseBody("content that would normally raise <a> an alert");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
     void shouldNotRaiseAlertWithBasicHtml() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -55,6 +68,7 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200\r\n" + "Content-Type: text/html; charset=UTF-8\r\n");
         msg.setResponseBody("<html><head></head><body><a href=\"#\">Link</a></body></html>");
         // When
         scanHttpResponseReceive(msg);
@@ -68,6 +82,7 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200\r\n" + "Content-Type: text/html; charset=UTF-8\r\n");
         msg.setResponseBody("<html><head></head><body><a href=\"#blah\">Link</a></body></html>");
         // When
         scanHttpResponseReceive(msg);
@@ -80,6 +95,7 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200\r\n" + "Content-Type: text/html; charset=UTF-8\r\n");
         msg.setResponseBody(
                 "<html><head></head><body><a href=\"link\" target=\"_self\">Link</a></body></html>");
         // When
@@ -96,6 +112,7 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200\r\n" + "Content-Type: text/html; charset=UTF-8\r\n");
         msg.setResponseBody("<html><head></head><body><a href=\"\">Link</a></body></html>");
         // When
         scanHttpResponseReceive(msg);
@@ -109,6 +126,7 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200\r\n" + "Content-Type: text/html; charset=UTF-8\r\n");
         msg.setResponseBody(
                 "<html><head></head><body><script src=\"/script.js\"></script></body></html>");
         // When
@@ -123,6 +141,7 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200\r\n" + "Content-Type: text/html; charset=UTF-8\r\n");
         msg.setResponseBody(
                 "<html><head><script src=\"/script.js\"></script></head><body></body></html>");
         // When
@@ -137,6 +156,7 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200\r\n" + "Content-Type: text/html; charset=UTF-8\r\n");
         msg.setResponseBody(
                 "<html><head><script src=\"/script.js\"></script></head><body><a href=\"link\">link</a><noscript>You need to enable JavaScript to run this app.</noscript></body></html>");
         // When


### PR DESCRIPTION
Return was missing, see zaproxy/zaproxy#7617

Fix zaproxy/zaproxy#7617.