### PR TITLE
retest: include HTTP version for requestor job

### DIFF
--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Include the HTTP version of the alerts' message when creating the `requestor` job.
 
 ## [0.4.0] - 2022-10-27
 ### Changed

--- a/addOns/retest/retest.gradle.kts
+++ b/addOns/retest/retest.gradle.kts
@@ -10,7 +10,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("automation") {
-                    version.set(">=0.6.0")
+                    version.set(">=0.20.0")
                 }
             }
         }

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/RetestPlanGenerator.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/RetestPlanGenerator.java
@@ -88,7 +88,9 @@ public class RetestPlanGenerator {
                                                 t.getUrl(),
                                                 t.getAlertName(),
                                                 t.getMethod(),
+                                                t.getMsg().getRequestHeader().getVersion(),
                                                 t.getMsg().getRequestBody().toString(),
+                                                null,
                                                 null))
                         .collect(Collectors.toList());
         reqJob.getData().setRequests(requests);

--- a/addOns/retest/src/test/java/org/zaproxy/addon/retest/RetestPlanGeneratorUnitTest.java
+++ b/addOns/retest/src/test/java/org/zaproxy/addon/retest/RetestPlanGeneratorUnitTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
@@ -50,6 +51,7 @@ class RetestPlanGeneratorUnitTest {
     static void init() {
         List<AlertData> alertData = new ArrayList<>();
         HttpMessage msgOne = new HttpMessage();
+        msgOne.getRequestHeader().setVersion(HttpHeader.HTTP11);
         Alert alertOne = new Alert(100);
         alertOne.setSource(Alert.Source.ACTIVE);
         AlertData alertOneData = new AlertData();
@@ -67,6 +69,7 @@ class RetestPlanGeneratorUnitTest {
         alertOneData.setAlert(alertOne);
 
         HttpMessage msgTwo = new HttpMessage();
+        msgTwo.getRequestHeader().setVersion("HTTP/2");
         msgTwo.setRequestBody(new HttpRequestBody("Test Body"));
         Alert alertTwo = new Alert(200);
         alertTwo.setSource(Alert.Source.PASSIVE);
@@ -129,11 +132,13 @@ class RetestPlanGeneratorUnitTest {
         assertThat(requests.get(0).getName(), is(equalTo("Test Alert One")));
         assertThat(requests.get(0).getData(), is(equalTo("")));
         assertThat(requests.get(0).getResponseCode(), is(equalTo(null)));
+        assertThat(requests.get(0).getHttpVersion(), is(equalTo(HttpHeader.HTTP11)));
         assertThat(requests.get(1).getUrl(), is(equalTo("https://www.exampletwo.com")));
         assertThat(requests.get(1).getMethod(), is(equalTo("POST")));
         assertThat(requests.get(1).getName(), is(equalTo("Test Alert Two")));
         assertThat(requests.get(1).getData(), is(equalTo("Test Body")));
         assertThat(requests.get(1).getResponseCode(), is(equalTo(null)));
+        assertThat(requests.get(1).getHttpVersion(), is(equalTo("HTTP/2")));
     }
 
     @Test


### PR DESCRIPTION
Include the HTTP version of the alerts' message when creating the requestor job.