### PR TITLE
network: enable ALPN, remove lower case header

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Support HTTP/2.
+
 ### Changed
 - Update dependency.
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
@@ -447,7 +447,7 @@ public class LocalServersOptions extends VersionedAbstractParam {
                 serverConfig.setTlsProtocols(TlsUtils.getSupportedTlsProtocols());
             }
 
-            serverConfig.setAlpnEnabled(config.getBoolean(SERVER_ALPN_ENABLED, false));
+            serverConfig.setAlpnEnabled(config.getBoolean(SERVER_ALPN_ENABLED, true));
             protocols =
                     config.getList(SERVER_ALPN_PROTOCOLS + "." + SERVER_ALPN_PROTOCOL).stream()
                             .map(Object::toString)

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -760,8 +759,7 @@ public class HttpSenderApache
                             path == null ? "/" : path);
 
             for (HttpHeaderField header : requestHeader.getHeaders()) {
-                // XXX Remove lower case once the codebase uses fields' names compatible with HTTP/2
-                String name = header.getName().toLowerCase(Locale.ROOT);
+                String name = header.getName();
                 String value = header.getValue();
                 request.addHeader(name, value);
             }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsConfig.java
@@ -44,10 +44,10 @@ public class TlsConfig {
 
     /**
      * Constructs a {@code TlsConfig} with all the SSL/TLS protocol versions supported, with ALPN
-     * disabled, and with all application protocols.
+     * enabled, and with all application protocols.
      */
     public TlsConfig() {
-        this(DEFAULT_PROTOCOLS, false, DEFAULT_APPLICATION_PROTOCOLS);
+        this(DEFAULT_PROTOCOLS, true, DEFAULT_APPLICATION_PROTOCOLS);
     }
 
     /**

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServerConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServerConfig.java
@@ -98,7 +98,7 @@ public class LocalServerConfig extends Enableable implements ServerConfig {
         port = DEFAULT_PORT;
         mode = ServerMode.API_AND_PROXY;
         tlsProtocols = TlsUtils.getSupportedTlsProtocols();
-        alpnEnabled = false;
+        alpnEnabled = true;
         applicationProtocols = TlsUtils.getSupportedApplicationProtocols();
         removeAcceptEncoding = true;
         decodeResponse = true;

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
@@ -154,7 +154,7 @@ class LocalServersOptionsUnitTest {
         assertThat(mainProxy.getPort(), is(equalTo(LocalServerConfig.DEFAULT_PORT)));
         assertThat(mainProxy.getMode(), is(equalTo(LocalServerConfig.ServerMode.API_AND_PROXY)));
         assertThat(mainProxy.getTlsProtocols(), is(equalTo(TlsUtils.getSupportedTlsProtocols())));
-        assertThat(mainProxy.isAlpnEnabled(), is(equalTo(false)));
+        assertThat(mainProxy.isAlpnEnabled(), is(equalTo(true)));
         assertThat(
                 mainProxy.getApplicationProtocols(),
                 is(equalTo(TlsUtils.getSupportedApplicationProtocols())));
@@ -305,7 +305,7 @@ class LocalServersOptionsUnitTest {
         assertThat(
                 config.getProperty(MAIN_PROXY_KEY + ".tlsProtocols.protocol(0)"),
                 is(notNullValue()));
-        assertThat(config.getProperty(MAIN_PROXY_KEY + ".alpn.enabled"), is(equalTo(false)));
+        assertThat(config.getProperty(MAIN_PROXY_KEY + ".alpn.enabled"), is(equalTo(true)));
         assertThat(
                 config.getProperty(MAIN_PROXY_KEY + ".alpn.protocols.protocol(0)"),
                 is(notNullValue()));
@@ -358,7 +358,7 @@ class LocalServersOptionsUnitTest {
         assertThat(config.getProperty(SERVER_KEY + ".api"), is(equalTo(api)));
         assertThat(
                 config.getProperty(SERVER_KEY + ".tlsProtocols.protocol(0)"), is(notNullValue()));
-        assertThat(config.getProperty(SERVER_KEY + ".alpn.enabled"), is(equalTo(false)));
+        assertThat(config.getProperty(SERVER_KEY + ".alpn.enabled"), is(equalTo(true)));
         assertThat(
                 config.getProperty(SERVER_KEY + ".alpn.protocols.protocol(0)"), is(notNullValue()));
         assertThat(config.getProperty(SERVER_KEY + ".behindNat"), is(equalTo(behindNat)));
@@ -585,7 +585,7 @@ class LocalServersOptionsUnitTest {
                 true,
                 true,
                 true,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
     }
 
@@ -613,7 +613,7 @@ class LocalServersOptionsUnitTest {
                 true,
                 true,
                 true,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
     }
 
@@ -831,7 +831,7 @@ class LocalServersOptionsUnitTest {
                 true,
                 true,
                 true,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
     }
 
@@ -863,7 +863,7 @@ class LocalServersOptionsUnitTest {
                 true,
                 true,
                 true,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
     }
 
@@ -907,7 +907,7 @@ class LocalServersOptionsUnitTest {
                 true,
                 true,
                 true,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
     }
 
@@ -1485,7 +1485,7 @@ class LocalServersOptionsUnitTest {
                 false,
                 false,
                 true,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
         assertThat(config.getProperty("proxy.ip"), is(nullValue()));
     }
@@ -1506,7 +1506,7 @@ class LocalServersOptionsUnitTest {
                 true,
                 true,
                 true,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
         assertThat(config.getProperty("proxy.port"), is(nullValue()));
     }
@@ -1573,7 +1573,7 @@ class LocalServersOptionsUnitTest {
                 true,
                 true,
                 true,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
         assertServerFields(
                 options.getServers().get(1),
@@ -1584,7 +1584,7 @@ class LocalServersOptionsUnitTest {
                 false,
                 false,
                 false,
-                false,
+                true,
                 DEFAULT_APPLICATION_PROTOCOLS);
         assertThat(config.getProperty("proxies.confirmRemoveProxy"), is(nullValue()));
         assertThat(config.getProperty("proxies.all"), is(nullValue()));

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsConfigUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsConfigUnitTest.java
@@ -62,7 +62,7 @@ class TlsConfigUnitTest {
         TlsConfig tlsConfig = new TlsConfig();
         // Then
         assertThat(tlsConfig.getTlsProtocols(), hasItem(TLS_V1_2));
-        assertThat(tlsConfig.isAlpnEnabled(), is(equalTo(false)));
+        assertThat(tlsConfig.isAlpnEnabled(), is(equalTo(true)));
         assertThat(
                 tlsConfig.getApplicationProtocols(),
                 is(equalTo(getSupportedApplicationProtocols())));

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
@@ -32,7 +32,10 @@ import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.network.internal.ChannelAttributes;
+import org.zaproxy.addon.network.internal.TlsUtils;
 import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
+import org.zaproxy.addon.network.internal.handlers.TlsConfig;
 import org.zaproxy.addon.network.internal.server.http.HttpServer;
 import org.zaproxy.addon.network.internal.server.http.MainServerHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
@@ -43,6 +46,11 @@ public class TestHttpServer extends HttpServer {
 
     private static final ServerCertificateService CERTIFICATE_SERVICE =
             TestServerCertificateService.createInstance();
+    private static final TlsConfig DEFAULT_TLS_CONFIG =
+            new TlsConfig(
+                    TlsUtils.getSupportedTlsProtocols(),
+                    false,
+                    TlsUtils.getSupportedApplicationProtocols());
 
     private final List<HttpMessage> receivedMessages;
     private HttpMessageHandler handler;
@@ -65,6 +73,8 @@ public class TestHttpServer extends HttpServer {
     @Override
     protected void initChannel(SocketChannel ch) {
         super.initChannel(ch);
+
+        ch.attr(ChannelAttributes.TLS_CONFIG).set(DEFAULT_TLS_CONFIG);
 
         if (fixedLengthMessage != null) {
             ch.pipeline()


### PR DESCRIPTION
Enable ALPN by default.
Remove lower case header workaround.