### PR TITLE
Ascan rules alpha: LDAP tech support

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- LDAP protocol technology support.
+
 ### Fixed
 - Preserve the HTTP version in Web Cache Deception scan rule.
 

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -38,6 +38,8 @@ import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.DiceMatcher;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
 
 /**
  * The LdapInjectionScanRule scan rule identifies LDAP injection vulnerabilities with LDAP based
@@ -73,6 +75,10 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
     private static final char[] RANDOM_PARAMETER_CHARS =
             "abcdefghijklmnopqrstuvwyxz0123456789".toCharArray();
 
+    public static final Tech Protocol =
+            new Tech("Protocol", I18N_PREFIX + "ldapinjection.technologies.protocol");
+    public static final Tech LDAP = new Tech(Protocol, "LDAP");
+
     static {
         ResourceBundle resourceBundle =
                 ResourceBundle.getBundle(
@@ -104,6 +110,9 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                 LDAP_ERRORS.put(errorPattern, ldapImplementation);
             }
         }
+
+        Tech.add(Protocol);
+        Tech.add(LDAP);
     }
 
     @Override
@@ -134,6 +143,11 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
     @Override
     public String getReference() {
         return Constant.messages.getString(I18N_PREFIX + "ldapinjection.refs");
+    }
+
+    @Override
+    public boolean targets(TechSet technologies) {
+        return technologies.includes(LDAP);
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -18,6 +18,7 @@ ascanalpha.ldapinjection.booleanbased.alert.extrainfo=parameter [{0}] on [{1}] [
 #ascanalpha.ldapinjection.alert.attack=[{0}] field [{1}] set to [{2}]
 ascanalpha.ldapinjection.alert.attack=parameter [{0}] set to [{1}]
 ascanalpha.ldapinjection.booleanbased.alert.attack=Equivalent LDAP expression: [{0}]. Random parameter: [{1}].
+ascanalpha.ldapinjection.technologies.protocol = Protocol
 
 ascanalpha.mongodb.name=NoSQL Injection - MongoDB
 ascanalpha.mongodb.desc=MongoDB query injection may be possible.

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.model.TechSet;
 
 /** Unit test for {@link LdapInjectionScanRule}. */
 class LdapInjectionScanRuleUnitTest extends ActiveScannerTest<LdapInjectionScanRule> {
@@ -63,5 +64,16 @@ class LdapInjectionScanRuleUnitTest extends ActiveScannerTest<LdapInjectionScanR
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_INPV_06_LDAPI.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_INPV_06_LDAPI.getValue())));
+    }
+
+    @Test
+    void shouldTargetExpectedTech() {
+        // Given / When
+        TechSet allButLdap = techSetWithout(LdapInjectionScanRule.LDAP);
+        TechSet justLdap = techSet(LdapInjectionScanRule.LDAP);
+
+        // Then
+        assertThat(rule.targets(allButLdap), is(equalTo(false)));
+        assertThat(rule.targets(justLdap), is(equalTo(true)));
     }
 }


### PR DESCRIPTION
Also tested manually in the UI - if LDAP tech is enabled then the rule runs, if not then it doesnt.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>