### PR TITLE
pscanrules: CSP Meta Handling and dependency update

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The Private Address Disclosure and Session ID in URL Rewrite scan rules now include example alert functionality for documentation generation purposes (Issue 6119 and 7100).
 - The Content Security Policy scan rule will now alert when "unsafe-eval" is allowed.
 - Maintenance changes.
+- The Salvation2 library used by the CSP scan rule was upgraded to v3.0.1. Alerts may now have an alert condition if the policy contains characters outside the accepted set.
+- The CSP scan rule now includes handling for policies defined in META tags, as well as two new alerts pertaining to those policies (Issue 7303).
 
 ### Fixed
 - The Modern App Detection scan rule now ignores non-HTML files (Issue 7617).

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -38,7 +38,8 @@ zapAddOn {
 
 dependencies {
     implementation("com.google.re2j:re2j:1.6")
-    implementation("com.shapesecurity:salvation2:3.0.0")
+    implementation("com.shapesecurity:salvation2:3.0.1")
+
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CspUtils.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CspUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import net.htmlparser.jericho.Element;
+import net.htmlparser.jericho.HTMLElementName;
+import net.htmlparser.jericho.Source;
+import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
+
+/** A utility class to help dealing with Content-Security-Policy (CSP). */
+public class CspUtils {
+
+    private CspUtils() {}
+
+    protected static boolean hasMetaCsp(Source source) {
+        for (Element metaElement : source.getAllElements(HTMLElementName.META)) {
+            String httpEquiv = metaElement.getAttributeValue("http-equiv");
+            if (HttpFieldsNames.CONTENT_SECURITY_POLICY.equalsIgnoreCase(httpEquiv)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -158,7 +158,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 
 <H2>CSP (Content Security Policy)</H2>
 
-The Content Security Policy (CSP) passive scan rule parses and analyzes CSP headers for potential misconfiguration
+The Content Security Policy (CSP) passive scan rule parses and analyzes CSP headers and META definitions for potential misconfiguration
 or weakness. This rule leverages Shape Security's <a href="https://github.com/shapesecurity/salvation">Salvation</a> 
 library to perform it's parsing and assessment of CSPs.
 <p>

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -348,6 +348,10 @@ pscanrules.csp.desc=Content Security Policy (CSP) is an added layer of security 
 pscanrules.csp.otherinfo.extended=\n\nThe directive(s): {0} are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.
 pscanrules.csp.refs=http://www.w3.org/TR/CSP2/\nhttp://www.w3.org/TR/CSP/\nhttp://caniuse.com/#search=content+security+policy\nhttp://content-security-policy.com/\nhttps://github.com/shapesecurity/salvation\nhttps://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
 pscanrules.csp.soln=Ensure that your web server, application server, load balancer, etc. is properly configured to set the Content-Security-Policy header.
+pscanrules.csp.both.name=Header & Meta
+pscanrules.csp.both.desc=The message contained both CSP specified via header and via Meta tag. It was not possible to union these policies in order to perform an analysis. Therefore, they have been evaluated individually.
+pscanrules.csp.meta.bad.directive.name=Meta Policy Invalid Directive
+pscanrules.csp.meta.bad.directive.desc=The policy specified via meta element contains either or both the sandbox or frame-ancestors directive, which are not permitted inside meta CSP definitions.
 pscanrules.csp.notices.name=Notices
 pscanrules.csp.notices.errors=Errors:
 pscanrules.csp.notices.warnings=Warnings:


### PR DESCRIPTION
- Update Salvation library dependency to 3.0.1. Update tests to accommodate updated functionality.
- CHANGELOG > Add change notes.
- CspUtils > Extract a convenience method to identify if a response has CSP defined via meta. Extract the field name string into a constant.
- ContentSecurityPolicyMissingScanRule > Updated to use CspUtils.
- ContentSecurityPolicyScanRule > Updated to handle META tag CSP definitions, and additional alerts applicable to their use.
- ContentSecurityPolicyScanRuleUnitTest > Add tests to assert the updated and new functionality.
- pscanrules.html > Updated to mention META policies are also checked.

Fixes zaproxy/zaproxy#7303

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>