### PR TITLE
spider: Don't initiate get requests for bare anchor links

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- A and Area element hrefs that are bare anchor links (#) will no longer cause a GET request (Issue 7265).
+
 ## [0.1.0] - 2022-10-27
 
 ### Functional Improvements Compared to Previous Core Release

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHtmlParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHtmlParser.java
@@ -417,7 +417,7 @@ public class SpiderHtmlParser extends SpiderParser {
             CustomUrlProcessor customUrlProcessor) {
         // The URL as written in the attribute (can be relative or absolute)
         String localURL = element.getAttributeValue(attributeName);
-        if (localURL == null) {
+        if (localURL == null || localURL.equals("#")) {
             return false;
         }
 

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SpiderHtmlParserUnitTest.java
@@ -99,7 +99,7 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils<SpiderHtmlParser> {
         boolean completelyParsed = parser.parseResource(ctx);
         // Then
         assertThat(completelyParsed, is(equalTo(false)));
-        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(8)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(9)));
         assertThat(
                 listener.getUrlsFound(),
                 contains(
@@ -110,7 +110,8 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils<SpiderHtmlParser> {
                         "http://example.com/sample/a/relative",
                         "http://example.com/sample/",
                         "http://example.com/a/absolute",
-                        "ftp://a.example.com/"));
+                        "ftp://a.example.com/",
+                        "http://example.com/sample/"));
     }
 
     @Test
@@ -322,7 +323,7 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils<SpiderHtmlParser> {
         boolean completelyParsed = parser.parseResource(ctx);
         // Then
         assertThat(completelyParsed, is(equalTo(false)));
-        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(8)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(9)));
         assertThat(
                 listener.getUrlsFound(),
                 contains(
@@ -333,7 +334,8 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils<SpiderHtmlParser> {
                         "http://example.com/sample/area/relative",
                         "http://example.com/sample/",
                         "http://example.com/area/absolute",
-                        "ftp://area.example.com/"));
+                        "ftp://area.example.com/",
+                        "http://example.com/sample/"));
     }
 
     @Test

--- a/addOns/spider/src/test/resources/org/zaproxy/addon/spider/parser/html/AElementsSpiderHtmlParser.html
+++ b/addOns/spider/src/test/resources/org/zaproxy/addon/spider/parser/html/AElementsSpiderHtmlParser.html
@@ -14,12 +14,14 @@
 <a href="">relative (same page)</a><br />
 <a href="/a/absolute">absolute</a><br />
 <a href="ftp://a.example.com/">ftp</a><br />
+<a href="#local">named local anchor</a>
 
 Ignored:<br />
 <a>no href</a><br />
 <a href="mailto:a@example.com">mailto:</a><br />
 <a href="javascript:hello();">javascript:</a><br />
 <a href="scheme://a.example.com/invalid">scheme:</a>
+<a href="#">local anchor</a>
 
 </body>
 </html>

--- a/addOns/spider/src/test/resources/org/zaproxy/addon/spider/parser/html/AreaElementsSpiderHtmlParser.html
+++ b/addOns/spider/src/test/resources/org/zaproxy/addon/spider/parser/html/AreaElementsSpiderHtmlParser.html
@@ -14,6 +14,7 @@
 <area href="" />
 <area href="/area/absolute" />
 <area href="ftp://area.example.com/" />
+<area href="#local" />
 </map>
 
 <!--  Ignored: -->
@@ -22,6 +23,7 @@
 <area href="mailto:area@example.com" />
 <area href="javascript:hello();" />
 <area href="scheme://area.example.com/invalid" />
+<area href="#" />
 </map>
 
 </body>


### PR DESCRIPTION
- CHANGELOG > Added fix note.
- SpiderHtmlParser > Minor tweak to ignore bare anchors.
- SpiderHtmlParserUnitTest > Updated A and Area test methods to count named but not bare anchors. (Updated associated html test resources.)

Fixes zaproxy/zaproxy#7265

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>