### PR TITLE
Prevent Toolkit initialisation without view

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Prevent exception if no display (Issue 3978).
 
 ## [14] - 2022-10-27
 ### Changed

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.swing.SwingUtilities;
 import org.apache.commons.configuration.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -65,6 +64,7 @@ import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.utils.Stats;
+import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
 import org.zaproxy.zap.view.ContextPanelFactory;
 
@@ -454,7 +454,7 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
                 this.handleAlert(alert);
             } else {
                 // Have to add the SiteNode on the EDT
-                SwingUtilities.invokeLater(
+                ThreadUtils.invokeLater(
                         () -> {
                             try {
                                 StructuralNode node =

--- a/addOns/allinonenotes/CHANGELOG.md
+++ b/addOns/allinonenotes/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.12.0.
 - Maintenance changes.
 
+### Fixed
+- Prevent exception if no display (Issue 3978).
+
 ## [2] - 2021-10-07
 ### Added
 - Add info and repo URLs.

--- a/addOns/allinonenotes/src/main/java/org/zaproxy/zap/extension/allinonenotes/ExtensionAllInOneNotes.java
+++ b/addOns/allinonenotes/src/main/java/org/zaproxy/zap/extension/allinonenotes/ExtensionAllInOneNotes.java
@@ -54,9 +54,6 @@ public class ExtensionAllInOneNotes extends ExtensionAdaptor implements SessionC
      */
     private static final String RESOURCES = "resources";
 
-    private static final ImageIcon ICON =
-            new ImageIcon(ExtensionAllInOneNotes.class.getResource(RESOURCES + "/notepad.png"));
-
     private AbstractPanel statusPanel;
     private NotesTableModel notesTableModel = null;
     private JXTable notesTable = null;
@@ -144,7 +141,7 @@ public class ExtensionAllInOneNotes extends ExtensionAdaptor implements SessionC
             statusPanel = new AbstractPanel();
             statusPanel.setLayout(new BorderLayout());
             statusPanel.setName(Constant.messages.getString(PREFIX + ".panel.title"));
-            statusPanel.setIcon(ICON);
+            statusPanel.setIcon(new ImageIcon(getClass().getResource(RESOURCES + "/notepad.png")));
             statusPanel.add(getToolBar(), BorderLayout.NORTH);
             statusPanel.add(new JScrollPane(getNotesTable()), BorderLayout.CENTER);
         }

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Prevent exception if no display (Issue 3978).
+
 ## [13.8.0] - 2022-10-27
 ### Changed
 - Update minimum ZAP version to 2.12.0.

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -128,15 +128,6 @@ public class ExtensionFuzz extends ExtensionAdaptor {
 
     private static final Logger LOGGER = LogManager.getLogger(ExtensionFuzz.class);
 
-    private static final ImageIcon SCRIPT_PAYLOAD_GENERATOR_ICON =
-            new ImageIcon(
-                    ExtensionFuzz.class.getResource(
-                            "resources/icons/script-payload-generator.png"));
-    private static final ImageIcon SCRIPT_PAYLOAD_PROCESSOR_ICON =
-            new ImageIcon(
-                    ExtensionFuzz.class.getResource(
-                            "resources/icons/script-payload-processor.png"));
-
     public static final String NAME = "ExtensionFuzz";
 
     private static final String JBROFUZZ_CATEGORY_PREFIX = "jbrofuzz";
@@ -308,7 +299,7 @@ public class ExtensionFuzz extends ExtensionAdaptor {
                     new ScriptType(
                             ScriptStringPayloadGenerator.TYPE_NAME,
                             "fuzz.payloads.script.type.payloadgenerator",
-                            SCRIPT_PAYLOAD_GENERATOR_ICON,
+                            createIcon("script-payload-generator.png"),
                             true,
                             true);
             extensionScript.registerScriptType(scriptTypeGenerator);
@@ -320,7 +311,7 @@ public class ExtensionFuzz extends ExtensionAdaptor {
                     new ScriptType(
                             ScriptStringPayloadProcessor.TYPE_NAME,
                             "fuzz.payloads.script.type.payloadprocessor",
-                            SCRIPT_PAYLOAD_PROCESSOR_ICON,
+                            createIcon("script-payload-processor.png"),
                             true,
                             true);
             extensionScript.registerScriptType(scriptTypeProcessor);
@@ -331,6 +322,13 @@ public class ExtensionFuzz extends ExtensionAdaptor {
 
         clientMessagePanelManager = new MessagePanelManager();
         serverMessagePanelManager = new MessagePanelManager();
+    }
+
+    private ImageIcon createIcon(String path) {
+        if (hasView()) {
+            return new ImageIcon(getClass().getResource("resources/icons/" + path));
+        }
+        return null;
     }
 
     @Override

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
@@ -57,9 +57,6 @@ import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 
 public class ExtensionHttpFuzzer extends ExtensionAdaptor {
 
-    private static final ImageIcon HTTP_FUZZER_PROCESSOR_SCRIPT_ICON =
-            new ImageIcon(ZAP.class.getResource("/resource/icon/16/script-fuzz.png"));
-
     private static final List<Class<? extends Extension>> DEPENDENCIES;
 
     static {
@@ -117,7 +114,11 @@ public class ExtensionHttpFuzzer extends ExtensionAdaptor {
                     new ScriptType(
                             HttpFuzzerProcessorScript.TYPE_NAME,
                             "fuzz.httpfuzzer.script.type.fuzzerprocessor",
-                            HTTP_FUZZER_PROCESSOR_SCRIPT_ICON,
+                            hasView()
+                                    ? new ImageIcon(
+                                            ZAP.class.getResource(
+                                                    "/resource/icon/16/script-fuzz.png"))
+                                    : null,
                             true,
                             true);
             extensionScript.registerScriptType(scriptType);

--- a/addOns/plugnhack/CHANGELOG.md
+++ b/addOns/plugnhack/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Prevent exception if no display (Issue 3978).
 
 ## [13] - 2022-10-27
 ### Changed

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ClientListCellRenderer.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ClientListCellRenderer.java
@@ -91,9 +91,9 @@ public class ClientListCellRenderer extends JPanel implements ListCellRenderer<M
         }
 
         if (page.isActive()) {
-            id.setIcon(DisplayUtils.getScaledIcon(ExtensionPlugNHack.CLIENT_ACTIVE_ICON));
+            id.setIcon(DisplayUtils.getScaledIcon(ExtensionPlugNHack.getClientActiveIcon()));
         } else {
-            id.setIcon(DisplayUtils.getScaledIcon(ExtensionPlugNHack.CLIENT_INACTIVE_ICON));
+            id.setIcon(DisplayUtils.getScaledIcon(ExtensionPlugNHack.getClientInactiveIcon()));
         }
         url.setIcon(DisplayUtils.getScaledIcon(page.getIcon()));
 

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ClientsPanel.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ClientsPanel.java
@@ -90,7 +90,7 @@ public class ClientsPanel extends AbstractPanel implements MonitoredPageListener
         this.setLayout(new CardLayout());
         this.setSize(274, 251);
         this.setName(Constant.messages.getString("plugnhack.client.panel.title"));
-        this.setIcon(ExtensionPlugNHack.CLIENT_ACTIVE_ICON);
+        this.setIcon(ExtensionPlugNHack.getClientActiveIcon());
         this.setDefaultAccelerator(
                 this.extension
                         .getView()
@@ -168,9 +168,9 @@ public class ClientsPanel extends AbstractPanel implements MonitoredPageListener
             final ZapToggleButton activeSwitch = new ZapToggleButton();
             activeSwitch.setSelected(true);
             activeSwitch.setIcon(
-                    DisplayUtils.getScaledIcon(ExtensionPlugNHack.CLIENT_INACTIVE_ICON));
+                    DisplayUtils.getScaledIcon(ExtensionPlugNHack.getClientInactiveIcon()));
             activeSwitch.setSelectedIcon(
-                    DisplayUtils.getScaledIcon(ExtensionPlugNHack.CLIENT_ACTIVE_ICON));
+                    DisplayUtils.getScaledIcon(ExtensionPlugNHack.getClientActiveIcon()));
             activeSwitch.setToolTipText(
                     Constant.messages.getString("plugnhack.client.button.active.off"));
             activeSwitch.setSelectedToolTipText(

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
@@ -124,27 +124,8 @@ public class ExtensionPlugNHack extends ExtensionAdaptor
     public static final String SAFARI_ICON_RESOURCE =
             "/org/zaproxy/zap/extension/plugnhack/resources/icons/safari-icon.png";
 
-    public static final ImageIcon CLIENT_ACTIVE_ICON =
-            new ImageIcon(ZAP.class.getResource(CLIENT_ACTIVE_ICON_RESOURCE));
-    public static final ImageIcon CLIENT_INACTIVE_ICON =
-            new ImageIcon(ZAP.class.getResource(CLIENT_INACTIVE_ICON_RESOURCE));
-
-    public static final ImageIcon CHANGED_ICON =
-            new ImageIcon(
-                    ExtensionPlugNHack.class.getResource(
-                            "/org/zaproxy/zap/extension/plugnhack/resources/icons/screwdriver.png"));
-    public static final ImageIcon DROPPED_ICON =
-            new ImageIcon(
-                    ExtensionPlugNHack.class.getResource(
-                            "/org/zaproxy/zap/extension/plugnhack/resources/icons/bin-metal.png"));
-    public static final ImageIcon PENDING_ICON =
-            new ImageIcon(
-                    ExtensionPlugNHack.class.getResource(
-                            "/org/zaproxy/zap/extension/plugnhack/resources/icons/hourglass.png"));
-    public static final ImageIcon ORACLE_ICON =
-            new ImageIcon(
-                    ExtensionPlugNHack.class.getResource(
-                            "/org/zaproxy/zap/extension/plugnhack/resources/icons/burn.png"));
+    private static ImageIcon clientActiveIcon;
+    private static ImageIcon clientInactiveIcon;
 
     private static final int poll = 3000;
 
@@ -190,6 +171,21 @@ public class ExtensionPlugNHack extends ExtensionAdaptor
     @Override
     public List<Class<? extends Extension>> getDependencies() {
         return DEPENDENCIES;
+    }
+
+    public static ImageIcon getClientActiveIcon() {
+        if (clientActiveIcon == null) {
+            clientActiveIcon = new ImageIcon(ZAP.class.getResource(CLIENT_ACTIVE_ICON_RESOURCE));
+        }
+        return clientActiveIcon;
+    }
+
+    public static ImageIcon getClientInactiveIcon() {
+        if (clientInactiveIcon == null) {
+            clientInactiveIcon =
+                    new ImageIcon(ZAP.class.getResource(CLIENT_INACTIVE_ICON_RESOURCE));
+        }
+        return clientInactiveIcon;
     }
 
     @Override

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/MessageListTableModel.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/MessageListTableModel.java
@@ -31,6 +31,23 @@ import org.parosproxy.paros.Constant;
 @SuppressWarnings("serial")
 public class MessageListTableModel extends AbstractTableModel {
 
+    private static final ImageIcon CHANGED_ICON =
+            new ImageIcon(
+                    ExtensionPlugNHack.class.getResource(
+                            "/org/zaproxy/zap/extension/plugnhack/resources/icons/screwdriver.png"));
+    private static final ImageIcon DROPPED_ICON =
+            new ImageIcon(
+                    ExtensionPlugNHack.class.getResource(
+                            "/org/zaproxy/zap/extension/plugnhack/resources/icons/bin-metal.png"));
+    private static final ImageIcon PENDING_ICON =
+            new ImageIcon(
+                    ExtensionPlugNHack.class.getResource(
+                            "/org/zaproxy/zap/extension/plugnhack/resources/icons/hourglass.png"));
+    private static final ImageIcon ORACLE_ICON =
+            new ImageIcon(
+                    ExtensionPlugNHack.class.getResource(
+                            "/org/zaproxy/zap/extension/plugnhack/resources/icons/burn.png"));
+
     private static final SimpleDateFormat SDF = new SimpleDateFormat("HH:mm:ss.SSS");
     private static final long serialVersionUID = 1L;
 
@@ -79,20 +96,20 @@ public class MessageListTableModel extends AbstractTableModel {
                 switch (msg.getState()) {
                     case received:
                         if (msg.isChanged()) {
-                            obj = ExtensionPlugNHack.CHANGED_ICON;
+                            obj = CHANGED_ICON;
                         }
                         break;
                     case pending:
-                        obj = ExtensionPlugNHack.PENDING_ICON;
+                        obj = PENDING_ICON;
                         break;
                     case resent:
-                        obj = ExtensionPlugNHack.CHANGED_ICON;
+                        obj = CHANGED_ICON;
                         break;
                     case dropped:
-                        obj = ExtensionPlugNHack.DROPPED_ICON;
+                        obj = DROPPED_ICON;
                         break;
                     case oraclehit:
-                        obj = ExtensionPlugNHack.ORACLE_ICON;
+                        obj = ORACLE_ICON;
                         break;
                 }
                 break;

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Correctly unload the add-on.
+- Prevent exception if no display (Issue 3978).
 
 ## [35] - 2022-10-27
 ### Changed

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -49,6 +49,7 @@ public class AttackPanel extends QuickStartSubPanel {
 
     private static final String DEFAULT_VALUE_URL_FIELD = "http://";
 
+    private ImageIcon icon;
     private JButton attackButton;
     private JButton stopButton;
     private JComboBox<String> urlField;
@@ -460,7 +461,16 @@ public class AttackPanel extends QuickStartSubPanel {
 
     @Override
     public ImageIcon getIcon() {
-        return ExtensionQuickStart.ZAP_ICON;
+        if (icon == null) {
+            icon =
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    getClass()
+                                            .getResource(
+                                                    ExtensionQuickStart.RESOURCES
+                                                            + "/zap64x64.png")));
+        }
+        return icon;
     }
 
     @Override

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
@@ -49,6 +49,7 @@ public class DefaultExplorePanel extends QuickStartSubPanel {
     private static final String OWASP_ZAP_ROOT_CA_FILENAME =
             OWASP_ZAP_ROOT_CA_NAME + OWASP_ZAP_ROOT_CA_FILE_EXT;
 
+    private ImageIcon icon;
     private JPanel contentPanel;
     private JButton saveButton;
     private ZapTextField hostPortField;
@@ -204,7 +205,16 @@ public class DefaultExplorePanel extends QuickStartSubPanel {
 
     @Override
     public ImageIcon getIcon() {
-        return ExtensionQuickStart.HUD_ICON;
+        if (icon == null) {
+            icon =
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    getClass()
+                                            .getResource(
+                                                    ExtensionQuickStart.RESOURCES
+                                                            + "/hud_logo_64px.png")));
+        }
+        return icon;
     }
 
     @Override

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 import javax.swing.ComboBoxModel;
-import javax.swing.ImageIcon;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.tree.ConfigurationNode;
 import org.apache.commons.httpclient.URI;
@@ -59,7 +58,6 @@ import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.reports.ExtensionReports;
 import org.zaproxy.zap.extension.ext.ExtensionExtension;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
-import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public class ExtensionQuickStart extends ExtensionAdaptor
@@ -67,28 +65,6 @@ public class ExtensionQuickStart extends ExtensionAdaptor
 
     public static final String NAME = "ExtensionQuickStart";
     public static final String RESOURCES = "/org/zaproxy/zap/extension/quickstart/resources";
-    public static final ImageIcon ZAP_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            QuickStartSubPanel.class.getResource(RESOURCES + "/zap64x64.png")));
-    public static final ImageIcon HUD_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            QuickStartSubPanel.class.getResource(
-                                    RESOURCES + "/hud_logo_64px.png")));
-    public static final ImageIcon HELP_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(QuickStartSubPanel.class.getResource(RESOURCES + "/help.png")));
-    public static final ImageIcon ONLINE_DOC_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            QuickStartSubPanel.class.getResource(
-                                    RESOURCES + "/document-globe.png")));
-    public static final ImageIcon PDF_DOC_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            QuickStartSubPanel.class.getResource(
-                                    RESOURCES + "/document-pdf-text.png")));
 
     private static final Logger LOGGER = LogManager.getLogger(ExtensionQuickStart.class);
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/LearnMorePanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/LearnMorePanel.java
@@ -50,6 +50,7 @@ public class LearnMorePanel extends QuickStartSubPanel {
     private static final String ZAP_VIDEOS_LINK = "https://www.zaproxy.org/videos/";
     private static final String ZAP_AUTOMATE_LINK = "https://www.zaproxy.org/docs/automate/";
 
+    private ImageIcon icon;
     private JPanel contentPanel;
     private JLabel lowerPadding;
     private int paddingY;
@@ -129,7 +130,13 @@ public class LearnMorePanel extends QuickStartSubPanel {
                 if (isGuideAvailable) {
                     JLabel qsLabel =
                             ulJLabel(Constant.messages.getString("quickstart.link.startguide"));
-                    qsLabel.setIcon(ExtensionQuickStart.PDF_DOC_ICON);
+                    qsLabel.setIcon(
+                            DisplayUtils.getScaledIcon(
+                                    new ImageIcon(
+                                            getClass()
+                                                    .getResource(
+                                                            ExtensionQuickStart.RESOURCES
+                                                                    + "/document-pdf-text.png"))));
                     qsLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
                     qsLabel.addMouseListener(
                             new MouseAdapter() {
@@ -250,7 +257,13 @@ public class LearnMorePanel extends QuickStartSubPanel {
 
     private JLabel getOnlineLink(String key, String url) {
         JLabel label = ulJLabel(Constant.messages.getString(key));
-        label.setIcon(ExtensionQuickStart.ONLINE_DOC_ICON);
+        label.setIcon(
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(
+                                getClass()
+                                        .getResource(
+                                                ExtensionQuickStart.RESOURCES
+                                                        + "/document-globe.png"))));
         label.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         label.addMouseListener(
                 new MouseAdapter() {
@@ -278,7 +291,15 @@ public class LearnMorePanel extends QuickStartSubPanel {
 
     @Override
     public ImageIcon getIcon() {
-        return ExtensionQuickStart.HELP_ICON;
+        if (icon == null) {
+            icon =
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    getClass()
+                                            .getResource(
+                                                    ExtensionQuickStart.RESOURCES + "/help.png")));
+        }
+        return icon;
     }
 
     @Override

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -53,23 +53,6 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
 
     public static final String RESOURCES = "/org/zaproxy/zap/extension/quickstart/resources";
 
-    private static final ImageIcon CHROME_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            ExtensionQuickStart.class.getResource(RESOURCES + "/chrome.png")));
-    private static final ImageIcon CHROMIUM_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            ExtensionQuickStart.class.getResource(RESOURCES + "/chromium.png")));
-    private static final ImageIcon FIREFOX_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            ExtensionQuickStart.class.getResource(RESOURCES + "/firefox.png")));
-    private static final ImageIcon SAFARI_ICON =
-            DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            ExtensionQuickStart.class.getResource(RESOURCES + "/safari.png")));
-
     private OptionsQuickStartLaunchPanel optionsPanel;
     private LaunchPanel launchPanel;
 
@@ -83,6 +66,11 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
         dependencies.add(ExtensionSelenium.class);
         DEPENDENCIES = Collections.unmodifiableList(dependencies);
     }
+
+    private ImageIcon chromeIcon;
+    private ImageIcon chromiumIcon;
+    private ImageIcon firefoxIcon;
+    private ImageIcon safariIcon;
 
     public ExtensionQuickStartLaunch() {
         super(NAME);
@@ -173,15 +161,33 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
     }
 
     protected void setToolbarButtonIcon(String browser) {
+        initBrowserIcons();
+
         if ("firefox".equalsIgnoreCase(browser)) {
-            launchToolbarButton.setIcon(FIREFOX_ICON);
+            launchToolbarButton.setIcon(firefoxIcon);
         } else if ("chrome".equalsIgnoreCase(browser)) {
-            launchToolbarButton.setIcon(CHROME_ICON);
+            launchToolbarButton.setIcon(chromeIcon);
         } else if ("safari".equalsIgnoreCase(browser)) {
-            launchToolbarButton.setIcon(SAFARI_ICON);
+            launchToolbarButton.setIcon(safariIcon);
         } else {
-            launchToolbarButton.setIcon(CHROMIUM_ICON);
+            launchToolbarButton.setIcon(chromiumIcon);
         }
+    }
+
+    private void initBrowserIcons() {
+        chromeIcon =
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(getClass().getResource(RESOURCES + "/chrome.png")));
+
+        chromiumIcon =
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(getClass().getResource(RESOURCES + "/chromium.png")));
+        firefoxIcon =
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(getClass().getResource(RESOURCES + "/firefox.png")));
+        safariIcon =
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(getClass().getResource(RESOURCES + "/safari.png")));
     }
 
     @Override

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
@@ -66,6 +66,7 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
     private static final String EVENT_HUD_ENABLED_FOR_DESKTOP = "desktop.enabled";
     private static final String EVENT_HUD_DISABLED_FOR_DESKTOP = "desktop.disabled";
 
+    private ImageIcon icon;
     private ExtensionQuickStartLaunch extLaunch;
     private JXPanel contentPanel;
     private JComboBox<String> urlField;
@@ -388,7 +389,16 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
 
     @Override
     public ImageIcon getIcon() {
-        return ExtensionQuickStart.HUD_ICON;
+        if (icon == null) {
+            icon =
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    getClass()
+                                            .getResource(
+                                                    ExtensionQuickStart.RESOURCES
+                                                            + "/hud_logo_64px.png")));
+        }
+        return icon;
     }
 
     @Override

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Prevent exception if no display (Issue 3978).
 
 ## [0.17.0] - 2022-11-22
 ### Added

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -83,9 +83,6 @@ public class ExtensionReports extends ExtensionAdaptor {
 
     private static final String RESOURCES_DIR = "/org/zaproxy/addon/reports/resources/";
 
-    private static final ImageIcon REPORT_ICON =
-            new ImageIcon(ExtensionReports.class.getResource(RESOURCES_DIR + "report.png"));
-
     private static final String SITE_PATTERN = "[[site]]";
     private static final String DATETIME_REGEX = "\\{\\{(.*)\\}\\}";
     private static final Pattern DATETIME_PATTERN = Pattern.compile(DATETIME_REGEX);
@@ -143,7 +140,8 @@ public class ExtensionReports extends ExtensionAdaptor {
     private JButton getReportButton() {
         if (reportButton == null) {
             reportButton = new JButton();
-            reportButton.setIcon(REPORT_ICON);
+            reportButton.setIcon(
+                    new ImageIcon(getClass().getResource(RESOURCES_DIR + "report.png")));
             reportButton.setToolTipText(
                     Constant.messages.getString("reports.toolbar.button.genreport"));
             reportButton.addActionListener(

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Prevent exception if no display (Issue 3978).
 
 ## [33] - 2022-10-27
 ### Changed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -64,12 +64,7 @@ import org.zaproxy.zap.model.Context;
 public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventListener, ScriptUI {
 
     public static final String NAME = "ExtensionScripts";
-    public static final ImageIcon ICON =
-            new ImageIcon(ZAP.class.getResource("/resource/icon/16/059.png")); // Script icon
-    public static final ImageIcon SCRIPT_EXT_ICON =
-            new ImageIcon(
-                    ExtensionScriptsUI.class.getResource(
-                            "/org/zaproxy/zap/extension/scripts/resources/icons/script-extender.png")); // Script icon
+    private static ImageIcon icon;
     public static final String SCRIPT_EXT_TYPE = "extender";
 
     /**
@@ -86,8 +81,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 
     private static final Logger LOGGER = LogManager.getLogger(ExtensionScriptsUI.class);
 
-    private ScriptType extScriptType =
-            new ScriptType(SCRIPT_EXT_TYPE, "scripts.type.extender", SCRIPT_EXT_ICON, true, true);
+    private ScriptType extScriptType;
     private ExtenderScriptHelper helper;
     private Map<String, ExtenderScript> installedExtenderScripts = new HashMap<>();
     private ScriptEngineWrapper nullEngineWrapper = null;
@@ -135,10 +129,28 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
         }
     }
 
+    public static ImageIcon getIcon() {
+        if (icon == null) {
+            icon = new ImageIcon(ZAP.class.getResource("/resource/icon/16/059.png"));
+        }
+        return icon;
+    }
+
     @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
         this.getExtScript().addListener(this);
+        extScriptType =
+                new ScriptType(
+                        SCRIPT_EXT_TYPE,
+                        "scripts.type.extender",
+                        hasView()
+                                ? new ImageIcon(
+                                        ExtensionScriptsUI.class.getResource(
+                                                "/org/zaproxy/zap/extension/scripts/resources/icons/script-extender.png"))
+                                : null,
+                        true,
+                        true);
         this.getExtScript().registerScriptType(extScriptType);
 
         nullEngineWrapper = new NullScriptEngineWrapper();

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanel.java
@@ -143,7 +143,7 @@ public class OutputPanel extends AbstractPanel {
             scriptLockButton.setSelectedToolTipText(
                     Constant.messages.getString(
                             "scripts.output.scriptLock.button.enabled.toolTip"));
-            scriptLockButton.setIcon(DisplayUtils.getScaledIcon(ExtensionScriptsUI.ICON));
+            scriptLockButton.setIcon(DisplayUtils.getScaledIcon(ExtensionScriptsUI.getIcon()));
             scriptLockButton.addActionListener(
                     e -> extension.setLockOutputToDisplayedScript(scriptLockButton.isSelected()));
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -116,7 +116,7 @@ public class ScriptsListPanel extends AbstractPanel {
 
         this.setLayout(new CardLayout());
         this.setName(Constant.messages.getString("scripts.list.panel.title"));
-        this.setIcon(ExtensionScriptsUI.ICON);
+        this.setIcon(ExtensionScriptsUI.getIcon());
         this.setDefaultAccelerator(
                 extension
                         .getView()

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsTreeCellRenderer.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsTreeCellRenderer.java
@@ -124,7 +124,7 @@ public class ScriptsTreeCellRenderer extends DefaultTreeCellRenderer {
 
             if (node.isRoot() || node.getParent().isRoot()) {
                 // Top 2 levels use same icon .. for now ;)
-                setIcon(DisplayUtils.getScaledIcon(ExtensionScriptsUI.ICON));
+                setIcon(DisplayUtils.getScaledIcon(ExtensionScriptsUI.getIcon()));
 
             } else if (userObject != null && userObject instanceof ScriptWrapper) {
                 OverlayIcon icon;
@@ -152,13 +152,16 @@ public class ScriptsTreeCellRenderer extends DefaultTreeCellRenderer {
                         } else {
                             icon =
                                     new OverlayIcon(
-                                            DisplayUtils.getScaledIcon(ExtensionScriptsUI.ICON));
+                                            DisplayUtils.getScaledIcon(
+                                                    ExtensionScriptsUI.getIcon()));
                         }
                     } else if (engine.getIcon() != null) {
                         icon = new OverlayIcon(DisplayUtils.getScaledIcon(engine.getIcon()));
                     } else {
                         // Default to the blank script
-                        icon = new OverlayIcon(DisplayUtils.getScaledIcon(ExtensionScriptsUI.ICON));
+                        icon =
+                                new OverlayIcon(
+                                        DisplayUtils.getScaledIcon(ExtensionScriptsUI.getIcon()));
                     }
                     if (script.isChanged() && !node.isTemplate()) {
                         icon.add(DisplayUtils.getScaledIcon(PENCIL_OVERLAY_ICON));

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Update minimum ZAP version to 2.12.0.
 
+### Fixed
+- Prevent exception if no display (Issue 3978).
+
 ## [6] - 2021-10-07
 ### Added
 - Add info and repo URLs.

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/ExtensionSequence.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/ExtensionSequence.java
@@ -49,10 +49,6 @@ public class ExtensionSequence extends ExtensionAdaptor implements ScannerHook {
     private ExtensionScript extScript;
     private ExtensionActiveScan extActiveScan;
     public static final Logger logger = LogManager.getLogger(ExtensionSequence.class);
-    public static final ImageIcon ICON =
-            new ImageIcon(
-                    ExtensionSequence.class.getResource(
-                            "/org/zaproxy/zap/extension/sequence/resources/icons/script-sequence.png"));
     public static final String TYPE_SEQUENCE = "sequence";
 
     static {
@@ -122,7 +118,11 @@ public class ExtensionSequence extends ExtensionAdaptor implements ScannerHook {
                 new ScriptType(
                         TYPE_SEQUENCE,
                         "script.type.sequence",
-                        ICON,
+                        hasView()
+                                ? new ImageIcon(
+                                        getClass()
+                                                .getResource("resources/icons/script-sequence.png"))
+                                : null,
                         false,
                         new String[] {"append"});
         getExtScript().registerScriptType(scriptType);

--- a/addOns/simpleexample/src/main/java/org/zaproxy/addon/simpleexample/ExtensionSimpleExample.java
+++ b/addOns/simpleexample/src/main/java/org/zaproxy/addon/simpleexample/ExtensionSimpleExample.java
@@ -59,9 +59,6 @@ public class ExtensionSimpleExample extends ExtensionAdaptor {
      */
     private static final String RESOURCES = "resources";
 
-    private static final ImageIcon ICON =
-            new ImageIcon(ExtensionSimpleExample.class.getResource(RESOURCES + "/cake.png"));
-
     private static final String EXAMPLE_FILE = "example/ExampleFile.txt";
 
     private ZapMenuItem menuExample;
@@ -115,7 +112,7 @@ public class ExtensionSimpleExample extends ExtensionAdaptor {
             statusPanel = new AbstractPanel();
             statusPanel.setLayout(new CardLayout());
             statusPanel.setName(Constant.messages.getString(PREFIX + ".panel.title"));
-            statusPanel.setIcon(ICON);
+            statusPanel.setIcon(new ImageIcon(getClass().getResource(RESOURCES + "/cake.png")));
             JTextPane pane = new JTextPane();
             pane.setEditable(false);
             // Obtain (and set) a font with the size defined in the options

--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Prevent exception if no display (Issue 3978).
+
 ## [0.1.0] - 2022-10-27
 
 ### Functional Improvements Compared to Previous Core Release

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderThread.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderThread.java
@@ -49,6 +49,7 @@ import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.users.User;
+import org.zaproxy.zap.utils.ThreadUtils;
 
 /**
  * The Class SpiderThread that controls the spidering process on a particular site. Being a
@@ -450,25 +451,16 @@ public class SpiderThread extends ScanThread implements SpiderListener {
 
     private void addUriToAddedNodesModel(
             final String uri, final String method, final String params) {
-        if (!EventQueue.isDispatchThread()) {
-            EventQueue.invokeLater(
-                    new Runnable() {
+        ThreadUtils.invokeLater(
+                () -> {
+                    // Add the new result
+                    addedNodesModel.addScanResult(uri, method, null, false);
 
-                        @Override
-                        public void run() {
-                            addUriToAddedNodesModel(uri, method, params);
-                        }
-                    });
-            return;
-        }
-
-        // Add the new result
-        addedNodesModel.addScanResult(uri, method, null, false);
-
-        if (extension.getView() != null) {
-            // Update the count of added nodes
-            extension.getSpiderPanel().updateAddedCount();
-        }
+                    if (extension.getView() != null) {
+                        // Update the count of added nodes
+                        extension.getSpiderPanel().updateAddedCount();
+                    }
+                });
     }
 
     private String getStatusLabel(FetchStatus status) {

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
 
-
+### Fixed
+- Prevent exception if no display (Issue 3978).
 
 ## [21.16.0] - 2022-11-14
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import javax.swing.ImageIcon;
 import javax.swing.tree.TreeNode;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -60,8 +59,6 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
 
     public static final String RESOURCE = "/org/zaproxy/zap/extension/wappalyzer/resources";
 
-    public static final ImageIcon WAPPALYZER_ICON =
-            new ImageIcon(ExtensionWappalyzer.class.getResource(RESOURCE + "/wappalyzer.png"));
     public static final String TECHNOLOGIES_PATH = "resources/technologies/";
     public static final String CATEGORIES_PATH = "resources/categories.json";
 
@@ -116,7 +113,8 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
             logger.error("Failed to enumerate Wappalyzer technologies:", e);
         }
 
-        WappalyzerData result = new WappalyzerJsonParser().parse(CATEGORIES_PATH, technologyFiles);
+        WappalyzerData result =
+                new WappalyzerJsonParser().parse(CATEGORIES_PATH, technologyFiles, hasView());
         this.applications = result.getApplications();
         this.categories = result.getCategories();
 

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -95,7 +95,9 @@ public class TechPanel extends AbstractPanel {
         this.setLayout(new CardLayout());
         this.setSize(474, 251);
         this.setName(Constant.messages.getString("wappalyzer.panel.title"));
-        this.setIcon(ExtensionWappalyzer.WAPPALYZER_ICON);
+        this.setIcon(
+                new ImageIcon(
+                        getClass().getResource(ExtensionWappalyzer.RESOURCE + "/wappalyzer.png")));
         this.setDefaultAccelerator(
                 this.extension
                         .getView()

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -75,11 +75,12 @@ public class WappalyzerJsonParser {
         this.parsingExceptionHandler = parsingExceptionHandler;
     }
 
-    WappalyzerData parse(String categories, List<String> technologies) {
+    WappalyzerData parse(String categories, List<String> technologies, boolean createIcons) {
         logger.info("Starting to parse Wappalyzer technologies.");
         WappalyzerData wappalyzerData = new WappalyzerData();
         parseCategories(wappalyzerData, getStringResource(categories));
-        technologies.forEach(path -> parseJson(wappalyzerData, getStringResource(path)));
+        technologies.forEach(
+                path -> parseJson(wappalyzerData, getStringResource(path), createIcons));
         logger.info("Loaded {} Wappalyzer technologies.", wappalyzerData.getApplications().size());
         return wappalyzerData;
     }
@@ -118,7 +119,7 @@ public class WappalyzerJsonParser {
     }
 
     @SuppressWarnings("unchecked")
-    private void parseJson(WappalyzerData wappalyzerData, String jsonStr) {
+    private void parseJson(WappalyzerData wappalyzerData, String jsonStr, boolean createIcons) {
 
         try {
             if (!jsonStr.isEmpty()) {
@@ -149,19 +150,24 @@ public class WappalyzerJsonParser {
                     app.setImplies(this.jsonToStringList(appData.get("implies")));
                     app.setCpe(appData.optString("cpe"));
 
-                    URL iconUrl =
-                            ExtensionWappalyzer.class.getResource(
-                                    ExtensionWappalyzer.RESOURCE + "/icons/" + appName + ".png");
-                    if (iconUrl != null) {
-                        app.setIcon(createPngIcon(iconUrl));
-                    } else {
-                        iconUrl =
+                    if (createIcons) {
+                        URL iconUrl =
                                 ExtensionWappalyzer.class.getResource(
                                         ExtensionWappalyzer.RESOURCE
                                                 + "/icons/"
                                                 + appName
-                                                + ".svg");
-                        app.setIcon(createSvgIcon(iconUrl));
+                                                + ".png");
+                        if (iconUrl != null) {
+                            app.setIcon(createPngIcon(iconUrl));
+                        } else {
+                            iconUrl =
+                                    ExtensionWappalyzer.class.getResource(
+                                            ExtensionWappalyzer.RESOURCE
+                                                    + "/icons/"
+                                                    + appName
+                                                    + ".svg");
+                            app.setIcon(createSvgIcon(iconUrl));
+                        }
                     }
 
                     wappalyzerData.addApplication(app);

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAppsJsonParseUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAppsJsonParseUnitTest.java
@@ -38,7 +38,7 @@ class WappalyzerAppsJsonParseUnitTest {
         WappalyzerJsonParser parser =
                 new WappalyzerJsonParser(
                         (pattern, e) -> errs.add(e.toString()), parsingExceptions::add);
-        parser.parse("categories.json", generateFileList());
+        parser.parse("categories.json", generateFileList(), true);
         // Then
         assertEquals(Collections.emptyList(), errs);
         assertEquals(Collections.emptyList(), parsingExceptions);

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
@@ -33,7 +33,7 @@ class WappalyzerJsonParserUnitTest {
         // Given
         WappalyzerJsonParser wjp = new WappalyzerJsonParser();
         WappalyzerData wappData =
-                wjp.parse("categories.json", Collections.singletonList("apps.json"));
+                wjp.parse("categories.json", Collections.singletonList("apps.json"), true);
         List<String> expectedCategory = new ArrayList<>(1);
         expectedCategory.add("Advertising"); // 36 - Advertising
         // When

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
@@ -49,7 +49,8 @@ class WappalyzerPassiveScannerUnitTest extends PassiveScannerTestUtils<Wappalyze
                 defaultHolder = new WappalyzerApplicationTestHolder();
                 WappalyzerJsonParser parser = new WappalyzerJsonParser();
                 WappalyzerData result =
-                        parser.parse("categories.json", Collections.singletonList("apps.json"));
+                        parser.parse(
+                                "categories.json", Collections.singletonList("apps.json"), true);
                 defaultHolder.setApplications(result.getApplications());
             } catch (Exception ex) {
                 throw new RuntimeException(ex);

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Prevent exception if no display (Issue 3978).
 
 ## [27] - 2022-10-27
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
@@ -49,9 +49,6 @@ import org.zaproxy.zap.extension.websocket.ui.WebSocketPanel;
 
 public class ExtensionWebSocketFuzzer extends ExtensionAdaptor {
 
-    private static final ImageIcon WEBSOCKET_FUZZER_PROCESSOR_SCRIPT_ICON =
-            new ImageIcon(ZAP.class.getResource("/resource/icon/16/script-fuzz.png"));
-
     private static final List<Class<? extends Extension>> DEPENDENCIES;
 
     static {
@@ -107,7 +104,11 @@ public class ExtensionWebSocketFuzzer extends ExtensionAdaptor {
                     new ScriptType(
                             WebSocketFuzzerProcessorScript.TYPE_NAME,
                             "websocket.fuzzer.script.type.fuzzerprocessor",
-                            WEBSOCKET_FUZZER_PROCESSOR_SCRIPT_ICON,
+                            hasView()
+                                    ? new ImageIcon(
+                                            ZAP.class.getResource(
+                                                    "/resource/icon/16/script-fuzz.png"))
+                                    : null,
                             true,
                             true);
             extensionScript.registerScriptType(scriptType);

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Prevent exception if no display (Issue 3978).
 
 ## [37] - 2022-10-27
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -101,19 +101,7 @@ import org.zaproxy.zest.impl.ZestScriptEngineFactory;
 public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, ScriptEventListener {
 
     public static final String NAME = "ExtensionZest";
-    public static final ImageIcon ZEST_ICON =
-            new ImageIcon(
-                    ExtensionZest.class.getResource(
-                            "/org/zaproxy/zap/extension/zest/resources/icons/fruit-orange.png"));
-
-    private static final ImageIcon RECORD_OFF_ICON =
-            new ImageIcon(
-                    ExtensionZest.class.getResource(
-                            "/org/zaproxy/zap/extension/zest/resources/icons/cassette.png"));
-    private static final ImageIcon RECORD_ON_ICON =
-            new ImageIcon(
-                    ExtensionZest.class.getResource(
-                            "/org/zaproxy/zap/extension/zest/resources/icons/cassette-red.png"));
+    private static ImageIcon zestIcon;
 
     public static final String HTTP_HEADER_X_SECURITY_PROXY = "X-Security-Proxy";
     public static final String VALUE_RECORD = "record";
@@ -160,6 +148,16 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     public ExtensionZest() {
         super(NAME);
         this.setOrder(73); // Almost looks like ZE ;)
+    }
+
+    public static ImageIcon getZestIcon() {
+        if (zestIcon == null) {
+            zestIcon =
+                    new ImageIcon(
+                            ExtensionZest.class.getResource(
+                                    "/org/zaproxy/zap/extension/zest/resources/icons/fruit-orange.png"));
+        }
+        return zestIcon;
     }
 
     @Override
@@ -394,8 +392,16 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     private JToggleButton getRecordButton() {
         if (recordButton == null) {
             recordButton = new ZapToggleButton();
-            recordButton.setIcon(RECORD_OFF_ICON);
-            recordButton.setSelectedIcon(RECORD_ON_ICON);
+            recordButton.setIcon(
+                    new ImageIcon(
+                            getClass()
+                                    .getResource(
+                                            "/org/zaproxy/zap/extension/zest/resources/icons/cassette.png")));
+            recordButton.setSelectedIcon(
+                    new ImageIcon(
+                            getClass()
+                                    .getResource(
+                                            "/org/zaproxy/zap/extension/zest/resources/icons/cassette-red.png")));
             recordButton.setToolTipText(
                     Constant.messages.getString("zest.toolbar.button.record.off"));
             recordButton.setSelectedToolTipText(

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestEngineWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestEngineWrapper.java
@@ -44,7 +44,7 @@ public class ZestEngineWrapper extends DefaultEngineWrapper {
 
     @Override
     public ImageIcon getIcon() {
-        return ExtensionZest.ZEST_ICON;
+        return ExtensionZest.getZestIcon();
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
@@ -58,7 +58,7 @@ public class ZestResultsPanel extends AbstractPanel {
         this.extension = extension;
         this.setLayout(new CardLayout());
         this.setName(Constant.messages.getString("zest.results.panel.title"));
-        this.setIcon(ExtensionZest.ZEST_ICON);
+        this.setIcon(ExtensionZest.getZestIcon());
         this.setDefaultAccelerator(
                 this.extension
                         .getView()

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeCellRenderer.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeCellRenderer.java
@@ -285,7 +285,7 @@ public class ZestTreeCellRenderer extends DefaultTreeCellRenderer {
 
             if (obj != null && obj instanceof ZestScriptWrapper) {
                 OverlayIcon icon =
-                        new OverlayIcon(DisplayUtils.getScaledIcon(ExtensionZest.ZEST_ICON));
+                        new OverlayIcon(DisplayUtils.getScaledIcon(ExtensionZest.getZestIcon()));
                 ZestScriptWrapper script = (ZestScriptWrapper) obj;
 
                 // Copied from ScriptsTreeCellRenderer as we want to add an additional overlay

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
@@ -132,7 +132,7 @@ public class ZestDialogManager extends AbstractPanel {
     private void initialize() {
         this.setLayout(new CardLayout());
         this.setName(Constant.messages.getString("zest.scripts.panel.title"));
-        this.setIcon(ExtensionZest.ZEST_ICON);
+        this.setIcon(ExtensionZest.getZestIcon());
 
         mouseListener =
                 new java.awt.event.MouseAdapter() {


### PR DESCRIPTION
Do not initialise icons and other UI components if there's no view.

Part of zaproxy/zaproxy#3798.