### PR TITLE
network: allow access to the API in cmd line mode

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,10 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Added
-- Support HTTP/2 (Issue 5038).
-
 ### Changed
+- Allow access to the ZAP API when running in command line mode.
 - Update dependency.
 
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -100,7 +100,6 @@ import org.zaproxy.addon.network.internal.server.AliasChecker;
 import org.zaproxy.addon.network.internal.server.http.HttpServer;
 import org.zaproxy.addon.network.internal.server.http.LocalServer;
 import org.zaproxy.addon.network.internal.server.http.LocalServerConfig;
-import org.zaproxy.addon.network.internal.server.http.LocalServerConfig.ServerMode;
 import org.zaproxy.addon.network.internal.server.http.LocalServerHandler;
 import org.zaproxy.addon.network.internal.server.http.MainProxyHandler;
 import org.zaproxy.addon.network.internal.server.http.MainServerHandler;
@@ -805,10 +804,6 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
         }
 
         updateCoreProxy(serverConfig);
-
-        if (commandLineMode) {
-            serverConfig.setMode(ServerMode.PROXY);
-        }
 
         mainProxyServer = createLocalServer(serverConfig);
         if (overridePort == INVALID_PORT) {

--- a/addOns/network/src/main/javahelp/help/contents/cmdline.html
+++ b/addOns/network/src/main/javahelp/help/contents/cmdline.html
@@ -37,7 +37,8 @@
 	</table>
 
 	<H3>Local Servers/Proxies</H3>
-	When ZAP is running in command line mode (i.e. <code>-cmd</code>) only the main proxy is started, for example, to proxy integration tests.
+	When ZAP is running in command line mode (i.e. <code>-cmd</code>) only the main proxy is started, for example, to proxy integration tests
+	or access the ZAP API.
 	If unable to start the main proxy in command line mode or in daemon mode (i.e. <code>-daemon</code>) ZAP is terminated, when running with
 	GUI an appropriate warning is shown instead.
 


### PR DESCRIPTION
Do not disable the API when starting the main server in command line mode, allow both to proxy and access the API.