### PR TITLE
network: improve dynamic unload

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -1310,10 +1310,13 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
         connectionParam.load(getModel().getOptionsParam().getConfig());
 
         if (httpSenderNetwork != null) {
+            HttpSender.setImpl(null);
             httpSenderNetwork.close();
         }
 
         Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+        // TODO needs https://github.com/bcgit/bc-java/issues/1254
+        // ThreadUtils.findThreadsByName("BC Entropy Daemon").forEach(Thread::interrupt);
 
         if (hasView()) {
             OptionsDialog optionsDialog = View.getSingleton().getOptionsDialog("");
@@ -1322,6 +1325,8 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
             localServerInfoLabel.unload();
 
             optionsDialog.removeParamPanel(localServersOptionsPanel);
+            optionsDialog.removeParamPanel(connectionOptionsPanel);
+            optionsDialog.removeParamPanel(clientCertificatesOptionsPanel);
 
             if (removeBreakListenerMethod != null) {
                 try {

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSenderContext.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSenderContext.java
@@ -19,12 +19,24 @@
  */
 package org.zaproxy.addon.network.internal.client;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.network.HttpSenderContext;
 import org.zaproxy.zap.users.User;
 
 public abstract class BaseHttpSenderContext implements HttpSenderContext {
+
+    static final String INITIATOR_FIELD = "initiator";
+    private static final String FOLLOW_REDIRECTS_FIELD = "followRedirects";
+    private static final String USER_FIELD = "user";
+    private static final String USE_COOKIES_FIELD = "useCookies";
+    private static final String USE_GLOBAL_STATE_FIELD = "useGlobalState";
+    private static final String MAX_REDIRECTS_FIELD = "maxRedirects";
+    private static final String MAX_RETRIES_ON_IO_ERROR_FIELD = "maxRetriesOnIoError";
+    private static final String REMOVE_USER_DEFINED_AUTH_HEADERS_FIELD =
+            "removeUserDefinedAuthHeaders";
 
     private final HttpSender parent;
     private final int initiator;
@@ -42,6 +54,29 @@ public abstract class BaseHttpSenderContext implements HttpSenderContext {
         this.initiator = initiator;
         this.maxRedirects = 100;
         setMaxRetriesOnIoError(3);
+    }
+
+    Map<String, Object> toMap() {
+        Map<String, Object> data = new HashMap<>();
+        data.put(INITIATOR_FIELD, initiator);
+        data.put(FOLLOW_REDIRECTS_FIELD, followRedirects);
+        data.put(USER_FIELD, user);
+        data.put(USE_COOKIES_FIELD, useCookies);
+        data.put(USE_GLOBAL_STATE_FIELD, useGlobalState);
+        data.put(MAX_REDIRECTS_FIELD, maxRedirects);
+        data.put(MAX_RETRIES_ON_IO_ERROR_FIELD, maxRetriesOnIoError);
+        data.put(REMOVE_USER_DEFINED_AUTH_HEADERS_FIELD, removeUserDefinedAuthHeaders);
+        return data;
+    }
+
+    void fromMap(Map<String, Object> data) {
+        setFollowRedirects((boolean) data.get(FOLLOW_REDIRECTS_FIELD));
+        setUser((User) data.get(USER_FIELD));
+        setUseCookies((boolean) data.get(USE_COOKIES_FIELD));
+        setUseGlobalState((boolean) data.get(USE_GLOBAL_STATE_FIELD));
+        setMaxRedirects((int) data.get(MAX_REDIRECTS_FIELD));
+        setMaxRetriesOnIoError((int) data.get(MAX_RETRIES_ON_IO_ERROR_FIELD));
+        setRemoveUserDefinedAuthHeaders((boolean) data.get(REMOVE_USER_DEFINED_AUTH_HEADERS_FIELD));
     }
 
     public int getInitiator() {

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CloseableHttpSenderImpl.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CloseableHttpSenderImpl.java
@@ -19,6 +19,11 @@
  */
 package org.zaproxy.addon.network.internal.client;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.network.HttpSenderContext;
 import org.zaproxy.zap.network.HttpSenderImpl;
 
@@ -31,4 +36,20 @@ public interface CloseableHttpSenderImpl<T extends HttpSenderContext> extends Ht
 
     /** Close the sender implementation. */
     void close();
+
+    default T getContext(HttpSender httpSender) {
+        return null;
+    }
+
+    default void sendAndReceive(
+            HttpSender parent, HttpRequestConfig config, HttpMessage msg, Path file)
+            throws IOException {
+        sendAndReceive(getContext(parent), config, msg, file);
+    }
+
+    default Object saveState() {
+        return null;
+    }
+
+    default void restoreState(Object implState) {}
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -274,7 +274,7 @@ public class HttpSenderApache
     }
 
     @Override
-    public HttpSenderContextApache createContext(HttpSender parent, int initiator) {
+    public HttpSenderContextApache createContextImpl(HttpSender parent, int initiator) {
         return new HttpSenderContextApache(parent, initiator);
     }
 


### PR DESCRIPTION
Remove on unload:
 - `HttpSender` implementation;
 - Connection options panel;
 - Client Certificates panel.

Save and restore the `HttpSender` implementation state.