### PR TITLE
openapi: Handle cases where no response is defined

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- When a definition doesn't define a response then an appropriate warning bubbles up, no longer resulting in a NullPointerException (Issue 7115).
+
 ## [30] - 2022-11-15
 ### Changed
 - Dependency updates.

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/HeadersGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/HeadersGenerator.java
@@ -136,15 +136,17 @@ public class HeadersGenerator {
     void generateAcceptHeaders(Operation operation, List<HttpHeaderField> headers) {
 
         Set<String> contentSet = new LinkedHashSet<>();
-        operation.getResponses().values().stream()
-                .map(
-                        response -> {
-                            if (response.getContent() == null) {
-                                return Collections.<String>emptySet();
-                            }
-                            return response.getContent().keySet();
-                        })
-                .forEach(contentSet::addAll);
+        if (operation.getResponses() != null) {
+            operation.getResponses().values().stream()
+                    .map(
+                            response -> {
+                                if (response.getContent() == null) {
+                                    return Collections.<String>emptySet();
+                                }
+                                return response.getContent().keySet();
+                            })
+                    .forEach(contentSet::addAll);
+        }
         StringBuilder sb = new StringBuilder();
         for (String type : contentSet) {
             // Claim we accept everything

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/HeadersGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/HeadersGeneratorUnitTest.java
@@ -170,6 +170,18 @@ class HeadersGeneratorUnitTest {
     }
 
     @Test
+    void shouldAcceptAllContentsIfNoResponsesDefined() {
+        // Given
+        Operation operation = mock(Operation.class);
+        given(operation.getResponses()).willReturn(null);
+        List<HttpHeaderField> headers = new ArrayList<>();
+        // When
+        headersGenerator.generateAcceptHeaders(operation, headers);
+        // Then
+        assertThat(headers, contains(header("Accept", "*/*")));
+    }
+
+    @Test
     void shouldAcceptContentPresentInResponse() {
         // Given
         ApiResponse response = mockResponseWithMediaTypes("text/plain");


### PR DESCRIPTION
- CHANGELOG > Added fix note.
- HeaderGenerator > Add a condition to handle instances where responses are undefined, allowing a warning (such as: `attribute paths.'/users'(get).responses is missing`) to bubble up.
- HeaderGeneratorUnitTest > Add a test that asserts the new behavior.

Fixes zaproxy/zaproxy#7115

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>