### PR TITLE
ascanrules: address XSS false negative

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -25,8 +25,6 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -311,26 +309,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             }
 
             for (HtmlContext ctx : contexts2) {
-                if (ctx.isInUrlAttribute()) {
-
-                    // No payload modifications should be made in case of "javascript:" protocol
-                    // attacks
-                    Pattern attAndPayloadRegex =
-                            Pattern.compile(
-                                    Pattern.quote(ctx.getTagAttribute())
-                                            + "\\s*=\\s*"
-                                            + Pattern.quote(ctx.getSurroundingQuote())
-                                            + "\\s*"
-                                            + Pattern.quote(ctx.getTarget())
-                                            + "\\s*"
-                                            + Pattern.quote(ctx.getSurroundingQuote()));
-                    Matcher attAndPayloadMatcher =
-                            attAndPayloadRegex.matcher(ctx.getMsg().getResponseBody().toString());
-                    if (!attAndPayloadMatcher.find()) {
-                        // No match found
-                        continue;
-                    }
-
+                if (ctx.isInUrlAttribute() && isJavaScriptSchemeInjectionValid(ctx)) {
                     // Yep, its vulnerable
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
@@ -433,6 +412,10 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 "Failed to find vuln in with simple onmounseover {}",
                 msg.getRequestHeader().getURI());
         return false;
+    }
+
+    private static boolean isJavaScriptSchemeInjectionValid(HtmlContext ctx) {
+        return ctx.getTagAttributeValue().stripLeading().startsWith(ctx.getTarget());
     }
 
     private boolean performCommentAttack(HtmlContext context, HttpMessage msg, String param) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContext.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContext.java
@@ -42,6 +42,7 @@ public class HtmlContext {
     private int end = 0;
     private List<String> parentTags = new ArrayList<>();
     private String tagAttribute = null;
+    private String tagAttributeValue;
     private Map<String, String> tagAttributes = new HashMap<>();
     private boolean inScriptAttribute = false;
     private boolean inUrlAttribute = false;
@@ -134,6 +135,14 @@ public class HtmlContext {
 
     public void setTagAttribute(String tagAttribute) {
         this.tagAttribute = tagAttribute;
+    }
+
+    public String getTagAttributeValue() {
+        return tagAttributeValue;
+    }
+
+    public void setTagAttributeValue(String value) {
+        tagAttributeValue = value;
     }
 
     public void addParentTag(String name) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
@@ -328,6 +328,7 @@ public class HtmlContextAnalyser {
                             && att.getValue().toLowerCase().indexOf(target.toLowerCase()) >= 0) {
                         // Found the injected value
                         context.setTagAttribute(att.getName());
+                        context.setTagAttributeValue(att.getValue());
                         context.setInUrlAttribute(this.isUrlAttribute(att.getName()));
                         context.setInScriptAttribute(this.isScriptAttribute(att.getName()));
                     } else if (att.getName().equalsIgnoreCase(target)

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyserUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyserUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.ascanrules.httputils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.util.List;
@@ -33,6 +34,22 @@ import org.zaproxy.zap.testutils.TestUtils;
 
 public class HtmlContextAnalyserUnitTest extends TestUtils {
     private HttpMessage msg;
+
+    @Test
+    void shouldGetAttributeAndValue() throws Exception {
+        // Given
+        msg = new HttpMessage();
+        msg.setResponseBody("<html><body att=\" Value with target... \"></body></html>");
+        HtmlContextAnalyser analyser = new HtmlContextAnalyser(msg);
+        String target = "target";
+        // When
+        List<HtmlContext> contexts = analyser.getHtmlContexts(target, null, 0);
+        // Then
+        assertThat(contexts, hasSize(1));
+        HtmlContext ctx = contexts.get(0);
+        assertThat(ctx.getTagAttribute(), is(equalTo("att")));
+        assertThat(ctx.getTagAttributeValue(), is(equalTo(" Value with target... ")));
+    }
 
     @Test
     void shouldGetCorrectParentTag() throws Exception {


### PR DESCRIPTION
Only require that the attribute value starts with the javascript scheme injection (ignoring leading whitespaces), the presence of other characters following the injection do not necessarily invalidate it.
For example, if it's also injected with a comment (e.g. `//`) it would make it valid, even if it has more/other characters after.