### PR TITLE
network: retain cookie attributes when converting

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not change the case of the Content-Length header.
 - Use the available response content when the Content-Length is more than what is available.
 - Properly persist proxy error responses.
+- Correctly manage cookies with domain and path attributes (Issue 7631).
 
 ## [0.5.0] - 2022-11-09
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/LegacyUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/LegacyUtils.java
@@ -19,6 +19,9 @@
  */
 package org.zaproxy.addon.network.internal.client;
 
+import static org.apache.hc.client5.http.cookie.Cookie.DOMAIN_ATTR;
+import static org.apache.hc.client5.http.cookie.Cookie.PATH_ATTR;
+
 import java.time.Instant;
 import java.util.Date;
 import org.apache.commons.httpclient.Cookie;
@@ -46,6 +49,12 @@ public final class LegacyUtils {
             if (expiryDate != null) {
                 c.setExpiryDate(expiryDate.toInstant());
             }
+            if (cookie.isDomainAttributeSpecified()) {
+                c.setAttribute(DOMAIN_ATTR, cookie.getDomain());
+            }
+            if (cookie.isPathAttributeSpecified()) {
+                c.setAttribute(PATH_ATTR, cookie.getPath());
+            }
             cookieStore.addCookie(c);
         }
         return cookieStore;
@@ -58,14 +67,17 @@ public final class LegacyUtils {
 
         httpState.clearCookies();
         for (org.apache.hc.client5.http.cookie.Cookie cookie : cookieStore.getCookies()) {
-            httpState.addCookie(
+            Cookie c =
                     new Cookie(
                             cookie.getDomain(),
                             cookie.getName(),
                             cookie.getValue(),
                             cookie.getPath(),
                             getExpiryDate(cookie),
-                            cookie.isSecure()));
+                            cookie.isSecure());
+            c.setDomainAttributeSpecified(cookie.containsAttribute(DOMAIN_ATTR));
+            c.setPathAttributeSpecified(cookie.containsAttribute(PATH_ATTR));
+            httpState.addCookie(c);
         }
     }
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/LegacyUtilsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/LegacyUtilsUnitTest.java
@@ -19,7 +19,10 @@
  */
 package org.zaproxy.addon.network.internal.client;
 
+import static org.apache.hc.client5.http.cookie.Cookie.DOMAIN_ATTR;
+import static org.apache.hc.client5.http.cookie.Cookie.PATH_ATTR;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -39,6 +42,16 @@ import org.junit.jupiter.api.Test;
 class LegacyUtilsUnitTest {
 
     @Test
+    void shouldConvertNullHttpStateToEmptyCookieStore() {
+        // Given
+        HttpState httpState = null;
+        // When
+        CookieStore cookieStore = LegacyUtils.httpStateToCookieStore(httpState);
+        // Then
+        assertThat(cookieStore.getCookies(), is(empty()));
+    }
+
+    @Test
     void shouldConvertHttpStateToCookieStore() {
         // Given
         HttpState httpState = new HttpState();
@@ -56,6 +69,39 @@ class LegacyUtilsUnitTest {
         assertThat(cookie.getName(), is(equalTo(name)));
         assertThat(cookie.getValue(), is(equalTo(value)));
         assertThat(cookie.getExpiryInstant(), is(equalTo(expiryDate.toInstant())));
+        assertThat(cookie.getAttribute(DOMAIN_ATTR), is(nullValue()));
+        assertThat(cookie.getAttribute(PATH_ATTR), is(nullValue()));
+    }
+
+    @Test
+    void shouldConvertHttpStateToCookieStoreRetainingDomainAttribute() {
+        // Given
+        HttpState httpState = new HttpState();
+        String domain = "example.org";
+        Cookie cookieLegacy = cookieLegacy(domain, "Name", "Value", null);
+        cookieLegacy.setDomainAttributeSpecified(true);
+        httpState.addCookie(cookieLegacy);
+        // When
+        CookieStore cookieStore = LegacyUtils.httpStateToCookieStore(httpState);
+        // Then
+        assertThat(cookieStore.getCookies(), hasSize(1));
+        assertThat(cookieStore.getCookies().get(0).getAttribute(DOMAIN_ATTR), is(equalTo(domain)));
+    }
+
+    @Test
+    void shouldConvertHttpStateToCookieStoreRetainingPathAttribute() {
+        // Given
+        HttpState httpState = new HttpState();
+        String path = "/path";
+        Cookie cookieLegacy = cookieLegacy("example.org", "Name", "Value", null);
+        cookieLegacy.setPath(path);
+        cookieLegacy.setPathAttributeSpecified(true);
+        httpState.addCookie(cookieLegacy);
+        // When
+        CookieStore cookieStore = LegacyUtils.httpStateToCookieStore(httpState);
+        // Then
+        assertThat(cookieStore.getCookies(), hasSize(1));
+        assertThat(cookieStore.getCookies().get(0).getAttribute(PATH_ATTR), is(equalTo(path)));
     }
 
     @Test
@@ -91,6 +137,41 @@ class LegacyUtilsUnitTest {
         assertThat(cookie.getName(), is(equalTo(name)));
         assertThat(cookie.getValue(), is(equalTo(value)));
         assertThat(cookie.getExpiryDate().toInstant(), is(expiryDate));
+        assertThat(cookie.isDomainAttributeSpecified(), is(equalTo(false)));
+        assertThat(cookie.isPathAttributeSpecified(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldUpdateHttpStateWithCookieStoreRetainingDomainAttribute() {
+        // Given
+        BasicCookieStore cookieStore = new BasicCookieStore();
+        String domain = "example.org";
+        BasicClientCookie clientCookie = cookie(domain, "Name", "Value", null);
+        clientCookie.setAttribute(DOMAIN_ATTR, domain);
+        cookieStore.addCookie(clientCookie);
+        HttpState httpState = new HttpState();
+        // When
+        LegacyUtils.updateHttpState(httpState, cookieStore);
+        // Then
+        assertThat(httpState.getCookies().length, is(equalTo(1)));
+        assertThat(httpState.getCookies()[0].isDomainAttributeSpecified(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldUpdateHttpStateWithCookieStoreRetainingPathAttribute() {
+        // Given
+        BasicCookieStore cookieStore = new BasicCookieStore();
+        String path = "/path";
+        BasicClientCookie clientCookie = cookie("example.org", "Name", "Value", null);
+        clientCookie.setPath(path);
+        clientCookie.setAttribute(PATH_ATTR, path);
+        cookieStore.addCookie(clientCookie);
+        HttpState httpState = new HttpState();
+        // When
+        LegacyUtils.updateHttpState(httpState, cookieStore);
+        // Then
+        assertThat(httpState.getCookies().length, is(equalTo(1)));
+        assertThat(httpState.getCookies()[0].isPathAttributeSpecified(), is(equalTo(true)));
     }
 
     @Test
@@ -114,7 +195,7 @@ class LegacyUtilsUnitTest {
         return cookie;
     }
 
-    private static org.apache.hc.client5.http.cookie.Cookie cookie(
+    private static BasicClientCookie cookie(
             String domain, String name, String value, Instant expiryDate) {
         BasicClientCookie cookie = new BasicClientCookie(name, value);
         cookie.setDomain(domain);


### PR DESCRIPTION
Copy the state of the domain and path cookie attributes when converting between types.

Fix zaproxy/zaproxy#7631.