### PR TITLE
network: fallback to HTTP/1.1 in internal servers

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Allow access to the ZAP API when running in command line mode.
+- Fallback to HTTP/1.1 in internal local servers/proxies if the client does not negotiate a protocol (ALPN).
 - Update dependency.
 - Maintenance changes.
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsConfig.java
@@ -41,13 +41,20 @@ public class TlsConfig {
     private List<String> tlsProtocols;
     private boolean alpnEnabled;
     private List<String> applicationProtocols;
+    private String fallbackApplicationProtocol;
 
     /**
      * Constructs a {@code TlsConfig} with all the SSL/TLS protocol versions supported, with ALPN
      * enabled, and with all application protocols.
+     *
+     * <p>If no protocol is negotiated it falls back to HTTP/1.1.
      */
     public TlsConfig() {
-        this(DEFAULT_PROTOCOLS, true, DEFAULT_APPLICATION_PROTOCOLS);
+        this(
+                DEFAULT_PROTOCOLS,
+                true,
+                DEFAULT_APPLICATION_PROTOCOLS,
+                TlsUtils.APPLICATION_PROTOCOL_HTTP_1_1);
     }
 
     /**
@@ -63,10 +70,19 @@ public class TlsConfig {
      */
     public TlsConfig(
             List<String> tlsProtocols, boolean alpnEnabled, List<String> applicationProtocols) {
+        this(tlsProtocols, alpnEnabled, applicationProtocols, null);
+    }
+
+    private TlsConfig(
+            List<String> tlsProtocols,
+            boolean alpnEnabled,
+            List<String> applicationProtocols,
+            String fallbackApplicationProtocol) {
         this.tlsProtocols = TlsUtils.filterUnsupportedTlsProtocols(tlsProtocols);
         this.alpnEnabled = alpnEnabled;
         this.applicationProtocols =
                 TlsUtils.filterUnsupportedApplicationProtocols(applicationProtocols);
+        this.fallbackApplicationProtocol = fallbackApplicationProtocol;
     }
 
     /**
@@ -94,6 +110,15 @@ public class TlsConfig {
      */
     public List<String> getApplicationProtocols() {
         return applicationProtocols;
+    }
+
+    /**
+     * Gets the protocol to use if no protocol was negotiated (ALPN).
+     *
+     * @return the fallback protocol, or {@code null} if none.
+     */
+    public String getFallbackApplicationProtocol() {
+        return fallbackApplicationProtocol;
     }
 
     @Override

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsConfigUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsConfigUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -66,6 +67,9 @@ class TlsConfigUnitTest {
         assertThat(
                 tlsConfig.getApplicationProtocols(),
                 is(equalTo(getSupportedApplicationProtocols())));
+        assertThat(
+                tlsConfig.getFallbackApplicationProtocol(),
+                is(equalTo(APPLICATION_PROTOCOL_HTTP_1_1)));
     }
 
     @Test
@@ -133,6 +137,7 @@ class TlsConfigUnitTest {
         TlsConfig tlsConfig = new TlsConfig(getSupportedTlsProtocols(), false, protocols);
         // Then
         assertThat(tlsConfig.getApplicationProtocols(), is(equalTo(protocols)));
+        assertThat(tlsConfig.getFallbackApplicationProtocol(), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
The ALPN is now enabled by default for internal local server/proxies but a client might not negotiate a protocol which would lead to the connection to be closed, instead fallback to HTTP/1.1, keeping the same behaviour as before enabling ALPN.