### PR TITLE
Move time based attacks to their own scan rules

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - The Format String Error scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
+### Changed
+- Move time based attacks to their own scan rules (Issue 7341).
+
 ## [55] - 2023-06-06
 ### Changed
 - The Parameter Tamper Scan rule now includes example alert functionality for documentation generation purposes (Issue 6119)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionTimingScanRule.java
@@ -1,0 +1,447 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2013 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import org.apache.commons.configuration.ConversionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.extension.ascanrules.timing.TimingUtils;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+import org.zaproxy.zap.model.Vulnerabilities;
+import org.zaproxy.zap.model.Vulnerability;
+
+/**
+ * Active scan rule for Command Injection testing and verification.
+ * https://owasp.org/www-community/attacks/Command_Injection
+ *
+ * @author yhawke (2013)
+ * @author kingthorin+owaspzap@gmail.com (2015)
+ */
+public class CommandInjectionTimingScanRule extends AbstractAppParamPlugin {
+
+    /** The name of the rule to obtain the time, in seconds, for time-based attacks. */
+    private static final String RULE_SLEEP_TIME = RuleConfigParam.RULE_COMMON_SLEEP_TIME;
+
+    /** Prefix for internationalised messages used by this rule */
+    private static final String MESSAGE_PREFIX = "ascanrules.commandinjection.";
+
+    // Useful if space char isn't allowed by filters
+    // http://www.blackhatlibrary.net/Command_Injection
+    private static final String BASH_SPACE_REPLACEMENT = "${IFS}";
+
+    private static final Map<String, String> ALERT_TAGS =
+            CommonAlertTag.toMap(
+                    CommonAlertTag.OWASP_2021_A03_INJECTION,
+                    CommonAlertTag.OWASP_2017_A01_INJECTION,
+                    CommonAlertTag.WSTG_V42_INPV_12_COMMAND_INJ);
+
+    /** The default number of seconds used in time-based attacks (i.e. sleep commands). */
+    private static final int DEFAULT_TIME_SLEEP_SEC = 5;
+
+    // time-based attack detection will not send more than the following number of requests
+    private static final int BLIND_REQUEST_LIMIT = 5;
+    // time-based attack detection will try to take less than the following number of seconds
+    // note: detection of this length will generally only happen in the positive (detecting) case.
+    private static final double BLIND_SECONDS_LIMIT = 20.0;
+
+    // error range allowable for statistical time-based blind attacks (0-1.0)
+    private static final double TIME_CORRELATION_ERROR_RANGE = 0.15;
+    private static final double TIME_SLOPE_ERROR_RANGE = 0.30;
+
+    // *NIX Blind OS Command constants
+    private static final String NIX_BLIND_TEST_CMD = "sleep {0}";
+    // Windows Blind OS Command constants
+    private static final String WIN_BLIND_TEST_CMD = "timeout /T {0}";
+    // PowerSHell Blind Command constants
+    private static final String PS_BLIND_TEST_CMD = "start-sleep -s {0}";
+
+    // OS Command payloads for blind command Injection testing
+    private static final List<String> NIX_BLIND_OS_PAYLOADS = new LinkedList<>();
+    private static final List<String> WIN_BLIND_OS_PAYLOADS = new LinkedList<>();
+    private static final List<String> PS_BLIND_PAYLOADS = new LinkedList<>();
+
+    static {
+        // No quote payloads
+        NIX_BLIND_OS_PAYLOADS.add("&" + NIX_BLIND_TEST_CMD + "&");
+        NIX_BLIND_OS_PAYLOADS.add(";" + NIX_BLIND_TEST_CMD + ";");
+        WIN_BLIND_OS_PAYLOADS.add("&" + WIN_BLIND_TEST_CMD);
+        WIN_BLIND_OS_PAYLOADS.add("|" + WIN_BLIND_TEST_CMD);
+        PS_BLIND_PAYLOADS.add(";" + PS_BLIND_TEST_CMD);
+
+        // Double quote payloads
+        NIX_BLIND_OS_PAYLOADS.add("\"&" + NIX_BLIND_TEST_CMD + "&\"");
+        NIX_BLIND_OS_PAYLOADS.add("\";" + NIX_BLIND_TEST_CMD + ";\"");
+        WIN_BLIND_OS_PAYLOADS.add("\"&" + WIN_BLIND_TEST_CMD + "&\"");
+        WIN_BLIND_OS_PAYLOADS.add("\"|" + WIN_BLIND_TEST_CMD);
+        PS_BLIND_PAYLOADS.add("\";" + PS_BLIND_TEST_CMD);
+
+        // Single quote payloads
+        NIX_BLIND_OS_PAYLOADS.add("'&" + NIX_BLIND_TEST_CMD + "&'");
+        NIX_BLIND_OS_PAYLOADS.add("';" + NIX_BLIND_TEST_CMD + ";'");
+        WIN_BLIND_OS_PAYLOADS.add("'&" + WIN_BLIND_TEST_CMD + "&'");
+        WIN_BLIND_OS_PAYLOADS.add("'|" + WIN_BLIND_TEST_CMD);
+        PS_BLIND_PAYLOADS.add("';" + PS_BLIND_TEST_CMD);
+
+        // Special payloads
+        NIX_BLIND_OS_PAYLOADS.add("\n" + NIX_BLIND_TEST_CMD + "\n"); // force enter
+        NIX_BLIND_OS_PAYLOADS.add("`" + NIX_BLIND_TEST_CMD + "`"); // backtick execution
+        NIX_BLIND_OS_PAYLOADS.add("||" + NIX_BLIND_TEST_CMD); // or control concatenation
+        NIX_BLIND_OS_PAYLOADS.add("&&" + NIX_BLIND_TEST_CMD); // and control concatenation
+        NIX_BLIND_OS_PAYLOADS.add("|" + NIX_BLIND_TEST_CMD + "#"); // pipe & comment
+        // FoxPro for running os commands
+        WIN_BLIND_OS_PAYLOADS.add("run " + WIN_BLIND_TEST_CMD);
+        PS_BLIND_PAYLOADS.add(";" + PS_BLIND_TEST_CMD + " #"); // chain & comment
+
+        // uninitialized variable waf bypass
+        String insertedCMD = insertUninitVar(NIX_BLIND_TEST_CMD);
+        // No quote payloads
+        NIX_BLIND_OS_PAYLOADS.add("&" + insertedCMD + "&");
+        NIX_BLIND_OS_PAYLOADS.add(";" + insertedCMD + ";");
+        // Double quote payloads
+        NIX_BLIND_OS_PAYLOADS.add("\"&" + insertedCMD + "&\"");
+        NIX_BLIND_OS_PAYLOADS.add("\";" + insertedCMD + ";\"");
+        // Single quote payloads
+        NIX_BLIND_OS_PAYLOADS.add("'&" + insertedCMD + "&'");
+        NIX_BLIND_OS_PAYLOADS.add("';" + insertedCMD + ";'");
+        // Special payloads
+        NIX_BLIND_OS_PAYLOADS.add("\n" + insertedCMD + "\n");
+        NIX_BLIND_OS_PAYLOADS.add("`" + insertedCMD + "`");
+        NIX_BLIND_OS_PAYLOADS.add("||" + insertedCMD);
+        NIX_BLIND_OS_PAYLOADS.add("&&" + insertedCMD);
+        NIX_BLIND_OS_PAYLOADS.add("|" + insertedCMD + "#");
+    }
+
+    // Logger instance
+    private static final Logger LOGGER = LogManager.getLogger(CommandInjectionTimingScanRule.class);
+
+    // Get WASC Vulnerability description
+    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_31");
+
+    /** The number of seconds used in time-based attacks (i.e. sleep commands). */
+    private int timeSleepSeconds = DEFAULT_TIME_SLEEP_SEC;
+
+    @Override
+    public int getId() {
+        return 90037;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public boolean targets(TechSet technologies) {
+        if (technologies.includes(Tech.Linux)
+                || technologies.includes(Tech.MacOS)
+                || technologies.includes(Tech.Windows)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INJECTION;
+    }
+
+    @Override
+    public String getSolution() {
+        if (vuln != null) {
+            return vuln.getSolution();
+        }
+
+        return "Failed to load vulnerability solution from file";
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return ALERT_TAGS;
+    }
+
+    @Override
+    public int getCweId() {
+        return 78;
+    }
+
+    @Override
+    public int getWascId() {
+        return 31;
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_HIGH;
+    }
+
+    private String getOtherInfo(String testType, String testValue) {
+        return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo." + testType, testValue);
+    }
+
+    @Override
+    public void init() {
+        try {
+            timeSleepSeconds = this.getConfig().getInt(RULE_SLEEP_TIME, DEFAULT_TIME_SLEEP_SEC);
+        } catch (ConversionException e) {
+            LOGGER.debug(
+                    "Invalid value for '{}': {}",
+                    RULE_SLEEP_TIME,
+                    this.getConfig().getString(RULE_SLEEP_TIME));
+        }
+        LOGGER.debug("Sleep set to {} seconds", timeSleepSeconds);
+    }
+
+    /**
+     * Gets the number of seconds used in time-based attacks.
+     *
+     * <p><strong>Note:</strong> Method provided only to ease the unit tests.
+     *
+     * @return the number of seconds used in time-based attacks.
+     */
+    int getTimeSleep() {
+        return timeSleepSeconds;
+    }
+
+    /**
+     * Scan for OS Command Injection Vulnerabilities
+     *
+     * @param msg a request only copy of the original message (the response isn't copied)
+     * @param paramName the parameter name that need to be exploited
+     * @param value the original parameter value
+     */
+    @Override
+    public void scan(HttpMessage msg, String paramName, String value) {
+
+        // Begin scan rule execution
+        LOGGER.debug(
+                "Checking [{}][{}], parameter [{}] for OS Command Injection Vulnerabilities",
+                msg.getRequestHeader().getMethod(),
+                msg.getRequestHeader().getURI(),
+                paramName);
+
+        // Number of targets to try
+        int blindTargetCount = 0;
+
+        switch (this.getAttackStrength()) {
+            case LOW:
+                blindTargetCount = 2;
+                break;
+
+            case MEDIUM:
+                blindTargetCount = 6;
+                break;
+
+            case HIGH:
+                blindTargetCount = 12;
+                break;
+
+            case INSANE:
+                blindTargetCount =
+                        Math.max(
+                                PS_BLIND_PAYLOADS.size(),
+                                (Math.max(
+                                        NIX_BLIND_OS_PAYLOADS.size(),
+                                        WIN_BLIND_OS_PAYLOADS.size())));
+                break;
+
+            default:
+                // Default to off
+        }
+
+        if (inScope(Tech.Linux) || inScope(Tech.MacOS)) {
+            if (testCommandInjection(paramName, value, blindTargetCount, NIX_BLIND_OS_PAYLOADS)) {
+                return;
+            }
+        }
+
+        if (isStop()) {
+            return;
+        }
+
+        if (inScope(Tech.Windows)) {
+            // Windows Command Prompt
+            if (testCommandInjection(paramName, value, blindTargetCount, WIN_BLIND_OS_PAYLOADS)) {
+                return;
+            }
+            // Check if the user has stopped the scan
+            if (isStop()) {
+                return;
+            }
+            // Windows PowerShell
+            if (testCommandInjection(paramName, value, blindTargetCount, PS_BLIND_PAYLOADS)) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Tests for injection vulnerabilities with the given payloads.
+     *
+     * @param paramName the name of the parameter that will be used for testing for injection
+     * @param value the value of the parameter that will be used for testing for injection
+     * @param blindTargetCount the number of requests for blind payloads
+     * @param blindOsPayloads the blind payloads
+     * @return {@code true} if the vulnerability was found, {@code false} otherwise.
+     */
+    private boolean testCommandInjection(
+            String paramName, String value, int blindTargetCount, List<String> blindOsPayloads) {
+        // Start testing OS Command Injection patterns
+        // ------------------------------------------
+        String paramValue;
+        Iterator<String> it = blindOsPayloads.iterator();
+
+        // -----------------------------------------------
+        // Check 1: Time-based Blind OS Command Injection
+        // -----------------------------------------------
+        // Check for a sleep shell execution by using
+        // linear regression to check for a correlation
+        // between requested delay and actual delay.
+        // -----------------------------------------------
+        for (int i = 0; it.hasNext() && (i < blindTargetCount); i++) {
+            AtomicReference<HttpMessage> message = new AtomicReference<>();
+            String sleepPayload = it.next();
+            paramValue = value + sleepPayload.replace("{0}", String.valueOf(timeSleepSeconds));
+
+            // the function that will send each request
+            TimingUtils.RequestSender requestSender =
+                    x -> {
+                        HttpMessage msg = getNewMsg();
+                        message.set(msg);
+                        String finalPayload =
+                                value + sleepPayload.replace("{0}", String.valueOf(x));
+                        setParameter(msg, paramName, finalPayload);
+                        LOGGER.debug("Testing [{}] = [{}]", paramName, finalPayload);
+
+                        // send the request and retrieve the response
+                        sendAndReceive(msg, false);
+                        return msg.getTimeElapsedMillis() / 1000.0;
+                    };
+
+            boolean isInjectable;
+            try {
+                try {
+                    // use TimingUtils to detect a response to sleep payloads
+                    isInjectable =
+                            TimingUtils.checkTimingDependence(
+                                    BLIND_REQUEST_LIMIT,
+                                    BLIND_SECONDS_LIMIT,
+                                    requestSender,
+                                    TIME_CORRELATION_ERROR_RANGE,
+                                    TIME_SLOPE_ERROR_RANGE);
+                } catch (SocketException ex) {
+                    LOGGER.debug(
+                            "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            message.get().getRequestHeader().getURI());
+                    continue; // Something went wrong, move to next blind iteration
+                }
+
+                if (isInjectable) {
+                    // We Found IT!
+                    // First do logging
+                    LOGGER.debug(
+                            "[Blind OS Command Injection Found] on parameter [{}] with value [{}]",
+                            paramName,
+                            paramValue);
+                    String otherInfo = getOtherInfo("time-based", paramValue);
+
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(paramName)
+                            .setAttack(paramValue)
+                            // just attach this alert to the last sent message
+                            .setMessage(message.get())
+                            .setOtherInfo(otherInfo)
+                            .raise();
+
+                    // All done. No need to look for vulnerabilities on subsequent
+                    // payloads on the same request (to reduce performance impact)
+                    return true;
+                }
+            } catch (IOException ex) {
+                // Do not try to internationalise this.. we need an error message in any event..
+                // if it's in English, it's still better than not having it at all.
+                LOGGER.warn(
+                        "Blind Command Injection vulnerability check failed for parameter [{}] and payload [{}] due to an I/O error",
+                        paramName,
+                        paramValue,
+                        ex);
+            }
+
+            // Check if the scan has been stopped
+            // if yes dispose resources and exit
+            if (isStop()) {
+                // Dispose all resources
+                // Exit the scan rule
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Generate payload variants for uninitialized variable waf bypass
+     * https://www.secjuice.com/web-application-firewall-waf-evasion/
+     *
+     * @param cmd the cmd to insert uninitialized variable
+     */
+    private static String insertUninitVar(String cmd) {
+        int varLength = ThreadLocalRandom.current().nextInt(1, 3) + 1;
+        char[] array = new char[varLength];
+        // $xx
+        array[0] = '$';
+        for (int i = 1; i < varLength; ++i) {
+            array[i] = (char) ThreadLocalRandom.current().nextInt(97, 123);
+        }
+        String var = new String(array);
+
+        // insert variable before each space and '/' in the path
+        return cmd.replaceAll("\\s", Matcher.quoteReplacement(var + " "))
+                .replaceAll("\\/", Matcher.quoteReplacement(var + "/"));
+    }
+}

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicTimingScanRule.java
@@ -60,7 +60,7 @@ import org.zaproxy.zap.model.TechSet;
  *
  * @author 70pointer
  */
-public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
+public class SqlInjectionHypersonicTimingScanRule extends AbstractAppParamPlugin {
 
     private boolean doUnionBased = false; // TODO: use in Union based, when we implement it
     private boolean doTimeBased = false;
@@ -187,7 +187,8 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
                     CommonAlertTag.WSTG_V42_INPV_05_SQLI);
 
     /** for logging. */
-    private static final Logger LOGGER = LogManager.getLogger(SqlInjectionHypersonicScanRule.class);
+    private static final Logger LOGGER =
+            LogManager.getLogger(SqlInjectionHypersonicTimingScanRule.class);
 
     @Override
     public int getId() {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlTimingScanRule.java
@@ -46,7 +46,7 @@ import org.zaproxy.zap.model.TechSet;
  * http://www.websec.ca/kb/sql_injection#MSSQL_Stacked_Queries
  * http://pentestmonkey.net/cheat-sheet/sql-injection/mssql-sql-injection-cheat-sheet
  */
-public class SqlInjectionMsSqlScanRule extends AbstractAppParamPlugin {
+public class SqlInjectionMsSqlTimingScanRule extends AbstractAppParamPlugin {
 
     /** MSSQL one-line comment */
     private static final String SQL_ONE_LINE_COMMENT = " -- ";
@@ -79,7 +79,8 @@ public class SqlInjectionMsSqlScanRule extends AbstractAppParamPlugin {
     };
 
     /** for logging. */
-    private static final Logger LOGGER = LogManager.getLogger(SqlInjectionMsSqlScanRule.class);
+    private static final Logger LOGGER =
+            LogManager.getLogger(SqlInjectionMsSqlTimingScanRule.class);
 
     private static final int DEFAULT_SLEEP_TIME = 15;
     private static final Map<String, String> ALERT_TAGS =

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMySqlTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMySqlTimingScanRule.java
@@ -48,7 +48,7 @@ import org.zaproxy.zap.model.TechSet;
  *
  * @author 70pointer
  */
-public class SqlInjectionMySqlScanRule extends AbstractAppParamPlugin {
+public class SqlInjectionMySqlTimingScanRule extends AbstractAppParamPlugin {
 
     private boolean doTimeBased = false;
 
@@ -195,7 +195,8 @@ public class SqlInjectionMySqlScanRule extends AbstractAppParamPlugin {
                     CommonAlertTag.WSTG_V42_INPV_05_SQLI);
 
     /** for logging. */
-    private static final Logger LOGGER = LogManager.getLogger(SqlInjectionMySqlScanRule.class);
+    private static final Logger LOGGER =
+            LogManager.getLogger(SqlInjectionMySqlTimingScanRule.class);
 
     @Override
     public int getId() {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionPostgreTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionPostgreTimingScanRule.java
@@ -19,8 +19,10 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
+import java.net.SocketException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.apache.commons.configuration.ConversionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -29,46 +31,42 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
 /**
- * TODO: maybe implement a more specific UNION based check for Oracle (with table names)
- *
- * <p>The SqlInjectionOracleScanRule identifies Oracle specific SQL Injection vulnerabilities using
- * Oracle specific syntax. If it doesn't use Oracle specific syntax, it belongs in the generic
- * SQLInjection class! Note the ordering of checks, for efficiency is : 1) Error based (N/A) 2)
- * Boolean Based (N/A - uses standard syntax) 3) UNION based (TODO) 4) Stacked (N/A - uses standard
- * syntax) 5) Blind/Time Based (Yes)
+ * The SqlInjectionPostgreScanRule identifies Postgresql specific SQL Injection vulnerabilities
+ * using Postgresql specific syntax. If it doesn't use Postgresql specific syntax, it belongs in the
+ * generic SQLInjection class! Note the ordering of checks, for efficiency is : 1) Error based (N/A)
+ * 2) Boolean Based (N/A - uses standard syntax) 3) UNION based (N/A - uses standard syntax) 4)
+ * Stacked (N/A - uses standard syntax) 5) Blind/Time Based (Yes)
  *
  * <p>See the following for some great specific tricks which could be integrated here
  * http://www.websec.ca/kb/sql_injection
- * http://pentestmonkey.net/cheat-sheet/sql-injection/oracle-sql-injection-cheat-sheet
+ * http://pentestmonkey.net/cheat-sheet/sql-injection/postgres-sql-injection-cheat-sheet
  *
- * <p>Important Notes for the Oracle database (and useful in the code): - takes -- style comments -
- * requires a table name in normal select statements (like Hypersonic: cannot just say "select 1" or
- * "select 2" like in most RDBMSs - requires a table name in "union select" statements (like
- * Hypersonic). - does NOT allow stacked queries via JDBC driver or in PHP. - Constants in select
- * must be in single quotes, not doubles (like Hypersonic). - supports UDFs (very interesting!!) - 5
- * second delay select statement: SELECT UTL_INADDR.get_host_name('10.0.0.1') from dual union SELECT
- * UTL_INADDR.get_host_name('10.0.0.2') from dual union SELECT UTL_INADDR.get_host_name('10.0.0.3')
- * from dual union SELECT UTL_INADDR.get_host_name('10.0.0.4') from dual union SELECT
- * UTL_INADDR.get_host_name('10.0.0.5') from dual - metadata select statement: TODO
+ * <p>Important Notes for the POSTGRES database (and useful in the code): - takes -- style comments
+ * - allows stacked queries via JDBC driver or in PHP??? - Constants in select must be in single
+ * quotes, not doubles (like Hypersonic). - supports UDFs (very interesting!!) - 5 (by default)
+ * second delay select statement (not taking into account casting, etc.): SELECT pg_sleep(5) -
+ * metadata select statement: TODO
  *
  * @author 70pointer
  */
-public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
+public class SqlInjectionPostgreTimingScanRule extends AbstractAppParamPlugin {
 
-    private int expectedDelayInMs = 5000;
-
-    private boolean doUnionBased = false; // TODO: use in Union based, when we implement it
     private boolean doTimeBased = false;
 
-    private int doUnionMaxRequests = 0; // TODO: use in Union based, when we implement it
     private int doTimeMaxRequests = 0;
 
-    /** Oracle one-line comment */
+    private int sleepInSeconds = 15;
+
+    /** Postgresql one-line comment */
     public static final String SQL_ONE_LINE_COMMENT = " -- ";
+
+    private static final String ORIG_VALUE_TOKEN = "<<<<ORIGINALVALUE>>>>";
+    private static final String SLEEP_TOKEN = "<<<<SLEEP>>>>";
 
     /**
      * create a map of SQL related error message fragments, and map them back to the RDBMS that they
@@ -80,66 +78,102 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
     private static final Map<String, String> SQL_ERROR_TO_DBMS = new LinkedHashMap<>();
 
     static {
-        SQL_ERROR_TO_DBMS.put("oracle.jdbc", "Oracle");
-        SQL_ERROR_TO_DBMS.put("SQLSTATE[HY", "Oracle");
-        SQL_ERROR_TO_DBMS.put("ORA-00933", "Oracle");
-        SQL_ERROR_TO_DBMS.put("ORA-06512", "Oracle"); // indicates the line number of an error
-        SQL_ERROR_TO_DBMS.put("SQL command not properly ended", "Oracle");
-        SQL_ERROR_TO_DBMS.put("ORA-00942", "Oracle"); // table or view does not exist
-        SQL_ERROR_TO_DBMS.put("ORA-29257", "Oracle"); // host unknown
-        SQL_ERROR_TO_DBMS.put("ORA-00932", "Oracle"); // inconsistent datatypes
-
-        // Note: only Oracle mappings here.
-        // TODO: is this all?? we need more error messages for Oracle for different languages. PHP
-        // (oci8), ASP, JSP(JDBC), etc
+        SQL_ERROR_TO_DBMS.put("org.postgresql.util.PSQLException", "PostgreSQL");
+        SQL_ERROR_TO_DBMS.put("org.postgresql", "PostgreSQL");
+        // Note: only Postgresql mappings here.
+        // TODO: is this all?? we need more error messages for Postgresql for different languages.
+        // PHP, ASP, JSP(JDBC), etc.
     }
 
-    /** the 5 second sleep function in Oracle SQL */
-    private static String SQL_ORACLE_TIME_SELECT =
-            "SELECT  UTL_INADDR.get_host_name('10.0.0.1') from dual union SELECT  UTL_INADDR.get_host_name('10.0.0.2') from dual union SELECT  UTL_INADDR.get_host_name('10.0.0.3') from dual union SELECT  UTL_INADDR.get_host_name('10.0.0.4') from dual union SELECT  UTL_INADDR.get_host_name('10.0.0.5') from dual";
+    /**
+     * The sleep function in Postgresql cast it back to an int, so we can use it in nested select
+     * statements and stuff.
+     */
+    private static String SQL_POSTGRES_TIME_FUNCTION =
+            "case when cast(pg_sleep(" + SLEEP_TOKEN + ") as varchar) > '' then 0 else 1 end";
 
-    /** Oracle specific time based injection strings. each for 5 seconds */
+    /** Postgres specific time based injection strings. */
 
+    // issue with "+" symbols in here:
+    // we cannot encode them here as %2B, as then the database gets them double encoded as %252B
+    // we cannot leave them as unencoded '+' characters either, as then they are NOT encoded by the
+    // HttpMessage.setGetParams (x) or by AbstractPlugin.sendAndReceive (HttpMessage)
+    // and are seen by the database as spaces :(
+    // in short, we cannot use the "+" character in parameters, unless we mean to use it as a space
+    // character!!!! Particularly Nasty.
+    // Workaround: use RDBMS specific functions like "CONCAT(a,b,c)" which mean parsing the original
+    // value into the middle of the parameter value to be passed,
+    // rather than just appending to it
+    // Issue: this technique does not close the open ' or " in the query.. so do not use it..
     // Note: <<<<ORIGINALVALUE>>>> is replaced with the original parameter value at runtime in these
     // examples below (see * comment)
     // TODO: maybe add support for ')' after the original value, before the sleeps
-    private static String[] SQL_ORACLE_TIME_REPLACEMENTS = {
-        "(" + SQL_ORACLE_TIME_SELECT + ")",
-        "<<<<ORIGINALVALUE>>>> / (" + SQL_ORACLE_TIME_SELECT + ") ",
-        "<<<<ORIGINALVALUE>>>>' / (" + SQL_ORACLE_TIME_SELECT + ") / '",
-        "<<<<ORIGINALVALUE>>>>\" / (" + SQL_ORACLE_TIME_SELECT + ") / \"",
-        "<<<<ORIGINALVALUE>>>> and exists ("
-                + SQL_ORACLE_TIME_SELECT
-                + ")"
-                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
-        "<<<<ORIGINALVALUE>>>>' and exists ("
-                + SQL_ORACLE_TIME_SELECT
-                + ")"
-                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
-        "<<<<ORIGINALVALUE>>>>\" and exists ("
-                + SQL_ORACLE_TIME_SELECT
-                + ")"
-                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
-        "<<<<ORIGINALVALUE>>>>) and exists ("
-                + SQL_ORACLE_TIME_SELECT
-                + ")"
-                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
-        "<<<<ORIGINALVALUE>>>> or exists ("
-                + SQL_ORACLE_TIME_SELECT
-                + ")"
-                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
-        "<<<<ORIGINALVALUE>>>>' or exists ("
-                + SQL_ORACLE_TIME_SELECT
-                + ")"
-                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
-        "<<<<ORIGINALVALUE>>>>\" or exists ("
-                + SQL_ORACLE_TIME_SELECT
-                + ")"
-                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
-        "<<<<ORIGINALVALUE>>>>) or exists ("
-                + SQL_ORACLE_TIME_SELECT
-                + ")"
-                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
+
+    private static String[] SQL_POSTGRES_TIME_REPLACEMENTS = {
+        SQL_POSTGRES_TIME_FUNCTION,
+        SQL_POSTGRES_TIME_FUNCTION + SQL_ONE_LINE_COMMENT,
+        "'" + SQL_POSTGRES_TIME_FUNCTION + SQL_ONE_LINE_COMMENT,
+        "\"" + SQL_POSTGRES_TIME_FUNCTION + SQL_ONE_LINE_COMMENT,
+        ORIG_VALUE_TOKEN
+                + " / "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " ", // Try without a comment, to target use of the field in the SELECT clause,
+        // but also in the WHERE clauses.
+        ORIG_VALUE_TOKEN
+                + "' / "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " / '", // Try without a comment, to target use of the field in the SELECT clause,
+        // but also in the WHERE clauses.
+        ORIG_VALUE_TOKEN
+                + "\" / "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " / \"", // Try without a comment, to target use of the field in the SELECT
+        // clause, but also in the WHERE clauses.
+        ORIG_VALUE_TOKEN
+                + " where 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in SELECT/UPDATE/DELETE clause.
+        ORIG_VALUE_TOKEN
+                + "' where 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in SELECT/UPDATE/DELETE clause.
+        ORIG_VALUE_TOKEN
+                + "\" where 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in SELECT/UPDATE/DELETE clause.
+        ORIG_VALUE_TOKEN
+                + " and 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause.
+        ORIG_VALUE_TOKEN
+                + "' and 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause.
+        ORIG_VALUE_TOKEN
+                + "\" and 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause.
+        ORIG_VALUE_TOKEN
+                + " or 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause.
+        ORIG_VALUE_TOKEN
+                + "' or 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause.
+        ORIG_VALUE_TOKEN
+                + "\" or 0 in (select "
+                + SQL_POSTGRES_TIME_FUNCTION
+                + " )"
+                + SQL_ONE_LINE_COMMENT, // Param in WHERE clause.
     };
 
     private static final Map<String, String> ALERT_TAGS =
@@ -149,21 +183,22 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
                     CommonAlertTag.WSTG_V42_INPV_05_SQLI);
 
     /** for logging. */
-    private static final Logger LOGGER = LogManager.getLogger(SqlInjectionOracleScanRule.class);
+    private static final Logger LOGGER =
+            LogManager.getLogger(SqlInjectionPostgreTimingScanRule.class);
 
     @Override
     public int getId() {
-        return 40021;
+        return 40022;
     }
 
     @Override
     public String getName() {
-        return Constant.messages.getString("ascanrules.sqlinjection.oracle.name");
+        return Constant.messages.getString("ascanrules.sqlinjection.postgres.name");
     }
 
     @Override
     public boolean targets(TechSet technologies) {
-        return technologies.includes(Tech.Oracle);
+        return technologies.includes(Tech.PostgreSQL);
     }
 
     @Override
@@ -194,33 +229,34 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
         if (this.getAttackStrength() == AttackStrength.LOW) {
             doTimeBased = true;
             doTimeMaxRequests = 3;
-            doUnionBased = true;
-            doUnionMaxRequests = 3;
         } else if (this.getAttackStrength() == AttackStrength.MEDIUM) {
             doTimeBased = true;
             doTimeMaxRequests = 5;
-            doUnionBased = true;
-            doUnionMaxRequests = 5;
         } else if (this.getAttackStrength() == AttackStrength.HIGH) {
             doTimeBased = true;
             doTimeMaxRequests = 10;
-            doUnionBased = true;
-            doUnionMaxRequests = 10;
         } else if (this.getAttackStrength() == AttackStrength.INSANE) {
             doTimeBased = true;
             doTimeMaxRequests = 100;
-            doUnionBased = true;
-            doUnionMaxRequests = 100;
         }
+        // Read the sleep value from the configs
+        try {
+            this.sleepInSeconds =
+                    this.getConfig().getInt(RuleConfigParam.RULE_COMMON_SLEEP_TIME, 15);
+        } catch (ConversionException e) {
+            LOGGER.debug(
+                    "Invalid value for 'rules.common.sleep': {}",
+                    this.getConfig().getString(RuleConfigParam.RULE_COMMON_SLEEP_TIME));
+        }
+        LOGGER.debug("Sleep set to {} seconds", sleepInSeconds);
     }
 
     /**
-     * scans for SQL Injection vulnerabilities, using Oracle specific syntax. If it doesn't use
-     * specifically Oracle syntax, it does not belong in here, but in SQLInjection
+     * scans for SQL Injection vulnerabilities, using POSTGRES specific syntax. If it doesn't use
+     * specifically POSTGRES syntax, it does not belong in here, but in SQLInjection
      */
     @Override
     public void scan(HttpMessage originalMessage, String paramName, String paramValue) {
-
         try {
             // Timing Baseline check: we need to get the time that it took the original query, to
             // know if the time based check is working correctly..
@@ -234,31 +270,40 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
                         "The Base Time Check timed out on [{}] URL [{}]",
                         msgTimeBaseline.getRequestHeader().getMethod(),
                         msgTimeBaseline.getRequestHeader().getURI());
+            } catch (SocketException ex) {
+                LOGGER.debug(
+                        "Caught {} {} when accessing: {}",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        msgTimeBaseline.getRequestHeader().getURI());
+                return; // No need to keep going
             }
             long originalTimeUsed = msgTimeBaseline.getTimeElapsedMillis();
             // end of timing baseline check
 
-            int countUnionBasedRequests = 0;
             int countTimeBasedRequests = 0;
 
             LOGGER.debug(
-                    "Scanning URL [{}] [{}], field [{}] with value [{}] for Oracle SQL Injection",
+                    "Scanning URL [{}] [{}], field [{}] with original value [{}] for SQL Injection",
                     getBaseMsg().getRequestHeader().getMethod(),
                     getBaseMsg().getRequestHeader().getURI(),
                     paramName,
                     paramValue);
 
-            // Check for time based SQL Injection, using Oracle specific syntax
+            // POSTGRES specific time based SQL injection checks
             for (int timeBasedSQLindex = 0;
-                    timeBasedSQLindex < SQL_ORACLE_TIME_REPLACEMENTS.length
+                    timeBasedSQLindex < SQL_POSTGRES_TIME_REPLACEMENTS.length
                             && doTimeBased
                             && countTimeBasedRequests < doTimeMaxRequests;
                     timeBasedSQLindex++) {
                 HttpMessage msgAttack = getNewMsg();
                 String newTimeBasedInjectionValue =
-                        SQL_ORACLE_TIME_REPLACEMENTS[timeBasedSQLindex].replace(
-                                "<<<<ORIGINALVALUE>>>>", paramValue);
+                        SQL_POSTGRES_TIME_REPLACEMENTS[timeBasedSQLindex]
+                                .replace(ORIG_VALUE_TOKEN, paramValue)
+                                .replace(SLEEP_TOKEN, Integer.toString(sleepInSeconds));
+
                 setParameter(msgAttack, paramName, newTimeBasedInjectionValue);
+
                 // send it.
                 try {
                     sendAndReceive(msgAttack, false); // do not follow redirects
@@ -271,6 +316,13 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
                             msgTimeBaseline.getRequestHeader().getMethod(),
                             msgTimeBaseline.getRequestHeader().getURI(),
                             paramName);
+                } catch (SocketException ex) {
+                    LOGGER.debug(
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msgTimeBaseline.getRequestHeader().getURI());
+                    return; // No need to keep going
                 }
                 long modifiedTimeUsed = msgAttack.getTimeElapsedMillis();
 
@@ -282,8 +334,9 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
                         modifiedTimeUsed,
                         originalTimeUsed);
 
-                if (modifiedTimeUsed >= (originalTimeUsed + expectedDelayInMs)) {
-                    // takes more than 5 extra seconds => likely time based SQL injection.
+                if (modifiedTimeUsed >= (originalTimeUsed + (sleepInSeconds * 1000))) {
+                    // takes more than 15 (by default) extra seconds => likely time based SQL
+                    // injection
 
                     // But first double check
                     HttpMessage msgc = getNewMsg();
@@ -293,7 +346,7 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
                         // Ignore all exceptions
                     }
                     long checkTimeUsed = msgc.getTimeElapsedMillis();
-                    if (checkTimeUsed >= (originalTimeUsed + this.expectedDelayInMs - 200)) {
+                    if (checkTimeUsed >= (originalTimeUsed + (this.sleepInSeconds * 1000) - 200)) {
                         // Looks like the server is overloaded, very unlikely this is a real issue
                         continue;
                     }
@@ -313,8 +366,8 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
 
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setName(getName() + " - Time Based")
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setParam(paramName)
                             .setAttack(attack)
                             .setOtherInfo(extraInfo)
@@ -335,12 +388,13 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
             // Do not try to internationalise this.. we need an error message in any event..
             // if it's in English, it's still better than not having it at all.
             LOGGER.error(
-                    "An error occurred checking a url for Oracle SQL Injection vulnerabilities", e);
+                    "An error occurred checking a url for POSTGRES SQL Injection vulnerabilities",
+                    e);
         }
     }
 
-    public void setExpectedDelayInMs(int delay) {
-        expectedDelayInMs = delay;
+    public void setSleepInSeconds(int sleep) {
+        this.sleepInSeconds = sleep;
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionSqLiteTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionSqLiteTimingScanRule.java
@@ -1,0 +1,587 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2014 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+
+/**
+ * The SqlInjectionSqLiteScanRule identifies SQLite specific SQL Injection vulnerabilities using
+ * SQLite specific syntax. If it doesn't use SQLite specific syntax, it belongs in the generic
+ * SQLInjection class!
+ *
+ * @author 70pointer
+ */
+public class SqlInjectionSqLiteTimingScanRule extends AbstractAppParamPlugin {
+
+    // Some relevant notes about SQLite's support for various functions, which will affect what SQL
+    // is valid,
+    // and can be used to exploit each particular version :)
+    // some of the functions noted here are *very* useful in exploiting the system hosting the
+    // SQLite instance,
+    // but I won't give the game away too easily. Go have a play!
+    // 3.8.6       (2014-08-15) - hex integer literals supported, likely(X) supported, readfile(X)
+    // and writefile(X,Y) supported (if extension loading enabled)
+    // 3.8.3       (2014-02-03) - common table subexpressions supported ("WITH" keyword), printf
+    // function supported
+    // 3.8.1       (2013-10-17) - unlikely() and likelihood() functions supported
+    // 3.8.0       (2013-08-26) - percentile() function added as loadable extension
+    // 3.7.17      (2013-05-20) - new loadable extensions: including amatch, closure, fuzzer,
+    // ieee754, nextchar, regexp, spellfix, and wholenumber
+    // 3.7.16      (2013-03-18) - unicode(A) and char(X1,...,XN) supported
+    // 3.7.15      (2012-12-12) - instr() supported
+    // 3.6.8       (2009-01-12) - nested transactions supported
+    // 3.5.7       (2008-03-17) - ALTER TABLE uses double-quotes instead of single-quotes for
+    // quoting filenames (why filenames????).
+    // 3.3.13      (2007-02-13) - randomBlob() and hex() supported
+    // 3.3.8       (2006-10-09) - IF EXISTS on CREATE/DROP TRIGGER/VIEW
+    // 3.3.7       (2006-08-12) - virtual tables, dynamically loaded extensions, MATCH operator
+    // supported
+    // 3.2.6       (2005-09-17) - COUNT(DISTINCT expr) supported
+    // 3.2.3       (2005-08-21) - CAST operator, grave-accent quoting supported
+    // 3.2.0       (2005-03-21) - ALTER TABLE ADD COLUMN supported
+    // 3.1.0 ALPHA (2005-01-21) - ALTER TABLE ... RENAME TABLE, CURRENT_TIME, CURRENT_DATE, and
+    // CURRENT_TIMESTAMP, EXISTS clause, correlated subqueries supported
+    // 3.0.0 alpha (2004-06-18) - dropped support for COPY function, possibly added
+    // sqlite_source_id(), replace() (which were not in 2.8.17)
+    // 2.8.6       (2003-08-21) - date functions added
+    // 2.8.5       (2003-07-22) - supports LIMIT on a compound SELECT statement
+    // 2.8.1       (2003-05-16) - ATTACH and DETACH commands supported
+    // 2.5.0       (2002-06-17) - Double-quoted strings interpreted as column names not text
+    // literals,
+    //                           SQL-92 compliant handling of NULLs, full SQL-92 join syntax and
+    // LEFT OUTER JOINs supported
+    // 2.4.7       (2002-04-06) - "select TABLE.*", last_insert_rowid() supported
+    // 2.4.4       (2002-03-24) - CASE expressions supported
+    // 2.4.0       (2002-03-10) - coalesce(), lower(), upper(), and random() supported
+    // 2.3.3       (2002-02-18) - Allow identifiers to be quoted in square brackets, "CREATE TABLE
+    // AS SELECT" supported
+    // 2.2.0       (2001-12-22) - "SELECT rowid, * FROM table1" supported
+    // 2.0.3       (2001-10-13) - &, |,~,<<,>>,round() and abs() supported
+    // 2.0.1       (2001-10-02) - "expr NOT NULL", "expr NOTNULL" supported
+    // 1.0.32      (2001-07-23) - quoted strings supported as table and column names in expressions
+    // 1.0.28      (2001-04-04) - special column names ROWID, OID, and _ROWID_ supported (with
+    // random values)
+    // 1.0.4       (2000-08-28) - length() and substr() supported
+    // 1.0         (2000-08-17) - covers lots of unversioned releases.  ||, fcnt(), UNION, UNION
+    // ALL, INTERSECT, and EXCEPT, LIKE, GLOB, COPY supported
+
+    private int expectedDelayInMs = 5000;
+
+    private boolean doTimeBased = false;
+
+    private int doTimeMaxRequests = 0;
+
+    /** SQLite one-line comment */
+    public static final String SQL_ONE_LINE_COMMENT = "--";
+
+    /**
+     * SQLite specific time based injection strings, where each tries to cause a measurable delay
+     */
+
+    // Note: <<<<ORIGINALVALUE>>>> is replaced with the original parameter value at runtime in these
+    // examples below
+    // TODO: maybe add support for ')' after the original value, before the sleeps
+    // Note: randomblob is supported from SQLite 3.3.13 (2007-02-13)
+    //		case statement is supported from SQLite 2.4.4 (2002-03-24)
+    private static String[] SQL_SQLITE_TIME_REPLACEMENTS = {
+        // omitting original param
+        "case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then 1 else 1 end ", // integer
+        "' | case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then \"\" else \"\" end | '", // character/string (single quote)
+        "\" | case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then \"\" else \"\" end | \"", // character/string (double quote)
+        "case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then 1 else 1 end "
+                + SQL_ONE_LINE_COMMENT, // integer
+        "' | case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then \"\" else \"\" end "
+                + SQL_ONE_LINE_COMMENT, // character/string (single quote)
+        "\" | case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then \"\" else \"\" end "
+                + SQL_ONE_LINE_COMMENT, // character/string (double quote)
+
+        // with the original parameter
+        "<<<<ORIGINALVALUE>>>> * case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then 1 else 1 end ", // integer
+        "<<<<ORIGINALVALUE>>>>' | case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then \"\" else \"\" end | '", // character/string (single quote)
+        "<<<<ORIGINALVALUE>>>>\" | case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then \"\" else \"\" end | \"", // character/string (double quote)
+        "<<<<ORIGINALVALUE>>>> * case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then 1 else 1 end "
+                + SQL_ONE_LINE_COMMENT, // integer
+        "<<<<ORIGINALVALUE>>>>' | case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then \"\" else \"\" end "
+                + SQL_ONE_LINE_COMMENT, // character/string (single quote)
+        "<<<<ORIGINALVALUE>>>>\" | case randomblob(<<<<NUMBLOBBYTES>>>>) when not null then \"\" else \"\" end "
+                + SQL_ONE_LINE_COMMENT, // character/string (double quote)
+    };
+
+    /** if the following errors occur during the attack, it's a SQL injection vuln */
+    private Pattern errorMessagePatterns[] = {
+        Pattern.compile(
+                "no such function: randomblob",
+                Pattern.CASE_INSENSITIVE) // this one is specific to the time-based attack
+        // attempted here, and is indicative of SQLite versions <
+        // 3.3.13, and >= 2.4.4 (because the CASE statement is
+        // used)
+        ,
+        Pattern.compile("near \\\".+\\\": syntax error", Pattern.CASE_INSENSITIVE)
+    };
+
+    /** set depending on the attack strength / threshold */
+    private long maxBlobBytes = 0;
+
+    private long minBlobBytes = 100000;
+    private long parseDelayDifference = 0;
+    private long incrementalDelayIncreasesForAlert = 0;
+
+    private char[] RANDOM_PARAMETER_CHARS = "abcdefghijklmnopqrstuvwyxz0123456789".toCharArray();
+    private static final Map<String, String> ALERT_TAGS =
+            CommonAlertTag.toMap(
+                    CommonAlertTag.OWASP_2021_A03_INJECTION,
+                    CommonAlertTag.OWASP_2017_A01_INJECTION,
+                    CommonAlertTag.WSTG_V42_INPV_05_SQLI);
+
+    /** for logging. */
+    private static final Logger LOGGER =
+            LogManager.getLogger(SqlInjectionSqLiteTimingScanRule.class);
+
+    @Override
+    public int getId() {
+        return 90038;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString("ascanrules.sqlinjection.sqlite.name");
+    }
+
+    @Override
+    public boolean targets(TechSet technologies) {
+        return technologies.includes(Tech.SQLite);
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("ascanrules.sqlinjection.desc");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INJECTION;
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString("ascanrules.sqlinjection.soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString("ascanrules.sqlinjection.refs");
+    }
+
+    @Override
+    public void init() {
+        LOGGER.debug("Initialising");
+
+        // set up what we are allowed to do, depending on the attack strength that was set.
+        if (this.getAttackStrength() == Plugin.AttackStrength.LOW) {
+            doTimeBased = true;
+            doTimeMaxRequests = 0;
+            this.maxBlobBytes = 1000000000;
+        } else if (this.getAttackStrength() == Plugin.AttackStrength.MEDIUM) {
+            doTimeBased = true;
+            doTimeMaxRequests = 4;
+            this.maxBlobBytes = 1000000000;
+        } else if (this.getAttackStrength() == Plugin.AttackStrength.HIGH) {
+            doTimeBased = true;
+            doTimeMaxRequests = 20;
+            this.maxBlobBytes = 1000000000;
+        } else if (this.getAttackStrength() == Plugin.AttackStrength.INSANE) {
+            doTimeBased = true;
+            doTimeMaxRequests = 100;
+            this.maxBlobBytes = 1000000000;
+        }
+
+        // the allowable difference between a parse delay and an attack delay is controlled by the
+        // threshold
+        if (this.getAlertThreshold() == Plugin.AlertThreshold.LOW) {
+            parseDelayDifference = 100;
+            incrementalDelayIncreasesForAlert = 1;
+        } else if (this.getAlertThreshold() == Plugin.AlertThreshold.MEDIUM) {
+            parseDelayDifference = 200;
+            incrementalDelayIncreasesForAlert = 2;
+        } else if (this.getAlertThreshold() == Plugin.AlertThreshold.HIGH) {
+            parseDelayDifference = 400;
+            incrementalDelayIncreasesForAlert = 3;
+        }
+    }
+
+    /**
+     * scans for SQL Injection vulnerabilities, using SQLite specific syntax. If it doesn't use
+     * specifically SQLite syntax, it does not belong in here, but in TestSQLInjection
+     */
+    @Override
+    public void scan(HttpMessage originalMessage, String paramName, String originalParamValue) {
+
+        try {
+            // the original message passed to us never has the response populated. fix that by
+            // re-retrieving it..
+            sendAndReceive(originalMessage, false); // do not follow redirects
+
+            // Do time based SQL injection checks..
+            // Timing Baseline check: we need to get the time that it took the original query, to
+            // know if the time based check is working correctly..
+            HttpMessage msgTimeBaseline = getNewMsg();
+            try {
+                sendAndReceive(msgTimeBaseline);
+            } catch (SocketTimeoutException e) {
+                // to be expected occasionally, if the base query was one that contains some
+                // parameters exploiting time based SQL injection?
+                LOGGER.debug(
+                        "The Base Time Check timed out on [{}] URL [{}]",
+                        msgTimeBaseline.getRequestHeader().getMethod(),
+                        msgTimeBaseline.getRequestHeader().getURI());
+            }
+            long originalTimeUsed = msgTimeBaseline.getTimeElapsedMillis();
+            // if the time was very slow (because JSP was being compiled on first call, for
+            // instance)
+            // then the rest of the time based logic will fail.  Lets double-check for that scenario
+            // by requesting the url again.
+            // If it comes back in a more reasonable time, we will use that time instead as our
+            // baseline.  If it come out in a slow fashion again,
+            // we will abort the check on this URL, since we will only spend lots of time trying
+            // request, when we will (very likely) not get positive results.
+            if (originalTimeUsed > expectedDelayInMs) {
+                try {
+                    sendAndReceive(msgTimeBaseline);
+                } catch (SocketTimeoutException e) {
+                    // to be expected occasionally, if the base query was one that contains some
+                    // parameters exploiting time based SQL injection?
+                    LOGGER.debug(
+                            "Base Time Check 2 timed out on [{}] URL [{}]",
+                            msgTimeBaseline.getRequestHeader().getMethod(),
+                            msgTimeBaseline.getRequestHeader().getURI());
+                }
+                long originalTimeUsed2 = msgTimeBaseline.getTimeElapsedMillis();
+                if (originalTimeUsed2 > expectedDelayInMs) {
+                    // no better the second time around.  we need to bale out.
+                    LOGGER.debug(
+                            "Both base time checks 1 and 2 for [{}] URL [{}] are way too slow to be usable for the purposes of checking for time based SQL Injection checking.  We are aborting the check on this particular url.",
+                            msgTimeBaseline.getRequestHeader().getMethod(),
+                            msgTimeBaseline.getRequestHeader().getURI());
+                    return;
+                } else {
+                    // phew.  the second time came in within the limits. use the later timing
+                    // details as the base time for the checks.
+                    originalTimeUsed = originalTimeUsed2;
+                }
+            }
+            // end of timing baseline check
+
+            int countTimeBasedRequests = 0;
+            LOGGER.debug(
+                    "Scanning URL [{}] [{}], [{}] with value [{}] for SQL Injection",
+                    getBaseMsg().getRequestHeader().getMethod(),
+                    getBaseMsg().getRequestHeader().getURI(),
+                    paramName,
+                    originalParamValue);
+
+            // SQLite specific time-based SQL injection checks
+            boolean foundTimeBased = false;
+            for (int timeBasedSQLindex = 0;
+                    timeBasedSQLindex < SQL_SQLITE_TIME_REPLACEMENTS.length
+                            && doTimeBased
+                            && countTimeBasedRequests < doTimeMaxRequests;
+                    timeBasedSQLindex++) {
+                // since we have no means to create a deterministic delay in SQLite, we need to take
+                // a different approach:
+                // in each iteration, increase the number of random blobs for SQLite to create.  If
+                // we can detect an increasing delay, we know
+                // that the payload has been successfully injected.
+                int numberOfSequentialIncreases = 0;
+                String detectableDelayParameter = null;
+                long detectableDelay = 0;
+                String maxDelayParameter = null;
+                long maxDelay = 0;
+                HttpMessage detectableDelayMessage = null;
+                long previousDelay = originalTimeUsed;
+                boolean potentialTimeBasedSQLInjection = false;
+                boolean timeExceeded = false;
+
+                for (long numBlobsToCreate = minBlobBytes;
+                        numBlobsToCreate <= this.maxBlobBytes
+                                && !timeExceeded
+                                && numberOfSequentialIncreases < incrementalDelayIncreasesForAlert;
+                        numBlobsToCreate *= 10) {
+
+                    HttpMessage msgDelay = getNewMsg();
+                    String newTimeBasedInjectionValue =
+                            SQL_SQLITE_TIME_REPLACEMENTS[timeBasedSQLindex].replace(
+                                    "<<<<ORIGINALVALUE>>>>", originalParamValue);
+                    newTimeBasedInjectionValue =
+                            newTimeBasedInjectionValue.replace(
+                                    "<<<<NUMBLOBBYTES>>>>", Long.toString(numBlobsToCreate));
+                    setParameter(msgDelay, paramName, newTimeBasedInjectionValue);
+
+                    LOGGER.debug(
+                            "\nTrying '{}'. The number of Sequential Increases already is {}",
+                            newTimeBasedInjectionValue,
+                            numberOfSequentialIncreases);
+
+                    // send it.
+                    try {
+                        sendAndReceive(msgDelay);
+                        countTimeBasedRequests++;
+                    } catch (SocketTimeoutException e) {
+                        // to be expected occasionally, if the contains some parameters exploiting
+                        // time based SQL injection
+                        LOGGER.debug(
+                                "The time check query timed out on [{}] URL [{}] on field: [{}]",
+                                msgTimeBaseline.getRequestHeader().getMethod(),
+                                msgTimeBaseline.getRequestHeader().getURI(),
+                                paramName);
+                    }
+                    long modifiedTimeUsed = msgDelay.getTimeElapsedMillis();
+
+                    // before we do the time based checking, first check for a known error message
+                    // from the attack, indicating a SQL injection vuln
+                    for (Pattern errorMessagePattern : errorMessagePatterns) {
+                        Matcher matcher =
+                                errorMessagePattern.matcher(msgDelay.getResponseBody().toString());
+                        boolean errorFound = matcher.find();
+                        if (errorFound) {
+                            // Likely an error based SQL Injection. Raise it
+                            String extraInfo =
+                                    Constant.messages.getString(
+                                            "ascanrules.sqlinjection.sqlite.alert.errorbased.extrainfo",
+                                            errorMessagePattern);
+                            // raise the alert
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setUri(getBaseMsg().getRequestHeader().getURI().toString())
+                                    .setParam(paramName)
+                                    .setAttack(newTimeBasedInjectionValue)
+                                    .setOtherInfo(extraInfo)
+                                    .setEvidence(matcher.group())
+                                    .setMessage(msgDelay)
+                                    .raise();
+
+                            LOGGER.debug(
+                                    "A likely Error Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}], by matching for pattern [{}]",
+                                    msgDelay.getRequestHeader().getMethod(),
+                                    msgDelay.getRequestHeader().getURI(),
+                                    paramName,
+                                    errorMessagePattern);
+                            foundTimeBased =
+                                    true; // yeah, I know. we found an error based, while looking
+                            // for a time based. bale out anyways.
+                            break; // out of the loop
+                        }
+                    }
+                    // outta the time based loop..
+                    if (foundTimeBased) break;
+
+                    // no error message detected from the time based attack.. continue looking for
+                    // time based injection point.
+
+                    // cap the time we will delay by to 10 seconds
+                    if (modifiedTimeUsed > 10000) timeExceeded = true;
+
+                    boolean parseTimeEquivalent = false;
+                    if (modifiedTimeUsed > previousDelay) {
+                        LOGGER.debug(
+                                "The response time {} is > the previous response time {}",
+                                modifiedTimeUsed,
+                                previousDelay);
+                        // in order to rule out false positives due to the increasing SQL parse time
+                        // for longer parameter values
+                        // we send a random (alphanumeric only) string value of the same length as
+                        // the attack parameter
+                        // we expect the response time for the SQLi attack to be greater than or
+                        // equal to the response time for
+                        // the random alphanumeric string parameter
+                        // if this is not the case, then we assume that the attack parameter is not
+                        // a potential SQL injection causing payload.
+                        HttpMessage msgParseDelay = getNewMsg();
+                        String parseDelayCheckParameter =
+                                RandomStringUtils.random(
+                                        newTimeBasedInjectionValue.length(),
+                                        RANDOM_PARAMETER_CHARS);
+                        setParameter(msgParseDelay, paramName, parseDelayCheckParameter);
+                        sendAndReceive(msgParseDelay);
+                        countTimeBasedRequests++;
+                        long parseDelayTimeUsed = msgParseDelay.getTimeElapsedMillis();
+
+                        // figure out if the attack delay and the (non-sql-injection) parse delay
+                        // are within X ms of each other..
+                        parseTimeEquivalent =
+                                (Math.abs(modifiedTimeUsed - parseDelayTimeUsed)
+                                        < this.parseDelayDifference);
+                        LOGGER.debug(
+                                "The parse time a random parameter of the same length is {}, so the attack and random parameter are {} equivalent (given the user defined attack threshold)",
+                                parseDelayTimeUsed,
+                                parseTimeEquivalent ? "" : "NOT ");
+                    }
+
+                    if (modifiedTimeUsed > previousDelay && !parseTimeEquivalent) {
+
+                        maxDelayParameter = newTimeBasedInjectionValue;
+                        maxDelay = modifiedTimeUsed;
+
+                        // potential for SQL injection, detectable with "numBlobsToCreate" random
+                        // blobs being created..
+                        numberOfSequentialIncreases++;
+                        if (!potentialTimeBasedSQLInjection) {
+                            LOGGER.debug(
+                                    "Setting the Detectable Delay parameter to '{}'",
+                                    newTimeBasedInjectionValue);
+                            detectableDelayParameter = newTimeBasedInjectionValue;
+                            detectableDelay = modifiedTimeUsed;
+                            detectableDelayMessage = msgDelay;
+                        }
+                        potentialTimeBasedSQLInjection = true;
+                    } else {
+                        // either no SQL injection, invalid SQL syntax, or timing difference is not
+                        // detectable with "numBlobsToCreate" random blobs being created.
+                        // keep trying with larger numbers of "numBlobsToCreate", since that's the
+                        // thing we can most easily control and verify
+                        // note also: if for some reason, an earlier attack with a smaller number of
+                        // blobs indicated there might be a vulnerability
+                        // then this case will rule that out if it was a fluke...
+                        // the timing delay must keep increasing, as the number of blobs is
+                        // increased.
+                        potentialTimeBasedSQLInjection = false;
+                        numberOfSequentialIncreases = 0;
+                        detectableDelayParameter = null;
+                        detectableDelay = 0;
+                        detectableDelayMessage = null;
+                        maxDelayParameter = null;
+                        maxDelay = 0;
+                        // do not break at this point, since we may simply need to keep increasing
+                        // numBlobsToCreate to
+                        // a point where we can detect the resulting delay
+                    }
+                    LOGGER.debug(
+                            "Time Based SQL Injection test for {} random blob bytes: [{}] on field: [{}] with value [{}] took {}ms, where the original took {}ms.",
+                            numBlobsToCreate,
+                            newTimeBasedInjectionValue,
+                            paramName,
+                            newTimeBasedInjectionValue,
+                            modifiedTimeUsed,
+                            originalTimeUsed);
+                    previousDelay = modifiedTimeUsed;
+
+                    // bale out if we were asked nicely
+                    if (isStop()) {
+                        LOGGER.debug("Stopping the scan due to a user request");
+                        return;
+                    }
+                } // end of for loop to increase the number of random blob bytes to create
+
+                // the number of times that we could sequentially increase the delay by increasing
+                // the "number of random blob bytes to create"
+                // is the basis for the threshold of the alert.  In some cases, the user may want to
+                // see a solid increase in delay
+                // for say 4 or 5 iterations, in order to be confident the vulnerability exists.  In
+                // other cases, the user may be happy with just 2 sequential increases...
+                LOGGER.debug("Number of sequential increases: {}", numberOfSequentialIncreases);
+                if (numberOfSequentialIncreases >= this.incrementalDelayIncreasesForAlert) {
+                    // Likely a SQL Injection. Raise it
+                    String extraInfo =
+                            Constant.messages.getString(
+                                    "ascanrules.sqlinjection.sqlite.alert.timebased.extrainfo",
+                                    detectableDelayParameter,
+                                    detectableDelay,
+                                    maxDelayParameter,
+                                    maxDelay,
+                                    originalParamValue,
+                                    originalTimeUsed);
+
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
+                            .setParam(paramName)
+                            .setAttack(detectableDelayParameter)
+                            .setOtherInfo(extraInfo)
+                            .setEvidence(extraInfo)
+                            .setMessage(detectableDelayMessage)
+                            .raise();
+
+                    if (detectableDelayMessage != null)
+                        LOGGER.debug(
+                                "A likely Time Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}]",
+                                detectableDelayMessage.getRequestHeader().getMethod(),
+                                detectableDelayMessage.getRequestHeader().getURI(),
+                                paramName);
+
+                    // outta the time based loop..
+                    break;
+                } // the user-define threshold has been exceeded. raise it.
+
+                // outta the time based loop..
+                if (foundTimeBased) break;
+
+                // bale out if we were asked nicely
+                if (isStop()) {
+                    LOGGER.debug("Stopping the scan due to a user request");
+                    return;
+                }
+            } // for each time based SQL index
+            // end of check for SQLite time based SQL Injection
+        } catch (UnknownHostException | URIException e) {
+            LOGGER.debug("Failed to send HTTP message, cause: {}", e.getMessage());
+        } catch (Exception e) {
+            // Do not try to internationalise this.. we need an error message in any event..
+            // if it's in English, it's still better than not having it at all.
+            LOGGER.error(
+                    "An error occurred checking a url for SQLite SQL Injection vulnerabilities", e);
+        }
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_HIGH;
+    }
+
+    @Override
+    public int getCweId() {
+        return 89;
+    }
+
+    @Override
+    public int getWascId() {
+        return 19;
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return ALERT_TAGS;
+    }
+}

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -55,14 +55,19 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 This rule submits *NIX and Windows OS commands as URL parameter values to determine whether or not the web application is passing unchecked
 user input directly to the underlying OS. The injection strings consist of meta-characters that may be interpreted by the OS
 as join commands along with a payload that should generate output in the response if the application is vulnerable. If the content of a response body
-matches the payload, the scanner raises an alert and returns immediately. In the event that none of the error-based matching attempts
-return output in the response, the scanner will attempt a blind injection attack by submitting sleep instructions as the payload and comparing the elapsed time between sending the request
+matches the payload, the scanner raises an alert and returns immediately.
+<p>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java">CommandInjectionScanRule.java</a>
+
+<H2>Command Injection Timing</H2>
+
+This rule attempts a blind injection attack by submitting sleep instructions as the payload and comparing the elapsed time between sending the request
 and receiving the response against a heuristic time-delay lower limit. If the elapsed time is greater than this limit, an alert is raised with medium confidence
 and the scanner returns immediately.
 <br>
 Post 2.5.0 you can change the length of time used for the blind injection attack by changing the <code>rules.common.sleep</code> parameter via the Options 'Rule configuration' panel.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScaRule.java">CommandInjectionScaRule.java</a>
+  Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionTimingScanRule.java">CommandInjectionTimingScanRule.java</a>
 
 <H2>Cross Site Scripting (Reflected)</H2>
 
@@ -327,6 +332,11 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 This active scan rule attempts to inject SQLite specific commands into parameter values and analyzes the server's responses to see if the commands were effectively executed on the server (indicating a successful SQL injection attack).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionSqLiteScanRule.java">SqlInjectionSqLiteScanRule.java</a>
+
+<H2>Time Based SQL Injection - SQLite</H2>
+This active scan rule attempts to inject time based SQLite specific commands into parameter values and analyzes the server's responses to see if the commands were effectively executed on the server (indicating a successful SQL injection attack).
+<p>
+  Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionSqLiteTimingScanRule.java">SqlInjectionSqLiteTimingScanRule.java</a>
 
 <H2>Trace.axd Information Leak</H2>
 Tests to see if Trace Viewer (trace.axd) is available. Although this component is convenient for developers and 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionTimingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionTimingScanRuleUnitTest.java
@@ -1,0 +1,198 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.function.Predicate;
+import org.apache.commons.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link CommandInjectionScanRule}. */
+class CommandInjectionTimingScanRuleUnitTest
+        extends ActiveScannerTest<CommandInjectionTimingScanRule> {
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
+        int recommendMax = super.getRecommendMaxNumberMessagesPerParam(strength);
+        switch (strength) {
+            case LOW:
+                return recommendMax + 9;
+            case MEDIUM:
+            default:
+                return recommendMax + 23;
+            case HIGH:
+                return recommendMax + 30;
+            case INSANE:
+                return recommendMax + 17;
+        }
+    }
+
+    @Override
+    protected CommandInjectionTimingScanRule createScanner() {
+        CommandInjectionTimingScanRule scanner = new CommandInjectionTimingScanRule();
+        scanner.setConfig(new ZapXmlConfiguration());
+        return scanner;
+    }
+
+    @Test
+    void shouldFailToInitWithoutConfig() throws Exception {
+        // Given
+        CommandInjectionTimingScanRule scanner = new CommandInjectionTimingScanRule();
+        HttpMessage msg = getHttpMessage("");
+        // When / Then
+        assertThrows(NullPointerException.class, () -> scanner.init(msg, parent));
+    }
+
+    @Test
+    void shouldUse5SecsByDefaultForTimeBasedAttacks() throws Exception {
+        // Given / When
+        int time = rule.getTimeSleep();
+        // Then
+        assertThat(time, is(equalTo(5)));
+    }
+
+    @Test
+    void shouldUseTimeDefinedInConfigForTimeBasedAttacks() throws Exception {
+        // Given
+        rule.setConfig(configWithSleepRule("10"));
+        // When
+        rule.init(getHttpMessage(""), parent);
+        // Then
+        assertThat(rule.getTimeSleep(), is(equalTo(10)));
+    }
+
+    @Test
+    void shouldDefaultTo5SecsIfConfigTimeIsMalformedValueForTimeBasedAttacks() throws Exception {
+        // Given
+        rule.setConfig(configWithSleepRule("not a valid value"));
+        // When
+        rule.init(getHttpMessage(""), parent);
+        // Then
+        assertThat(rule.getTimeSleep(), is(equalTo(5)));
+    }
+
+    @Test
+    void shouldUseSpecifiedTimeInAllTimeBasedPayloads() throws Exception {
+        // Given
+        String sleepTime = "987";
+        CommandInjectionTimingScanRuleUnitTest.PayloadCollectorHandler payloadCollector =
+                new CommandInjectionTimingScanRuleUnitTest.PayloadCollectorHandler(
+                        "/", "p", v -> v.contains("sleep") || v.contains("timeout"));
+        nano.addHandler(payloadCollector);
+        rule.setConfig(configWithSleepRule(sleepTime));
+        rule.setAttackStrength(AttackStrength.INSANE);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        for (String payload : payloadCollector.getPayloads()) {
+            assertThat(payload, not(containsString("{0}")));
+            assertThat(payload, containsString(sleepTime));
+        }
+    }
+
+    @Test
+    void shouldDetectTimeBasedInjection()
+            throws org.parosproxy.paros.network.HttpMalformedHeaderException {
+        // Given
+        java.util.regex.Pattern sleepPattern =
+                java.util.regex.Pattern.compile("(?:sleep|timeout /T|start-sleep -s) (\\d+)");
+        String regularContent = "<!DOCTYPE html><html><body>Nothing to see here.</body></html>";
+        nano.addHandler(
+                new NanoServerHandler("/") {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String value = getFirstParamValue(session, "p");
+                        if (value == null) {
+                            return newFixedLengthResponse(regularContent);
+                        }
+                        java.util.regex.Matcher match = sleepPattern.matcher(value);
+                        if (!match.find()) {
+                            return newFixedLengthResponse(regularContent);
+                        }
+                        try {
+                            int sleepInput = Integer.parseInt(match.group(1));
+                            Thread.sleep(sleepInput * 1000L);
+                        } catch (InterruptedException ex) {
+                            fail("failed to sleep thread for time-based command injection");
+                        }
+                        return newFixedLengthResponse(regularContent);
+                    }
+                });
+        rule.init(getHttpMessage("/?p=a"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(sleepPattern.matcher(alertsRaised.get(0).getAttack()).find(), is(true));
+    }
+
+    private static Configuration configWithSleepRule(String value) {
+        Configuration config = new ZapXmlConfiguration();
+        config.setProperty(RuleConfigParam.RULE_COMMON_SLEEP_TIME, value);
+        return config;
+    }
+
+    private static class PayloadCollectorHandler extends NanoServerHandler {
+
+        private final String param;
+        private final Predicate<String> valuePredicate;
+        private final java.util.List<String> payloads;
+
+        public PayloadCollectorHandler(
+                String path, String param, Predicate<String> valuePredicate) {
+            super(path);
+
+            this.param = param;
+            this.valuePredicate = valuePredicate;
+            this.payloads = new java.util.ArrayList<>();
+        }
+
+        public java.util.List<String> getPayloads() {
+            return payloads;
+        }
+
+        @Override
+        protected Response serve(IHTTPSession session) {
+            String value = getFirstParamValue(session, param);
+            if (valuePredicate.test(value)) {
+                payloads.add(value);
+            }
+            return newFixedLengthResponse(
+                    Response.Status.OK, fi.iki.elonen.NanoHTTPD.MIME_HTML, "Content");
+        }
+    }
+}

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMySqlTimingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMySqlTimingScanRuleUnitTest.java
@@ -35,12 +35,13 @@ import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-/** Unit test for {@link SqlInjectionMySqlScanRule}. */
-class SqlInjectionMySqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMySqlScanRule> {
+/** Unit test for {@link SqlInjectionMySqlTimingScanRule}. */
+class SqlInjectionMySqlTimingScanRuleUnitTest
+        extends ActiveScannerTest<SqlInjectionMySqlTimingScanRule> {
 
     @Override
-    protected SqlInjectionMySqlScanRule createScanner() {
-        return new SqlInjectionMySqlScanRule();
+    protected SqlInjectionMySqlTimingScanRule createScanner() {
+        return new SqlInjectionMySqlTimingScanRule();
     }
 
     @Test

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionOracleTimingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionOracleTimingScanRuleUnitTest.java
@@ -35,12 +35,13 @@ import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-/** Unit test for {@link SqlInjectionOracleScanRule}. */
-class SqlInjectionOracleScanRuleUnitTest extends ActiveScannerTest<SqlInjectionOracleScanRule> {
+/** Unit test for {@link SqlInjectionOracleTimingScanRule}. */
+class SqlInjectionOracleTimingScanRuleUnitTest
+        extends ActiveScannerTest<SqlInjectionOracleTimingScanRule> {
 
     @Override
-    protected SqlInjectionOracleScanRule createScanner() {
-        return new SqlInjectionOracleScanRule();
+    protected SqlInjectionOracleTimingScanRule createScanner() {
+        return new SqlInjectionOracleTimingScanRule();
     }
 
     @Test

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionSQLiteScanRuleTimingUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionSQLiteScanRuleTimingUnitTest.java
@@ -1,0 +1,190 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link SqlInjectionSqLiteScanRule}. */
+class SqlInjectionSQLiteScanRuleTimingUnitTest
+        extends ActiveScannerTest<SqlInjectionSqLiteTimingScanRule> {
+
+    @Override
+    protected SqlInjectionSqLiteTimingScanRule createScanner() {
+        return new SqlInjectionSqLiteTimingScanRule();
+    }
+
+    // Give a bit more leeway
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(
+            org.parosproxy.paros.core.scanner.Plugin.AttackStrength strength) {
+        switch (strength) {
+            case LOW:
+                return NUMBER_MSGS_ATTACK_STRENGTH_LOW;
+            case MEDIUM:
+            default:
+                return NUMBER_MSGS_ATTACK_STRENGTH_MEDIUM + 2;
+            case HIGH:
+                return NUMBER_MSGS_ATTACK_STRENGTH_HIGH + 10;
+            case INSANE:
+                return NUMBER_MSGS_ATTACK_STRENGTH_INSANE + 22;
+        }
+    }
+
+    @Test
+    void shouldTargetSqLiteSQLTech() throws Exception {
+        // Given
+        org.zaproxy.zap.model.TechSet techSet = techSet(org.zaproxy.zap.model.Tech.SQLite);
+        // When
+        boolean targets = rule.targets(techSet);
+        // Then
+        assertThat(targets, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotTargetNonSqLiteSQLTechs() throws Exception {
+        // Given
+        org.zaproxy.zap.model.TechSet techSet = techSetWithout(org.zaproxy.zap.model.Tech.SQLite);
+        // When
+        boolean targets = rule.targets(techSet);
+        // Then
+        assertThat(targets, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldAlertIfSqlErrorReturned() throws Exception {
+        String test = "/shouldReportSqlErrorMessage/";
+
+        this.nano.addHandler(
+                new org.zaproxy.zap.testutils.NanoServerHandler(test) {
+                    @Override
+                    protected fi.iki.elonen.NanoHTTPD.Response serve(
+                            fi.iki.elonen.NanoHTTPD.IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response = "<html><body></body></html>";
+                        if (name != null && name.contains(" randomblob(")) {
+                            response =
+                                    "<html><body>SQL error: no such function: randomblob</body></html>";
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        org.parosproxy.paros.network.HttpMessage msg = this.getHttpMessage(test + "?name=test");
+
+        this.rule.init(msg, this.parent);
+
+        this.rule.scan();
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("no such function: randomblob"));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("name"));
+        assertThat(
+                alertsRaised.get(0).getAttack(),
+                equalTo("case randomblob(100000) when not null then 1 else 1 end "));
+        assertThat(
+                alertsRaised.get(0).getRisk(),
+                equalTo(org.parosproxy.paros.core.scanner.Alert.RISK_HIGH));
+        assertThat(
+                alertsRaised.get(0).getConfidence(),
+                equalTo(org.parosproxy.paros.core.scanner.Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
+    void shouldAlertIfRandomBlobTimesGetLonger() throws Exception {
+        String test = "/shouldReportSqlTimingIssue/";
+
+        this.nano.addHandler(
+                new org.zaproxy.zap.testutils.NanoServerHandler(test) {
+                    private int time = 100;
+
+                    @Override
+                    protected fi.iki.elonen.NanoHTTPD.Response serve(
+                            fi.iki.elonen.NanoHTTPD.IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response = "<html><body></body></html>";
+                        if (name != null && name.contains(" randomblob(")) {
+                            try {
+                                Thread.sleep(time);
+                            } catch (InterruptedException e) {
+                                // Ignore
+                            }
+                            time += 100;
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        org.parosproxy.paros.network.HttpMessage msg = this.getHttpMessage(test + "?name=test");
+
+        this.rule.init(msg, this.parent);
+
+        this.rule.scan();
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(
+                alertsRaised.get(0).getEvidence(),
+                startsWith("The query time is controllable using parameter value"));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("name"));
+        assertThat(alertsRaised.get(0).getAttack(), startsWith("case randomblob(100"));
+        assertThat(
+                alertsRaised.get(0).getRisk(),
+                equalTo(org.parosproxy.paros.core.scanner.Alert.RISK_HIGH));
+        assertThat(
+                alertsRaised.get(0).getConfidence(),
+                equalTo(org.parosproxy.paros.core.scanner.Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
+    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
+        String test = "/shouldReportSqlTimingIssue/";
+
+        this.nano.addHandler(
+                new org.zaproxy.zap.testutils.NanoServerHandler(test) {
+                    private int time = 100;
+
+                    @Override
+                    protected fi.iki.elonen.NanoHTTPD.Response serve(
+                            fi.iki.elonen.NanoHTTPD.IHTTPSession session) {
+                        String response = "<html><body></body></html>";
+                        try {
+                            Thread.sleep(time);
+                        } catch (InterruptedException e) {
+                            // Ignore
+                        }
+                        time += 100;
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        org.parosproxy.paros.network.HttpMessage msg = this.getHttpMessage(test + "?name=test");
+
+        this.rule.init(msg, this.parent);
+
+        this.rule.scan();
+
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+}

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Move time based attacks to their own scan rules (Issue 7341).
 
 ## [42] - 2022-12-13
 ### Added

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionTimingScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionTimingScanRule.java
@@ -1,0 +1,317 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.NameValuePair;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+
+/**
+ * The MongoInjection scan rule identifies MongoDB injection vulnerabilities
+ *
+ * @author l.casciaro
+ */
+public class MongoDbInjectionTimingScanRule extends AbstractAppParamPlugin {
+
+    // Prefix for internationalised messages used by this rule
+    private static final String MESSAGE_PREFIX = "ascanalpha.mongodb.";
+    // Constants
+    private static final String SLEEP_ATTACK = "sleep";
+    private int SLEEP_SHORT_TIME, SLEEP_LONG_TIME;
+    private static final String INSERT_SHORT_TIME = "INSERT_SHORT_TIME",
+            INSERT_LONG_TIME = "INSERT_LONG_TIME";
+    private static final int SHORT_THRESHOLD = 1500;
+    private static final int LONG_THRESHOLD = 3000;
+
+    // Packages of attack rules
+    private static final String[][] SLEEP_INJECTION = {
+        // Attacking $where clause
+        // function() { var x = md5( some_input ); return this.password == x;}
+        {
+            "'); sleep(" + INSERT_SHORT_TIME + "); print('",
+            "'); sleep(" + INSERT_LONG_TIME + "); print('"
+        },
+        {
+            "\"); sleep(" + INSERT_SHORT_TIME + "); print(\"",
+            "\"); sleep(" + INSERT_LONG_TIME + "); print(\""
+        },
+        {
+            "0); sleep(" + INSERT_SHORT_TIME + "); print(\"",
+            "0); sleep(" + INSERT_LONG_TIME + "); print(\""
+        },
+        // function() { var x = this.value == some_input; return x;}
+        {
+            "'; sleep(" + INSERT_SHORT_TIME + "); var x='",
+            "'; sleep(" + INSERT_LONG_TIME + "); var x='"
+        },
+        {
+            "\"; sleep(" + INSERT_SHORT_TIME + "); var x=\"",
+            "\"; sleep(" + INSERT_LONG_TIME + "); var x=\""
+        },
+        {"0; sleep(" + INSERT_SHORT_TIME + ")", "0; sleep(" + INSERT_LONG_TIME + ")"},
+        // function() { return this.value == some_input }
+        {
+            "zap' || sleep(" + INSERT_SHORT_TIME + ") && 'zap'=='zap",
+            "zap' || sleep(" + INSERT_LONG_TIME + ") && 'zap'=='zap"
+        },
+        {
+            "zap\" || sleep(" + INSERT_SHORT_TIME + ") && \"zap\"==\"zap",
+            "zap\" || sleep(" + INSERT_LONG_TIME + ") && \"zap\"==\"zap"
+        },
+        {"0 || sleep(" + INSERT_SHORT_TIME + ")", "0 || sleep(" + INSERT_LONG_TIME + ")"},
+        // function() { return this.value == some_function(some_imput) }
+        {
+            "zap') || sleep(" + INSERT_SHORT_TIME + ") && hex_md5('zap",
+            "zap') || sleep(" + INSERT_LONG_TIME + ") && md5('zap"
+        },
+        {
+            "zap\") || sleep(" + INSERT_SHORT_TIME + ") && md5(\"zap",
+            "zap\") || sleep(" + INSERT_LONG_TIME + ") && md5(\"zap"
+        },
+        {"0)  || sleep(" + INSERT_SHORT_TIME, "0) || sleep(" + INSERT_LONG_TIME},
+        // Attacking mapReduce clause (only for old versions of mongodb)
+        {
+            "_id);}, function(inj) { sleep("
+                    + INSERT_SHORT_TIME
+                    + ");return 1;}, { out: 'x'}); "
+                    + "db.injection.mapReduce(function() { emit(1,1",
+            "_id);}, function(inj) { sleep("
+                    + INSERT_LONG_TIME
+                    + "); return 1;}, { out: 'x'}); "
+                    + "db.injection.mapReduce(function() { emit(1,1"
+        }
+    };
+    // Log prints
+    private static final String IO_EX_LOG = "trying to send an http message";
+    private static final String STOP_LOG = "Stopping the scan due to a user request";
+    private static final Logger LOGGER = LogManager.getLogger(MongoDbInjectionTimingScanRule.class);
+    private static final Map<String, String> ALERT_TAGS =
+            CommonAlertTag.toMap(
+                    CommonAlertTag.OWASP_2021_A03_INJECTION,
+                    CommonAlertTag.OWASP_2017_A01_INJECTION,
+                    CommonAlertTag.WSTG_V42_INPV_05_SQLI);
+    // Variables
+    private boolean doTimedScan;
+
+    @Override
+    public int getCweId() {
+        return 943;
+    }
+
+    @Override
+    public int getWascId() {
+        return 19;
+    }
+
+    @Override
+    public int getId() {
+        return 90039;
+    }
+
+    @Override
+    public boolean targets(TechSet technologies) {
+        return technologies.includes(Tech.MongoDB);
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_HIGH;
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INJECTION;
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    public String getExtraInfo(String attack) {
+        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo." + attack);
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return ALERT_TAGS;
+    }
+
+    @Override
+    public void init() {
+        LOGGER.debug("Initialising MongoDB penetration tests");
+        switch (this.getAttackStrength()) {
+            case LOW:
+                SLEEP_SHORT_TIME = 1000;
+                SLEEP_LONG_TIME = 2000;
+                doTimedScan = true;
+                break;
+            default:
+                SLEEP_SHORT_TIME = 1000;
+                SLEEP_LONG_TIME = 3000;
+                doTimedScan = true;
+                break;
+        }
+    }
+
+    @Override
+    public void scan(HttpMessage msg, NameValuePair originalParam) {
+        super.scan(msg, originalParam);
+    }
+
+    @Override
+    public void scan(HttpMessage msg, String param, String value) {
+        List<Integer> rtt = new ArrayList<>();
+        HttpMessage msgInjAttack;
+
+        LOGGER.debug(
+                "Scanning URL [{}] [{}] on param: [{}] with value: [{}] for MongoDB Injection",
+                msg.getRequestHeader().getMethod(),
+                msg.getRequestHeader().getURI(),
+                param,
+                value);
+        // injection attack to $Where and $mapReduce clauses
+        // The $where clause executes associated JS function one time for each tuple --> sleep time
+        // = interval * nTuples
+        if (doTimedScan) {
+            if (isStop()) {
+                LOGGER.debug(STOP_LOG);
+                return;
+            }
+            LOGGER.debug("Starting with the javascript code injection payloads:");
+            int aveRtt = getAveRtts(rtt),
+                    index = 0,
+                    timeShort = SLEEP_SHORT_TIME,
+                    timeLong = SLEEP_LONG_TIME;
+            String phase = null;
+            boolean hadTimeout = false;
+            String sleepValueToInj;
+            while (index < SLEEP_INJECTION.length) {
+                if (isStop()) {
+                    LOGGER.debug(STOP_LOG);
+                    return;
+                }
+                LOGGER.debug("Trying  with the value: {}", SLEEP_INJECTION[index][0]);
+                try {
+                    msgInjAttack = getNewMsg();
+                    sleepValueToInj =
+                            SLEEP_INJECTION[index][0].replaceFirst(
+                                    INSERT_SHORT_TIME, Integer.toString(timeShort));
+                    phase = INSERT_SHORT_TIME;
+                    setParameter(msgInjAttack, param, sleepValueToInj);
+                    sendAndReceive(msgInjAttack, false);
+                    LOGGER.debug(
+                            "Trying for a longer time with the value: {}",
+                            SLEEP_INJECTION[index][1]);
+                    if (msgInjAttack.getTimeElapsedMillis() >= aveRtt + SHORT_THRESHOLD) {
+                        phase = INSERT_LONG_TIME;
+                        sleepValueToInj =
+                                SLEEP_INJECTION[index][1].replaceFirst(
+                                        INSERT_LONG_TIME, Integer.toString(timeLong));
+                        msgInjAttack = getNewMsg();
+                        setParameter(msgInjAttack, param, sleepValueToInj);
+                        sendAndReceive(msgInjAttack, false);
+                        if (msgInjAttack.getTimeElapsedMillis() >= aveRtt + LONG_THRESHOLD) {
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_HIGH)
+                                    .setParam(param)
+                                    .setAttack(sleepValueToInj)
+                                    .setOtherInfo(getExtraInfo(SLEEP_ATTACK))
+                                    .setMessage(msgInjAttack)
+                                    .raise();
+                            break;
+                        }
+                    }
+                    if (hadTimeout) {
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_LOW)
+                                .setParam(param)
+                                .setAttack(sleepValueToInj)
+                                .setOtherInfo(getExtraInfo(SLEEP_ATTACK))
+                                .setMessage(msgInjAttack)
+                                .raise();
+                        break;
+                    }
+                    index++;
+                } catch (SocketTimeoutException ex) {
+                    hadTimeout = true;
+                    if (INSERT_LONG_TIME.equals(phase)) {
+                        // Timeout: 40s --> 14 <= n. tuples < 40
+                        timeShort /= 3;
+                        timeLong /= 3;
+                    } else {
+                        // n. tuples >= 40
+                        timeShort /= 10;
+                        timeLong /= 10;
+                    }
+                    LOGGER.debug(
+                            "Caught {} {} when {} due to socket timeout, trying with the lowest interval({})",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            IO_EX_LOG,
+                            timeLong);
+                } catch (IOException ex) {
+                    LOGGER.debug(
+                            "Caught {} {} when {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            IO_EX_LOG);
+                    return;
+                }
+            }
+        }
+    }
+
+    private static int getAveRtts(List<Integer> rtt) {
+        double sum = 0;
+        for (Integer i : rtt) {
+            sum += i;
+        }
+        return (int) sum / rtt.size();
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -29,10 +29,16 @@ LDAP Injection may be possible. It may be possible for an attacker to bypass aut
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java">LdapInjectionScanRule.java</a>
 
 <H2>NoSQL Injection - MongoDB</H2>
-This rule attempts to identify MongoDB specific NoSQL Injection vulnerabilities. It attempts various types of attacks including: boolean based, error based, time based, and authentication bypass. 
-It will also attempt JSON parameter specific payloads if the scan is configured to include JSON parameter variants.
+This rule attempts to identify MongoDB specific NoSQL Injection vulnerabilities. It attempts various types of attacks including: boolean based, error based, and authentication bypass.
+It does not include time based attacks. It will also attempt JSON parameter specific payloads if the scan is configured to include JSON parameter variants.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java">MongoDbInjectionScanRule.java</a>
+
+<H2>Time Based NoSQL Injection - MongoDB</H2>
+This rule attempts to identify MongoDB specific NoSQL Injection vulnerabilities. This rule attempts only time based attacks.
+It will also attempt JSON parameter specific payloads if the scan is configured to include JSON parameter variants.
+<p>
+    Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionTimingScanRule.java">MongoDbInjectionTimingScanRule.java</a>
 
 <H2>Web Cache Deception</H2>
 This rule attempts to identify Web Cache Deception vulnerabilities. It checks whether a static path appended to original URIs can be used to leak sensitive user information or not.


### PR DESCRIPTION
Fix zaproxy/zaproxy#7341
Breaking out time based attack from list in issue into their own rules. Most of the RDBMS specific SqlInjection rules were already exclusively performing time based attacks, so these simply got renamed, with the exception of the SqlLite rule, which was split up and the new timing rule was given its own new plugin ID. Most other rules were also split up in this manner to create a new timing based version with its own plugin ID. There is mention in the issue of modifying the Alert tags that correspond to these rules, so I would appreciate some feedback on what to do around that. 