### PR TITLE
network: use custom executor to process messages

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use the available response content when the Content-Length is more than what is available.
 - Properly persist proxy error responses.
 - Correctly manage cookies with domain and path attributes (Issue 7631).
+- Do not prevent serving internal requests to the local servers/proxies.
 
 ## [0.5.0] - 2022-11-09
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServer.java
@@ -25,6 +25,7 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.network.internal.ChannelAttributes;
 import org.zaproxy.addon.network.internal.cert.ServerCertificateService;
@@ -42,6 +43,7 @@ import org.zaproxy.addon.network.internal.server.http.handlers.ZapApiHandler;
 /** A local server/proxy, ones managed by the user. */
 public class LocalServer extends HttpServer {
 
+    private final Executor executor;
     private final LegacyProxyListenerHandler legacyHandler;
     private final PassThroughHandler passThroughHandler;
     private final HttpSenderHandler httpSenderHandler;
@@ -61,6 +63,7 @@ public class LocalServer extends HttpServer {
      *
      * @param group the event loop group.
      * @param mainHandlerExecutor the event executor for the main handler.
+     * @param executor the executor to process the HTTP messages.
      * @param certificateService the certificate service.
      * @param legacyHandler the handler for legacy (core) listeners.
      * @param passThroughHandler the pass-through handler.
@@ -72,6 +75,7 @@ public class LocalServer extends HttpServer {
     public LocalServer(
             NioEventLoopGroup group,
             EventExecutorGroup mainHandlerExecutor,
+            Executor executor,
             ServerCertificateService certificateService,
             LegacyProxyListenerHandler legacyHandler,
             PassThroughHandler passThroughHandler,
@@ -80,6 +84,7 @@ public class LocalServer extends HttpServer {
             SerialiseState serialiseState,
             Model model) {
         super(group, mainHandlerExecutor, certificateService);
+        this.executor = executor;
         this.legacyHandler = legacyHandler;
         this.passThroughHandler = Objects.requireNonNull(passThroughHandler);
         this.httpSenderHandler = httpSenderHandler;
@@ -99,6 +104,7 @@ public class LocalServer extends HttpServer {
 
     private MainServerHandler createLocalServerHandler() {
         return new LocalServerHandler(
+                executor,
                 legacyHandler,
                 Arrays.asList(
                         ConnectReceivedHandler.getSetAndContinueInstance(),

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServerHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServerHandler.java
@@ -21,6 +21,7 @@ package org.zaproxy.addon.network.internal.server.http;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.network.internal.server.http.handlers.LegacyProxyListenerHandler;
@@ -37,17 +38,19 @@ public class LocalServerHandler extends MainProxyHandler {
     /**
      * Constructs a {@code LocalServer} with the given properties.
      *
+     * @param executor the executor to process the HTTP messages.
      * @param legacyHandler the handler for legacy (core) listeners.
      * @param handlers the message handlers.
      * @param serialiseState the serialisation state.
      * @param model the model to obtain the proxy excludes.
      */
     public LocalServerHandler(
+            Executor executor,
             LegacyProxyListenerHandler legacyHandler,
             List<HttpMessageHandler> handlers,
             SerialiseState serialiseState,
             Model model) {
-        super(legacyHandler, handlers);
+        super(executor, legacyHandler, handlers);
 
         this.serialiseState = serialiseState;
         this.model = Objects.requireNonNull(model);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainProxyHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainProxyHandler.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.network.internal.handlers.LegacySocketAdapter;
 import org.zaproxy.addon.network.internal.server.http.handlers.LegacyProxyListenerHandler;
@@ -42,13 +43,16 @@ public class MainProxyHandler extends MainServerHandler {
      * Constructs a {@code HttpMessageServerBridge} with the given legacy handler and message
      * handlers.
      *
+     * @param executor the executor to process the HTTP messages.
      * @param legacyHandler the legacy listeners.
      * @param handlers the message handlers.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     public MainProxyHandler(
-            LegacyProxyListenerHandler legacyHandler, List<HttpMessageHandler> handlers) {
-        super(handlers);
+            Executor executor,
+            LegacyProxyListenerHandler legacyHandler,
+            List<HttpMessageHandler> handlers) {
+        super(executor, handlers);
 
         this.legacyHandler = Objects.requireNonNull(legacyHandler);
     }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainProxyHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainProxyHandlerUnitTest.java
@@ -36,6 +36,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.util.Attribute;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
@@ -47,6 +48,7 @@ import org.zaproxy.addon.network.server.HttpMessageHandler;
 /** Unit test for {@link MainProxyHandler}. */
 class MainProxyHandlerUnitTest {
 
+    private Executor executor;
     private ChannelHandlerContext ctx;
     private HttpResponseHeader responseHeader;
     private HttpMessage msg;
@@ -68,7 +70,8 @@ class MainProxyHandlerUnitTest {
         msg = mock(HttpMessage.class);
         given(msg.getResponseHeader()).willReturn(responseHeader);
         legacyHandler = mock(LegacyProxyListenerHandler.class);
-        handler = new MainProxyHandler(legacyHandler, Collections.emptyList());
+        executor = cmd -> cmd.run();
+        handler = new MainProxyHandler(executor, legacyHandler, Collections.emptyList());
     }
 
     @Test
@@ -78,7 +81,8 @@ class MainProxyHandlerUnitTest {
         List<HttpMessageHandler> handlers = Collections.emptyList();
         // When / Then
         assertThrows(
-                NullPointerException.class, () -> new MainProxyHandler(legacyHandler, handlers));
+                NullPointerException.class,
+                () -> new MainProxyHandler(executor, legacyHandler, handlers));
     }
 
     @Test
@@ -87,7 +91,8 @@ class MainProxyHandlerUnitTest {
         List<HttpMessageHandler> handlers = null;
         // When / Then
         assertThrows(
-                NullPointerException.class, () -> new MainProxyHandler(legacyHandler, handlers));
+                NullPointerException.class,
+                () -> new MainProxyHandler(executor, legacyHandler, handlers));
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainServerHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainServerHandlerUnitTest.java
@@ -74,7 +74,7 @@ class MainServerHandlerUnitTest {
                 new EmbeddedChannel(
                         new HttpRequestDecoder(),
                         HttpResponseEncoder.getInstance(),
-                        new MainServerHandler(Arrays.asList(handler1, handler2)),
+                        new MainServerHandler(cmd -> cmd.run(), Arrays.asList(handler1, handler2)),
                         new SimpleChannelInboundHandler<HttpMessage>() {
 
                             @Override
@@ -100,7 +100,9 @@ class MainServerHandlerUnitTest {
         // Given
         List<HttpMessageHandler> handlers = null;
         // When / Then
-        assertThrows(NullPointerException.class, () -> new MainServerHandler(handlers));
+        assertThrows(
+                NullPointerException.class,
+                () -> new MainServerHandler(cmd -> cmd.run(), handlers));
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
@@ -67,7 +67,10 @@ public class TestHttpServer extends HttpServer {
         super(group, mainHandlerExecutor, CERTIFICATE_SERVICE);
 
         receivedMessages = Collections.synchronizedList(new ArrayList<>());
-        setMainServerHandler(() -> new MainServerHandler(Collections.singletonList(this::handle)));
+        setMainServerHandler(
+                () ->
+                        new MainServerHandler(
+                                cmd -> cmd.run(), Collections.singletonList(this::handle)));
     }
 
     @Override


### PR DESCRIPTION
Process the messages in a specific executor, to not prevent serving own requests to the local servers/proxies.