### PR TITLE
Automation: Warn if unexpected element under activeScan job

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Warning if unexpected element under `activeScan` job (e.g. misplaced `rules`).
 
 ## [0.20.0] - 2022-12-14
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -82,13 +82,34 @@ public class ActiveScanJob extends AutomationJob {
         if (jobData == null) {
             return;
         }
-        LinkedHashMap<?, ?> params = (LinkedHashMap<?, ?>) jobData.get("parameters");
-        JobUtils.applyParamsToObject(params, this.parameters, this.getName(), null, progress);
+
+        for (Object key : jobData.keySet().toArray()) {
+            switch (key.toString()) {
+                case "parameters":
+                    LinkedHashMap<?, ?> params = (LinkedHashMap<?, ?>) jobData.get(key);
+                    JobUtils.applyParamsToObject(
+                            params, this.parameters, this.getName(), null, progress);
+                    break;
+                case "policyDefinition":
+                    // Parse the policy defn
+                    parsePolicyDefinition(jobData.get(key), progress);
+                    break;
+                case "type":
+                    // Handled before we get here
+                    break;
+                default:
+                    progress.warn(
+                            Constant.messages.getString(
+                                    "automation.error.element.unknown", this.getName(), key));
+
+                    break;
+            }
+        }
 
         this.verifyUser(this.getParameters().getUser(), progress);
+    }
 
-        // Parse the policy defn
-        Object policyDefn = this.getJobData().get("policyDefinition");
+    private void parsePolicyDefinition(Object policyDefn, AutomationProgress progress) {
         if (policyDefn instanceof LinkedHashMap<?, ?>) {
             LinkedHashMap<?, ?> policyDefnData = (LinkedHashMap<?, ?>) policyDefn;
 

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -275,6 +275,7 @@ automation.error.context.url.deprecated = The context 'url' field has been repla
 
 automation.error.delay.badtime = Invalid time: {0}
 
+automation.error.element.unknown = Unrecognised element for job {0} : {1}
 automation.error.env.auth.field.bad = Invalid authentication {0}: {1}
 automation.error.env.auth.script.bad = Cannot read authentication script: {0}
 automation.error.env.missing = Missing environment: {0}

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -372,6 +372,25 @@ class ActiveScanJobUnitTest {
     }
 
     @Test
+    void shouldReturnWarningOnUnexpectedElement() throws MalformedURLException {
+        // Given
+        ActiveScanJob job = new ActiveScanJob();
+        AutomationProgress progress = new AutomationProgress();
+        LinkedHashMap<String, String> data = new LinkedHashMap<>();
+        data.put("unexpected", "data");
+
+        // When
+        job.setJobData(data);
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(
+                progress.getWarnings().get(0), is(equalTo("!automation.error.element.unknown!")));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    @Test
     void shouldReturnScanPolicyForDefaultData() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();


### PR DESCRIPTION
This has actually happened a couple of times with scripts shared with me, and it took me a few mins to work out why the rules were being 'ignored' ;)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>