### PR TITLE
reports: document riskdesc field

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- A description of riskdesc fields in the relevant report templates' help (Issue 7445).
 ### Changed
 - Maintenance changes.
 

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json-plus.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json-plus.html
@@ -7,7 +7,11 @@
 	<H1>Traditional JSON Report with Requests and Responses</H1>
 
 	<H3>Sample</H3>
-
+	<H4>About riskdesc</H4>
+	riskdesc - Is a combination identifier, showing Risk followed by
+	Confidence (in brackets). For example
+	<code>High (Medium)</code>
+	would indicate a High risk issue identified with Medium confidence.
 	<pre>
 {
     "@version": "Dev Build",

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json.html
@@ -7,7 +7,11 @@
 	<H1>Traditional JSON Report</H1>
 
 	<H3>Sample</H3>
-
+	<H4>About riskdesc</H4>
+	riskdesc - Is a combination identifier, showing Risk followed by
+	Confidence (in brackets). For example
+	<code>High (Medium)</code>
+	would indicate a High risk issue identified with Medium confidence.
 	<pre>
 {
     "@version": "Dev Build",

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-markdown.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-markdown.html
@@ -7,7 +7,12 @@
 	<H1>Traditional Markdown Report</H1>
 
 	<H3>Sample</H3>
-
+	<H4>About riskdesc</H4>
+	riskdesc - Is a combination identifier, showing Risk followed by
+	Confidence (in brackets). For example
+	<code>High (Medium)</code>
+	as shown in example below, would indicate a High risk issue identified
+	with Medium confidence.
 	<pre>
 
 # ZAP Scanning Report

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-xml-plus.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-xml-plus.html
@@ -7,7 +7,11 @@
 	<H1>Traditional XML Report with Requests and Responses</H1>
 
 	<H3>Sample</H3>
-
+	<H4>About riskdesc</H4>
+	riskdesc - Is a combination identifier, showing Risk followed by
+	Confidence (in brackets). For example
+	<code>High (Medium)</code>
+	would indicate a High risk issue identified with Medium confidence.
 	<pre>
         &lt;?xml version=&quot;1.0&quot;?&gt;
         &lt;OWASPZAPReport version=&quot;2.11.1&quot; generated=&quot;Fr., 30 Sep. 2022 08:40:35&quot;&gt;

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-xml.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-xml.html
@@ -7,7 +7,11 @@
 	<H1>Traditional XML Report</H1>
 
 	<H3>Sample</H3>
-
+	<H4>About riskdesc</H4>
+	riskdesc - Is a combination identifier, showing Risk followed by
+	Confidence (in brackets). For example
+	<code>High (Medium)</code>
+	would indicate a High risk issue identified with Medium confidence.
 	<pre>
 &lt;?xml version="1.0"?&gt;
 &lt;OWASPZAPReport version="Dev Build" generated="Fri, 4 Feb 2022 17:42:18"&gt;


### PR DESCRIPTION
Added documentation to template file. This is to clarify ambiguity of output. Specifically, level of risk and level of confidence.

Fix zaproxy/zaproxy#7445