### PR TITLE
network: dynamically unload on newer versions

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Allow access to the ZAP API when running in command line mode.
 - Fallback to HTTP/1.1 in internal local servers/proxies if the client does not negotiate a protocol (ALPN).
+- Dynamically unload the add-on on newer core versions.
 - Update dependencies.
 - Maintenance changes.
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -121,6 +121,7 @@ import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.api.ApiElement;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.brk.ExtensionBreak;
+import org.zaproxy.zap.network.HttpSenderImpl;
 import org.zaproxy.zap.utils.ZapPortNumberSpinner;
 
 public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineListener {
@@ -143,6 +144,8 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
     private static final int ARG_HOST_IDX = 3;
     private static final int ARG_PORT_IDX = 4;
+
+    private Boolean dynamicUnload;
 
     private CloseableHttpSenderImpl<?> httpSenderNetwork;
 
@@ -1302,8 +1305,16 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
     @Override
     public boolean canUnload() {
-        // Do not allow, the HttpSender implementation is used everywhere.
-        return false;
+        if (dynamicUnload != null) {
+            return dynamicUnload;
+        }
+
+        try {
+            dynamicUnload = HttpSenderImpl.class.getMethod("restoreState", Object.class) != null;
+        } catch (Exception e) {
+            dynamicUnload = false;
+        }
+        return dynamicUnload;
     }
 
     @Override


### PR DESCRIPTION
Allow to dynamically unload when the newer `HttpSenderImpl` is present, which allows to save/restore the implementation's state.