### PR TITLE
Cache WebDrivers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,12 @@ jobs:
           java-version: ${{ matrix.java }}
       - uses: gradle/wrapper-validation-action@v1
       - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            wdm
       - run: ./gradlew -Dorg.gradle.jvmargs=-Xmx2g assemble
+        env:
+          WDM_CACHEPATH: "~/.gradle/wdm"
       - run: ./gradlew check


### PR DESCRIPTION
Change CI workflow to cache the WebDrivers to avoid hitting rate limits which could fail the build.