### PR TITLE
actions: Webdriver Update - be more defensive

### DIFF
--- a/.github/workflows/create_webdriver_update.yml
+++ b/.github/workflows/create_webdriver_update.yml
@@ -89,6 +89,10 @@ jobs:
           git add .
           git commit -m "Webdriver Update" -m "geckodriver update to $GECKO_VERS" --signoff
         fi
+        if [ "$CHROME_VERS" == "null" ] || [ "$GECKO_VERS" == "null" ]; then
+          echo "Could not retrieve one (or both) of the new version identifiers"
+          exit
+        fi
         ## If there are changes: push and PR
         if [ $IS_UPDT -eq 1 ]; then
           git push --set-upstream origin $BRANCH --force


### PR DESCRIPTION
If one (or both) of the 'current' versions is null (not retrieved) then just exit quietly.

See #4331 for reference/background.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>