### PR TITLE
network: consume response body always

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Properly persist proxy error responses.
 - Correctly manage cookies with domain and path attributes (Issue 7631).
 - Do not prevent serving internal requests to the local servers/proxies.
+- Consume the response body even when none expected (e.g. 204, HEAD), otherwise the previous body
+would not be cleared when reusing the same message.
 
 ## [0.5.0] - 2022-11-09
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSender.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSender.java
@@ -63,6 +63,8 @@ import org.zaproxy.zap.utils.Pair;
 public abstract class BaseHttpSender<T1 extends BaseHttpSenderContext, T2, T3>
         implements CloseableHttpSenderImpl<T1> {
 
+    protected static final byte[] EMPTY_BODY = {};
+
     private static final String CONTEXTS_FIELD = "contexts";
 
     private static final String LISTENERS_FIELD = "listeners";
@@ -203,7 +205,8 @@ public abstract class BaseHttpSender<T1 extends BaseHttpSenderContext, T2, T3>
                     return;
                 }
 
-                msg.setResponseBody(getBytes(entity));
+                byte[] bodyContent = getBytes(entity);
+                msg.setResponseBody(bodyContent == null ? EMPTY_BODY : bodyContent);
             };
 
     protected abstract InputStream getStream(T3 body) throws IOException;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -310,6 +310,10 @@ public class HttpSenderApache
 
     @Override
     protected byte[] getBytes(HttpEntity body) throws IOException {
+        if (body == null) {
+            return null;
+        }
+
         int entityContentLength = (int) Args.checkContentLength(body);
         int contentLength = entityContentLength < 0 ? BUFFER_SIZE : entityContentLength;
         try (InputStream is = body.getContent()) {
@@ -339,6 +343,10 @@ public class HttpSenderApache
 
     @Override
     protected InputStream getStream(HttpEntity body) throws IOException {
+        if (body == null) {
+            return null;
+        }
+
         return body.getContent();
     }
 
@@ -710,12 +718,11 @@ public class HttpSenderApache
         }
         copyHeaders(response, responseHeader);
 
+        HttpEntity entity = null;
         if (response instanceof ClassicHttpResponse) {
-            HttpEntity entity = ((ClassicHttpResponse) response).getEntity();
-            if (entity != null) {
-                responseBodyConsumer.accept(message, entity);
-            }
+            entity = ((ClassicHttpResponse) response).getEntity();
         }
+        responseBodyConsumer.accept(message, entity);
     }
 
     private static boolean isSet(HttpContext context, String attributeName) {


### PR DESCRIPTION
Consume the response body even when none expected (e.g. 204, HEAD), otherwise the previous body would not be cleared when reusing the same message.

---
Reported in the IRC channel.