### PR TITLE
Spelling batch 8

### DIFF
--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlScannerThread.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlScannerThread.java
@@ -73,9 +73,9 @@ public class AccessControlScannerThread
          */
         ILLEGAL(Constant.messages.getString("accessControl.scanResult.illegal")),
         /**
-         * This result is associated to nodes whose corresponding corresponding {@link AccessRule}
-         * is {@link AccessRule#UNKNOWN} so we cannot make any assumption regarding the validity of
-         * the access to the resource.
+         * This result is associated to nodes whose corresponding {@link AccessRule} is {@link
+         * AccessRule#UNKNOWN} so we cannot make any assumption regarding the validity of the access
+         * to the resource.
          */
         UNKNOWN(Constant.messages.getString("accessControl.scanResult.unknown"));
 

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/ContextAccessControlPanel.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/ContextAccessControlPanel.java
@@ -213,7 +213,7 @@ public class ContextAccessControlPanel extends AbstractContextPropertiesPanel {
         // NOTE: We are setting the internal context in the ContextAccessRulesManager as the 'real'
         // Context instead of the UI one, as the ContextSiteTree is, currently, reloaded only in
         // here and with the field separators that have been already defined. If any changes are
-        // done to the the field separators in the currently open SessionProperties Dialog, they
+        // done to the field separators in the currently open SessionProperties Dialog, they
         // will not be visible in the tree. Thus, in order to keep consistency, we stick to also
         // using the 'real' Context in the internal Rules Manager so any rules are inferred
         // according to the 'old' field separators.

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -750,7 +750,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
 
                             // if the "error message" occurs in the result of sending the modified
                             // query, but did NOT occur in the original result of the original query
-                            // then we may may have a SQL Injection vulnerability
+                            // then we may have a SQL Injection vulnerability
                             StringBuilder sb = new StringBuilder();
                             if (!matchBodyPattern(getBaseMsg(), errorPattern, null)
                                     && matchBodyPattern(msg1, errorPattern, sb)) {
@@ -1749,7 +1749,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
 
             // if the "error message" occurs in the result of sending the modified query, but did
             // NOT occur in the original result of the original query
-            // then we may may have a SQL Injection vulnerability
+            // then we may have a SQL Injection vulnerability
             StringBuilder sb = new StringBuilder();
             if (!matchBodyPattern(getBaseMsg(), errorPattern, null)
                     && matchBodyPattern(msg1, errorPattern, sb)) {
@@ -1798,7 +1798,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
 
             // if the "error message" occurs in the result of sending the modified query, but did
             // NOT occur in the original result of the original query
-            // then we may may have a SQL Injection vulnerability
+            // then we may have a SQL Injection vulnerability
             String sqlUnionBodyUnstripped = msg.getResponseBody().toString();
             String sqlUnionBodyStripped =
                     stripOffOriginalAndAttackParam(sqlUnionBodyUnstripped, originalParam, attack);

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -102,7 +102,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
             errorMessages = errorMessageFlat.split(":");
 
             for (String errorMessage :
-                    errorMessages) { // for each error message for the given LDAP implemention
+                    errorMessages) { // for each error message for the given LDAP implementation
                 // compile it into a pattern
                 errorPattern = Pattern.compile(errorMessage);
 
@@ -170,7 +170,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                 break;
         }
         // how hard should we try to find an LDAP injection point (primarily by looking at how
-        // deeply embedded it might be in paremtheses)
+        // deeply embedded it might be in parentheses)
         // this is important in complex LDAP expressions which are deeply nested, i.e., where there
         // are various AND, OR, or NOT expressions
         // (&, |, ! respectively in LDAP)
@@ -406,7 +406,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                             .setMessage(getBaseMsg())
                             .raise();
 
-                    logBoolenInjection(
+                    logBooleanInjection(
                             getBaseMsg(), paramname, appendTrueAttack, randomparameterAttack);
 
                     // all done for this parameter. return.
@@ -506,7 +506,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                             .setMessage(getBaseMsg())
                             .raise();
 
-                    logBoolenInjection(
+                    logBooleanInjection(
                             getBaseMsg(), paramname, hopefullyTrueAttack, randomparameterAttack);
 
                     // all done for this parameter. return.
@@ -533,7 +533,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
         }
     }
 
-    private static void logBoolenInjection(
+    private static void logBooleanInjection(
             HttpMessage msg, String parameterName, String attack, String falseAttack) {
         if (!log.isDebugEnabled()) {
             return;
@@ -641,7 +641,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                 }
                 return true; // threw an alert
             }
-        } // for each error message for the given LDAP implemention
+        } // for each error message for the given LDAP implementation
 
         return false; // did not throw an alert
     }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GitMetadata.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GitMetadata.java
@@ -303,7 +303,7 @@ public class GitMetadata {
             // There are also separate version numbers in the Git "index file" (unrelated to the
             // "pack index" files mentioned above), which are probably similarly inter-related.
             // I do not have a mapping of the Git version number (1.7.6 / 1.8.5, for instance) to
-            // any of the the internal file version numbers that they create (by default) or
+            // any of the internal file version numbers that they create (by default) or
             // support. So sue me.
 
             URI uri =
@@ -525,7 +525,7 @@ public class GitMetadata {
                     }
                 }
                 // final sanity check, if all of the above panned out for version 1 index file.
-                // Note: we *think* that that "pack index" file version 1 is compatible with "pack"
+                // Note: we *think* that the "pack index" file version 1 is compatible with "pack"
                 // file version 3 and 4, but really, we don't know for sure.. Again, so sue me.
                 int packindexFileVersion = 1;
                 if (packFileVersion != 2 && packFileVersion != 3 && packFileVersion != 4) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
@@ -304,7 +304,7 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
         }
 
         // Look for SVN < 1.7 metadata (i.e. internal SVN format < 29) containing source code
-        // These versions all store the pristine copies in the the same format (insofar as the logic
+        // These versions all store the pristine copies in the same format (insofar as the logic
         // here is concerned, at least)
         try {
             String pathminusfilename = path.substring(0, path.lastIndexOf(urlfilename));

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
@@ -602,8 +602,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin {
                 // if we didn't hit something with one of the iterations for the parameter (ie, if
                 // the output when changing the param is stable),
                 // check if the parameter might be vulnerable by comparing its LCS with the
-                // original
-                // LCS for a valid login
+                // original LCS for a valid login
                 if (longestCommonSubstringB != null && continueForParameter) {
                     // get rid of any remnants of cookie setting and Date headers in the responses,
                     // as these cause false positives, and can be safely ignored

--- a/addOns/authstats/CHANGELOG.md
+++ b/addOns/authstats/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.12.0.
+- Maintenance changes.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/authstats/src/main/javahelp/org/zaproxy/zap/extension/authstats/resources/help/contents/authStats.html
+++ b/addOns/authstats/src/main/javahelp/org/zaproxy/zap/extension/authstats/resources/help/contents/authStats.html
@@ -38,7 +38,7 @@ the statistics can be accessed via the ZAP API.
 The icon for this add-on was derived from the 
 <a href="https://github.com/yusukekamiyamane/fugue-icons">Fugue icons</a> 
 <a href="https://github.com/yusukekamiyamane/fugue-icons/blob/master/icons/chart.png">chart.png</a> and
-<a href="https://github.com/yusukekamiyamane/fugue-icons/blob/master/icons/lock-small.png">locl-small.png</a>
+<a href="https://github.com/yusukekamiyamane/fugue-icons/blob/master/icons/lock-small.png">lock-small.png</a>
 
 </BODY>
 </HTML>

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Maintenance changes.
+
 ### Added
 - Warning if unexpected element under `activeScan` job (e.g. misplaced `rules`).
 - Help details warning against specifying default ports (80/443) (Issue 7649).

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAscanRuleDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAscanRuleDialog.java
@@ -44,7 +44,7 @@ public class AddAscanRuleDialog extends StandardFieldsDialog {
 
     private static final String TITLE = "automation.dialog.addrule.title";
     private static final String RULE_PARAM = "automation.dialog.addrule.rule";
-    private static final String THREHOLD_PARAM = "automation.dialog.addrule.threshold";
+    private static final String THRESHOLD_PARAM = "automation.dialog.addrule.threshold";
     private static final String STRENGTH_PARAM = "automation.dialog.addrule.strength";
 
     private ActiveScanJob.Rule rule;
@@ -96,7 +96,7 @@ public class AddAscanRuleDialog extends StandardFieldsDialog {
             allthresholds.add(JobUtils.thresholdToI18n(at.name()));
         }
 
-        this.addComboField(THREHOLD_PARAM, allthresholds, thresholdName);
+        this.addComboField(THRESHOLD_PARAM, allthresholds, thresholdName);
 
         List<String> allstrengths = new ArrayList<>();
 
@@ -116,11 +116,11 @@ public class AddAscanRuleDialog extends StandardFieldsDialog {
             Plugin plugin = this.nameToPlugin.get(this.getStringValue(RULE_PARAM));
             rule.setId(plugin.getId());
             rule.setName(plugin.getName());
-            rule.setThreshold(JobUtils.i18nToThreshold(this.getStringValue(THREHOLD_PARAM)));
+            rule.setThreshold(JobUtils.i18nToThreshold(this.getStringValue(THRESHOLD_PARAM)));
             rule.setStrength(JobUtils.i18nToStrength(this.getStringValue(STRENGTH_PARAM)));
             this.model.add(rule);
         } else {
-            rule.setThreshold(JobUtils.i18nToThreshold(this.getStringValue(THREHOLD_PARAM)));
+            rule.setThreshold(JobUtils.i18nToThreshold(this.getStringValue(THRESHOLD_PARAM)));
             rule.setStrength(JobUtils.i18nToStrength(this.getStringValue(STRENGTH_PARAM)));
             this.model.update(tableIndex, rule);
         }
@@ -128,7 +128,7 @@ public class AddAscanRuleDialog extends StandardFieldsDialog {
 
     @Override
     public String validateFields() {
-        if (JobUtils.i18nToThreshold(this.getStringValue(THREHOLD_PARAM)).equals("default")
+        if (JobUtils.i18nToThreshold(this.getStringValue(THRESHOLD_PARAM)).equals("default")
                 && JobUtils.i18nToStrength(this.getStringValue(STRENGTH_PARAM)).equals("default")) {
             return Constant.messages.getString("automation.dialog.addrule.error.defaults");
         }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/NewPlanDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/NewPlanDialog.java
@@ -51,7 +51,7 @@ public class NewPlanDialog extends StandardFieldsDialog {
     private static final long serialVersionUID = 1L;
 
     private static final String TITLE = "automation.dialog.newplan.title";
-    private static final String COMTEXTS_PARAM = "automation.dialog.newplan.contexts";
+    private static final String CONTEXTS_PARAM = "automation.dialog.newplan.contexts";
     private static final String PROFILE_PARAM = "automation.dialog.newplan.profile";
     private static final String JOBS_PARAM = "automation.dialog.newplan.jobs";
 
@@ -133,7 +133,7 @@ public class NewPlanDialog extends StandardFieldsDialog {
         if (contextListModel.getSize() > 0) {
             contextList.setSelectedIndex(0);
         }
-        this.addCustomComponent(COMTEXTS_PARAM, new JScrollPane(contextList));
+        this.addCustomComponent(CONTEXTS_PARAM, new JScrollPane(contextList));
 
         List<AutomationJob> jobs =
                 ext.getAutomationJobs().values().stream()

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Maintenance changes.
+
 ### Added
 - Add info URL.
 

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CookieUtils.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CookieUtils.java
@@ -50,7 +50,7 @@ public final class CookieUtils {
      *
      * @param headerValue the value of the header
      * @param attributeName the name of the attribute to check
-     * @return {@code true} if the the header has the attribute, {@code false} otherwise
+     * @return {@code true} if the header has the attribute, {@code false} otherwise
      * @see <a href="https://tools.ietf.org/html/rfc6265#section-5.2">RFC 6265 - Section 5.2</a>
      */
     public static boolean hasAttribute(String headerValue, String attributeName) {

--- a/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/ZapDiffRowGenerator.java
+++ b/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/ZapDiffRowGenerator.java
@@ -362,7 +362,7 @@ public class ZapDiffRowGenerator {
  /**
   * Wrap the elements in the sequence with the given tag
   * @param startPosition the position from which tag should start. The counting start from a zero.
-  * @param endPosition the position before which tag should should be closed.
+  * @param endPosition the position before which tag should be closed.
   * @param tag the tag name without angle brackets, just a word
   * @param cssClass the optional css class
   */

--- a/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/diff_match_patch.java
+++ b/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/diff_match_patch.java
@@ -547,7 +547,7 @@ public class diff_match_patch {
     String line;
     StringBuilder chars = new StringBuilder();
     // Walk the text, pulling out a substring for each line.
-    // text.split('\n') would would temporarily double our memory footprint.
+    // text.split('\n') would temporarily double our memory footprint.
     // Modifying text would create many large strings to garbage collect.
     while (lineEnd < text.length() - 1) {
       lineEnd = text.indexOf('\n', lineStart);

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
@@ -124,9 +124,7 @@ public class GraphQlParam extends VersionedAbstractParam {
         POST_JSON,
         /** The method is POST and the Content-type is application/graphql. */
         POST_GRAPHQL,
-        /**
-         * The method is GET and the the query is appended to the endpoint URL in a query string.
-         */
+        /** The method is GET and the query is appended to the endpoint URL in a query string. */
         GET;
 
         public String getName() {

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -218,11 +218,11 @@ public class Base64Disclosure extends PluginPassiveScanner {
                                 base64evidence);
                         if (noDigitInString)
                             log.trace(
-                                    "The candidate Base64 has no digit characters, and the the probability of this occurring for a string of this length is {}%. The threshold is {}%",
+                                    "The candidate Base64 has no digit characters, and the probability of this occurring for a string of this length is {}%. The threshold is {}%",
                                     probabilityOfNoDigitInString * 100, probabilityThreshold * 100);
                         if (noAlphaInString)
                             log.trace(
-                                    "The candidate Base64 has no alphabetic characters, and the the probability of this occurring for a string of this length is {}%. The threshold is {}%",
+                                    "The candidate Base64 has no alphabetic characters, and the probability of this occurring for a string of this length is {}%. The threshold is {}%",
                                     probabilityOfNoAlphaInString * 100, probabilityThreshold * 100);
                         // if (noOtherInString)
                         // log.trace("The candidate Base64 has no 'other' characters, and the
@@ -231,12 +231,12 @@ public class Base64Disclosure extends PluginPassiveScanner {
                         // 100,probabilityThreshold *100);
                         if (noLowerInString)
                             log.trace(
-                                    "The candidate Base64 has no lowercase characters, and the the probability of this occurring for a string of this length is {}%. The threshold is {}%",
+                                    "The candidate Base64 has no lowercase characters, and the probability of this occurring for a string of this length is {}%. The threshold is {}%",
                                     probabilityOfNoLowerInString * 100, probabilityThreshold * 100);
 
                         if (noUpperInString)
                             log.trace(
-                                    "The candidate Base64 has no uppercase characters, and the the probability of this occurring for a string of this length is {}%. The threshold is {}%",
+                                    "The candidate Base64 has no uppercase characters, and the probability of this occurring for a string of this length is {}%. The threshold is {}%",
                                     probabilityOfNoUpperInString * 100, probabilityThreshold * 100);
 
                         continue;

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
@@ -89,9 +89,9 @@ public class Repo {
 
     /*
      * This is the top level function called from the scanner. It first checks if:
-     * 1)Matching vulnerability is found in database for JS file URL, if YES return return HashSet of related info.
-     * 2)Matching vulnerability is found in database for JS file name, if YES return return HashSet of related info.
-     * 3)Matching vulnerability is found in database for JS file content, if YES return return HashSet of related info.
+     * 1)Matching vulnerability is found in database for JS file URL, if YES return HashSet of related info.
+     * 2)Matching vulnerability is found in database for JS file name, if YES return HashSet of related info.
+     * 3)Matching vulnerability is found in database for JS file content, if YES return HashSet of related info.
      * 4)Matching vulnerability is found in database for JS file hash, if YES return HashSet of related info .
      * 5)Return empty HashSet.
      */

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -274,8 +274,8 @@ public class ExtensionSelenium extends ExtensionAdaptor {
      * Adds the given WebDriver provider.
      *
      * @param webDriverProvider the WebDriver provider to add
-     * @throws IllegalArgumentException if the the given WebDriver provider is {@code null} or its
-     *     ID is {@code null} or empty. Also, if the ID already exists.
+     * @throws IllegalArgumentException if the given WebDriver provider is {@code null} or its ID is
+     *     {@code null} or empty. Also, if the ID already exists.
      * @since 1.1.0
      */
     public void addWebDriverProvider(SingleWebDriverProvider webDriverProvider) {
@@ -324,8 +324,8 @@ public class ExtensionSelenium extends ExtensionAdaptor {
      * empty ID.
      *
      * @param webDriverProvider the WebDriver provider to validate.
-     * @throws IllegalArgumentException if the the given WebDriver provider is {@code null} or its
-     *     ID is {@code null} or empty.
+     * @throws IllegalArgumentException if the given WebDriver provider is {@code null} or its ID is
+     *     {@code null} or empty.
      */
     private static void validateWebDriverProvider(SingleWebDriverProvider webDriverProvider) {
         if (webDriverProvider == null) {
@@ -342,8 +342,8 @@ public class ExtensionSelenium extends ExtensionAdaptor {
      * Removes the given WebDriver provider.
      *
      * @param webDriverProvider the WebDriver provider to remove
-     * @throws IllegalArgumentException if the the given WebDriver provider is {@code null} or its
-     *     ID is {@code null} or empty.
+     * @throws IllegalArgumentException if the given WebDriver provider is {@code null} or its ID is
+     *     {@code null} or empty.
      * @since 1.1.0
      */
     public void removeWebDriverProvider(SingleWebDriverProvider webDriverProvider) {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/Spider.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/Spider.java
@@ -65,7 +65,7 @@ public class Spider {
     /** If the spider is currently paused. */
     private volatile boolean paused;
 
-    /** The the spider is currently stopped. */
+    /** The spider is currently stopped. */
     private volatile boolean stopped;
 
     /** The pause lock, used for locking access to the "paused" variable. */

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/filters/FetchFilter.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/filters/FetchFilter.java
@@ -44,7 +44,7 @@ public abstract class FetchFilter {
         OUT_OF_SCOPE,
         /** The uri has an illegal protocol. */
         ILLEGAL_PROTOCOL,
-        /** The The uri is skipped because of user rules. */
+        /** The uri is skipped because of user rules. */
         USER_RULES
     }
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/utility/LazyViewport.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/utility/LazyViewport.java
@@ -42,7 +42,7 @@ public class LazyViewport extends JViewport {
         return scrollpane;
     }
 
-    /** overridden to not repaint during during a vertical drag */
+    /** overridden to not repaint during a vertical drag */
     @Override
     public void setViewPosition(Point p) {
         Component parent = getParent();

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeCellRenderer.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeCellRenderer.java
@@ -401,7 +401,7 @@ public class ZestTreeCellRenderer extends DefaultTreeCellRenderer {
                         setIcon(CLIENT_WINDOW_OPEN_URL_ICON);
                     } else {
                         logger.error(
-                                "Unrecognised element element class={}",
+                                "Unrecognised element class={}",
                                 zew.getElement().getClass().getCanonicalName());
                     }
                 }


### PR DESCRIPTION
Per: https://github.com/zaproxy/zap-extensions/pull/3083#issuecomment-1368085064 and https://github.com/check-spelling/zap-extensions/actions/runs/3808821577#summary-10368675301.

I've still left occurrences of "GitHub" or "JavaScript" not following the caps expectations (I'm not sure they're worth changing). There's also still a ton of stuff in the bruteforce sittinglittleducks package(s).

* the the
* should should
* would would
* corresponding corresponding
* may may
* that that
* return return
* during during
* element element
* COMTEXT > CONTEXT
* THREHOLD > THRESHOLD
* locl > lock
* implemention > implementation
* paremtheses > parentheses
* Boolen > Boolean

- tweak one set of short wrapped lines

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>