### PR TITLE
Automation: Get running plans

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Method to get running plans - can be used by scripts to interact with the plans.
 
 ## [0.21.0] - 2023-01-03
 ### Changed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -84,6 +84,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
     private OptionsPanel optionsPanel;
     private AutomationParam param;
     private LinkedHashMap<Integer, AutomationPlan> plans = new LinkedHashMap<>();
+    private List<AutomationPlan> runningPlans = Collections.synchronizedList(new ArrayList<>());
 
     private CommandLineArgument[] arguments = new CommandLineArgument[4];
     private static final int ARG_AUTO_RUN_IDX = 0;
@@ -258,9 +259,20 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
                 AutomationEventPublisher.PLAN_FINISHED, plan, plan.getProgress().toMap());
         Stats.incCounter(ERROR_COUNT_STATS, plan.getProgress().getErrors().size());
         Stats.incCounter(WARNING_COUNT_STATS, plan.getProgress().getWarnings().size());
+        runningPlans.remove(plan);
+    }
+
+    /**
+     * Returns a list of currently running plans in the order they were started
+     *
+     * @return a list of currently running plans in the order they were started
+     */
+    public List<AutomationPlan> getRunningPlans() {
+        return Collections.unmodifiableList(runningPlans);
     }
 
     public AutomationProgress runPlan(AutomationPlan plan, boolean resetProgress) {
+        runningPlans.add(plan);
         if (resetProgress) {
             plan.resetProgress();
         }

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnErrorApplyingParameters.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnErrorApplyingParameters.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: true
     failOnWarning: false
-    progressToStdout: true
+    progressToStdout: false
 
 jobs:
   - type: job

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnLoggedTestError.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnLoggedTestError.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: true
     failOnWarning: false
-    progressToStdout: true
+    progressToStdout: false
 
 jobs:
   - type: job1

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnWarningApplyingParameters.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnWarningApplyingParameters.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: false
     failOnWarning: true
-    progressToStdout: true
+    progressToStdout: false
 
 jobs:
   - type: job

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-withTests.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-withTests.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: false
     failOnWarning: false
-    progressToStdout: true
+    progressToStdout: false
 
 jobs:
   - type: job

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-applyResolvedParams.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-applyResolvedParams.yaml
@@ -8,7 +8,7 @@ env:
   parameters:
     failOnError: true
     failOnWarning: false
-    progressToStdout: true
+    progressToStdout: false
 
 jobs:
   - type: job

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-dontfail.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-dontfail.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: false                  
     failOnWarning: false               
-    progressToStdout: true            
+    progressToStdout: false            
 
 jobs:
   - type: job1

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-failonerror.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-failonerror.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: true                  
     failOnWarning: false               
-    progressToStdout: true            
+    progressToStdout: false            
 
 jobs:
   - type: job1

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-failonwarning.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-failonwarning.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: true                  
     failOnWarning: true               
-    progressToStdout: true            
+    progressToStdout: false            
 
 jobs:
   - type: job1

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-sametype.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-sametype.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: false                  
     failOnWarning: false               
-    progressToStdout: true            
+    progressToStdout: false            
 
 jobs:
   - type: job1

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-withwarnings.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-withwarnings.yaml
@@ -6,7 +6,7 @@ env:
   parameters:
     failOnError: false                  
     failOnWarning: false               
-    progressToStdout: true            
+    progressToStdout: false            
 
 jobs:
   - type: job1

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Help explaining how to interact with Automation Framework plans.
 
 ## [34] - 2023-01-03
 ### Fixed

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/automation.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/automation.html
@@ -73,5 +73,21 @@
       target:                    # String: The URL to be invoked for "targeted" script type
 	</pre>
 
+	<H2>Interacting with plans</H2>
+
+	Scripts can interact with running plans using code like:
+	
+	<pre><code>
+var extAF = control.getExtensionLoader().getExtension("ExtensionAutomation");
+
+var plans = extAF.getRunningPlans();
+
+if (plans.size() >  0) {
+  plans.get(0).getProgress().info("An info message added by a script");
+} else {
+  print('No running plans');
+}
+	</code></pre>
+
 </BODY>
 </HTML>


### PR DESCRIPTION
The script help should indicate why this is so potentially useful 😉 

The tests took me longer to write than they should have done because the new test plan was failing silently.
This was caused by using the AutomationProgress.info(..) method which failed as the CommandLine was not initialised.
Changing `progressToStdout` to false avoids this problem which is why I've changed it for all of the test plans.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>