### PR TITLE
ascanrulesBeta: use same port in HTTP Only Site

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Use same non-default port in the HTTP Only Site scan rule.
+
 ## [44] - 2022-12-13
 ### Changed
 - Use lower case HTTP field names for compatibility with HTTP/2.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java
@@ -147,7 +147,9 @@ public class HttpOnlySiteScanRule extends AbstractHostPlugin {
         try {
             String host = newRequest.getRequestHeader().getURI().getHost();
             String path = newRequest.getRequestHeader().getURI().getPath();
-            newRequest.getRequestHeader().setURI(new URI("https", null, host, 443, path));
+            newRequest
+                    .getRequestHeader()
+                    .setURI(new URI("https", null, host, getPort(newRequest), path));
         } catch (URIException e) {
             LOGGER.error("Error creating HTTPS URL from HTTP URL:", e);
             return;
@@ -210,5 +212,13 @@ public class HttpOnlySiteScanRule extends AbstractHostPlugin {
             LOGGER.error("Request couldn't go through:", e);
             return;
         }
+    }
+
+    private static int getPort(HttpMessage message) {
+        int port = message.getRequestHeader().getURI().getPort();
+        if (port == 80 || port == 443) {
+            return -1;
+        }
+        return port;
     }
 }


### PR DESCRIPTION
Use the same non-default port otherwise it could be testing other site if using always 443.