### PR TITLE
Increase heap memory when running Sonar

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Sonarcloud Scan
       env:
         SONAR_TOKEN: ${{ secrets.ZAPBOT_SONARCLOUD_TOKEN }}
-      run: ./gradlew sonarqube --stacktrace
+      run: ./gradlew sonarqube --stacktrace -Dorg.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
Update Run Sonar workflow to use more memory when running the `sonarqube` task, it has been failing often with `OutOfMemoryError`.

---
e.g. https://github.com/zaproxy/zap-extensions/actions/runs/3862674942/jobs/6584392570#step:5:563