### PR TITLE
domxss: update WebDriver versions for tests

### DIFF
--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
 tasks.withType<Test>().configureEach {
     systemProperties.putAll(
         mapOf(
-            "wdm.chromeDriverVersion" to "83.0.4103.39",
-            "wdm.geckoDriverVersion" to "0.29.0",
+            "wdm.chromeDriverVersion" to "108.0.5359.71",
+            "wdm.geckoDriverVersion" to "0.32.0",
             "wdm.forceCache" to "true"
         )
     )


### PR DESCRIPTION
Use the same versions as the ones being currently cached/downloaded for the WebDriver add-ons.