### PR TITLE
pscanrules: PII Disclosure only consider PDFs at Low Threshold

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Now includes a solution statement.
     - Now more specifically portrays alert Evidence.
     - Now includes example alert functionality for documentation generation purposes (Issue 6119).
+    - Will now only consider PDFs at Low threshold.
 - Maintenance changes.
 
 ## [45] - 2023-01-03

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -276,6 +276,8 @@ PII is information like credit card number, SSN etc. This check currently report
 At MEDIUM and HIGH threshold it attempts to use three characters of context on each side of potential matches to exclude matches within decimal like content.
 At LOW threshold, alerts will be raised for such matches.
 <p>
+PDFs are only evaluated at LOW threshold.
+<p>
 Note: In the case of suspected credit card values, the potential credit card numbers are looked up against a Bank Identification Number List 
 (BINList). If a match is found the alert is raised at High confidence and additional details are added to the 'Other Information' field in the 
 alert, otherwise the alerts will have Medium confidence.


### PR DESCRIPTION
- CHANGELOG > Add change note.
- PiiScanRule >Add utility method for identifying arbitrary types of messages based on file extension or content-type (pdf in this case). Only consider PDFs at Low threshold.
- PiiScanRuleUnitTest > Add supporting Unit Tests.
- pscanrules.html > Update help entry.

Apparently PDFs don't always [contain control characters](https://answers.acrobatusers.com/How-I-control-Characters-PDF-excel-Page-Break-Continous-problem-q143845.aspx) so without adding another utility method to core (like isImage etc) this seemed like  a more usable/generic way to go.

Part of: zaproxy/zaproxy#7676

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>