### PR TITLE
pscanrules: PII Scan Rule add Solution, Example Alerts

### DIFF
--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/binlist/BinRecord.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/binlist/BinRecord.java
@@ -32,7 +32,11 @@ public final class BinRecord {
     private final String category;
     private final String issuer;
 
-    BinRecord(String bin, String brand, String category, String issuer) {
+    /**
+     * This constructor is only public in order to facilitate Example Alerts. Regular use should be
+     * done via {@link BinList#getSingleton()} and {@link BinList#get(String)}
+     */
+    public BinRecord(String bin, String brand, String category, String issuer) {
         this.bin = bin;
         this.brand = brand;
         this.category = category;

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The PII Disclosure scan rule:
+    - Now includes a solution statement.
+    - Now more specifically portrays alert Evidence.
+    - Now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [45] - 2023-01-03
 ### Changed

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -176,6 +176,7 @@ pscanrules.noanticsrftokens.extrainfo.annotation=This is an informational alert 
 pscanrules.pii.name = PII Disclosure
 pscanrules.pii.desc = The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
 pscanrules.pii.extrainfo = Credit Card Type detected: {0}
+pscanrules.pii.soln = Check the response for the potential presence of personally identifiable information (PII), ensure nothing sensitive is leaked by the application.
 pscanrules.pii.bin.field=Bank Identification Number:
 pscanrules.pii.brand.field=Brand:
 pscanrules.pii.category.field=Category:

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PiiScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PiiScanRuleUnitTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.commons.httpclient.URI;
@@ -34,6 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -81,7 +83,7 @@ class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
         // Then
         assertThat(alertsRaised.size(), is(1));
         assertThat(alertsRaised.get(0).getName(), equalTo("PII Disclosure"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo(cardNumber.replaceAll("\\s+", "")));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo(cardNumber));
     }
 
     @Test
@@ -308,6 +310,25 @@ class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getValue())));
+    }
+
+    @Test
+    void shouldReturnExampleAlerts() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_HIGH)));
+        assertThat(
+                alert.getOtherInfo(),
+                is(
+                        equalTo(
+                                "Credit Card Type detected: Visa\n"
+                                        + "Bank Identification Number: 471618\n"
+                                        + "Brand: VISA\n"
+                                        + "Category: PURCHASING\n"
+                                        + "Issuer: U.S. BANK N.A. ND")));
     }
 
     private HttpMessage createMsg(String cardNumber) throws HttpMalformedHeaderException {


### PR DESCRIPTION
commonlib
- BinRecord > Expose constructor for testing purposes.
- Changelog already has a maint note.

pscanruls
- CHANGELOG > Added change notes.
- PiiScanRule > Added example alert and alert refs handling, which is also leveraged when raising alerts and includes the new solution text. Also exposes unaltered Evidence.
- PiiScanRuleUnitTest > Now asserts the expected example alerts, otherinfo, and alert refs.
- Messages.properties > Updated to include a name/value pair for PII Disclosure solution text.

Related to:
- zaproxy/zaproxy#6119
- zaproxy/zaproxy#7676

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>