### PR TITLE
pscanrulesBeta: Address NumberFormatException in Cacheable rule

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- The Cacheable scan rule should now be more tolerant when parsing s-max-age values.
+
 ## [31] - 2022-10-27
 ### Added
 - The following scan rules were added, having been promoted from Alpha:


### PR DESCRIPTION
- CHANGELOG > Add change note.
- CacheableScanRule > Tweak s-maxage extraction logic.
- CacheableScanRuleUnitTest > Add a test to ensure parsing various different patterns of s-maxage and max-age works without exception. (Adjust one other UnitTest to be parameterized instead of being called multiple times. . Remove some unnecessary comments.)

<details>
<summary>The exception that lead me here, <sub>(Click the triangle/control to the left to expand)</sub></summary>

```text
307740 [ZAP-PassiveScan-3] ERROR org.zaproxy.zap.extension.pscanrulesBeta.CacheableScanRule - An error occurred while checking a URI [https://practiceapi.geeksforgeeks.org/api/vr/courses/home/] for cacheability
java.lang.NumberFormatException: For input string: "600,max-age=0"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[?:?]
	at java.lang.Long.parseLong(Long.java:692) ~[?:?]
	at java.lang.Long.parseLong(Long.java:817) ~[?:?]
	at org.zaproxy.zap.extension.pscanrulesBeta.CacheableScanRule.scanHttpResponseReceive(CacheableScanRule.java:431) ~[?:?]
	at org.zaproxy.zap.extension.pscan.PassiveScanTask.run(PassiveScanTask.java:148) ~[main/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

</details>

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>