### PR TITLE
Allow to exclude 3rd-party code from all checks

### DIFF
--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -5,13 +5,16 @@ import org.gradle.api.Project
 /**
  * Configures the java extension with all Java files except the given ones and configures
  * a format with Google Java Format (AOSP) for the given files.
+ *
+ * <p>It also allows to exclude additional files from both formatting and license checks.
  */
-fun SpotlessExtension.javaWith3rdPartyFormatted(project: Project, files: List<String>) {
+fun SpotlessExtension.javaWith3rdPartyFormatted(project: Project, files: List<String>, excluded: List<String> = listOf()) {
     java {
         target(
             project.fileTree(project.projectDir) {
                 include("src/**/*.java")
                 exclude(files)
+                exclude(excluded)
             }
         )
     }


### PR DESCRIPTION
Update `javaWith3rdPartyFormatted` to allow to exclude files from all checks.

---
Extracted from eff7d56ac6488a0483b5c76ca33f01059db05039, pushed in #3838.