### PR TITLE
quickstart: add scheme to URL if not present

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Show correct error message when unable to access the provided URL, also, add the scheme if none provided.
+
 ## [36] - 2023-01-03
 ### Fixed
 - Correctly unload the add-on.

--- a/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
+++ b/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
@@ -70,6 +70,7 @@ quickstart.launch.start.option.label	= Start Page:
 quickstart.launch.start.pulldown.url	= URL (specify below)
 quickstart.launch.start.pulldown.zap	= Default ZAP Page
 quickstart.launch.start.pulldown.blank	= Blank Page
+quickstart.launch.start.url.access.error = Failed to access: {0}\nTry specifying the URL directly in the browser.
 quickstart.launch.start.url.label		= URL:
 quickstart.launch.start.url.warn		= You must specify a valid URL, including the initial 'http(s):'
 


### PR DESCRIPTION
Add a scheme to the URL if not already present, also, access the URL separately to provide an appropriate error message (i.e. failed to access the URL rather than launch the browser).