### PR TITLE
webdriverlinux: include aarch64 geckodriver

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Add aarch64/arm64 geckodriver (Issue 7650).
 
 ## [48] - 2023-01-12
 ### Changed

--- a/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
+++ b/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
@@ -26,6 +26,11 @@ tasks {
         arch.set(DownloadWebDriver.Arch.X64)
     }
 
+    register<DownloadWebDriver>("downloadGeckodriverArm") {
+        browser.set(DownloadWebDriver.Browser.FIREFOX)
+        arch.set(DownloadWebDriver.Arch.ARM64)
+    }
+
     register<DownloadWebDriver>("downloadGeckodriverX32") {
         browser.set(DownloadWebDriver.Browser.FIREFOX)
         arch.set(DownloadWebDriver.Arch.X32)


### PR DESCRIPTION
Add task to download/include the geckodriver for aarch64.

Fix zaproxy/zaproxy#7650.