### PR TITLE
various: Linkify CVE Alert Tags

### DIFF
--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.12.0 & < 2.0.0")
+                    version.set(">= 1.13.0 & < 2.0.0")
                 }
                 register("network") {
                     version.set(">= 0.3.0")

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HeartBleedActiveScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HeartBleedActiveScanRule.java
@@ -64,7 +64,7 @@ public class HeartBleedActiveScanRule extends AbstractHostPlugin {
                         CommonAlertTag.OWASP_2021_A06_VULN_COMP,
                         CommonAlertTag.OWASP_2017_A09_VULN_COMP,
                         CommonAlertTag.WSTG_V42_CRYP_01_TLS));
-        ALERT_TAGS.put(CVE, "");
+        CommonAlertTag.putCve(ALERT_TAGS, CVE);
     }
 
     static final byte handShakeClientHello = 0x01;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRule.java
@@ -78,7 +78,7 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin {
                         CommonAlertTag.OWASP_2021_A06_VULN_COMP,
                         CommonAlertTag.OWASP_2017_A09_VULN_COMP,
                         CommonAlertTag.WSTG_V42_INPV_12_COMMAND_INJ));
-        ALERT_TAGS.put(CVE, "");
+        CommonAlertTag.putCve(ALERT_TAGS, CVE);
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRule.java
@@ -65,7 +65,7 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin {
                 CommonAlertTag.toMap(
                         CommonAlertTag.OWASP_2021_A06_VULN_COMP,
                         CommonAlertTag.OWASP_2017_A09_VULN_COMP));
-        ALERT_TAGS.put(CVE, "");
+        CommonAlertTag.putCve(ALERT_TAGS, CVE);
     }
     /**
      * details of the vulnerability which we are attempting to find WASC 20 = Improper Input

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -11,7 +11,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.9.0 & < 2.0.0")
+                    version.set(">= 1.13.0 & < 2.0.0")
                 }
                 register("oast") {
                     version.set(">= 0.14.0")

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Text4ShellScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Text4ShellScanRule.java
@@ -96,7 +96,7 @@ public class Text4ShellScanRule extends AbstractAppParamPlugin {
                                 CommonAlertTag.OWASP_2017_A09_VULN_COMP,
                                 CommonAlertTag.WSTG_V42_INPV_11_CODE_INJ));
         alertTags.put(ExtensionOast.OAST_ALERT_TAG_KEY, ExtensionOast.OAST_ALERT_TAG_VALUE);
-        alertTags.put(CVE, "");
+        CommonAlertTag.putCve(alertTags, CVE);
         return alertTags;
     }
 

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.12.0 & < 2.0.0")
+                    version.set(">= 1.13.0 & < 2.0.0")
                 }
                 register("network") {
                     version.set(">= 0.3.0")

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Log4ShellScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Log4ShellScanRule.java
@@ -114,8 +114,8 @@ public class Log4ShellScanRule extends AbstractAppParamPlugin {
                                 CommonAlertTag.OWASP_2017_A09_VULN_COMP,
                                 CommonAlertTag.WSTG_V42_INPV_11_CODE_INJ));
         alertTags.put(ExtensionOast.OAST_ALERT_TAG_KEY, ExtensionOast.OAST_ALERT_TAG_VALUE);
-        alertTags.put(CVE_44228, "");
-        alertTags.put(CVE_45046, "");
+        CommonAlertTag.putCve(alertTags, CVE_44228);
+        CommonAlertTag.putCve(alertTags, CVE_45046);
         return alertTags;
     }
 

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
@@ -424,4 +424,19 @@ public enum CommonAlertTag {
         }
         return map;
     }
+
+    /**
+     * Inserts a CVE reference and standardized link into the provided map of alert tags.
+     *
+     * @param alertTags the map which the CVE reference and link should be added to.
+     * @param cve the CVE identifier (CVE-YYYY-######) to be added.
+     * @since 1.13.0
+     */
+    public static void putCve(Map<String, String> alertTags, String cve) {
+        alertTags.put(cve, createCveLink(cve));
+    }
+
+    private static String createCveLink(String cve) {
+        return "https://nvd.nist.gov/vuln/detail/" + cve;
+    }
 }

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CommonAlertTagUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CommonAlertTagUnitTest.java
@@ -24,10 +24,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class CommonAlertTagsUnitTest {
+class CommonAlertTagUnitTest {
 
     private static final Map<String, String> BASE_TAGS =
             CommonAlertTag.toMap(
@@ -67,5 +68,22 @@ class CommonAlertTagsUnitTest {
                         CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getTag()));
         assertTrue(allTags.containsKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
         assertTrue(allTags.containsKey(CommonAlertTag.WSTG_V42_SESS_09_SESS_HIJACK.getTag()));
+    }
+
+    @Test
+    void shouldLinkifyCveIdentifierString() {
+        // Given
+        Map<String, String> allTags = new HashMap<>();
+        String cve = "CVE-2020-1234";
+        allTags.put(
+                CommonAlertTag.CUSTOM_PAYLOADS.getTag(), CommonAlertTag.CUSTOM_PAYLOADS.getValue());
+        // When
+        CommonAlertTag.putCve(allTags, cve);
+        String link = allTags.get(cve);
+        // Then
+        assertThat(allTags.size(), is(equalTo(2)));
+        assertTrue(allTags.containsKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
+        assertTrue(allTags.containsKey(cve));
+        assertThat(link, is(equalTo("https://nvd.nist.gov/vuln/detail/CVE-2020-1234")));
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java
@@ -76,7 +76,7 @@ public class HeartBleedScanRule extends PluginPassiveScanner {
                         CommonAlertTag.OWASP_2021_A06_VULN_COMP,
                         CommonAlertTag.OWASP_2017_A09_VULN_COMP,
                         CommonAlertTag.WSTG_V42_CRYP_01_TLS));
-        ALERT_TAGS.put(CVE, "");
+        CommonAlertTag.putCve(ALERT_TAGS, CVE);
     }
 
     @Override

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Alert Tags for CVEs now include standardized links.
 
 ## [0.19.0] - 2023-01-10
 ### Changed

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -21,7 +21,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.7.0 & < 2.0.0")
+                    version.set(">= 1.13.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -136,7 +136,7 @@ public class RetireScanRule extends PluginPassiveScanner {
 
     private Map<String, String> getAllAlertTags(Result result) {
         Map<String, String> alertTags = new HashMap<>();
-        result.getCves().forEach(value -> alertTags.put(value, ""));
+        result.getCves().forEach(value -> CommonAlertTag.putCve(alertTags, value));
         alertTags.putAll(getAlertTags());
         return alertTags;
     }


### PR DESCRIPTION
- commonlib > Add CommonAlertTag.putCve(Map<String, String> alertTags, String cve) method to leverage across other add-ons.
- commonlib > Rename CommonAlertTagsUnitTest to CommonAlertTagUnitTest to match the class being tested (dropping the s on tags).
- ascanrules, ascanrulesBeta, ascanrulesAlpha, pscanrules, retire > Leverage the new utility method to linkify the relevant CVE Alert Tags.
- retire > Add change note. In other add-ons I believe this change can fall under existing notes.

Follow-up to: https://github.com/zaproxy/zap-extensions/pull/4368

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>