### PR TITLE
commonlib: correct parsing of set-cookie without semicolon

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add info URL.
 - Constant for default number of threads.
 
+### Fixed
+- Correctly parse cookie name when set-cookie header value doesn't end with semicolon.
+
 ## [1.12.0] - 2022-12-13
 ### Added
 - Provide HTTP Fields names.

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CookieUtils.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CookieUtils.java
@@ -119,8 +119,9 @@ public final class CookieUtils {
         }
 
         int nameValuePairIdx = cookieHeaderValue.indexOf('=');
+        int semicolonIdx = cookieHeaderValue.indexOf(';');
         if (nameValuePairIdx == NOT_FOUND
-                || cookieHeaderValue.indexOf('=') > cookieHeaderValue.indexOf(';')) {
+                || (semicolonIdx != NOT_FOUND && nameValuePairIdx > semicolonIdx)) {
             return null;
         }
 

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CookieUtilsUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CookieUtilsUnitTest.java
@@ -274,6 +274,24 @@ class CookieUtilsUnitTest {
         assertThat(expired, is(equalTo(false)));
     }
 
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "sessionId=38afes7a8",
+                "sessionId=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT",
+                "sessionId=a3fWa; Max-Age=2592000",
+                "sessionId=219ffwef9w0f; Domain=somecompany.pt",
+                "sessionId=34d8g; SameSite=None; Secure; Path=/; Partitioned;",
+                "sessionId=value123; HttpOnly",
+                "sessionId=value123; Path=/lala/",
+            })
+    void shouldGetTheCorrectCookieName(String headerValue) {
+        // When / When
+        String name = CookieUtils.getCookieName(headerValue);
+        // Then
+        assertThat(name, is(equalTo("sessionId")));
+    }
+
     static Stream<String> expiresFutureProvider() {
         ZonedDateTime future =
                 ZonedDateTime.ofInstant(Instant.now().plus(1, ChronoUnit.DAYS), ZoneOffset.UTC);


### PR DESCRIPTION
Signed-off-by: Diogo Silva <diogo@probely.com>