### PR TITLE
browserView: support building in aarch64

### DIFF
--- a/addOns/browserView/CHANGELOG.md
+++ b/addOns/browserView/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.12.0.
 - Maintenance changes.
 - Make missing JavaFX logging less verbose in regular use.
+- Update help with the requirements to use the add-on.
 
 ## 5 - 2017-07-21
 

--- a/addOns/browserView/browserView.gradle.kts
+++ b/addOns/browserView/browserView.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 description = "Adds an option to render HTML responses like a browser"
 
 javafx {
-    version = "11"
+    version = if (System.getProperty("os.arch")!!.contains("aarch64")) "17" else "11"
     modules("javafx.swing", "javafx.web")
     configuration = "compileOnly"
 }

--- a/addOns/browserView/src/main/javahelp/org/zaproxy/zap/extension/browserView/resources/help/contents/browserView.html
+++ b/addOns/browserView/src/main/javahelp/org/zaproxy/zap/extension/browserView/resources/help/contents/browserView.html
@@ -15,5 +15,16 @@ Browser View
 	It can be selected via the Response tab toolbar.
 </p>
 
+<h2>Requirements</h2>
+JavaFX is required to use this add-on, it can be obtained, for example, from <a href="https://gluonhq.com/products/javafx/">Gluon HQ</a>.
+<p>
+Once obtained ZAP needs to be configured to use JavaFX, which can be done with the following JVM arguments replacing with the appropriate path to the JavaFX's lib directory:
+<br>
+<code>
+--module-path /path/to/javafx/lib/ --add-modules javafx.swing,javafx.web
+</code>
+<p>
+If ZAP is launched with the default startup scripts the JVM arguments can be specified through the JVM options panel.
+
 </BODY>
 </HTML>


### PR DESCRIPTION
Use JavaFX 17 when building on aarch64, which supports it.
Update help to mention the requirements of the add-on.

Fix zaproxy/zaproxy#7707