### PR TITLE
various: CVE Link Standardization

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [52] - 2023-02-03
 ### Changed

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -48,7 +48,7 @@ ascanrules.getforpost.soln=Ensure that only POST is accepted where POST is expec
 ascanrules.heartbleed.name=Heartbleed OpenSSL Vulnerability
 ascanrules.heartbleed.desc=The TLS implementation in OpenSSL 1.0.1 before 1.0.1g does not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory via crafted packets that trigger a buffer over-read, potentially disclosing sensitive information.
 ascanrules.heartbleed.soln=Update to OpenSSL 1.0.1g or later. Re-issue HTTPS certificates. Change asymmetric private keys and shared secret keys, since these may have been compromised, with no evidence of compromise in the server log files.
-ascanrules.heartbleed.refs=http://cvedetails.com/cve-details.php?t=1&cve_id=CVE-2014-0160
+ascanrules.heartbleed.refs=https://nvd.nist.gov/vuln/detail/CVE-2014-0160
 ascanrules.heartbleed.extrainfo=This issue was confirmed by exfiltrating data from the server, using {0}. This is unlikely to be a false positive.
 
 ascanrules.hidden.files.name = Hidden File Finder

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -47,7 +47,7 @@ This rule attempts to find Server Side Request Forgery vulnerabilities by inject
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SsrfScanRule.java">SsrfScanRule.java</a>
 
 <H2>Text4shell (CVE-2022-42889)</H2>
-This rule attempts to discover the Text4shell (<a href="https://www.cve.org/CVERecord?id=CVE-2022-42889">CVE-2022-42889</a>) vulnerability.
+This rule attempts to discover the Text4shell (<a href="https://nvd.nist.gov/vuln/detail/CVE-2022-42889">CVE-2022-42889</a>) vulnerability.
 It relies on the OAST add-on to generate out-of-band payloads and verify DNS interactions.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Text4ShellScanRule.java">Text4ShellScanRule.java</a>

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -42,7 +42,7 @@ ascanalpha.text4shell.desc=Apache Commons Text prior to 1.10.0 allows RCE when a
 Apache Commons Text performs variable interpolation, allowing properties to be dynamically evaluated and expanded.\
 The application has been shown to initial contact with remote servers via variable interpolation and may well be vulnerable to Remote Code Execution (RCE).
 ascanalpha.text4shell.soln=Upgrade Apache Commons Text prior to version 1.10.0 or newer.
-ascanalpha.text4shell.refs=https://www.cve.org/CVERecord?id=CVE-2022-42889\nhttps://securitylab.github.com/advisories/GHSL-2022-018_Apache_Commons_Text/
+ascanalpha.text4shell.refs=https://nvd.nist.gov/vuln/detail/CVE-2022-42889\nhttps://securitylab.github.com/advisories/GHSL-2022-018_Apache_Commons_Text/
 
 ascanalpha.ssrf.name=Server Side Request Forgery
 ascanalpha.ssrf.desc=The web server receives a remote address and retrieves the contents of this URL, but it does not sufficiently ensure that the request is being sent to the expected destination.

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - The Log4Shell scan rule alerts now include Alert References and Tags.
+- THe Spring4Shell scan rule now includes a CVE Alert Tag and reference link.
 
 ### Fixed
 - Use same non-default port in the HTTP Only Site scan rule.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Spring4ShellScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Spring4ShellScanRule.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
@@ -46,14 +47,19 @@ public class Spring4ShellScanRule extends AbstractAppPlugin {
     private static final String SAFE_PAYLOAD = "aaa=bbb";
 
     private static final Logger LOGGER = LogManager.getLogger(Spring4ShellScanRule.class);
+    private static final String CVE = "CVE-2022-22965";
+    private static final Map<String, String> ALERT_TAGS = new HashMap<>();
 
-    private static final Map<String, String> ALERT_TAGS =
-            CommonAlertTag.toMap(
-                    CommonAlertTag.OWASP_2021_A03_INJECTION,
-                    CommonAlertTag.OWASP_2021_A06_VULN_COMP,
-                    CommonAlertTag.OWASP_2017_A01_INJECTION,
-                    CommonAlertTag.OWASP_2017_A09_VULN_COMP,
-                    CommonAlertTag.WSTG_V42_INPV_12_COMMAND_INJ);
+    static {
+        ALERT_TAGS.putAll(
+                CommonAlertTag.toMap(
+                        CommonAlertTag.OWASP_2021_A03_INJECTION,
+                        CommonAlertTag.OWASP_2021_A06_VULN_COMP,
+                        CommonAlertTag.OWASP_2017_A01_INJECTION,
+                        CommonAlertTag.OWASP_2017_A09_VULN_COMP,
+                        CommonAlertTag.WSTG_V42_INPV_12_COMMAND_INJ));
+        CommonAlertTag.putCve(ALERT_TAGS, CVE);
+    }
 
     @Override
     public int getId() {

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -101,7 +101,7 @@ This rule attempts to identify if the Spring Actuators are enabled. Tests for th
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SpringActuatorScanRule.java">SpringActuatorScanRule.java</a>
 
 <H2>Log4Shell (CVE-2021-44228 and CVE-2021-45046)</H2>
-This rule attempts to discover the Log4Shell (<a href="https://www.cve.org/CVERecord?id=CVE-2021-44228">CVE-2021-44228</a> and <a href="https://www.cve.org/CVERecord?id=CVE-2021-45046">CVE-2021-45046</a>) vulnerabilities.
+This rule attempts to discover the Log4Shell (<a href="https://nvd.nist.gov/vuln/detail/CVE-2021-44228">CVE-2021-44228</a> and <a href="https://nvd.nist.gov/vuln/detail/CVE-2021-45046">CVE-2021-45046</a>) vulnerabilities.
 It relies on the OAST add-on to generate out-of-band payloads and verify DNS interactions.
 We recommend that this scan rule is used with header injection enabled for maximum coverage.
 <p>

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -126,12 +126,12 @@ ascanbeta.log4shell.skipped=no Active Scan OAST service is selected.
 ascanbeta.log4shell.cve44228.name=Log4Shell (CVE-2021-44228)
 ascanbeta.log4shell.cve44228.desc=Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default.
 ascanbeta.log4shell.cve44228.soln=Upgrade Log4j2 to version 2.17.1 or newer. In previous releases (>2.10) this behavior can be mitigated by setting system property "log4j2.formatMsgNoLookups" to "true" or by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class). Java 8u121 (see https://www.oracle.com/java/technologies/javase/8u121-relnotes.html) protects against remote code execution by defaulting "com.sun.jndi.rmi.object.trustURLCodebase" and "com.sun.jndi.cosnaming.object.trustURLCodebase" to "false".
-ascanbeta.log4shell.cve44228.refs=https://www.cve.org/CVERecord?id=CVE-2021-44228\nhttps://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-44228
+ascanbeta.log4shell.cve44228.refs=https://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-44228
 
 ascanbeta.log4shell.cve45046.name=Log4Shell (CVE-2021-45046)
 ascanbeta.log4shell.cve45046.desc=It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allow attackers to craft malicious input data using a JNDI Lookup pattern resulting in an information leak and remote code execution in some environments.
 ascanbeta.log4shell.cve45046.soln=Upgrade Log4j2 to version 2.17.1 or newer.
-ascanbeta.log4shell.cve45046.refs=https://www.cve.org/CVERecord?id=CVE-2021-45046\nhttps://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-45046
+ascanbeta.log4shell.cve45046.refs=https://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-45046
 
 ascanbeta.noanticsrftokens.name=Absence of Anti-CSRF Tokens
 ascanbeta.noanticsrftokens.desc=No Anti-CSRF tokens were found in a HTML submission form.
@@ -250,7 +250,7 @@ ascanbeta.sourcecodedisclosure.svnbased.extrainfo = The source code for [{0}] wa
 ascanbeta.spring4shell.name=Spring4Shell
 ascanbeta.spring4shell.desc=The application appears to be vulnerable to CVE-2022-22965 (otherwise known as Spring4Shell) - remote code execution (RCE) via data binding.
 ascanbeta.spring4shell.soln=Upgrade Spring Framework to versions 5.3.18, 5.2.20, or newer.
-ascanbeta.spring4shell.refs=https://www.rapid7.com/blog/post/2022/03/30/spring4shell-zero-day-vulnerability-in-spring-framework/\nhttps://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#vulnerability\nhttps://tanzu.vmware.com/security/cve-2022-22965
+ascanbeta.spring4shell.refs=https://nvd.nist.gov/vuln/detail/CVE-2022-22965\nhttps://www.rapid7.com/blog/post/2022/03/30/spring4shell-zero-day-vulnerability-in-spring-framework/\nhttps://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#vulnerability\nhttps://tanzu.vmware.com/security/cve-2022-22965
 
 ascanbeta.springactuator.name=Spring Actuator Information Leak
 ascanbeta.springactuator.desc=Spring Actuator for Health is enabled and may reveal sensitive information about this application. Spring Actuators can be used for real monitoring purposes, but should be used with caution as to not expose too much information about the application or the infrastructure running it.

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/Spring4ShellScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/Spring4ShellScanRuleUnitTest.java
@@ -233,7 +233,7 @@ class Spring4ShellScanRuleUnitTest extends ActiveScannerTest<Spring4ShellScanRul
         // Then
         assertThat(cwe, is(equalTo(78)));
         assertThat(wasc, is(equalTo(20)));
-        assertThat(tags.size(), is(equalTo(5)));
+        assertThat(tags.size(), is(equalTo(6)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
                 is(equalTo(true)));
@@ -249,6 +249,7 @@ class Spring4ShellScanRuleUnitTest extends ActiveScannerTest<Spring4ShellScanRul
         assertThat(
                 tags.containsKey(CommonAlertTag.WSTG_V42_INPV_12_COMMAND_INJ.getTag()),
                 is(equalTo(true)));
+        assertThat(tags.containsKey("CVE-2022-22965"), is(equalTo(true)));
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2021_A03_INJECTION.getValue())));

--- a/addOns/network/src/main/javahelp/help/contents/options/connection.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/connection.html
@@ -45,7 +45,7 @@
 	<br>Default: All protocols supported.
 
 	<H3>Enable unsafe SSL/TLS renegotiation</H3>
-	Allows unsafe SSL/TLS renegotiations (<a href="https://www.cve.org/CVERecord?id=CVE-2009-3555">CVE-2009-3555</a>) for
+	Allows unsafe SSL/TLS renegotiations (<a href="https://nvd.nist.gov/vuln/detail/CVE-2009-3555">CVE-2009-3555</a>) for
 	compatibility with older servers.<br/>
 	<strong>Note:</strong> The option must be set before establishing any HTTPS connection, a ZAP restart might be required.
 	<br>Default: <code>unselected</code>.

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java
@@ -46,10 +46,7 @@ public class HeartBleedScanRule extends PluginPassiveScanner {
     private static Pattern openSSLversionPattern =
             Pattern.compile("Server:.*?(OpenSSL/([0-9.]+[a-z-0-9]+))", Pattern.CASE_INSENSITIVE);
 
-    /**
-     * vulnerable versions, courtesy of
-     * http://cvedetails.com/cve-details.php?t=1&cve_id=CVE-2014-0160
-     */
+    /** vulnerable versions, courtesy of https://nvd.nist.gov/vuln/detail/CVE-2014-0160 */
     static String[] openSSLvulnerableVersions = {
         "1.0.1-Beta1",
         "1.0.1-Beta2",

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -99,7 +99,7 @@ pscanrules.hashdisclosure.extrainfo={0}
 pscanrules.heartbleed.name=Heartbleed OpenSSL Vulnerability (Indicative)
 pscanrules.heartbleed.desc=The TLS and DTLS implementations in OpenSSL 1.0.1 before 1.0.1g do not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory via crafted packets that trigger a buffer over-read, potentially disclosing sensitive information.	
 pscanrules.heartbleed.soln=Update to OpenSSL 1.0.1g or later. Re-issue HTTPS certificates. Change asymmetric private keys and shared secret keys, since these may have been compromised, with no evidence of compromise in the server log files.
-pscanrules.heartbleed.refs=http://cvedetails.com/cve-details.php?t=1&cve_id=CVE-2014-0160
+pscanrules.heartbleed.refs=https://nvd.nist.gov/vuln/detail/CVE-2014-0160
 pscanrules.heartbleed.extrainfo={0} is in use. Note however that the reported version could contain back-ported security fixes, and so the issue could be a false positive. This is common on Red Hat, for instance.
 
 pscanrules.informationdisclosuredebugerrors.name=Information Disclosure - Debug Error Messages


### PR DESCRIPTION
- Messages.properties > Standardize CVE links on NISTs NVD.
- Spring4ShellScanRule > Add CVE Alert Tag (previously missed).
- Spring4SHellScanRuleUnitTest > Update mappings unit test.
- CHANGELOG.md > Add notes where applicable. Others apply to existing "maintenance changes" notes.

Follow-up to zaproxy/zap-extensions#4380 and IRC discussion.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>