### PR TITLE
spiderAjax: add default resources to new config

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Default number of threads to 2 * processor count.
 
+### Fixed
+- Ensure default Allowed Resources are present with a new home directory (Issue 7719).
+
 ## [23.10.0] - 2022-10-27
 ### Changed
 - Update minimum ZAP version to 2.12.0.

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -292,8 +292,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
     protected void updateConfigsImpl(int fileVersion) {
         switch (fileVersion) {
             case NO_CONFIG_VERSION:
-                // No updates/changes needed, the configurations were not previously persisted
-                // and the current version is already written after this method.
+                setAllowedResources(DEFAULT_ALLOWED_RESOURCES);
                 break;
             case 1:
                 String crawlInDepthKey = AJAX_SPIDER_BASE_KEY + ".crawlInDepth";

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AllowedResource.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AllowedResource.java
@@ -66,7 +66,13 @@ public class AllowedResource extends Enableable {
             return false;
         }
         AllowedResource other = (AllowedResource) obj;
-        return pattern.equals(other.pattern);
+        return pattern.flags() == other.pattern.flags()
+                && pattern.pattern().equals(other.pattern.pattern());
+    }
+
+    @Override
+    public String toString() {
+        return "[Enabled=" + isEnabled() + ", Pattern=" + pattern + "]";
     }
 
     /**

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParamUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParamUnitTest.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.spiderAjax;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.parosproxy.paros.Constant;
@@ -63,6 +65,22 @@ class AjaxSpiderParamUnitTest {
     @Test
     void shouldHaveConfigVersionKey() {
         assertThat(param.getConfigVersionKey(), is(equalTo("ajaxSpider[@version]")));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(ints = {1, 2, 3, 4})
+    void shouldHaveAllowedResourcesByDefault(Integer version) {
+        // Given
+        configuration.setProperty(param.getConfigVersionKey(), version);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(
+                param.getAllowedResources(),
+                contains(
+                        allowedResource("^http.*\\.js(?:\\?.*)?$"),
+                        allowedResource("^http.*\\.css(?:\\?.*)?$")));
     }
 
     @ParameterizedTest
@@ -117,5 +135,9 @@ class AjaxSpiderParamUnitTest {
             // Then
             assertThat(param.getNumberOfBrowsers(), is(equalTo(3)));
         }
+    }
+
+    private static AllowedResource allowedResource(String regex) {
+        return new AllowedResource(AllowedResource.createDefaultPattern(regex), true);
     }
 }


### PR DESCRIPTION
Ensure the default allowed resources are added when using a new configuration.
Correct equals method of `AllowedResource` and add `toString()` to ease debug.

Fix zaproxy/zaproxy#7719.