### PR TITLE
Correct API client generation's classpath

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -156,6 +156,7 @@ subprojects {
         apiClientGen {
             classpath.run {
                 setFrom(apiGenClasspath)
+                from(configurations.named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME))
                 from(tasks.named(JavaPlugin.JAR_TASK_NAME))
             }
         }


### PR DESCRIPTION
Include the compile classpath as it might be needed during the generation.