### PR TITLE
oast: add context menu to paste payloads

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added 
+- A context menu to paste payloads from all the supported OAST services (Issue 7665).
 
 ## [0.14.0] - 2022-12-13
 ### Changed

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -54,6 +54,7 @@ import org.zaproxy.addon.oast.services.callback.CallbackService;
 import org.zaproxy.addon.oast.services.interactsh.InteractshOptionsPanelTab;
 import org.zaproxy.addon.oast.services.interactsh.InteractshService;
 import org.zaproxy.addon.oast.ui.GeneralOastOptionsPanelTab;
+import org.zaproxy.addon.oast.ui.OastInsertPayloadMenu;
 import org.zaproxy.addon.oast.ui.OastOptionsPanel;
 import org.zaproxy.addon.oast.ui.OastPanel;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
@@ -136,6 +137,7 @@ public class ExtensionOast extends ExtensionAdaptor {
             getOastOptionsPanel().addServicePanel(new BoastOptionsPanelTab(boastService));
             getOastOptionsPanel().addServicePanel(new CallbackOptionsPanelTab(callbackService));
             getOastOptionsPanel().addServicePanel(new InteractshOptionsPanelTab(interactshService));
+            extensionHook.getHookMenu().addPopupMenuItem(new OastInsertPayloadMenu(this));
             extensionHook.getHookView().addStatusPanel(getOastPanel());
             ExtensionHelp.enableHelpKey(getOastPanel(), "oast.tab");
         }

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/OastInsertPayloadMenu.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/OastInsertPayloadMenu.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.oast.ui;
+
+import java.awt.Component;
+import java.util.Map;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.oast.ExtensionOast;
+import org.zaproxy.addon.oast.OastService;
+import org.zaproxy.zap.extension.ExtensionPopupMenu;
+
+@SuppressWarnings("serial")
+public class OastInsertPayloadMenu extends ExtensionPopupMenu {
+    private static final long serialVersionUID = 2L;
+    private static final Logger LOGGER = LogManager.getLogger(OastInsertPayloadMenu.class);
+    private JTextComponent lastInvoker;
+
+    public OastInsertPayloadMenu(ExtensionOast extension) {
+        setText(Constant.messages.getString("oast.popup.menu.insertPayload"));
+        for (Map.Entry<String, OastService> serviceEntry : extension.getOastServices().entrySet()) {
+            String name = serviceEntry.getKey();
+            OastService service = serviceEntry.getValue();
+            JMenuItem menuItem = new JMenuItem(name);
+            add(menuItem);
+            menuItem.addActionListener(
+                    e -> {
+                        try {
+                            lastInvoker.replaceSelection(service.getNewPayload());
+                        } catch (Exception exception) {
+                            LOGGER.warn(exception.getMessage(), exception);
+                            View.getSingleton()
+                                    .showWarningDialog(
+                                            SwingUtilities.getWindowAncestor(lastInvoker),
+                                            Constant.messages.getString(
+                                                    "oast.popup.menu.warning",
+                                                    exception.getLocalizedMessage()));
+                        }
+                    });
+        }
+    }
+
+    @Override
+    public boolean isEnableForComponent(Component invoker) {
+        if (invoker instanceof JTextComponent) {
+            lastInvoker = (JTextComponent) invoker;
+            setEnabled(((JTextComponent) invoker).isEditable());
+
+            return true;
+        }
+
+        lastInvoker = null;
+        return false;
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+}

--- a/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/oast.html
+++ b/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/oast.html
@@ -14,6 +14,9 @@ The OAST Support add-on allows you to detect and exploit out-of-band vulnerabili
 <h2>Services</h2>
 For a list of the supported services, see the <a href="services/services.html">OAST Services</a> page.
 
+<h2>Context Menu</h2> 
+A context menu, "Insert OAST Payload", is available in editable text components that allow to insert new payloads from the supported OAST services.
+
 <h2>Scripts</h2>
 If the <em>Script Console</em> and the <em>GraalVM JavaScript</em> add-ons are installed, a new Extender script template
 called "OAST Request Handler.js" is added to ZAP. Using this template, you can create a script that performs an action

--- a/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
+++ b/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
@@ -60,6 +60,9 @@ oast.panel.table.column.referer=Referer
 oast.panel.currentState.tooltip.lastPolled = {0}: Last Polled Time
 oast.panel.currentState.lastPoll= {0}: {1}
 
+oast.popup.menu.insertPayload=Insert OAST Payload
+oast.popup.menu.warning=Failed to generate and insert the OAST payload.\n{0}
+
 oast.scripts.desc=Adds OAST scripts.
 oast.scripts.name=OAST Scripts
 oast.scripts.warn.couldNotAddScripts=Could not add OAST scripts: {0}.


### PR DESCRIPTION
Fixes zaproxy/zaproxy#7665

Now we can insert payload in http/websocket message panel using context menu as shown in the screenshots below.

![Screenshot from 2023-02-08 10-45-24](https://user-images.githubusercontent.com/87857234/217440781-89e59271-17dd-48d6-b8b4-5d814aadb36a.png)
![Screenshot from 2023-02-08 10-44-54](https://user-images.githubusercontent.com/87857234/217440796-e363641b-d6ba-4f8b-bbe9-232ccc437430.png)
![Screenshot from 2023-02-08 10-44-17](https://user-images.githubusercontent.com/87857234/217440807-305c746b-d01c-4e5a-bc4f-90fc429d79aa.png)
