### PR TITLE
Automation: Fix NPE when adding a context to an existing plan

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- NPE when adding a context to an existing plan.
 
 ## [0.23.0] - 2023-02-06
 ### Changed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/TechnologyUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/TechnologyUtils.java
@@ -62,8 +62,11 @@ public class TechnologyUtils {
 
     public static TechSet getTechSet(List<String> exclude) {
         TechSet ts = new TechSet(Tech.getAll());
-        exclude.stream()
-                .forEach(name -> TechnologyUtils.removeTechAndChildren(ts, getTech(name, null)));
+        if (exclude != null) {
+            exclude.stream()
+                    .forEach(
+                            name -> TechnologyUtils.removeTechAndChildren(ts, getTech(name, null)));
+        }
         return ts;
     }
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
@@ -75,8 +75,10 @@ public class ContextDialog extends StandardFieldsDialog {
 
         this.setCustomTabPanel(3, getTechnologyPanel());
 
-        getTechnologyPanel()
-                .setTechSet(TechnologyUtils.getTechSet(context.getTechnology().getExclude()));
+        if (context.getTechnology() != null) {
+            getTechnologyPanel()
+                    .setTechSet(TechnologyUtils.getTechSet(context.getTechnology().getExclude()));
+        }
     }
 
     private String listToString(List<String> list) {

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/TechnologyUtilsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/TechnologyUtilsUnitTest.java
@@ -303,4 +303,27 @@ class TechnologyUtilsUnitTest {
         assertThat(set.includes(Lang_C), is(equalTo(false)));
         assertThat(set.includes(Tech.Lang), is(equalTo(false)));
     }
+
+    @Test
+    void shouldReturnAllTechIfNullExcludes() {
+        // Given
+        TechSet set = TechnologyUtils.getTechSet(null);
+        Set<Tech> allTech = Tech.getAll();
+
+        // When / Then
+        assertThat(set.getIncludeTech().size(), is(equalTo(allTech.size())));
+        assertThat(set.getExcludeTech().size(), is(equalTo(0)));
+    }
+
+    @Test
+    void shouldRemoveTechIfExcludes() {
+        // Given
+        TechSet set = TechnologyUtils.getTechSet(Arrays.asList(Tech.ASP.getName()));
+        Set<Tech> allTech = Tech.getAll();
+
+        // When / Then
+        assertThat(set.getIncludeTech().size(), is(equalTo(allTech.size() - 1)));
+        assertThat(set.getIncludeTech().contains(Tech.ASP), is(equalTo(false)));
+        assertThat(set.getExcludeTech().size(), is(equalTo(1)));
+    }
 }


### PR DESCRIPTION
To reproduce:

1. Run the ZAP Desktop
2. Create a new AF plan using the default context
3. Add a new context

An NPE will be logged and the context not added.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>