### PR TITLE
network: fallback to HTTP/1.1 in the main proxy

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Fallback to HTTP/1.1 in the main proxy if the client does not negotiate a protocol (ALPN) (Issue 7699).
 
 ## [0.6.0] - 2023-01-03
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsConfig.java
@@ -41,7 +41,6 @@ public class TlsConfig {
     private List<String> tlsProtocols;
     private boolean alpnEnabled;
     private List<String> applicationProtocols;
-    private String fallbackApplicationProtocol;
 
     /**
      * Constructs a {@code TlsConfig} with all the SSL/TLS protocol versions supported, with ALPN
@@ -50,11 +49,7 @@ public class TlsConfig {
      * <p>If no protocol is negotiated it falls back to HTTP/1.1.
      */
     public TlsConfig() {
-        this(
-                DEFAULT_PROTOCOLS,
-                true,
-                DEFAULT_APPLICATION_PROTOCOLS,
-                TlsUtils.APPLICATION_PROTOCOL_HTTP_1_1);
+        this(DEFAULT_PROTOCOLS, true, DEFAULT_APPLICATION_PROTOCOLS);
     }
 
     /**
@@ -70,19 +65,10 @@ public class TlsConfig {
      */
     public TlsConfig(
             List<String> tlsProtocols, boolean alpnEnabled, List<String> applicationProtocols) {
-        this(tlsProtocols, alpnEnabled, applicationProtocols, null);
-    }
-
-    private TlsConfig(
-            List<String> tlsProtocols,
-            boolean alpnEnabled,
-            List<String> applicationProtocols,
-            String fallbackApplicationProtocol) {
         this.tlsProtocols = TlsUtils.filterUnsupportedTlsProtocols(tlsProtocols);
         this.alpnEnabled = alpnEnabled;
         this.applicationProtocols =
                 TlsUtils.filterUnsupportedApplicationProtocols(applicationProtocols);
-        this.fallbackApplicationProtocol = fallbackApplicationProtocol;
     }
 
     /**
@@ -110,15 +96,6 @@ public class TlsConfig {
      */
     public List<String> getApplicationProtocols() {
         return applicationProtocols;
-    }
-
-    /**
-     * Gets the protocol to use if no protocol was negotiated (ALPN).
-     *
-     * @return the fallback protocol, or {@code null} if none.
-     */
-    public String getFallbackApplicationProtocol() {
-        return fallbackApplicationProtocol;
     }
 
     @Override

--- a/addOns/network/src/main/javahelp/help/contents/options/localservers.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/localservers.html
@@ -37,7 +37,7 @@
 	<H4>ALPN</H4>
 	Allows to enable and select the application protocols negotiated during a TLS handshake (ALPN extension).
 	<br>
-	<strong>Note:</strong> The connection is closed if the client establishing the connection does not support ALPN or any of the selected protocols.
+	<strong>Note:</strong> The protocol falls back to HTTP/1.1 if the client establishing the connection does not support ALPN or any of the selected protocols.
 
 	<H4>Mode</H4>
 	Allows to specify if the API should be exposed or if it should be allowed to proxy requests. For example, one can configure a

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsConfigUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsConfigUnitTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -67,9 +66,6 @@ class TlsConfigUnitTest {
         assertThat(
                 tlsConfig.getApplicationProtocols(),
                 is(equalTo(getSupportedApplicationProtocols())));
-        assertThat(
-                tlsConfig.getFallbackApplicationProtocol(),
-                is(equalTo(APPLICATION_PROTOCOL_HTTP_1_1)));
     }
 
     @Test
@@ -137,7 +133,6 @@ class TlsConfigUnitTest {
         TlsConfig tlsConfig = new TlsConfig(getSupportedTlsProtocols(), false, protocols);
         // Then
         assertThat(tlsConfig.getApplicationProtocols(), is(equalTo(protocols)));
-        assertThat(tlsConfig.getFallbackApplicationProtocol(), is(nullValue()));
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
@@ -520,20 +520,6 @@ class TlsProtocolHandlerUnitTest {
     }
 
     @Test
-    void shouldCloseConnectionIfClientHasNoAlpnAndAlpnIsEnabledWithoutFallback() throws Exception {
-        // Given
-        int port = server.start(Server.ANY_PORT);
-        createClientTls(port);
-        given(tlsConfig.isAlpnEnabled()).willReturn(true);
-        given(tlsConfig.getApplicationProtocols()).willReturn(List.of("h0"));
-        given(tlsConfig.getFallbackApplicationProtocol()).willReturn(null);
-        // When
-        Channel ch = clientTls.connect(port, "");
-        // Then
-        assertThat(ch.isOpen(), is(equalTo(false)));
-    }
-
-    @Test
     void shouldCallPipelineConfiguratorAfterProtocolNegotiation() throws Exception {
         // Given
         int port = server.start(Server.ANY_PORT);
@@ -556,13 +542,11 @@ class TlsProtocolHandlerUnitTest {
         createClientTls(port);
         given(tlsConfig.isAlpnEnabled()).willReturn(true);
         given(tlsConfig.getApplicationProtocols()).willReturn(List.of("some-protocol"));
-        String fallbackProtocol = "fallback";
-        given(tlsConfig.getFallbackApplicationProtocol()).willReturn(fallbackProtocol);
         pipelineConfigurator = mock(PipelineConfigurator.class);
         // When
         clientTls.connect(port, "");
         // Then
-        verify(pipelineConfigurator).configure(any(), eq(fallbackProtocol));
+        verify(pipelineConfigurator).configure(any(), eq(TlsUtils.APPLICATION_PROTOCOL_HTTP_1_1));
     }
 
     @Test


### PR DESCRIPTION
Improve compatibility with clients that do not support ALPN, by falling back to HTTP/1.1 if no protocol is negotiated.

Fix zaproxy/zaproxy#7699.

---
This is now the same behaviour for both local servers/proxies (#4308) and main proxy thus the option to specify programmatically a fallback protocol was removed.