### PR TITLE
network: read any main proxy configs available

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Maintenance changes.
 - Fallback to HTTP/1.1 in the main proxy if the client does not negotiate a protocol (ALPN) (Issue 7699).
+- Read all main proxy configurations (`-config`) available, even if they don't include an address.
 
 ## [0.6.0] - 2023-01-03
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
@@ -380,7 +380,7 @@ public class LocalServersOptions extends VersionedAbstractParam {
     }
 
     private void readMainProxyAndServers() {
-        if (getConfig().containsKey(MAIN_PROXY_BASE_KEY + "." + SERVER_ADDRESS)) {
+        if (getConfig().getKeys(MAIN_PROXY_BASE_KEY).hasNext()) {
             mainProxy =
                     readServerConfig(
                             ((HierarchicalConfiguration) getConfig())

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
@@ -519,7 +519,6 @@ class LocalServersOptionsUnitTest {
                         "<network>\n"
                                 + "  <localServers version=\"1\">\n"
                                 + "    <mainProxy>\n"
-                                + "      <address>192.168.0.1</address>\n"
                                 + "      <tlsProtocols>\n"
                                 + "           <protocol>not something supported</protocol>\n"
                                 + "      </tlsProtocols>\n"
@@ -541,7 +540,6 @@ class LocalServersOptionsUnitTest {
                         "<network>\n"
                                 + "  <localServers version=\"1\">\n"
                                 + "    <mainProxy>\n"
-                                + "      <address>192.168.0.1</address>\n"
                                 + "      <alpn>\n"
                                 + "        <protocols>\n"
                                 + "          <protocol>not something supported</protocol>\n"
@@ -590,7 +588,7 @@ class LocalServersOptionsUnitTest {
     }
 
     @Test
-    void shouldUseDefaultsIfMainProxyHasNoAddress() {
+    void shouldUseDefaultsIfMainProxyHasNoData() {
         // Given
         ZapXmlConfiguration config =
                 configWith(
@@ -614,6 +612,53 @@ class LocalServersOptionsUnitTest {
                 true,
                 true,
                 true,
+                DEFAULT_APPLICATION_PROTOCOLS);
+    }
+
+    @Test
+    void shouldUseProvidedDataEvenIfMainProxyHasNoAddress() {
+        // Given
+        ZapXmlConfiguration config =
+                configWith(
+                        "<network>\n"
+                                + "  <localServers version=\"1\">\n"
+                                + "    <mainProxy>\n"
+                                + "      <proxy>true</proxy>\n"
+                                + "      <api>false</api>\n"
+                                + "      <port>8765</port>\n"
+                                + "      <tlsProtocols>\n"
+                                + "        <protocol>TLSv1.3</protocol>\n"
+                                + "        <protocol>TLSv1.2</protocol>\n"
+                                + "        <protocol>TLSv1.1</protocol>\n"
+                                + "      </tlsProtocols>"
+                                + "      <alpn>\n"
+                                + "        <enabled>false</enabled>\n"
+                                + "        <protocols>\n"
+                                + "          <protocol>http/1.1</protocol>\n"
+                                + "          <protocol>h2</protocol>\n"
+                                + "        </protocols>\n"
+                                + "      </alpn>\n"
+                                + "      <behindNat>true</behindNat>\n"
+                                + "      <removeAcceptEncoding>false</removeAcceptEncoding>\n"
+                                + "      <decodeResponse>false</decodeResponse>\n"
+                                + "      <enabled>false</enabled>\n"
+                                + "    </mainProxy>\n"
+                                + "  </localServers>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getServers(), hasSize(0));
+        assertServerFields(
+                options.getMainProxy(),
+                "localhost",
+                8765,
+                ServerMode.PROXY,
+                true,
+                false,
+                false,
+                true,
+                false,
                 DEFAULT_APPLICATION_PROTOCOLS);
     }
 


### PR DESCRIPTION
Read any available main proxy configurations, not just when the address is provided to make it easer to override the configs.

Related to zaproxy/zaproxy#7699.