### PR TITLE
spiderAjax: add allowed resources if none present

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Add default Allowed Resources if none present in existing home directory when updating the add-on (Issue 7719).
 
 ## [23.11.0] - 2023-02-06
 ### Changed

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -46,7 +46,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
      * @see #CONFIG_VERSION_KEY
      * @see #updateConfigsImpl(int)
      */
-    private static final int CURRENT_CONFIG_VERSION = 5;
+    private static final int CURRENT_CONFIG_VERSION = 6;
 
     private static final String AJAX_SPIDER_BASE_KEY = "ajaxSpider";
 
@@ -310,6 +310,10 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
                 if (getInt(NUMBER_OF_BROWSERS_KEY, 1) == 1) {
                     // the old default
                     this.setNumberOfBrowsers(Constants.getDefaultThreadCount());
+                }
+            case 5:
+                if (!getConfig().getKeys(ALL_ALLOWED_RESOURCES_KEY).hasNext()) {
+                    setAllowedResources(DEFAULT_ALLOWED_RESOURCES);
                 }
         }
     }

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParamUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParamUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.spiderAjax;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -69,9 +70,10 @@ class AjaxSpiderParamUnitTest {
 
     @ParameterizedTest
     @NullSource
-    @ValueSource(ints = {1, 2, 3, 4})
+    @ValueSource(ints = {1, 2, 3, 4, 5})
     void shouldHaveAllowedResourcesByDefault(Integer version) {
         // Given
+        configuration = new ZapXmlConfiguration();
         configuration.setProperty(param.getConfigVersionKey(), version);
         // When
         param.load(configuration);
@@ -81,6 +83,32 @@ class AjaxSpiderParamUnitTest {
                 contains(
                         allowedResource("^http.*\\.js(?:\\?.*)?$"),
                         allowedResource("^http.*\\.css(?:\\?.*)?$")));
+    }
+
+    @Test
+    void shouldNotAddDefaultAllowedResourcesForVersion5WithExistingResources() {
+        // Given
+        configuration = new ZapXmlConfiguration();
+        configuration.setProperty(param.getConfigVersionKey(), 5);
+        String allowedResourceKey = "ajaxSpider.allowedResources.allowedResource(0).";
+        String regex = "^https?://example\\.com/.*";
+        configuration.setProperty(allowedResourceKey + "regex", regex);
+        configuration.setProperty(allowedResourceKey + "enabled", "true");
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getAllowedResources(), contains(allowedResource(regex)));
+    }
+
+    @Test
+    void shouldNotAddDefaultAllowedResourcesForVersion6() {
+        // Given
+        configuration = new ZapXmlConfiguration();
+        configuration.setProperty(param.getConfigVersionKey(), 6);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getAllowedResources(), is(empty()));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Add the default allowed resources if none is present when updating from old versions to ensure the defaults are actually used, as they could be missing in older versions.

Fix zaproxy/zaproxy#7719.