### PR TITLE
network: deliver whole response before closing

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintenance changes.
 - Fallback to HTTP/1.1 in the main proxy if the client does not negotiate a protocol (ALPN) (Issue 7699).
 - Read all main proxy configurations (`-config`) available, even if they don't include an address.
+- Increase buffer used to read the HTTP body, to make reads more efficient.
+
+### Fixed
+- Ensure the whole HTTP response is delivered to the client before closing the connection.
 
 ## [0.6.0] - 2023-01-03
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpMessageDecoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpMessageDecoder.java
@@ -53,7 +53,7 @@ public abstract class HttpMessageDecoder extends ByteToMessageDecoder {
     private static final byte LF = 10;
     private static final byte CR = 13;
 
-    static final int MAX_CHUNK_SIZE = 80;
+    static final int MAX_CHUNK_SIZE = 4096;
 
     private final HeaderParser headerParser;
     private final LineParser lineParser;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainServerHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainServerHandler.java
@@ -19,7 +19,9 @@
  */
 package org.zaproxy.addon.network.internal.server.http;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.ssl.SslClosedEngineException;
@@ -192,7 +194,8 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
     }
 
     protected static void close(ChannelHandlerContext ctx) {
-        ctx.close()
+        ctx.writeAndFlush(Unpooled.EMPTY_BUFFER)
+                .addListener(ChannelFutureListener.CLOSE)
                 .addListener(
                         e -> {
                             if (!e.isSuccess()) {

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TextTestClient.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TextTestClient.java
@@ -94,7 +94,22 @@ public class TextTestClient extends TestClient {
      * @throws Exception if an error occurred while waiting for the response.
      */
     public static Object waitForResponse(Channel channel) throws Exception {
-        Object response = getCompletableFuture(channel).get(5, TimeUnit.SECONDS);
+        return waitForResponse(channel, 5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Waits for a response in the given channel.
+     *
+     * @param channel the channel where it's expected a response.
+     * @param timeout the maximum time to wait.
+     * @param unit the time unit of the timeout argument.
+     * @return the response.
+     * @throws Exception if an error occurred while waiting for the response.
+     */
+    public static <T> T waitForResponse(Channel channel, long timeout, TimeUnit unit)
+            throws Exception {
+        @SuppressWarnings("unchecked")
+        T response = (T) getCompletableFuture(channel).get(timeout, unit);
         channel.attr(RESPONSE_ATTRIBUTE).set(new CompletableFuture<>());
         return response;
     }


### PR DESCRIPTION
Only close after writing the whole response otherwise some chunks of the body could be dropped.
Increase body buffer in `HttpMessageDecoder` to make reads more efficient.