### PR TITLE
encoder: Add powershell encoder

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - A context menu active on the output text areas facilitating the replacement of input text.
+- PowerShell encoder (hat tip to hackvertor/hackvertor#71 for the idea and details).
 
 ## [1.0.0] - 2022-12-15
 

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
@@ -45,6 +45,7 @@ import org.zaproxy.addon.encoder.processors.predefined.IllegalUTF8With4ByteEncod
 import org.zaproxy.addon.encoder.processors.predefined.JavaScriptStringDecoder;
 import org.zaproxy.addon.encoder.processors.predefined.JavaScriptStringEncoder;
 import org.zaproxy.addon.encoder.processors.predefined.Md5Hasher;
+import org.zaproxy.addon.encoder.processors.predefined.PowerShellEncoder;
 import org.zaproxy.addon.encoder.processors.predefined.Sha1Hasher;
 import org.zaproxy.addon.encoder.processors.predefined.Sha256Hasher;
 import org.zaproxy.addon.encoder.processors.predefined.UnicodeDecoder;
@@ -101,6 +102,7 @@ public class EncodeDecodeProcessors {
         addPredefined("reverse", Reverse.getSingleton());
         addPredefined("lowercase", LowerCase.getSingleton());
         addPredefined("uppercase", UpperCase.getSingleton());
+        addPredefined("powershellencode", PowerShellEncoder.getSingleton());
     }
 
     private Map<String, EncodeDecodeProcessorItem> scriptProcessors = new HashMap<>();

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/PowerShellEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/PowerShellEncoder.java
@@ -1,0 +1,40 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors.predefined;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class PowerShellEncoder extends DefaultEncodeDecodeProcessor {
+
+    private static final PowerShellEncoder INSTANCE = new PowerShellEncoder();
+
+    @Override
+    protected String processInternal(String value) throws IOException {
+        return new String(
+                Base64.getEncoder().encode(value.getBytes(StandardCharsets.UTF_16LE)),
+                StandardCharsets.UTF_8);
+    }
+
+    public static PowerShellEncoder getSingleton() {
+        return INSTANCE;
+    }
+}

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -206,6 +206,27 @@ Reverses the order of the input.
 <H4>To Upper Case</H4>
 Converts the input to all upper case characters.
 
+<H3>Miscellaneous</H3>
+
+<H4>PowerShell Encode</H4>
+Converted to UTF-16LE and base64 encoded. Equivalent to one of the following examples (encoding "dir"):
+<p>
+<code> printf "dir"| iconv -t UTF-16LE | base64 -w 0 -</code>
+<br>
+<pre>
+<code>
+$command = 'dir'
+$bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
+$encodedCommand = [Convert]::ToBase64String($bytes)
+echo $encodedCommand
+</code>
+</pre>
+<br>
+Resulting in: <code>ZABpAHIA</code>.
+<p>
+Which can be leveraged via something like the following (where <code>$encodedCommand</code> is set to the encoded value <code>ZABpAHIA</code>):<br>
+<code>powershell -exec bypass -enc $encodedCommand</code>
+
 <H2>Accessed via</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -59,6 +59,7 @@ encoder.predefined.unicodeencode=Unicode Escaped Text
 encoder.predefined.urldecode=URL Decode
 encoder.predefined.urlencode=URL Encode
 encoder.predefined.md5hash=MD5 Hash
+encoder.predefined.powershellencode=PowerShell Encode
 encoder.predefined.removewhitespace=Remove Whitespace
 encoder.predefined.reverse=Reverse
 encoder.predefined.sha1hash=SHA1 Hash

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/PowerShellEncoderUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/PowerShellEncoderUnitTest.java
@@ -1,0 +1,44 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors.predefined;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
+
+class PowerShellEncoderUnitTest extends ProcessorTests<PowerShellEncoder> {
+
+    @Override
+    protected PowerShellEncoder createProcessor() {
+        return PowerShellEncoder.getSingleton();
+    }
+
+    @Test
+    void shouldEncodeSimpleString() throws Exception {
+        // Given / When
+        EncodeDecodeResult result = processor.process("admin");
+        // Then
+        assertThat(result.hasError(), is(equalTo(false)));
+        assertThat(result.getResult(), is(equalTo("YQBkAG0AaQBuAA==")));
+    }
+}


### PR DESCRIPTION
Based on tweets and the idea/details from hackvertor/hackvertor#71.

- CHANGELOG.md > Add note.
- EncodeDecodeProcessors > Register the new processor.
- encoder.html > Add help content and code examples.
- Messages.properties > Add key/value pair for the name.
- PowerShellEncoder > New encoder.
- PowerShellEncoderUnitTest > Unit Test for the new encoder.