### PR TITLE
AJAX Spider: AF Job in scope only

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Automation Framework - inScopeOnly option
+
 ### Changed
 - Add default Allowed Resources if none present in existing home directory when updating the add-on (Issue 7719).
 

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
@@ -61,6 +61,7 @@ public class AjaxSpiderJob extends AutomationJob {
     private static final String PARAM_CONTEXT = "context";
     private static final String PARAM_URL = "url";
     private static final String PARAM_USER = "user";
+    private static final String PARAM_IN_SCOPE_ONLY = "inScopeOnly";
     private static final String PARAM_ONLY_RUN_IF_MODERN = "runOnlyIfModern";
     private static final String PARAM_FAIL_IF_LESS_URLS = "failIfFoundUrlsLessThan";
     private static final String PARAM_WARN_IF_LESS_URLS = "warnIfFoundUrlsLessThan";
@@ -68,8 +69,6 @@ public class AjaxSpiderJob extends AutomationJob {
     private static final int MODERN_WEB_DETECTION_RULE_ID = 10109;
 
     private ExtensionAjax extSpider;
-
-    private boolean inScopeOnly = true;
 
     private Data data;
     private Parameters parameters = new Parameters();
@@ -118,6 +117,7 @@ public class AjaxSpiderJob extends AutomationJob {
                     PARAM_CONTEXT,
                     PARAM_URL,
                     PARAM_USER,
+                    PARAM_IN_SCOPE_ONLY,
                     PARAM_ONLY_RUN_IF_MODERN,
                     PARAM_FAIL_IF_LESS_URLS,
                     PARAM_WARN_IF_LESS_URLS
@@ -211,7 +211,7 @@ public class AjaxSpiderJob extends AutomationJob {
                 AjaxSpiderTarget.newBuilder(Model.getSingleton().getSession())
                         .setContext(context.getContext())
                         .setUser(user)
-                        .setInScopeOnly(inScopeOnly)
+                        .setInScopeOnly(JobUtils.unBox(this.getParameters().getInScopeOnly()))
                         .setOptions(getExtSpider().getAjaxSpiderParam())
                         .setStartUri(uri)
                         .setSubtreeOnly(false);
@@ -277,16 +277,6 @@ public class AjaxSpiderJob extends AutomationJob {
             default:
                 return false;
         }
-    }
-
-    /**
-     * Sets whether the ajax spider should only load URLs that are in scope - only intended to use
-     * for testing
-     *
-     * @param inScopeOnly whether the ajax spider should only load URLs that are in scope
-     */
-    protected void setInScopeOnly(boolean inScopeOnly) {
-        this.inScopeOnly = inScopeOnly;
     }
 
     @Override
@@ -410,6 +400,7 @@ public class AjaxSpiderJob extends AutomationJob {
         private Boolean clickDefaultElems;
         private Boolean clickElemsOnce;
         private Boolean randomInputs;
+        private Boolean inScopeOnly = Boolean.TRUE;
 
         private Boolean runOnlyIfModern;
 
@@ -511,6 +502,14 @@ public class AjaxSpiderJob extends AutomationJob {
 
         public void setRandomInputs(Boolean randomInputs) {
             this.randomInputs = randomInputs;
+        }
+
+        public Boolean getInScopeOnly() {
+            return inScopeOnly;
+        }
+
+        public void setInScopeOnly(Boolean inScopeOnly) {
+            this.inScopeOnly = inScopeOnly;
         }
 
         public Integer getReloadWait() {

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobDialog.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobDialog.java
@@ -54,6 +54,8 @@ public class AjaxSpiderJobDialog extends StandardFieldsDialog {
             "spiderajax.automation.dialog.ajaxspider.maxcrawldepth";
     private static final String NUM_BROWSERS_PARAM =
             "spiderajax.automation.dialog.ajaxspider.numbrowsers";
+    private static final String IN_SCOPE_ONLY =
+            "spiderajax.automation.dialog.ajaxspider.inScopeOnly";
     private static final String ONLY_IF_MODERN =
             "spiderajax.automation.dialog.ajaxspider.runOnlyIfModern";
     private static final String FIELD_ADVANCED = "spiderajax.automation.dialog.ajaxspider.advanced";
@@ -118,6 +120,8 @@ public class AjaxSpiderJobDialog extends StandardFieldsDialog {
                 1,
                 Integer.MAX_VALUE,
                 JobUtils.unBox(this.job.getParameters().getNumberOfBrowsers()));
+        this.addCheckBoxField(
+                0, IN_SCOPE_ONLY, JobUtils.unBox(this.job.getParameters().getInScopeOnly()));
         this.addCheckBoxField(
                 0, ONLY_IF_MODERN, JobUtils.unBox(this.job.getParameters().getRunOnlyIfModern()));
         this.addCheckBoxField(0, FIELD_ADVANCED, advOptionsSet());
@@ -215,6 +219,7 @@ public class AjaxSpiderJobDialog extends StandardFieldsDialog {
         this.job.getParameters().setMaxDuration(this.getIntValue(MAX_DURATION_PARAM));
         this.job.getParameters().setMaxCrawlDepth(this.getIntValue(MAX_CRAWL_DEPTH_PARAM));
         this.job.getParameters().setNumberOfBrowsers(this.getIntValue(NUM_BROWSERS_PARAM));
+        this.job.getParameters().setInScopeOnly(this.getBoolValue(IN_SCOPE_ONLY));
         this.job.getParameters().setRunOnlyIfModern(this.getBoolValue(ONLY_IF_MODERN));
 
         if (this.getBoolValue(FIELD_ADVANCED)) {

--- a/addOns/spiderAjax/src/main/javahelp/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/automation.html
+++ b/addOns/spiderAjax/src/main/javahelp/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/automation.html
@@ -25,6 +25,7 @@ This job supports monitor tests.
       maxCrawlDepth:                   # Int: The max depth that the crawler can reach, default: 10, 0 is unlimited
       numberOfBrowsers:                # Int: The number of browsers the spider will use, more will be faster but will use up more memory, default: 1
       runOnlyIfModern:                 # Boolean: If true then the spider will only run if a "modern app" alert is raised, default: false
+      inScopeOnly:                     # Boolean: If true then any URLs requested which are out of scope will be ignored, default: true
       browserId:                       # String: Browser Id to use, default: firefox-headless
       clickDefaultElems:               # Bool: When enabled only click the default element: 'a', 'button' and input, default: true
       clickElemsOnce:                  # Bool: When enabled only click each element once, default: true

--- a/addOns/spiderAjax/src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
+++ b/addOns/spiderAjax/src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
@@ -76,6 +76,7 @@ spiderajax.automation.dialog.ajaxspider.url = URL:
 spiderajax.automation.dialog.ajaxspider.maxduration = Max Duration (in mins):
 spiderajax.automation.dialog.ajaxspider.maxcrawldepth = Max Crawl Depth:
 spiderajax.automation.dialog.ajaxspider.numbrowsers = Number Of Browsers:
+spiderajax.automation.dialog.ajaxspider.inScopeOnly = Just In Scope:
 spiderajax.automation.dialog.ajaxspider.runOnlyIfModern = Run Only If Modern:
 spiderajax.automation.dialog.ajaxspider.advanced = Show Advanced Options:
 

--- a/addOns/spiderAjax/src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/spiderAjax-max.yaml
+++ b/addOns/spiderAjax/src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/spiderAjax-max.yaml
@@ -6,6 +6,7 @@
       maxCrawlDepth:                   # Int: The max depth that the crawler can reach, default: 10, 0 is unlimited
       numberOfBrowsers:                # Int: The number of browsers the spider will use, more will be faster but will use up more memory, default: 1
       runOnlyIfModern:                 # Boolean: If true then the spider will only run if a "modern app" alert is raised, default: false
+      inScopeOnly:                     # Boolean: If true then any URLs requested which are out of scope will be ignored, default: true
       browserId:                       # String: Browser Id to use, default: firefox-headless
       clickDefaultElems:               # Bool: When enabled only click the default element: 'a', 'button' and input, default: true
       clickElemsOnce:                  # Bool: When enabled only click each element once, default: true

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
@@ -191,7 +191,7 @@ class AjaxSpiderJobUnitTest {
         given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
 
         AjaxSpiderJob job = new AjaxSpiderJob();
-        job.setInScopeOnly(false);
+        job.getParameters().setInScopeOnly(false);
 
         // When
         job.runJob(env, progress);
@@ -362,7 +362,7 @@ class AjaxSpiderJobUnitTest {
         given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
 
         AjaxSpiderJob job = new AjaxSpiderJob();
-        job.setInScopeOnly(false);
+        job.getParameters().setInScopeOnly(false);
 
         // When
         job.applyCustomParameter("maxDuration", "1");
@@ -386,7 +386,7 @@ class AjaxSpiderJobUnitTest {
         AutomationProgress progress = new AutomationProgress();
 
         AjaxSpiderJob job = new AjaxSpiderJob();
-        job.setInScopeOnly(false);
+        job.getParameters().setInScopeOnly(false);
 
         // When
         job.addTest(


### PR DESCRIPTION
Expose inScopeOnly option in the AJAX Spider AF job.