### PR TITLE
Spider: Fix spurious AF user error

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for parsing .DS_Store files to find paths to try (Issue 30).
 
+### Fixed
+- Spurious error message on setting user in AF job.
+
 ## [0.2.0] - 2023-01-03
 ### Changed
 - Maintenance changes.

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJob.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJob.java
@@ -65,6 +65,7 @@ public class SpiderJob extends AutomationJob {
 
     private static final String PARAM_CONTEXT = "context";
     private static final String PARAM_URL = "url";
+    private static final String PARAM_USER = "user";
     private static final String PARAM_FAIL_IF_LESS_URLS = "failIfFoundUrlsLessThan";
     private static final String PARAM_WARN_IF_LESS_URLS = "warnIfFoundUrlsLessThan";
 
@@ -145,7 +146,11 @@ public class SpiderJob extends AutomationJob {
                 JobUtils.getJobOptions(this, progress),
                 this.getName(),
                 new String[] {
-                    PARAM_CONTEXT, PARAM_URL, PARAM_FAIL_IF_LESS_URLS, PARAM_WARN_IF_LESS_URLS
+                    PARAM_CONTEXT,
+                    PARAM_URL,
+                    PARAM_USER,
+                    PARAM_FAIL_IF_LESS_URLS,
+                    PARAM_WARN_IF_LESS_URLS
                 },
                 progress,
                 this.getPlan().getEnv());

--- a/addOns/spider/src/main/resources/org/zaproxy/addon/spider/resources/Messages.properties
+++ b/addOns/spider/src/main/resources/org/zaproxy/addon/spider/resources/Messages.properties
@@ -150,6 +150,7 @@ spider.automation.dialog.parsegit = Parse GIT:
 spider.automation.dialog.parserobots = Parse Robots.txt:
 spider.automation.dialog.parsesitemap = Parse Sitemap:
 spider.automation.dialog.parsessvn = Parse SVN:
+spider.automation.dialog.parsedsstore = Parse .DS_Store:
 
 spider.automation.dialog.postform = Post Forms:
 spider.automation.dialog.processform = Process Forms:


### PR DESCRIPTION
The error is logged but not reported via the AF, so not easy to add tests for.
Also added a missing i18n string.