### PR TITLE
automation: correct path resolution with env vars

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+### Fixed
+- Added fix for resolving fileName in import job when fileName is provided in an environment variable
+
 ## [0.24.0] - 2023-02-09
 ### Added
 - Support for relative file paths and ones including vars.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -633,7 +633,7 @@ public class JobUtils {
         String nameWithVars = plan.getEnv().replaceVars(name);
         File f;
 
-        if (planFile != null && !Paths.get(name).isAbsolute()) {
+        if (planFile != null && !Paths.get(nameWithVars).isAbsolute()) {
             f = new File(planFile.getParentFile(), nameWithVars);
         } else {
             f = new File(nameWithVars);


### PR DESCRIPTION
Fixed an issue where Automation framework is unable to load request files that have absolute path when request files are passed as environment variables. 

Details of the issue are available in this slack thread. https://owasp.slack.com/archives/C04SX2GAS/p1676893033077719