### PR TITLE
pscanrules: ignore RateLimit headers in Timestamp Disclosure

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Will now only consider PDFs at Low threshold.
 - Maintenance changes.
 - The HeartBleed scan rule alert now includes a CVE tag.
+- Timestamp Disclosure scan rule now excludes values in "RateLimit-Reset", "X-RateLimit-Reset", and "X-Rate-Limit-Reset" headers (Issue 7747).
 
 ## [45] - 2023-01-03
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -107,7 +107,10 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
         "Strict-Transport-Security",
         "Report-To",
         "NEL",
-        "Expect-CT"
+        "Expect-CT",
+        "RateLimit-Reset",
+        "X-RateLimit-Reset",
+        "X-Rate-Limit-Reset"
     };
 
     /**

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -82,7 +82,7 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
         List<String> ignoreList =
                 Arrays.asList(TimestampDisclosureScanRule.RESPONSE_HEADERS_TO_IGNORE);
         // Then
-        assertEquals(8, ignoreList.size());
+        assertEquals(11, ignoreList.size());
     }
 
     private static Stream<Arguments> headersToIgnoreSource() {


### PR DESCRIPTION
Ignore:
* "RateLimit-Reset"
* "X-RateLimit-Reset"
* "X-Rate-Limit-Reset"

Fixes zaproxy/zaproxy#7747