### PR TITLE
network: Add CRLDistributionPoint attribute option for generated certificates

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- Allow to add a CRL Distribution Point in generated server certificates.
 - On weekly releases and versions after 2.12 allow to manage global exclusions, supersedes core functionality.
 
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptions.java
@@ -81,11 +81,15 @@ public class ServerCertificatesOptions extends VersionedAbstractParam {
     private static final String SERVER_BASE_KEY = BASE_KEY + ".server.";
     private static final String SERVER_CERT_VALIDITY_DAYS = SERVER_BASE_KEY + "certValidityDays";
 
+    private static final String SERVER_CERT_CDP = SERVER_BASE_KEY + "crlDistributionPoint";
+
     private KeyStore rootCaKeyStore;
     private Duration rootCaCertValidity = Duration.ofDays(DEFAULT_ROOT_CA_CERT_VALIDITY);
     private CertConfig rootCaCertConfig = new CertConfig(rootCaCertValidity);
 
     private Duration serverCertValidity = Duration.ofDays(DEFAULT_SERVER_CERT_VALIDITY);
+    private String serverCrlDistributionPoint;
+
     private CertConfig serverCertConfig = new CertConfig(serverCertValidity);
 
     @Override
@@ -116,7 +120,12 @@ public class ServerCertificatesOptions extends VersionedAbstractParam {
             validity = DEFAULT_SERVER_CERT_VALIDITY;
         }
         serverCertValidity = Duration.ofDays(validity);
-        serverCertConfig = new CertConfig(serverCertValidity);
+        serverCrlDistributionPoint = getString(SERVER_CERT_CDP, null);
+        refreshServerCertConfig();
+    }
+
+    private void refreshServerCertConfig() {
+        serverCertConfig = new CertConfig(serverCertValidity, serverCrlDistributionPoint);
     }
 
     private void migrateCoreConfig() {
@@ -242,7 +251,28 @@ public class ServerCertificatesOptions extends VersionedAbstractParam {
         getConfig().setProperty(SERVER_CERT_VALIDITY_DAYS, days);
 
         serverCertValidity = validity;
-        serverCertConfig = new CertConfig(serverCertValidity);
+        refreshServerCertConfig();
+    }
+
+    /**
+     * Gets the CDP of the server certificate.
+     *
+     * @return the URL.
+     */
+    public String getServerCrlDistributionPoint() {
+        return serverCrlDistributionPoint;
+    }
+
+    /**
+     * Sets the URL for the Certificate Revocation List of the server certificates.
+     *
+     * @param crlDistributionPoint CRL Distribution Point URL.
+     */
+    public void setServerCrlDistributionPoint(String crlDistributionPoint) {
+        getConfig().setProperty(SERVER_CERT_CDP, crlDistributionPoint);
+
+        serverCrlDistributionPoint = crlDistributionPoint;
+        refreshServerCertConfig();
     }
 
     /**

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptionsPanel.java
@@ -52,6 +52,7 @@ import org.zaproxy.addon.network.internal.cert.CertificateUtils;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
+import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
@@ -514,6 +515,7 @@ class ServerCertificatesOptionsPanel extends AbstractParamPanel {
     private static class IssuedCertificatesPanel {
 
         private final ZapNumberSpinner numberSpinnerValidity;
+        private final ZapTextField cdpTextField;
 
         private final JPanel panel;
 
@@ -527,6 +529,14 @@ class ServerCertificatesOptionsPanel extends AbstractParamPanel {
                             1,
                             ServerCertificatesOptions.DEFAULT_SERVER_CERT_VALIDITY,
                             ServerCertificatesOptions.DEFAULT_SERVER_CERT_VALIDITY * 10);
+            labelValidity.setLabelFor(numberSpinnerValidity);
+
+            cdpTextField = new ZapTextField();
+            JLabel labelCdp =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.servercertificates.field.crldistpoint"));
+            labelCdp.setLabelFor(cdpTextField);
 
             panel = new JPanel();
             GroupLayout layout = new GroupLayout(panel);
@@ -536,16 +546,29 @@ class ServerCertificatesOptionsPanel extends AbstractParamPanel {
 
             layout.setHorizontalGroup(
                     layout.createSequentialGroup()
-                            .addComponent(labelValidity)
-                            .addComponent(numberSpinnerValidity));
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
+                                            .addComponent(labelValidity)
+                                            .addComponent(labelCdp))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                            .addComponent(numberSpinnerValidity)
+                                            .addComponent(cdpTextField)));
+
             layout.setVerticalGroup(
-                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                            .addComponent(labelValidity)
-                            .addComponent(
-                                    numberSpinnerValidity,
-                                    GroupLayout.PREFERRED_SIZE,
-                                    GroupLayout.PREFERRED_SIZE,
-                                    GroupLayout.PREFERRED_SIZE));
+                    layout.createSequentialGroup()
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(labelValidity)
+                                            .addComponent(
+                                                    numberSpinnerValidity,
+                                                    GroupLayout.PREFERRED_SIZE,
+                                                    GroupLayout.PREFERRED_SIZE,
+                                                    GroupLayout.PREFERRED_SIZE))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(labelCdp)
+                                            .addComponent(cdpTextField)));
         }
 
         JPanel getPanel() {
@@ -554,10 +577,13 @@ class ServerCertificatesOptionsPanel extends AbstractParamPanel {
 
         void init(ServerCertificatesOptions options) {
             numberSpinnerValidity.setValue(options.getServerCertValidity().toDays());
+            cdpTextField.setText(options.getServerCrlDistributionPoint());
+            cdpTextField.discardAllEdits();
         }
 
         void save(ServerCertificatesOptions options) {
             options.setServerCertValidity(createValidity(numberSpinnerValidity));
+            options.setServerCrlDistributionPoint(cdpTextField.getText());
         }
     }
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertConfig.java
@@ -21,11 +21,13 @@ package org.zaproxy.addon.network.internal.cert;
 
 import java.time.Duration;
 import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
 
 /** Configuration to generate certificates. */
 public class CertConfig {
 
     private Duration validity;
+    private String crlDistributionPoint;
 
     /**
      * Constructs a {@code CertConfig} with the given validity.
@@ -34,7 +36,20 @@ public class CertConfig {
      * @throws NullPointerException if the given validity is {@code null}.
      */
     public CertConfig(Duration validity) {
+        this(validity, null);
+    }
+
+    /**
+     * Constructs a {@code CertConfig} with the given validity and CRL distribution point.
+     *
+     * @param validity the validity duration.
+     * @param crlDistributionPoint the URL for the CRL.
+     * @throws NullPointerException if the given validity is {@code null}.
+     */
+    public CertConfig(Duration validity, String crlDistributionPoint) {
         this.validity = Objects.requireNonNull(validity);
+        this.crlDistributionPoint =
+                StringUtils.isBlank(crlDistributionPoint) ? null : crlDistributionPoint;
     }
 
     /**
@@ -44,5 +59,14 @@ public class CertConfig {
      */
     public Duration getValidity() {
         return validity;
+    }
+
+    /**
+     * The URL for the Certificate Revocation List Distribution Point.
+     *
+     * @return the URL, or {@code null} if none.
+     */
+    public String getCrlDistributionPoint() {
+        return crlDistributionPoint;
     }
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
@@ -48,16 +48,22 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.CRLDistPoint;
+import org.bouncycastle.asn1.x509.DistributionPoint;
+import org.bouncycastle.asn1.x509.DistributionPointName;
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
@@ -308,6 +314,17 @@ public final class CertificateUtils {
                     Extension.subjectAlternativeName,
                     certData.isSubjectAlternativeNameIsCritical(),
                     new GeneralNames(subjectAlternativeNames));
+        }
+
+        if (config.getCrlDistributionPoint() != null) {
+            GeneralName gn = new GeneralName(6, new DERIA5String(config.getCrlDistributionPoint()));
+            GeneralNames gns = new GeneralNames(gn);
+            DistributionPointName dpn = new DistributionPointName(0, gns);
+            List<DistributionPoint> l = new ArrayList<>();
+            l.add(new DistributionPoint(dpn, null, null));
+            CRLDistPoint crlDistPoint = new CRLDistPoint(l.toArray(new DistributionPoint[0]));
+
+            certGen.addExtension(Extension.cRLDistributionPoints, false, crlDistPoint);
         }
 
         X509Certificate certificate = createCertificate(rootCaPrivateKey, certGen);

--- a/addOns/network/src/main/javahelp/help/contents/options/servercertificates.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/servercertificates.html
@@ -203,6 +203,41 @@
 		</i>.
 	</p>
 
+	<h3>CRL Distribution Point</h3>
+	<p>
+		Sometimes, a valid certificate is not enough to have a working TLS MITM.
+		For example, <code>libcurl</code> on Windows uses <code>schannel</code> as its backend,
+		which by default will check if a valid Certificate Revocation List Distribution Point
+		is provided in the certificate, and try to contact and retrieve this CRL.
+		If you're lucky the binary is verbose, and the error message will be clear enough :
+	</p>
+
+	<p style="padding-left: 20pt;">
+		<code>
+			PS C:\Users\alice> curl.exe https://ifconfig.me/<br>
+			curl: (35) schannel: next InitializeSecurityContext failed: Unknown error (0x80092012) - The revocation function was unable to check revocation for the certificate.<br>
+		</code>
+	</p>
+	<p>
+		This may also manifest as a TLS Handshake Failure at the network level :
+	</p>
+
+	<p style="padding-left: 20pt;">
+		<code>
+			6    0.023470    192.168.56.104    1.2.3.4    TLSv1.2    273    Client Hello<br>
+			8    0.033465    1.2.3.4    192.168.56.104    TLSv1.2    144    Server Hello<br>
+		 11    0.033875    1.2.3.4    192.168.56.104    TLSv1.2    527    Certificate<br>
+		 13    0.084581    1.2.3.4    192.168.56.104    TLSv1.2    401    Server Key Exchange, Server Hello Done<br>
+		 16    0.158961    1.2.3.4    192.168.56.104    TLSv1.2    61    Alert (Level: Fatal, Description: Handshake Failure)<br>
+		</code>
+	</p>
+	<p>
+		This option enables you to specify a CRL Distribution Point that will be added in each of the generated certificates.
+		Obviously, you need to create a custom Root Certificate Authority, using for example <a href="https://github.com/kaysond/spki">https://github.com/kaysond/spki</a>,
+		a wrapper for OpenSSL that generates and manages a simple PKI suitable for small deployments, support CRLs and OCSP, and make the CRL available to the victim client,
+		using for example a tiny HTTP server.
+	</p>
+
 	<h2><a name="install">Install ZAP Root CA certificate</a></h2>
 	<p>
 		Any HTTPS client you want to use, has to know the OWASP Root CA certificate

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -382,6 +382,7 @@ network.ui.options.servercertificates.button.import = Import
 network.ui.options.servercertificates.button.save = Save
 network.ui.options.servercertificates.button.view = View
 network.ui.options.servercertificates.field.certvalidity = Validity in Days:
+network.ui.options.servercertificates.field.crldistpoint = CRL Dist. Point:
 network.ui.options.servercertificates.field.pem = PEM:
 network.ui.options.servercertificates.import.config.error = Failed to import Root CA certificate from the config file.\nPlease see log file for details.
 network.ui.options.servercertificates.import.config.error.title = Import Error


### PR DESCRIPTION
With some TLS Clients, valid certificates are not enough to establish a valid connection, but it may be required to provide a valid CRL Distribution Point in the generated certificate. 

A classical usecase on Windows is a binary based on libcurl, which uses schannel as backend :

```
PS C:\Users\alice> # using Invoke-webRequest is ok
PS C:\Users\alice> curl https://ifconfig.me/ | Select-Object content

Content
-------
1.2.3.4

PS C:\Users\alice> # but native curl is failing 
PS C:\Users\alice> curl.exe https://ifconfig.me/
curl: (35) schannel: next InitializeSecurityContext failed: Unknown error (0x80092012) - The revocation function was unable to check revocation for the certificate.
``` 

More information on this is available for example [here](https://github.com/curl/curl/issues/3727).

This PR add an optional parameter in Options > Network > ServerCertificates : 

![image](https://user-images.githubusercontent.com/20232176/220764471-ec5b2fd7-a334-408d-9abe-5e8f88960d15.png)

If an URL is provided in this parameter, generated certificates will then add this value in the X509v3 CRL Distribution Point :

```
openssl x509 -in ifconfig.fake.cer -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 208583969918084 (0xbdb4bd6ecc84)
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN = inter, C = US, ST = Somestate, L = Somewhere, O = Corp, OU = IT, emailAddress = jdoe@localhost.localdomain
        Validity
            Not Before: Jan 23 21:12:16 2023 GMT
            Not After : Jan 26 21:12:16 2024 GMT
        Subject: CN = ifconfig.me, OU = Zed Attack Proxy Project - Qb, O = OWASP, C = xx, emailAddress = zaproxy-develop@googlegroups.com
...
            X509v3 CRL Distribution Points: 
                Full Name:
                  URI:http://myfakecrl.com/intermediate.crl.der
```

Obviously, you need to create a custom RootCA, using for example https://github.com/kaysond/spki to manage all somewhat complex openssl commands, and import this RootCA in zaproxy. Then all you have to do is to start a tiny http server to expose the generated CRL ,  and then you can intercept the content without having to patch the binary
