### PR TITLE
Use `StringBuilder` whenever possible

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HexString.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HexString.java
@@ -30,7 +30,7 @@ class HexString {
 
     static String compile(String binaryRegex) {
         Matcher matcher = HEX_VALUE.matcher(binaryRegex);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (matcher.find()) {
             String value = matcher.group();
             if (!value.startsWith(ESCAPED_ESCAPE_CHAR)) {

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -344,7 +344,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                 // )(objectClass=*
                 // ))((objectClass=*
                 // )))(((objectClass=*
-                StringBuffer temp = new StringBuffer().append(paramvalue);
+                StringBuilder temp = new StringBuilder().append(paramvalue);
                 for (int i = 0; i < andAttackNumber; i++) temp.append(')');
                 for (int i = 0; i < andAttackNumber; i++) temp.append('(');
                 temp.append("objectClass=*");
@@ -432,8 +432,8 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
             int paramLength = paramvalue.length();
             if (paramLength > 1) {
 
-                StringBuffer temp =
-                        new StringBuffer()
+                StringBuilder temp =
+                        new StringBuilder()
                                 .append(
                                         paramvalue.substring(
                                                 0,

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Support for dynamically added header based session management method.
 
+### Changed
+- Maintenance changes.
+
 ## [0.24.0] - 2023-02-09
 ### Added
 - Support for relative file paths and ones including vars.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
@@ -153,7 +153,7 @@ public class AutomationEnvironment {
         }
         String text = value.toString();
         Matcher matcher = varPattern.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         while (matcher.find()) {
             String val = this.combinedVars.get(matcher.group(1));

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -154,7 +154,7 @@ public class BruteForceURLFuzz implements Runnable {
         int chrx;
         String temp = "";
         /* print the current index */
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (int x = 0; x < len; x++) {
 
             chrx = listindex[x];

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
@@ -209,7 +209,7 @@ public class BruteForceWorkGenerator implements Runnable {
         int chrx, endchr;
         String temp = "";
         /* print the current index */
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (int x = 0; x < len; x++) {
             chrx = listindex[x];
             // printf("%c", charlist[chrx]);

--- a/addOns/codedx/src/main/java/org/zaproxy/zap/extension/codedx/UploadPropertiesDialog.java
+++ b/addOns/codedx/src/main/java/org/zaproxy/zap/extension/codedx/UploadPropertiesDialog.java
@@ -204,7 +204,7 @@ public class UploadPropertiesDialog {
 				HttpResponse response = client.execute(get);
 				rd = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
 		
-				StringBuffer result = new StringBuffer();
+				StringBuilder result = new StringBuilder();
 				String line = "";
 				while ((line = rd.readLine()) != null) {
 					result.append(line);

--- a/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/ZapDiffRowGenerator.java
+++ b/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/ZapDiffRowGenerator.java
@@ -433,7 +433,7 @@ public class ZapDiffRowGenerator {
      if (!iter.hasNext()) {
          return "";
      }
-     StringBuffer buffer = new StringBuffer(String.valueOf(iter.next()));
+     StringBuilder buffer = new StringBuilder(String.valueOf(iter.next()));
      while (iter.hasNext()) {
          buffer.append(delimiter).append(String.valueOf(iter.next()));
      }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -138,7 +138,7 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
         LOGGER.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI());
 
         List<HttpHeaderField> responseheaders = msg.getResponseHeader().getHeaders();
-        StringBuffer filteredResponseheaders = new StringBuffer();
+        StringBuilder filteredResponseheaders = new StringBuilder();
         for (HttpHeaderField responseheader : responseheaders) {
             boolean ignoreHeader = false;
             for (String headerToIgnore : RESPONSE_HEADERS_TO_IGNORE) {
@@ -149,9 +149,11 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
                 }
             }
             if (!ignoreHeader) {
-                filteredResponseheaders.append("\n");
-                filteredResponseheaders.append(
-                        responseheader.getName() + ": " + responseheader.getValue());
+                filteredResponseheaders
+                        .append('\n')
+                        .append(responseheader.getName())
+                        .append(": ")
+                        .append(responseheader.getValue());
             }
         }
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ViewStateDecoder.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ViewStateDecoder.java
@@ -76,13 +76,13 @@ public class ViewStateDecoder {
      * @return a String (not including the NULL byte)
      */
     private static String readNullTerminatedString(ByteBuffer bb) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         byte b = bb.get();
         while (b != 0x00) {
             sb.append((char) b);
             b = bb.get();
         }
-        return new String(sb);
+        return sb.toString();
     }
 
     /**
@@ -114,13 +114,13 @@ public class ViewStateDecoder {
     }
 
     /**
-     * gets a StringBuffer containing the specified amount of indentation
+     * Gets a {@code StringBuilder} containing the specified amount of indentation.
      *
      * @param n the depth for the indentation
-     * @return a StringBuffer containing the specified amount of indentation
+     * @return a {@code StringBuilder} containing the specified amount of indentation.
      */
-    private StringBuffer getIndentation(int n) {
-        StringBuffer sb = new StringBuffer();
+    private StringBuilder getIndentation(int n) {
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < this.indentationlevel; i++) sb.append("   ");
         return sb;
     }
@@ -129,14 +129,14 @@ public class ViewStateDecoder {
      * decodes a single (ViewState-specific) object from the ByteBuffer.
      *
      * @param bb the ByteBuffer from which to read the next ViewState object
-     * @return a StringBuffer containing the human-readable and machine parseable representation
-     *     (XML based)
+     * @return a {@code StringBuilder} containing the human-readable and machine parseable
+     *     representation (XML based).
      * @throws NoMoreDataException
      * @throws Exception
      */
-    public StringBuffer decodeObjectAsXML(ByteBuffer bb) throws NoMoreDataException, Exception {
+    public StringBuilder decodeObjectAsXML(ByteBuffer bb) throws NoMoreDataException, Exception {
         int b = (int) bb.get();
-        StringBuffer representation = new StringBuffer();
+        StringBuilder representation = new StringBuilder();
         Matcher matcher = null;
         boolean malicious = false;
         switch (b) {
@@ -357,7 +357,7 @@ public class ViewStateDecoder {
             throw new Exception("Invalid Viewstate preamble");
         }
 
-        StringBuffer representation = new StringBuffer("<?xml version=\"1.0\" ?>\n");
+        StringBuilder representation = new StringBuilder("<?xml version=\"1.0\" ?>\n");
         representation.append("<viewstate>\n");
         this.indentationlevel++;
 

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/HexString.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/HexString.java
@@ -33,7 +33,7 @@ class HexString {
 
     static String compile(String binaryRegex) {
         Matcher matcher = HEX_VALUE.matcher(binaryRegex);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (matcher.find()) {
             String value = matcher.group();
             if (!value.startsWith(ESCAPED_ESCAPE_CHAR)) {

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/messagelocations/TextWebSocketMessageLocation.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/messagelocations/TextWebSocketMessageLocation.java
@@ -65,7 +65,7 @@ public class TextWebSocketMessageLocation implements WebSocketMessageLocation {
 
     @Override
     public String getDescription() {
-        StringBuffer description = new StringBuffer(25);
+        StringBuilder description = new StringBuilder(25);
         description.append(Constant.messages.getString("websocket.messagelocation.text.location"));
 
         description.append(" [").append(start);


### PR DESCRIPTION
Replace usage of `StringBuffer` with `StringBuilder` where the synchronisation of the former is not required.