### PR TITLE
commonlib: ComparableResponse handles JSONArrays without exception

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Comparable Response functionality is now more robust and doesn't fail when processing types other than JSON Object (Issue 7736).
 
 ## [1.13.0] - 2023-02-03
 ### Changed


### PR DESCRIPTION
- CHANGELOG.md > Add change note.
- ComparableResponse > Handle JSONArray.
- ComparableResponseUnitTest > Ensure JSONArrays are handled without throwing an exception.

Fixes zaproxy/zaproxy#7736