### PR TITLE
spiderAjax: close scan dialogue on uninstallation

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Close the AJAX Spider dialogue when uninstalling the add-on.
 
 ## [23.12.0] - 2023-02-23
 ### Added

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -139,6 +139,10 @@ public class ExtensionAjax extends ExtensionAdaptor {
                     .getMainFooterPanel()
                     .removeFooterToolbarRightLabel(
                             getSpiderPanel().getScanStatus().getCountLabel());
+
+            if (spiderDialog != null) {
+                spiderDialog.dispose();
+            }
         }
 
         super.unload();


### PR DESCRIPTION
Dispose of the scan dialogue when the extension is unloaded to not keep it open after the add-on is uninstalled.