### PR TITLE
GraphQl: dont report errors parsing valid JSON

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Do not report errors parsing valid JSON arrays.
 
 ## [0.13.0] - 2023-02-09
 ### Added

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -75,4 +75,5 @@ dependencies {
     testImplementation(parent!!.childProjects.get("formhandler")!!)
     testImplementation(parent!!.childProjects.get("spider")!!)
     testImplementation(project(":testutils"))
+    testImplementation("org.apache.logging.log4j:log4j-core:2.19.0")
 }


### PR DESCRIPTION
I'm testing a site that has APIs which all seem to return JSON Arrays.
The logging is not just annoying - its INFO level and I'm getting so many that its seriously impacting performance :/
If its not an error or warning then it should be logged at debug level, especially for variants which get invoked so many times.