### PR TITLE
pscanrules: update minimum commonlib version

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct required version of Common Library add-on.
 
 ## [46] - 2023-03-03
 ### Changed

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.10.0 & < 2.0.0")
+                    version.set(">= 1.13.0 & < 2.0.0")
                 }
             }
         }


### PR DESCRIPTION
Require 1.13.0 as minimum, the `HeartBleedScanRule` scan rule requires that version.

Noticed while working on zaproxy/zaproxy#7765.
It would lead to an exception when installing the add-on, e.g.:
```
ERROR AddOnLoaderUtils - Failed to initialise: HeartBleedScanRule
java.lang.NoSuchMethodError: 'void CommonAlertTag.putCve(Map, String)'
    at HeartBleedScanRule.<clinit>(HeartBleedScanRule.java:76) ~[?:?]
…
```