### PR TITLE
quickstart: wait for news fetch before unload

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Show correct error message when unable to access the provided URL, also, add the scheme if none provided.
+- Ensure the add-on is not in use before uninstalling.
 
 ## [36] - 2023-01-03
 ### Fixed


### PR DESCRIPTION
Wait for the news fetch to complete before unloading the extension, otherwise it could lead to an exception during the update.
Also, avoid further processing the news if there's no view.

Noticed while working on zaproxy/zaproxy#7765. e.g.:
```
ERROR UncaughtExceptionLogger - Exception in thread "ZAP-NewsFetcher"
NoClassDefFoundError: org/zaproxy/zap/extension/quickstart/NewsItem
    atExtensionQuickStart$1.run(ExtensionQuickStart.java:172) ~[?:?]
…
```