### PR TITLE
ascanrulesBeta: PUT/PATCH not insecure methods if returning JSON/XML data 

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- The Insecure HTTP Method Scan rule now allows PUT/PATCH methods, if they return JSON or XML data in response (Issue 7772).
 
 ## [45] - 2023-03-03
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
@@ -580,6 +580,11 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
         LOGGER.debug("Request Method: {}", httpMethod);
         LOGGER.debug("Response Code: {}", responseCode);
 
+        if ((httpMethod.equals(HttpRequestHeader.PUT) || httpMethod.equals(HttpRequestHeader.PATCH))
+                && (msg.getResponseHeader().isJson() || msg.getResponseHeader().isXml())) {
+            return;
+        }
+
         if (isPage200(msg) || responseCode == HttpStatusCode.CREATED) {
             evidence =
                     Constant.messages.getString(

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -85,7 +85,7 @@ There are difference in treatment of duplicate parameters impacting both clients
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java">HttpParameterPollutionScanRule.java</a> 
 
 <H2>Insecure HTTP Method</H2>
-Detects (and exploits, depending on the scan settings) known insecure HTTP methods enabled for the URL.
+Detects (and exploits, depending on the scan settings) known insecure HTTP methods enabled for the URL. It considers PUT/PATCH as insecure methods by default, but allows them if they return structured data like JSON or XML in response.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java">InsecureHttpMethodScanRule.java</a>
 


### PR DESCRIPTION
Fixes: Issue - https://github.com/zaproxy/zaproxy/issues/7772

Signed-off-by: Sparsh Sethi sparshsethi15@gmail.com