### PR TITLE
reports: fix typo in template ID and provide IDs

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -8,8 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - The Traditional JSON report, Traditional JSON Report with requests and responses, Traditional XML Report and Traditional XML Report with requests and responses now has "otherinfo" field per alert instance (Issue 7260).
 
+### Changed
+- Include templates available when reporting invalid template in the automation job.
+
 ### Deprecated
 - The "otherinfo" field in the alert will be removed and replaced by the "otherinfo" field in the alert instances.
+
+### Fixed
+- Correct ID of Markdown template listed in the help page.
 
 ## [0.19.0] - 2023-02-09
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -33,11 +33,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -603,9 +605,23 @@ public class ExtensionReports extends ExtensionAdaptor {
     }
 
     public List<String> getTemplateNames() {
-        return this.getTemplateMap().values().stream()
-                .map(Template::getDisplayName)
-                .collect(Collectors.toList());
+        return mapTemplates(Template::getDisplayName);
+    }
+
+    private List<String> mapTemplates(Function<Template, String> mapper) {
+        return getTemplateMap().values().stream().map(mapper).collect(Collectors.toList());
+    }
+
+    /**
+     * Gets the config names of the templates, in alphabetic order.
+     *
+     * @return the config names.
+     * @since 0.20.0
+     */
+    public List<String> getTemplateConfigNames() {
+        List<String> names = mapTemplates(Template::getConfigName);
+        Collections.sort(names);
+        return names;
     }
 
     public Template getTemplateByDisplayName(String name) {

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -103,7 +103,8 @@ public class ReportJob extends AutomationJob {
                     Constant.messages.getString(
                             "reports.automation.error.badtemplate",
                             this.getName(),
-                            this.getParameters().getTemplate()));
+                            getParameters().getTemplate(),
+                            getExtReport().getTemplateConfigNames()));
         }
         if (StringUtils.isEmpty(this.getParameters().getReportDir())) {
             this.getParameters().setReportDir(System.getProperty("user.home"));

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/templates.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/templates.html
@@ -83,7 +83,7 @@
 		<tr>
 			<td valign="top"><a href="report-traditional-markdown.html">Traditional
 					Markdown Report</a></td>
-			<td valign="top">traditional-markdown</td>
+			<td valign="top">traditional-md</td>
 			<td valign="top">Markdown</td>
 			<td valign="top">Yes</td>
 			<td valign="top"></td>

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
@@ -38,7 +38,7 @@ reports.automation.error.badconf = Job {0} invalid confidence: {1}
 reports.automation.error.badrisk = Job {0} invalid risk: {1}
 reports.automation.error.badsection = Job {0} invalid section {1} for template {2}, valid sections: {3}
 reports.automation.error.badsummaryfile = Job {0} failed to create summary file: {1}
-reports.automation.error.badtemplate = Job {0} invalid template: {1}
+reports.automation.error.badtemplate = Job {0} invalid template: {1}, valid templates: {2}
 
 reports.automation.dialog.summary = Template: {0}
 reports.automation.dialog.title = Report Job


### PR DESCRIPTION
Change `ReportJob` to provide the IDs of the templates available.
Fix typo in template ID listed in the help page.

---
Reported in OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/jlnKmkwG47A/m/_zYrvtVTAAAJ