### PR TITLE
exim: log cause of HAR import error

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Log cause of error when failed to import the HAR file.
 
 ## [0.4.0] - 2023-02-09
 ### Added

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -127,6 +127,7 @@ public class HarImporter {
             LOGGER.warn(
                     Constant.messages.getString(
                             ExtensionExim.EXIM_OUTPUT_ERROR, file.getAbsolutePath()));
+            LOGGER.warn(e);
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_ERROR);
             success = false;
         }


### PR DESCRIPTION
Log the exception message when failed to import the HAR file, to make it easier to know and potentially fix the problem.