### PR TITLE
scripts: do not require name when adding file

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Do not require a name if file provided when adding script with automation job.
 
 ## [36] - 2023-03-17
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/AddScriptAction.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/AddScriptAction.java
@@ -88,7 +88,9 @@ public class AddScriptAction extends ScriptAction {
                 progress.error(issue);
             }
         }
-        if (StringUtils.isEmpty(params.getName())) {
+
+        boolean inlined = !StringUtils.isEmpty(inline);
+        if (inlined && StringUtils.isEmpty(params.getName())) {
             issue = Constant.messages.getString("scripts.automation.error.name.missing", jobName);
             list.add(issue);
             if (progress != null) {
@@ -96,7 +98,7 @@ public class AddScriptAction extends ScriptAction {
             }
         }
 
-        if (!StringUtils.isEmpty(inline)) {
+        if (inlined) {
             if (!StringUtils.isEmpty(filename)) {
                 issue =
                         Constant.messages.getString(

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/ScriptJobUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/ScriptJobUnitTest.java
@@ -549,7 +549,7 @@ class ScriptJobUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldFailToAddIfNoName() throws IOException {
+    void shouldNotFailToAddIfScriptFileAndNoName() throws IOException {
         // Given
         AutomationPlan plan = new AutomationPlan();
         given(extScript.getEngineWrapper(TEST_JS_ENGINE)).willReturn(engineWrapper);
@@ -567,6 +567,36 @@ class ScriptJobUnitTest extends TestUtils {
                         "  type: \"standalone\"",
                         "  engine: " + TEST_JS_ENGINE,
                         "  file: " + f.getAbsolutePath());
+        setJobData(job, yamlStr);
+        job.setPlan(plan);
+        env.setPlan(plan);
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldFailToAddIfInlineAndNoName() {
+        // Given
+        AutomationPlan plan = new AutomationPlan();
+        given(extScript.getEngineWrapper(TEST_JS_ENGINE)).willReturn(engineWrapper);
+        Collection<ScriptType> types =
+                new ArrayList<>(Arrays.asList(new ScriptType("standalone", null, null, false)));
+        given(extScript.getScriptTypes()).willReturn(types);
+
+        ScriptJob job = new ScriptJob();
+        String yamlStr =
+                String.join(
+                        "\n",
+                        "parameters:",
+                        "  action: add",
+                        "  type: \"standalone\"",
+                        "  engine: " + TEST_JS_ENGINE,
+                        "  inline: print(\"A\")");
         setJobData(job, yamlStr);
         job.setPlan(plan);
         env.setPlan(plan);


### PR DESCRIPTION
Change `AddScriptAction` to not require the name when adding a script from a file, it falls back to the file name.

---
Noticed in zapbot's scans, e.g.:
https://github.com/zapbot/zap-mgmt-scripts/actions/runs/4453577519/jobs/7822193859#step:4:128