### PR TITLE
requester: allow to read HTTP/2 trailing headers

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Allow to read HTTP/2 trailing headers.
+
 ## [7.1.0] - 2022-12-19
 ### Added
 - Find control in footer

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/HttpPanelSender.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/HttpPanelSender.java
@@ -23,7 +23,8 @@ import java.awt.EventQueue;
 import java.awt.event.ItemEvent;
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import javax.net.ssl.SSLException;
 import javax.swing.JToggleButton;
 import org.apache.commons.httpclient.URI;
@@ -93,8 +94,9 @@ public class HttpPanelSender {
         // Reset the user before sending (e.g. Forced User mode sets the user, if needed).
         httpMessage.setRequestingUser(null);
 
-        httpMessage.setUserObject(
-                Collections.singletonMap("connection.manual.persistent", Boolean.TRUE));
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("connection.manual.persistent", Boolean.TRUE);
+        httpMessage.setUserObject(properties);
 
         if (getButtonFixContentLength().isSelected()) {
             HttpPanelViewModelUtils.updateRequestContentLength(httpMessage);


### PR DESCRIPTION
Use a mutable map for the message properties.

---
Reported in IRC.