### PR TITLE
network: improve desc of command line args

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fallback to HTTP/1.1 in the main proxy if the client does not negotiate a protocol (ALPN) (Issue 7699).
 - Read all main proxy configurations (`-config`) available, even if they don't include an address.
 - Increase buffer used to read the HTTP body, to make reads more efficient.
+- Clarify the description of command line arguments `-host` and `-port`.
 
 ### Fixed
 - Ensure the whole HTTP response is delivered to the client before closing the connection.

--- a/addOns/network/src/main/javahelp/help/contents/cmdline.html
+++ b/addOns/network/src/main/javahelp/help/contents/cmdline.html
@@ -27,12 +27,12 @@
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 			<td>-host</td>
-			<td>Overrides the host used for proxying specified in the configuration file.</td>
+			<td>Overrides the host of the main proxy, specified in the configuration file.</td>
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 			<td>-port</td>
-			<td>Overrides the port used for proxying specified in the configuration file.</td>
+			<td>Overrides the port of the main proxy, specified in the configuration file.</td>
 		</tr>
 	</table>
 

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -114,8 +114,8 @@ network.cmdline.proxy.error.message = An error occurred while starting the main 
 network.cmdline.proxy.error.port = Cannot listen on port {0}:{1} - try specifying a different port for ZAP to use.
 network.cmdline.proxy.error.port.retry = Unable to use the port {0}. Try:
 network.cmdline.proxy.error.title = Error Starting Main Proxy
-network.cmdline.proxy.host = Overrides the host used for proxying specified in the configuration file
-network.cmdline.proxy.port = Overrides the port used for proxying specified in the configuration file
+network.cmdline.proxy.host = Overrides the host of the main proxy, specified in the configuration file
+network.cmdline.proxy.port = Overrides the port of the main proxy, specified in the configuration file
 network.cmdline.proxy.port.invalid.title = Invalid Port Number
 network.cmdline.proxy.port.invalid.message = Unable to start the main proxy, -port value is not a valid port number:\n{0}
 


### PR DESCRIPTION
Make it clear that `-host` and `-port` is for the main proxy not e.g. the outgoing proxy.

---
From IRC channel.