### PR TITLE
pscanrulesAlpha: Add getExampleAlerts alertRefs for consistency/docs

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Base64, Example, Site Isolation, and Source Code Disclosure scan rules now all provide example alerts for documentation purposes. 
+As well as Alert Refs where applicable (Issues 6119 & 7100).
 
 ## [38] - 2023-03-03
 ### Fixed

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanRule.java
@@ -65,13 +65,13 @@ public class ExampleFilePassiveScanRule extends PluginPassiveScanner {
         if (msg.getResponseBody().length() > 0 && msg.getResponseHeader().isText()) {
             String parameter;
             if ((parameter = doesResponseContainString(msg.getResponseBody())) != null) {
-                this.raiseAlert(msg, id, parameter);
+                this.createAlert(parameter).raise();
             }
         }
     }
 
-    private void raiseAlert(HttpMessage msg, int id, String evidence) {
-        newAlert()
+    private AlertBuilder createAlert(String evidence) {
+        return newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription())
@@ -79,8 +79,12 @@ public class ExampleFilePassiveScanRule extends PluginPassiveScanner {
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(evidence)
-                .setWascId(13)
-                .raise();
+                .setWascId(13);
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(createAlert("").build());
     }
 
     private String doesResponseContainString(HttpBody body) {

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
+import java.util.List;
 import java.util.Random;
 import net.htmlparser.jericho.Source;
 import org.apache.logging.log4j.LogManager;
@@ -74,16 +75,24 @@ public class ExampleSimplePassiveScanRule extends PluginPassiveScanner {
         // For this example we're just going to raise the alert at random!
 
         if (rnd.nextInt(10) == 0) {
-            newAlert()
-                    .setRisk(Alert.RISK_MEDIUM)
-                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                    .setDescription(getDescription())
-                    .setSolution(getSolution())
-                    .setReference(getReference())
-                    .raise();
+            createAlert().raise();
         }
 
         LOGGER.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(createAlert().build());
+    }
+
+    private AlertBuilder createAlert() {
+        return newAlert()
+                .setRisk(Alert.RISK_MEDIUM)
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setDescription(getDescription())
+                .setSolution(getSolution())
+                .setReference(getReference());
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
@@ -117,9 +117,11 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
 
     abstract static class SiteIsolationHeaderScanRule {
         private final Supplier<AlertBuilder> newAlert;
+        private final String alertRef;
 
-        SiteIsolationHeaderScanRule(Supplier<AlertBuilder> newAlert) {
+        SiteIsolationHeaderScanRule(Supplier<AlertBuilder> newAlert, String alertReference) {
             this.newAlert = newAlert;
+            this.alertRef = PLUGIN_ID + alertReference;
         }
 
         protected abstract String getHeader();
@@ -146,7 +148,8 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
                     .setReference(getString("refs"))
                     .setCweId(693) // CWE-693: Protection Mechanism Failure
                     .setWascId(14) // WASC-14: Server Misconfiguration
-                    .setEvidence(evidence);
+                    .setEvidence(evidence)
+                    .setAlertRef(alertRef);
         }
 
         protected Stream<String> filterReportHeader(String coopHeader) {
@@ -162,7 +165,7 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
         public static final String CORS_PREFIX = "access-control-allow-";
 
         CorpHeaderScanRule(Supplier<AlertBuilder> newAlert) {
-            super(newAlert);
+            super(newAlert, "-1");
         }
 
         @Override
@@ -214,7 +217,7 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
         private static final String COEP_MESSAGE_PREFIX = SITE_ISOLATION_MESSAGE_PREFIX + "coep.";
 
         CoepHeaderScanRule(Supplier<AlertBuilder> newAlert) {
-            super(newAlert);
+            super(newAlert, "-2");
         }
 
         @Override
@@ -256,7 +259,7 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
         private static final String COOP_MESSAGE_PREFIX = SITE_ISOLATION_MESSAGE_PREFIX + "coop.";
 
         CoopHeaderScanRule(Supplier<AlertBuilder> newAlert) {
-            super(newAlert);
+            super(newAlert, "-3");
         }
 
         @Override

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -680,19 +681,27 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
         }
         if (evidence != null && evidence.length() > 0) {
             // we found something
-            newAlert()
-                    .setName(getName() + " - " + programminglanguage)
-                    .setRisk(Alert.RISK_MEDIUM)
-                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                    .setDescription(getDescription() + " - " + programminglanguage)
-                    .setOtherInfo(getExtraInfo(evidence))
-                    .setSolution(getSolution())
-                    .setReference(getReference())
-                    .setEvidence(evidence)
-                    .setCweId(540) // Information Exposure Through Source Code
-                    .setWascId(13) // WASC-13: Information Leakage
-                    .raise();
+            createAlert(programminglanguage, evidence).raise();
         }
+    }
+
+    private AlertBuilder createAlert(String programmingLanguage, String evidence) {
+        return newAlert()
+                .setName(getName() + " - " + programmingLanguage)
+                .setRisk(Alert.RISK_MEDIUM)
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setDescription(getDescription() + " - " + programmingLanguage)
+                .setOtherInfo(getExtraInfo(evidence))
+                .setSolution(getSolution())
+                .setReference(getReference())
+                .setEvidence(evidence)
+                .setCweId(540) // Information Exposure Through Source Code
+                .setWascId(13); // WASC-13: Information Leakage
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(createAlert("PHP", "<?php echo 'evils'; ?>").build());
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64DisclosureUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64DisclosureUnitTest.java
@@ -23,11 +23,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 
@@ -89,6 +91,26 @@ class Base64DisclosureUnitTest extends PassiveScannerTest<Base64Disclosure> {
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlerts() {
+        // Given / When
+        List<Alert> examples = rule.getExampleAlerts();
+        // Then
+        assertThat(examples.size(), is(equalTo(3)));
+        Alert vsAlert = examples.get(0);
+        Alert maclessAlert = examples.get(1);
+        Alert base64Alert = examples.get(2);
+        assertThat(vsAlert.getName(), is(equalTo("ASP.NET ViewState Disclosure")));
+        assertThat(vsAlert.getRisk(), is(equalTo(Alert.RISK_INFO)));
+        assertThat(vsAlert.getAlertRef(), is(equalTo("10094-1")));
+        assertThat(maclessAlert.getName(), is(equalTo("ASP.NET ViewState Integrity")));
+        assertThat(maclessAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(maclessAlert.getAlertRef(), is(equalTo("10094-2")));
+        assertThat(base64Alert.getName(), is(equalTo("Base64 Disclosure")));
+        assertThat(base64Alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
+        assertThat(base64Alert.getAlertRef(), is(equalTo("10094-3")));
     }
 
     private static HttpMessage createMessage() throws Exception {

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRuleTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRuleTest.java
@@ -26,10 +26,12 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 
@@ -409,6 +411,20 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getValue())));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlerts() {
+        // Given / When
+        List<Alert> examples = rule.getExampleAlerts();
+        // Then
+        assertThat(examples.size(), is(equalTo(3)));
+        Alert corp = examples.get(0);
+        Alert coep = examples.get(1);
+        Alert coop = examples.get(2);
+        assertThat(corp.getAlertRef(), is(equalTo("90004-1")));
+        assertThat(coep.getAlertRef(), is(equalTo("90004-2")));
+        assertThat(coop.getAlertRef(), is(equalTo("90004-3")));
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRuleUnitTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
@@ -218,6 +219,16 @@ class SourceCodeDisclosureScanRuleUnitTest
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getValue())));
+    }
+
+    @Test
+    void shouldHaveExpectedExamples() {
+        // Given / When
+        List<Alert> examples = rule.getExampleAlerts();
+        // Then
+        assertThat(examples.size(), is(equalTo(1)));
+        Alert example = examples.get(0);
+        assertThat(example.getName(), is(equalTo("Source Code Disclosure - PHP")));
     }
 
     private String wrapWithHTML(String code) {


### PR DESCRIPTION
- Base64Disclosure > Add getExampleAlerts and alertRefs for documentation purposes. Clean code slightly (remove unnecessary use of boolean literal).
- Base64Disclosure > Test expected example alerts.
- CHANGELOG.md > Add note.
- ExampleFilePassiveScanRule > Add getExampleAlerts for doc purposes.
- ExampleSimplePassiveScanRule > Add getExampleAlerts for doc purposes.
- SiteIsolationScanRule > Add getExampleAlerts and alertRefs for documentation purposes.
- SiteIsolationScanRuleTest > Test expected example alerts.
- SourceCodeDisclosureScanRule > Add getExampleAlerts for documentation purposes.
- SourceCodeDisclosureScanRuleUnitTest > Test expected example alerts.

Related to zaproxy/zaproxy#6119 and zaproxy/zaproxy#7100