### PR TITLE
pscanrules: fix NPE in CSP scan rule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Correct required version of Common Library add-on.
+- Prevent error with the CSP scan rule when scanning `meta` elements with missing `http-equiv` attribute.
 
 ## [46] - 2023-03-03
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -495,7 +495,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
 
     private static List<Element> getMetaPolicies(Source source) {
         return source.getAllElements(HTMLElementName.META).stream()
-                .filter(element -> !element.getAttributeValue("http-equiv").isEmpty())
+                .filter(element -> !StringUtils.isBlank(element.getAttributeValue("http-equiv")))
                 .collect(Collectors.toList());
     }
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -287,6 +288,22 @@ class ContentSecurityPolicyScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    void shouldNotFailToScanMetaWithMissingAttributes() {
+        // Given
+        HttpMessage msg =
+                createHttpMessageWithReasonableCsp(HttpFieldsNames.CONTENT_SECURITY_POLICY);
+        msg.setResponseBody(
+                "<html><head><meta http-equiv=\""
+                        + HttpFieldsNames.CONTENT_SECURITY_POLICY
+                        + "\" content=\""
+                        + REASONABLE_META_POLICY
+                        + "\"><meta /></head></html>");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When / Then
+        assertDoesNotThrow(() -> scanHttpResponseReceive(msg));
     }
 
     @Test


### PR DESCRIPTION
Check that the `http-equiv` is also non-null when filtering `meta` elements.