### PR TITLE
openapi: update swagger dependencies

### DIFF
--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -77,8 +77,8 @@ dependencies {
     compileOnly(parent!!.childProjects.get("formhandler")!!)
     compileOnly(parent!!.childProjects.get("spider")!!)
 
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.12")
-    implementation("io.swagger:swagger-compat-spec-parser:1.0.64") {
+    implementation("io.swagger.parser.v3:swagger-parser:2.1.13")
+    implementation("io.swagger:swagger-compat-spec-parser:1.0.65") {
         // Not needed:
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")


### PR DESCRIPTION
Use latest version of `swagger-parser` and `swagger-compat-spec-parse`.