### PR TITLE
graphql: Update dependencies

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Do not report errors parsing valid JSON arrays.
 
+### Changed
+- Dependency updates.
+
 ## [0.13.0] - 2023-02-09
 ### Added
 - Support for relative file paths in the Automation Framework job.

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -68,8 +68,8 @@ dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
     compileOnly(parent!!.childProjects.get("formhandler")!!)
     compileOnly(parent!!.childProjects.get("spider")!!)
-    implementation("com.google.code.gson:gson:2.10")
-    implementation("com.graphql-java:graphql-java:20.0")
+    implementation("com.google.code.gson:gson:2.10.1")
+    implementation("com.graphql-java:graphql-java:20.1")
 
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(parent!!.childProjects.get("formhandler")!!)


### PR DESCRIPTION
Update `graphql-java` and `gson` to latest versions.