### PR TITLE
pscanrules: ApplicationErrorScanRule JavaScript/CSS FalsePositives

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added Trusted Domains in Cross-Domain JavaScript Source File Inclusion (Issue 7775).
 
+### Changed
+- Application Error Scan Rule no longer checks JavaScript or CSS responses unless threshold is Low (Issue 7724).
+
 ## [47] - 2023-04-04
 ### Fixed
 - Correct required version of Common Library add-on.

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.utils.ContentMatcher;
 
@@ -170,6 +171,12 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
 
         } else if (!getHelper().isPage404(msg)
                 && !msg.getResponseHeader().hasContentType("application/wasm")) {
+
+            if (!AlertThreshold.LOW.equals(this.getAlertThreshold())
+                    && (ResourceIdentificationUtils.isJavaScript(msg)
+                            || ResourceIdentificationUtils.isCss(msg))) {
+                return;
+            }
             String body = msg.getResponseBody().toString();
             for (String payload : getCustomPayloads().get()) {
                 if (body.contains(payload)) {

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -43,7 +43,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <H2>Application Errors</H2>
 Check server responses for HTTP 500 - Internal Server Error type responses or those that contain a known error string. <br>
 <strong>Note:</strong> Matches made within script blocks or files are against the entire content not only comments.<br>
-At HIGH Threshold don’t alert on HTTP 500 (but do for other error patterns).<br>
+At HIGH Threshold don’t alert on HTTP 500 (but do for other error patterns). Also, such known error strings are much less likely to be relevant in static pages like JS / CSS so these files are only scanned at LOW threshold.<br>
 For Internal Server Error (HTTP 500) the Alert is set to Low risk and in other case it is set to Medium risk.
 
 <p><strong>Note:</strong> If the Custom Payloads addon is installed you can add your own Application Error strings (payloads) in the Custom Payloads options panel. 


### PR DESCRIPTION
Fixes: https://github.com/zaproxy/zaproxy/issues/7724

Changes 
- No alerts raised for JavaScript/CSS responses unless Threshold is set to LOW