### PR TITLE
exim: Correct ZAP Message export/import consistency

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Log cause of error when failed to import the HAR file.
 
+### Fixed
+- Ensure the 'ZAP messages' Export delimiters are consistent with the Import expectation.
+
 ## [0.4.0] - 2023-02-09
 ### Added
 - Support for relative file paths and ones including vars in the Automation Framework job.

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuExportMessages.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuExportMessages.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.exim;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.List;
 import javax.swing.JFileChooser;
 import javax.swing.JMenuItem;
@@ -116,18 +117,11 @@ public class PopupMenuExportMessages extends JMenuItem {
             if (responsesOnly) {
                 if (!msg.getResponseHeader().isEmpty()) {
                     bos.write(NEWLINE.getBytes());
-                    bos.write("===".getBytes());
-                    bos.write(String.valueOf(msg.getHistoryRef().getHistoryId()).getBytes());
-                    bos.write(" ==========".getBytes());
-                    bos.write(NEWLINE.getBytes());
-
+                    writeDelimiter(bos, String.valueOf(msg.getHistoryRef().getHistoryId()));
                     bos.write(msg.getResponseBody().getBytes());
                 }
             } else {
-                bos.write("===".getBytes());
-                bos.write(String.valueOf(msg.getHistoryRef().getHistoryId()).getBytes());
-                bos.write(" ==========".getBytes());
-                bos.write(NEWLINE.getBytes());
+                writeDelimiter(bos, String.valueOf(msg.getHistoryRef().getHistoryId()));
                 bos.write(msg.getRequestHeader().toString().getBytes());
                 String body = msg.getRequestBody().toString();
                 bos.write(body.getBytes());
@@ -150,6 +144,13 @@ public class PopupMenuExportMessages extends JMenuItem {
             LOGGER.warn(e.getMessage(), e);
             Stats.incCounter(STATS_EXPORT_MESSAGES_ERROR);
         }
+    }
+
+    private void writeDelimiter(BufferedOutputStream bos, String id) throws IOException {
+        bos.write("==== ".getBytes());
+        bos.write(id.getBytes());
+        bos.write(" ==========".getBytes());
+        bos.write(NEWLINE.getBytes());
     }
 
     private File getOutputFile() {

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/log/LogsImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/log/LogsImporter.java
@@ -173,12 +173,12 @@ public class LogsImporter {
         return true;
     }
 
-    private static List<String> readFile(File file) throws IOException {
+    static List<String> readFile(File file) throws IOException {
         List<String> parsed = new ArrayList<>();
         Charset charset = StandardCharsets.US_ASCII;
         BufferedReader reader = Files.newBufferedReader(file.toPath(), charset);
         Scanner sc = new Scanner(reader);
-        sc.useDelimiter(Pattern.compile("====\\s[0-9]*\\s=========="));
+        sc.useDelimiter(Pattern.compile("====?\\s?[0-9]*\\s=========="));
         while (sc.hasNext()) {
             parsed.add(sc.next());
         }

--- a/addOns/exim/src/test/resources/org/zaproxy/addon/exim/log/fourEqualsNoSpace.txt
+++ b/addOns/exim/src/test/resources/org/zaproxy/addon/exim/log/fourEqualsNoSpace.txt
@@ -1,0 +1,25 @@
+====1 ==========
+GET http://example.org/1 HTTP/1.1
+Host: example.org
+
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+content-length: 40
+
+<!DOCTYPE html>
+<html lang="en">
+</html>
+
+====2 ==========
+GET http://example.org/2 HTTP/1.1
+Host: example.org
+
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+content-length: 40
+
+<!DOCTYPE html>
+<html lang="en">
+</html>

--- a/addOns/exim/src/test/resources/org/zaproxy/addon/exim/log/fourEqualsSpace.txt
+++ b/addOns/exim/src/test/resources/org/zaproxy/addon/exim/log/fourEqualsSpace.txt
@@ -1,0 +1,25 @@
+==== 1 ==========
+GET http://example.org/1 HTTP/1.1
+Host: example.org
+
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+content-length: 40
+
+<!DOCTYPE html>
+<html lang="en">
+</html>
+
+==== 2 ==========
+GET http://example.org/2 HTTP/1.1
+Host: example.org
+
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+content-length: 40
+
+<!DOCTYPE html>
+<html lang="en">
+</html>

--- a/addOns/exim/src/test/resources/org/zaproxy/addon/exim/log/threeEqualsNoSpace.txt
+++ b/addOns/exim/src/test/resources/org/zaproxy/addon/exim/log/threeEqualsNoSpace.txt
@@ -1,0 +1,25 @@
+===1 ==========
+GET http://example.org/1 HTTP/1.1
+Host: example.org
+
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+content-length: 40
+
+<!DOCTYPE html>
+<html lang="en">
+</html>
+
+===2 ==========
+GET http://example.org/2 HTTP/1.1
+Host: example.org
+
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+content-length: 40
+
+<!DOCTYPE html>
+<html lang="en">
+</html>

--- a/addOns/exim/src/test/resources/org/zaproxy/addon/exim/log/threeEqualsSpace.txt
+++ b/addOns/exim/src/test/resources/org/zaproxy/addon/exim/log/threeEqualsSpace.txt
@@ -1,0 +1,25 @@
+=== 1 ==========
+GET http://example.org/1 HTTP/1.1
+Host: example.org
+
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+content-length: 40
+
+<!DOCTYPE html>
+<html lang="en">
+</html>
+
+=== 2 ==========
+GET http://example.org/2 HTTP/1.1
+Host: example.org
+
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+content-length: 40
+
+<!DOCTYPE html>
+<html lang="en">
+</html>


### PR DESCRIPTION
- CHANGELOG > Added change note.
- PopupMenuExportMessages > Ensure the export delimiter format is consistent with the expectation of the Import functionality.
- LogsImporter > Changed visibility of read(File) method to allow testing, added a note covering the same.
- LogsImporterUnitTest > Added tests to ensure import works with various delimiters. Plus associated resource files.

https://github.com/zaproxy/zap-extensions/blob/248b4a0850ba57650ce32032bcd2a7f7458b4b34/addOns/exim/src/main/java/org/zaproxy/addon/exim/log/LogsImporter.java#L181