### PR TITLE
graphql: Update dependencies

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [0.14.0] - 2023-04-04
 ### Fixed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     compileOnly(parent!!.childProjects.get("formhandler")!!)
     compileOnly(parent!!.childProjects.get("spider")!!)
     implementation("com.google.code.gson:gson:2.10.1")
-    implementation("com.graphql-java:graphql-java:20.1")
+    implementation("com.graphql-java:graphql-java:20.2")
 
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(parent!!.childProjects.get("formhandler")!!)


### PR DESCRIPTION
Update `graphql-java` to latest version (20.2).