### PR TITLE
spiderAjax: apply overrides to default resources

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Honour `-config` arguments when applying the default allowed resources (Issue 7809).
 
 ## [23.13.0] - 2023-03-15
 ### Added


### PR DESCRIPTION
Read the existing properties when applying the default allowed resources to honour the `-config` args.

Fix zaproxy/zaproxy#7809.