### PR TITLE
formhandler: correctly read fields with overrides

### DIFF
--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correctly read fields provided with `-config` arguments when setting up the default fields.
 
 ## [6.2.0] - 2023-04-04
 ### Added

--- a/addOns/formhandler/gradle.properties
+++ b/addOns/formhandler/gradle.properties
@@ -1,2 +1,2 @@
-version=6.3.0
+version=6.2.1
 release=false

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/FormHandlerParam.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/FormHandlerParam.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import org.apache.commons.configuration.ConversionException;
+import org.apache.commons.configuration.FileConfiguration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -305,21 +306,16 @@ public class FormHandlerParam extends VersionedAbstractParam {
         switch (fileVersion) {
             case NO_CONFIG_VERSION:
                 List<FormHandlerParamField> fieldsToAdd = new ArrayList<>();
-                Iterator<?> allTokenKeys = getConfig().getKeys(ALL_TOKENS_KEY);
-                if (!allTokenKeys.hasNext()) {
+                int count = countFields(getConfig());
+                if (count == 0) {
                     fieldsToAdd.addAll(DEFAULT_FIELDS_ORIGINAL);
                 }
                 fieldsToAdd.addAll(DEFAULT_FIELDS_V1);
-                addFields(fieldsToAdd, getIteratorSize(allTokenKeys));
+                addFields(fieldsToAdd, count);
         }
     }
 
-    private static int getIteratorSize(Iterator<?> iter) {
-        int size = 0;
-        while (iter.hasNext()) {
-            iter.next();
-            size++;
-        }
-        return size;
+    private static int countFields(FileConfiguration c) {
+        return ((HierarchicalConfiguration) c).configurationsAt(ALL_TOKENS_KEY).size();
     }
 }

--- a/addOns/formhandler/src/test/java/org/zaproxy/zap/extension/formhandler/FormHandlerParamUnitTest.java
+++ b/addOns/formhandler/src/test/java/org/zaproxy/zap/extension/formhandler/FormHandlerParamUnitTest.java
@@ -215,12 +215,14 @@ class FormHandlerParamUnitTest {
         configuration = buildConfig(new ZapXmlConfiguration(), fields);
         // When
         param.load(configuration);
+        // Then
         List<FormHandlerParamField> loadedFields = param.getFields();
-        FormHandlerParamField first = loadedFields.get(0);
         int fieldsCount = loadedFields.size();
         int enabledFieldsCount = param.getEnabledFieldsNames().size();
-        // Then
-        assertThat(first, is(equalTo(FormHandlerParam.DEFAULT_FIELDS_ORIGINAL.get(0))));
+        assertThat(
+                loadedFields.get(0), is(equalTo(FormHandlerParam.DEFAULT_FIELDS_ORIGINAL.get(0))));
+        assertThat(loadedFields.get(1), is(equalTo(FormHandlerParam.DEFAULT_FIELDS_V1.get(0))));
+        assertThat(loadedFields.get(2), is(equalTo(FormHandlerParam.DEFAULT_FIELDS_V1.get(1))));
         assertThat(fieldsCount, is(equalTo(FormHandlerParam.DEFAULT_FIELDS_V1.size() + 1)));
         assertThat(enabledFieldsCount, is(equalTo(FormHandlerParam.DEFAULT_FIELDS_V1.size() + 1)));
     }

--- a/addOns/spiderAjax/gradle.properties
+++ b/addOns/spiderAjax/gradle.properties
@@ -1,2 +1,2 @@
-version=23.14.0
+version=23.13.1
 release=false


### PR DESCRIPTION
Use the count of whole field configurations when adding the additional defaults, otherwise it would count more than the expected causing some fields to be missed or overlapped.

Mentioned in zaproxy/zaproxy#7809 and users mailing list: https://groups.google.com/g/zaproxy-users/c/CngE3LwxQH8/m/TVu-HRvcAAAJ

Tweak the versions of `formhandler` and `spiderAjax` for a patch release.