### PR TITLE
pscanrules: add example alerts to DirectoryBrowsingScanRule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,8 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added alert examples to Directory Browsing (Issue 6119).
-
-### Added
 - Added Trusted Domains in Cross-Domain JavaScript Source File Inclusion (Issue 7775).
 
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
 ### Added
 - Added alert examples to Directory Browsing (Issue 6119).
 - Added Trusted Domains in Cross-Domain JavaScript Source File Inclusion (Issue 7775).

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+
+### Added
+- Added alert examples to Directory Browsing (Issue 6119).
+
 ### Added
 - Added Trusted Domains in Cross-Domain JavaScript Source File Inclusion (Issue 7775).
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -69,10 +68,6 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG,
                     CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG);
-
-    private static String server;
-    private static String evidence;
-    private static HttpMessage msg;
     /**
      * gets the name of the scanner
      *
@@ -96,8 +91,8 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
         String responsebody = msg.getResponseBody().toString();
 
         // try each of the patterns in turn against the response.
-        evidence = null;
-        server = null;
+        String evidence = null;
+        String server = null;
         Iterator<Pattern> patternIterator = serverPatterns.keySet().iterator();
         while (patternIterator.hasNext()) {
             Pattern serverPattern = patternIterator.next();
@@ -114,7 +109,7 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
         }
     }
 
-    private AlertBuilder buildAlert(String server, String evidence, HttpMessage msg){
+    private AlertBuilder buildAlert(String server, String evidence, HttpMessage msg) {
         return newAlert()
                 .setName(getName() + " - " + server)
                 .setRisk(Alert.RISK_MEDIUM)
@@ -130,9 +125,7 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
 
     @Override
     public List<Alert> getExampleAlerts() {
-        List<Alert> alerts = new ArrayList<>();
-        alerts.add(buildAlert(server,evidence,msg).build());
-        return alerts;
+        return List.of(buildAlert("Apache 2", "Microsoft IIS", new HttpMessage()).build());
     }
 
     /**

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
@@ -105,17 +105,17 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
         }
         if (evidence != null && evidence.length() > 0) {
             // we found something
-            this.buildAlert(server, evidence, msg).raise();
+            this.buildAlert(server, evidence).raise();
         }
     }
 
-    private AlertBuilder buildAlert(String server, String evidence, HttpMessage msg) {
+    private AlertBuilder buildAlert(String server, String evidence) {
         return newAlert()
                 .setName(getName() + " - " + server)
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription() + " - " + server)
-                .setOtherInfo(getExtraInfo(msg, evidence))
+                .setOtherInfo(getExtraInfo(evidence))
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(evidence)
@@ -125,7 +125,10 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
 
     @Override
     public List<Alert> getExampleAlerts() {
-        return List.of(buildAlert("Apache 2", "Microsoft IIS", new HttpMessage()).build());
+        return List.of(
+                buildAlert("Apache 2", "<html><title>Index of /htdocs</title></html>").build(),
+                buildAlert("Microsoft IIS", "<pre><A HREF=\"/\">[To Parent Directory]</A><br><br>")
+                        .build());
     }
 
     /**
@@ -168,11 +171,10 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
     /**
      * gets extra information associated with the alert
      *
-     * @param msg
      * @param arg0
      * @return
      */
-    private String getExtraInfo(HttpMessage msg, String arg0) {
+    private String getExtraInfo(String arg0) {
         return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", arg0);
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
@@ -68,6 +68,7 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG,
                     CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG);
+
     /**
      * gets the name of the scanner
      *
@@ -105,7 +106,7 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
         }
         if (evidence != null && evidence.length() > 0) {
             // we found something
-            this.buildAlert(server, evidence).raise();
+            buildAlert(server, evidence).raise();
         }
     }
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
@@ -20,13 +20,15 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasKey;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
@@ -113,5 +115,20 @@ class DirectoryBrowsingScanRuleUnitTest extends PassiveScannerTest<DirectoryBrow
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        Map<String, String> tags = alert.getTags();
+        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
@@ -127,11 +127,15 @@ class DirectoryBrowsingScanRuleUnitTest extends PassiveScannerTest<DirectoryBrow
         assertThat(alertApache.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
         assertThat(alertApache.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
         assertThat(alertApache.getName(), is(equalTo("Directory Browsing - Apache 2")));
-        assertThat(alertApache.getEvidence(), is(equalTo("<html><title>Index of /htdocs</title></html>")));
+        assertThat(
+                alertApache.getEvidence(),
+                is(equalTo("<html><title>Index of /htdocs</title></html>")));
         Alert alertMicrosoft = alerts.get(1);
         assertThat(alertMicrosoft.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
         assertThat(alertMicrosoft.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        assertThat(alertMicrosoft.getEvidence(), is(equalTo("<pre><A HREF=\"/\">[To Parent Directory]</A><br><br>")));
+        assertThat(
+                alertMicrosoft.getEvidence(),
+                is(equalTo("<pre><A HREF=\"/\">[To Parent Directory]</A><br><br>")));
         assertThat(alertMicrosoft.getName(), is(equalTo("Directory Browsing - Microsoft IIS")));
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
@@ -123,11 +123,15 @@ class DirectoryBrowsingScanRuleUnitTest extends PassiveScannerTest<DirectoryBrow
         List<Alert> alerts = rule.getExampleAlerts();
         // Then
         assertThat(alerts.size(), is(equalTo(2)));
-        Alert alertOne = alerts.get(0);
-        assertThat(alertOne.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
-        assertThat(alertOne.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        Alert alertTwo = alerts.get(1);
-        assertThat(alertTwo.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
-        assertThat(alertTwo.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        Alert alertApache = alerts.get(0);
+        assertThat(alertApache.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alertApache.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alertApache.getName(), is(equalTo("Directory Browsing - Apache 2")));
+        assertThat(alertApache.getEvidence(), is(equalTo("<html><title>Index of /htdocs</title></html>")));
+        Alert alertMicrosoft = alerts.get(1);
+        assertThat(alertMicrosoft.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alertMicrosoft.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alertMicrosoft.getEvidence(), is(equalTo("<pre><A HREF=\"/\">[To Parent Directory]</A><br><br>")));
+        assertThat(alertMicrosoft.getName(), is(equalTo("Directory Browsing - Microsoft IIS")));
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
@@ -20,8 +20,8 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 import java.util.Map;
@@ -124,10 +124,6 @@ class DirectoryBrowsingScanRuleUnitTest extends PassiveScannerTest<DirectoryBrow
         // Then
         assertThat(alerts.size(), is(equalTo(1)));
         Alert alert = alerts.get(0);
-        Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(2)));
-        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
-        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
@@ -122,9 +122,12 @@ class DirectoryBrowsingScanRuleUnitTest extends PassiveScannerTest<DirectoryBrow
         // Given / When
         List<Alert> alerts = rule.getExampleAlerts();
         // Then
-        assertThat(alerts.size(), is(equalTo(1)));
-        Alert alert = alerts.get(0);
-        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
-        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alerts.size(), is(equalTo(2)));
+        Alert alertOne = alerts.get(0);
+        assertThat(alertOne.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alertOne.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        Alert alertTwo = alerts.get(1);
+        assertThat(alertTwo.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alertTwo.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 }


### PR DESCRIPTION
Added: 
- buildAlert()
- getExampleAlerts()
- shouldReturnExpectedExampleAlert() [Test]

Moved: 
- Local variables: server, msg and evidence changed to private static variables 
- newAlert() code into buildAlert()

Note: This is my first time contributing as a university student, so thorough examination is advised 

Part of zaproxy/zaproxy#6119.