### PR TITLE
todo: allow to dynamically unload the add-on

### DIFF
--- a/addOns/todo/src/main/java/org/zaproxy/zap/extension/todo/ExtensionTodoList.java
+++ b/addOns/todo/src/main/java/org/zaproxy/zap/extension/todo/ExtensionTodoList.java
@@ -46,4 +46,9 @@ public class ExtensionTodoList extends ExtensionAdaptor {
             extensionHook.getHookView().addWorkPanel(getTodoList());
         }
     }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
 }


### PR DESCRIPTION
Change `ExtensionTodoList` to declare that it can be unloaded.