### PR TITLE
network: do not pass-through ZAP domain/aliases

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Do not pass-through requests to the local proxies themselves (e.g. ZAP domain, aliases).
 
 ## [0.7.0] - 2023-04-04
 ### Changed


### PR DESCRIPTION
Make use of the `AliasChecker` when verifying if a pass-through, to prevent passing through requests to the proxies themselves.