### PR TITLE
graphql: show whole operation name

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Dependency updates.
 
+### Fixed
+- Display the whole operation name in the Sites tree (could be missing a character).
+
 ## [0.14.0] - 2023-04-04
 ### Fixed
 - Do not report errors parsing valid JSON arrays.

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/InlineInjector.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/InlineInjector.java
@@ -277,8 +277,7 @@ public final class InlineInjector {
                     // Add '1' if it has variables.
                     queryPrefix.insert(0, 1);
 
-                    // -1 for offset, -1 for parenthesis, -1 for whitespace.
-                    int startPos = vars.get(0).getSourceLocation().getColumn() - 3;
+                    int startPos = getVarStartPos(operation, vars.get(0));
                     VariableDefinition endVar = vars.get(vars.size() - 1);
                     int endPos =
                             endVar.getSourceLocation().getColumn()
@@ -299,6 +298,16 @@ public final class InlineInjector {
 
         queryBuilder.insert(0, queryPrefix.insert(0, '(').append(") "));
         return queryBuilder.toString();
+    }
+
+    private static int getVarStartPos(OperationDefinition operation, VariableDefinition variable) {
+        // -1 for offset, -1 for parenthesis.
+        int startPos = variable.getSourceLocation().getColumn() - 2;
+        if (operation.getName() != null) {
+            return startPos;
+        }
+        // -1 for whitespace when not named.
+        return startPos - 1;
     }
 
     @SuppressWarnings("rawtypes")

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/InlineInjectorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/InlineInjectorUnitTest.java
@@ -258,4 +258,12 @@ class InlineInjectorUnitTest extends TestUtils {
                 "(110) query{name} mutation{change_name} subscription{newMessage{sender}}";
         assertEquals(expectedQuery, injector.getNodeName(query));
     }
+
+    @Test
+    void nodeNameNamedOperationVariables() {
+        String query =
+                "query HeroNameAndFriends($episode: Episode) { hero(episode: $episode) { name friends { name } } }";
+        String expectedQuery = "(1) query HeroNameAndFriends{hero{name friends{name}}}";
+        assertEquals(expectedQuery, injector.getNodeName(query));
+    }
 }


### PR DESCRIPTION
Adjust the number of chars trimmed when creating the Sites tree node name to properly show the whole operation name when named and with variables.