### PR TITLE
Remove singleton usage in scripts

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add info URL.
 
+### Changed
+- Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
+
 ## [0.3.0] - 2022-10-27
 ### Changed
 - Update minimum ZAP version to 2.12.0.

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/standalone/Loop through history table GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/standalone/Loop through history table GraalJS.js
@@ -3,8 +3,7 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
-extHist = org.parosproxy.paros.control.Control.getSingleton().
-    getExtensionLoader().getExtension(
+extHist = control.getExtensionLoader().getExtension(
         org.parosproxy.paros.extension.history.ExtensionHistory.NAME) 
 if (extHist != null) {
     i=1

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/standalone/Traverse sites tree GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/standalone/Traverse sites tree GraalJS.js
@@ -11,8 +11,7 @@ function listChildren(node, level) {
     }
 }
 
-root = org.parosproxy.paros.model.Model.getSingleton().
-        getSession().getSiteTree().getRoot();
+root = model.getSession().getSiteTree().getRoot();
 
 listChildren(root, 0);
 

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.12.0.
+- Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 - Dependency updates.
 
 ## [3.1.0] - 2021-10-07

--- a/addOns/groovy/src/main/zapHomeFiles/scripts/templates/standalone/LoopThroughHistoryTable.groovy
+++ b/addOns/groovy/src/main/zapHomeFiles/scripts/templates/standalone/LoopThroughHistoryTable.groovy
@@ -6,10 +6,9 @@ They are only evaluated when you run them.
 */
 
 
-import org.parosproxy.paros.control.Control
 import org.parosproxy.paros.extension.history.ExtensionHistory
 
-def extHist = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class)
+def extHist = control.getExtensionLoader().getExtension(ExtensionHistory.class)
 if (extHist != null){
   def lastHist = extHist.getLastHistoryId()
   // Loop through the history table, printing out the history id and the URL

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.12.0.
+- Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 
 ## [12] - 2021-10-07
 ### Added

--- a/addOns/jython/src/main/zapHomeFiles/scripts/templates/standalone/Loop through history table.py
+++ b/addOns/jython/src/main/zapHomeFiles/scripts/templates/standalone/Loop through history table.py
@@ -5,10 +5,9 @@ Standalone scripts have no template.
 They are only evaluated when you run them.
 """ 
 
-from org.parosproxy.paros.control import Control
 from org.parosproxy.paros.extension.history import ExtensionHistory
 
-extHist = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME) 
+extHist = control.getExtensionLoader().getExtension(ExtensionHistory.NAME)
 if (extHist != None):
   i=1
   # Loop through the history table, printing out the history id and the URL

--- a/addOns/jython/src/main/zapHomeFiles/scripts/templates/standalone/Traverse sites tree.py
+++ b/addOns/jython/src/main/zapHomeFiles/scripts/templates/standalone/Traverse sites tree.py
@@ -5,8 +5,6 @@ Standalone scripts have no template.
 They are only evaluated when you run them.
 """ 
 
-from org.parosproxy.paros.model import Model
-
 def listChildren(node, level):
   indent = ""
   for i in range (0, level):
@@ -15,7 +13,7 @@ def listChildren(node, level):
     print(indent + node.getChildAt(j).getNodeName())
     listChildren(node.getChildAt(j), level+1)
 
-root = Model.getSingleton().getSession().getSiteTree().getRoot();
+root = model.getSession().getSiteTree().getRoot();
 
 listChildren(root, 0);
 

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 
 ## [0.15.0] - 2023-03-13
 ### Added 

--- a/addOns/oast/src/main/zapHomeFiles/scripts/scripts/standalone/OAST Get BOAST Servers.js
+++ b/addOns/oast/src/main/zapHomeFiles/scripts/scripts/standalone/OAST Get BOAST Servers.js
@@ -1,7 +1,6 @@
 // This script lists the details of all registered BOAST Servers.
 
-var Control = Java.type("org.parosproxy.paros.control.Control")
-var extOast = Control.getSingleton().getExtensionLoader().getExtension("ExtensionOast")
+var extOast = control.getExtensionLoader().getExtension("ExtensionOast")
 var boast = extOast.getBoastService()
 var registeredServers = boast.getRegisteredServers()
 

--- a/addOns/oast/src/main/zapHomeFiles/scripts/scripts/standalone/OAST Get Interactsh Payloads.js
+++ b/addOns/oast/src/main/zapHomeFiles/scripts/scripts/standalone/OAST Get Interactsh Payloads.js
@@ -1,7 +1,6 @@
 // This script demonstrates how to get Interactsh payloads in scripts.
 
-var Control = Java.type("org.parosproxy.paros.control.Control")
-var extOast = Control.getSingleton().getExtensionLoader().getExtension("ExtensionOast")
+var extOast = control.getExtensionLoader().getExtension("ExtensionOast")
 var interactsh = extOast.getInteractshService()
 
 if (!interactsh.isRegistered()) {

--- a/addOns/oast/src/main/zapHomeFiles/scripts/templates/extender/OAST Request Handler.js
+++ b/addOns/oast/src/main/zapHomeFiles/scripts/templates/extender/OAST Request Handler.js
@@ -1,8 +1,7 @@
 // This script handles out-of-band interactions.
 // Change it to do whatever you want to do :)
 
-var Control = Java.type("org.parosproxy.paros.control.Control")
-var extOast = Control.getSingleton().getExtensionLoader().getExtension("ExtensionOast")
+var extOast = control.getExtensionLoader().getExtension("ExtensionOast")
 var boast = extOast.getBoastService()
 var interactsh = extOast.getInteractshService()
 

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 
 ## [28] - 2023-01-03
 ### Changed

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Username Idor Scanner.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Username Idor Scanner.js
@@ -6,8 +6,6 @@
 
 // Author: Manos Kirtas (manolis.kirt@gmail.com)
 
-var Model = Java.type("org.parosproxy.paros.model.Model");
-var Control = Java.type("org.parosproxy.paros.control.Control");
 var ExtensionUserManagement = Java.type("org.zaproxy.zap.extension.users.ExtensionUserManagement");
 var DigestUtils = Java.type("org.apache.commons.codec.digest.DigestUtils");
 var WebSocketPassiveScript = Java.type('org.zaproxy.zap.extension.websocket.pscan.scripts.WebSocketPassiveScript');
@@ -34,7 +32,7 @@ function scan(helper,msg) {
 
         Object.keys(usernameHashes).forEach(function(hashType){
             if((matches = message.match(usernameHashes[hashType]))!= null) {
-                var contextname = Model.getSingleton().getSession().getContext(parseInt(user.getContextId())).getName();
+                var contextname = model.getSession().getContext(parseInt(user.getContextId())).getName();
                 matches.forEach(function(evidence){
                 	raiseAlert(helper, evidence, username, contextname, hashType);
                 });
@@ -89,7 +87,7 @@ function getHashes(username){
 function getUsers(){
     if(( extUserManagement = getExtensionUserManagement()) != null){
         usersList  = [];
-        var contexts = Model.getSingleton().getSession().getContexts();
+        var contexts = model.getSession().getContexts();
         var context;
 
         for(var i = 0; i < contexts.size(); i++){
@@ -107,9 +105,7 @@ function getUsers(){
 
 function getExtensionUserManagement(){
     if(extUserManagement == null){
-        extUserManagement = Control.getSingleton()
-            .getExtensionLoader()
-            .getExtension(ExtensionUserManagement.class);
+        extUserManagement = control.getExtensionLoader().getExtension(ExtensionUserManagement.class);
     }
     return extUserManagement;
 }


### PR DESCRIPTION
Replace singletons with the injected variables (`model` and `control`).

---
Ruby scripts were not yet changed, pending update of the library.