### PR TITLE
pscanrules: Add Example Alerts to CrossDomainScriptInclusionScanRule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Application Error Scan Rule no longer checks JavaScript or CSS responses unless threshold is Low (Issue 7724).
-- The Cross-Domain Javascript Source File Inclusion scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
+- The Cross-Domain JavaScript Source File Inclusion scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [47] - 2023-04-04
 ### Fixed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Application Error Scan Rule no longer checks JavaScript or CSS responses unless threshold is Low (Issue 7724).
+- The Cross-Domain Javascript Source File Inclusion scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [47] - 2023-04-04
 ### Fixed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
@@ -84,8 +84,8 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner {
         }
     }
 
-    private void raiseAlert(HttpMessage msg, int id, String crossDomainScript, String evidence) {
-        newAlert()
+    private AlertBuilder createAlert(String crossDomainScript, String evidence) {
+        return newAlert()
                 .setRisk(getRisk())
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription())
@@ -93,8 +93,20 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner {
                 .setSolution(getSolution())
                 .setEvidence(evidence)
                 .setCweId(getCweId())
-                .setWascId(getWascId())
-                .raise();
+                .setWascId(getWascId());
+    }
+
+    private void raiseAlert(HttpMessage msg, int id, String crossDomainScript, String evidence) {
+        createAlert(crossDomainScript, evidence).raise();
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                createAlert(
+                                "externalDomain.example.com/weatherwidget.js",
+                                "<script type=\"text/javascript\" src=\"externalDomain.example.com/weatherwidget.js\"></script>")
+                        .build());
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
@@ -104,8 +104,8 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner {
     public List<Alert> getExampleAlerts() {
         return List.of(
                 createAlert(
-                                "externalDomain.example.com/weatherwidget.js",
-                                "<script type=\"text/javascript\" src=\"externalDomain.example.com/weatherwidget.js\"></script>")
+                                "http://externalDomain.example.com/weatherwidget.js",
+                                "<script type=\"text/javascript\" src=\"http://externalDomain.example.com/weatherwidget.js\"></script>")
                         .build());
     }
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRuleUnitTest.java
@@ -27,10 +27,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
@@ -416,5 +418,18 @@ class CrossDomainScriptInclusionScanRuleUnitTest
         assertThat(
                 alertsRaised.get(0).getEvidence(),
                 equalTo("<script src=\"https://www.otherDomain.com/script2\"/>"));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        Map<String, String> tags = alert.getTags();
+        assertThat(tags.size(), is(equalTo(1)));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_LOW)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 }


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/6119

### Changes:
- Add example alert functionality.
- Add unit tests for example alerts functionality.
- Add note to changelog.