### PR TITLE
ascanrules: Cloud Metadata Potentially Exposed AWS/GCP IP Fix

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Correct IP used for AWS/GCP in the Cloud Metadata Potentially Exposed scan rule (Issue 7829).
+
 ## [53] - 2023-03-03
 ### Changed
 - Maintenance changes.

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CloudMetadataScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CloudMetadataScanRule.java
@@ -45,7 +45,7 @@ public class CloudMetadataScanRule extends AbstractHostPlugin {
     private static final String METADATA_PATH = "/latest/meta-data/";
     private static final List<String> METADATA_HOSTS =
             Arrays.asList(
-                    "169.154.169.254", "aws.zaproxy.org", "100.100.100.200", "alibaba.zaproxy.org");
+                    "169.254.169.254", "aws.zaproxy.org", "100.100.100.200", "alibaba.zaproxy.org");
 
     private static final Logger LOGGER = LogManager.getLogger(CloudMetadataScanRule.class);
     private static final Map<String, String> ALERT_TAGS =

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CloudMetadataScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CloudMetadataScanRuleUnitTest.java
@@ -68,7 +68,7 @@ class CloudMetadataScanRuleUnitTest extends ActiveScannerTest<CloudMetadataScanR
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "169.154.169.254",
+                "169.254.169.254",
                 "aws.zaproxy.org",
                 "100.100.100.200",
                 "alibaba.zaproxy.org"


### PR DESCRIPTION
- CHANGELOG > Add fix note.
- CloudMetadataScanRule > Correct IP.
- CloudMetadataScanRuleUnitTest > Correct IP.

Fixes zaproxy/zaproxy#7829