### PR TITLE
scripts: Mark script unchanged when cannot undo [WIP]

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Scripts are marked unchanged when all changes are undone.
 
 ## [38] - 2023-03-29
 ### Fixed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -98,6 +98,10 @@ public class CommandPanel extends AbstractPanel {
         return this.syntaxTxtArea;
     }
 
+    boolean canUndo() {
+        return getTxtOutput().canUndo();
+    }
+
     @Override
     public synchronized void addKeyListener(KeyListener l) {
         // Don't do anything, the (only) listener is specified through the constructor.

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -359,8 +359,9 @@ public class ConsolePanel extends AbstractPanel {
                     new KeyListener() {
                         @Override
                         public void keyTyped(KeyEvent e) {
-                            if (script != null && !script.isChanged()) {
-                                extension.getExtScript().setChanged(script, true);
+                            boolean canUndo = getCommandPanel().canUndo();
+                            if (script != null && script.isChanged() != canUndo) {
+                                extension.getExtScript().setChanged(script, canUndo);
                             }
                         }
 


### PR DESCRIPTION
Scripts are marked unchanged (the pencil icon from the script name in the sidebar disappears and the save icon is greyed out again) when all changes are undone (e.g. using `ctrl + Z`).

VS Code also behaves this way.