### PR TITLE
reports: validate output summary file has parent

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Validate that `outputSummary`'s job field `summaryFile` has a parent directory.
 
 ## [0.20.0] - 2023-04-04
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/OutputSummaryJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/OutputSummaryJob.java
@@ -95,18 +95,14 @@ public class OutputSummaryJob extends AutomationJob {
                 progress);
 
         if (this.getParameters().getSummaryFile() == null) {
-            progress.error(
-                    Constant.messages.getString(
-                            "reports.automation.error.noparent", this.getName(), ""));
+            reportNoParent(progress, "");
 
         } else {
             File parent = new File(this.getParameters().getSummaryFile()).getParentFile();
-            if (!parent.exists()) {
-                progress.error(
-                        Constant.messages.getString(
-                                "reports.automation.error.noparent",
-                                this.getName(),
-                                parent.getAbsolutePath()));
+            if (parent == null) {
+                reportNoParent(progress, "");
+            } else if (!parent.exists()) {
+                reportNoParent(progress, parent.getAbsolutePath());
             } else if (!parent.canWrite()) {
                 progress.error(
                         Constant.messages.getString(
@@ -133,6 +129,11 @@ public class OutputSummaryJob extends AutomationJob {
                 }
             }
         }
+    }
+
+    private void reportNoParent(AutomationProgress progress, String path) {
+        progress.error(
+                Constant.messages.getString("reports.automation.error.noparent", getName(), path));
     }
 
     @Override

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/OutputSummaryJobUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/OutputSummaryJobUnitTest.java
@@ -44,6 +44,9 @@ import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -115,10 +118,12 @@ class OutputSummaryJobUnitTest {
                         "!reports.automation.error.noparent!"));
     }
 
-    @Test
-    void shouldReportBadSummaryFile() throws Exception {
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"/", "/bad/path"})
+    void shouldReportBadSummaryFile(String path) throws Exception {
         // Given
-        String yamlStr = "parameters:\n  summaryFile: /bad/path";
+        String yamlStr = "parameters:\n  summaryFile: " + path;
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
         AutomationProgress realProgress = new AutomationProgress();


### PR DESCRIPTION
Validate that the summary file has a parent before validating it exists and is readable.
Extract a method to report the error.

---
From OWASP ZAP Developer Group: https://groups.google.com/g/zaproxy-develop/c/i6hjkgs5TKg/m/NSDvGhJfAAAJ