### PR TITLE
pscanrules: tweak alert of Directory Browsing

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Application Error Scan Rule no longer checks JavaScript or CSS responses unless threshold is Low (Issue 7724).
 - The Cross-Domain JavaScript Source File Inclusion scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
+- Adjust alert details of Directory Browsing, use same name and description, and use the other info field for the name of the web server identified.
 
 ## [47] - 2023-04-04
 ### Fixed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
@@ -112,11 +112,11 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
 
     private AlertBuilder buildAlert(String server, String evidence) {
         return newAlert()
-                .setName(getName() + " - " + server)
+                .setName(getName())
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription() + " - " + server)
-                .setOtherInfo(getExtraInfo(evidence))
+                .setDescription(getDescription())
+                .setOtherInfo(getExtraInfo(server))
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(evidence)
@@ -126,10 +126,7 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
 
     @Override
     public List<Alert> getExampleAlerts() {
-        return List.of(
-                buildAlert("Apache 2", "<html><title>Index of /htdocs</title></html>").build(),
-                buildAlert("Microsoft IIS", "<pre><A HREF=\"/\">[To Parent Directory]</A><br><br>")
-                        .build());
+        return List.of(buildAlert("Apache 2", "<title>Index of /htdocs</title>").build());
     }
 
     /**
@@ -169,14 +166,8 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
-    /**
-     * gets extra information associated with the alert
-     *
-     * @param arg0
-     * @return
-     */
-    private String getExtraInfo(String arg0) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", arg0);
+    private static String getExtraInfo(String server) {
+        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", server);
     }
 
     @Override

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -86,10 +86,10 @@ pscanrules.cookielooselyscoped.extrainfo=The origin domain used for comparison w
 pscanrules.cookielooselyscoped.extrainfo.cookie={0}\r\n
 
 pscanrules.directorybrowsing.name=Directory Browsing
-pscanrules.directorybrowsing.desc=It is possible to view a listing of the directory contents. Directory listings may reveal hidden scripts, include files , backup source files, etc., which be accessed to reveal sensitive information.
-pscanrules.directorybrowsing.soln=Configure the web server to disable directory browsing. 
+pscanrules.directorybrowsing.desc=It is possible to view a listing of the directory contents. Directory listings may reveal hidden scripts, include files, backup source files, etc., which can be accessed to reveal sensitive information.
+pscanrules.directorybrowsing.soln=Configure the web server to disable directory browsing.
 pscanrules.directorybrowsing.refs=https://cwe.mitre.org/data/definitions/548.html
-pscanrules.directorybrowsing.extrainfo={0}
+pscanrules.directorybrowsing.extrainfo=Web server identified: {0}
 
 pscanrules.hashdisclosure.name=Hash Disclosure
 pscanrules.hashdisclosure.desc=A hash was disclosed by the web server.


### PR DESCRIPTION
Use the same name and description for all alerts instead of changing depending on the server found, dynamic information should go on the other info instead.
Remove the evidence from the other info, there's a specific field for the evidence (already being populated).
Add missing word in description and remove extra space.
Adjust example alerts accordingly and verify alerts raised.