### PR TITLE
graphql: Better spider logic

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## Unreleased
 ### Changed
 - Dependency updates.
+- Improved detection of GraphQl endpoints while spidering.
+- It is no longer a requirement for schema URLs to end with `.graphql` or `.graphqls` when importing from the UI.
 
 ### Fixed
 - Display the whole operation name in the Sites tree (could be missing a character).

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -118,11 +118,7 @@ public class GraphQlParser {
     public void importUrl(URI schemaUrl) throws IOException {
         HttpMessage importMessage = new HttpMessage(schemaUrl);
         requestor.send(importMessage);
-        if (MessageValidator.validate(importMessage) == MessageValidator.Result.VALID_SCHEMA) {
-            parse(importMessage.getResponseBody().toString());
-        } else {
-            throw new IOException("Invalid Schema at " + schemaUrl);
-        }
+        parse(importMessage.getResponseBody().toString());
     }
 
     public void importFile(String filePath) throws IOException {

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/MessageValidatorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/MessageValidatorUnitTest.java
@@ -19,11 +19,15 @@
  */
 package org.zaproxy.addon.graphql;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.TestUtils;
 
@@ -37,5 +41,18 @@ class MessageValidatorUnitTest extends TestUtils {
     void nonExistentContentTypeHeader() throws Exception {
         HttpMessage message = new HttpMessage(new URI("http://example.com", true));
         assertEquals(MessageValidator.validate(message), MessageValidator.Result.INVALID);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{\"data\":{\"name\":\"John Doe\"}}",
+                "{\n\t\"data\": {\n\t\t\"name\": \"John Doe\"\r\n\t}\r\n}",
+                "{\"errors\": [{\"message\": \"Cannot query field \\\"name\\\" on type \\\"Query\\\".\"}]}",
+                "{\"extensions\": {\"tracing\": {\"version\": 1}}, \"data\": {\"name\": \"John Doe\"}}"
+            })
+    void shouldRecognizeGraphQlEndpointResponse(String response) {
+        assertThat(
+                MessageValidator.isGraphQlEndpointResponse(response, "application/json"), is(true));
     }
 }

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
@@ -427,7 +427,7 @@ class GraphQlJobUnitTest extends TestUtils {
         protected Response serve(IHTTPSession session) {
             accessedUrls.add(session.getUri());
             return newFixedLengthResponse(
-                    Status.OK, "application/graphql", "type Query { name: String }");
+                    Status.OK, "application/octet-stream", "type Query { name: String }");
         }
     }
 }


### PR DESCRIPTION
Got the idea from "[Chapter 4: Reconnaissance](https://nostarch.com/download/BlackHatGraphQL_ch4sample_011223.pdf)" of the book "Black Hat GraphQL".

Tested the spider against DVGA (https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application) and it sends introspection queries to fewer endpoints while also finding the actual endpoint (which it wasn't before).