### PR TITLE
Validate references of example alerts

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Leave data empty instead of adding "N/A" for the scan rules:
+  - Cross Site Scripting (Persistent) - Prime
+  - Cross Site Scripting (Persistent) - Spider
+
 ### Fixed
 - Threshold handling in the Hidden File Finder scan rule.
 - Improved the following scan rules by using time-based linear regression tests:

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
@@ -47,7 +47,7 @@ public class PersistentXssPrimeScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "misc");
+        return "";
     }
 
     @Override
@@ -57,12 +57,12 @@ public class PersistentXssPrimeScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "misc");
+        return "";
     }
 
     @Override
     public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "misc");
+        return "";
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
@@ -52,7 +52,7 @@ public class PersistentXssSpiderScanRule extends AbstractAppPlugin {
 
     @Override
     public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "misc");
+        return "";
     }
 
     @Override
@@ -62,12 +62,12 @@ public class PersistentXssSpiderScanRule extends AbstractAppPlugin {
 
     @Override
     public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "misc");
+        return "";
     }
 
     @Override
     public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "misc");
+        return "";
     }
 
     @Override

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -125,10 +125,8 @@ ascanrules.persistentxssattack.name = Cross Site Scripting (Persistent)
 ascanrules.persistentxssattack.otherinfo = Source URL: {0}
 ascanrules.persistentxssattack.otherinfo.nothtml = Raised with LOW confidence as the Content-Type is not HTML 
 
-ascanrules.persistentxssprime.misc = N/A
 ascanrules.persistentxssprime.name = Cross Site Scripting (Persistent) - Prime
 
-ascanrules.persistentxssspider.misc = N/A
 ascanrules.persistentxssspider.name = Cross Site Scripting (Persistent) - Spider
 
 ascanrules.remotecodeexecution.cve-2012-1823.desc = Some PHP versions, when configured to run using CGI, do not correctly handle query strings that lack an unescaped "=" character, enabling arbitrary code execution. In this case, an operating system command was caused to be executed on the web server, and the results were returned to the web browser. 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRuleUnitTest.java
@@ -19,11 +19,19 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
+import org.junit.jupiter.api.Test;
+
 /** Unit test for {@link PersistentXssPrimeScanRule}. */
 class PersistentXssPrimeScanRuleUnitTest extends ActiveScannerTest<PersistentXssPrimeScanRule> {
 
     @Override
     protected PersistentXssPrimeScanRule createScanner() {
         return new PersistentXssPrimeScanRule();
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRuleUnitTest.java
@@ -19,11 +19,19 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
+import org.junit.jupiter.api.Test;
+
 /** Unit test for {@link PersistentXssSpiderScanRule}. */
 class PersistentXssSpiderScanRuleUnitTest extends ActiveScannerTest<PersistentXssSpiderScanRule> {
 
     @Override
     protected PersistentXssSpiderScanRule createScanner() {
         return new PersistentXssSpiderScanRule();
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 }

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
@@ -66,7 +66,8 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
  *
  * @param <T> the type of the active scanner.
  */
-public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends TestUtils {
+public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends TestUtils
+        implements ScanRuleTests {
 
     /**
      * The recommended maximum number of messages that a scanner can send in {@link
@@ -180,6 +181,11 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
         if (rule.getConfig() == null) {
             rule.setConfig(new ZapXmlConfiguration());
         }
+    }
+
+    @Override
+    public Object getScanRule() {
+        return rule;
     }
 
     @AfterEach

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/AlertReferenceError.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/AlertReferenceError.java
@@ -1,0 +1,63 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.testutils;
+
+import java.util.function.Function;
+
+class AlertReferenceError {
+
+    enum Cause {
+        INVALID_URI(e -> "Invalid URI: '" + e.reference + "'. Reason: " + e.detail),
+        NOT_HTTPS(e -> "Not HTTPS: " + e.reference),
+        NOT_LINK(e -> "Not link: " + e.reference),
+        UNEXPECTED_STATUS_CODE(
+                e -> "Unexpected status code, 200 != " + e.detail + ", for: " + e.reference),
+        IO_EXCEPTION(e -> "I/O exception: " + e.detail + ", for: " + e.reference);
+
+        private final Function<AlertReferenceError, String> toString;
+
+        private Cause(Function<AlertReferenceError, String> toString) {
+            this.toString = toString;
+        }
+
+        AlertReferenceError create(String reference, Object detail) {
+            return new AlertReferenceError(this, reference, detail);
+        }
+
+        private String toString(AlertReferenceError error) {
+            return toString.apply(error);
+        }
+    }
+
+    private final Cause cause;
+    private final String reference;
+    private final Object detail;
+
+    private AlertReferenceError(Cause cause, String reference, Object detail) {
+        this.cause = cause;
+        this.reference = reference;
+        this.detail = detail;
+    }
+
+    @Override
+    public String toString() {
+        return cause.toString(this);
+    }
+}

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
@@ -56,7 +56,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @param <T> the type of the passive scanner.
  */
-public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends TestUtils {
+public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends TestUtils
+        implements ScanRuleTests {
 
     protected T rule;
     protected PassiveScanTaskHelper helper;
@@ -88,6 +89,11 @@ public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends 
         if (rule instanceof PluginPassiveScanner) {
             ((PluginPassiveScanner) rule).setHelper(passiveScanData);
         }
+    }
+
+    @Override
+    public Object getScanRule() {
+        return rule;
     }
 
     protected void defaultAssertions(Alert alert) {

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ScanRuleTests.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ScanRuleTests.java
@@ -1,0 +1,131 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.testutils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
+
+interface ScanRuleTests {
+
+    Object getScanRule();
+
+    @TestFactory
+    default Collection<DynamicTest> addScanRuleTests() {
+        List<DynamicTest> tests = new ArrayList<>();
+        // XXX Enable once all rules pass.
+        // tests.add(dynamicTest("shouldHaveValidReferences", this::shouldHaveValidReferences));
+        return tests;
+    }
+
+    default void shouldHaveValidReferences() {
+        // Given / When
+        Set<String> references = getAllReferences(getScanRule());
+        // Then
+        if (references.isEmpty()) {
+            return;
+        }
+
+        List<AlertReferenceError> errors = new ArrayList<>();
+        for (String reference : references) {
+            if (!reference.startsWith(HttpHeader.HTTP)) {
+                errors.add(AlertReferenceError.Cause.NOT_LINK.create(reference, ""));
+                continue;
+            }
+
+            URI uri;
+            try {
+                uri = new URI(reference, true);
+            } catch (Exception e) {
+                errors.add(AlertReferenceError.Cause.INVALID_URI.create(reference, e));
+                continue;
+            }
+
+            if (!HttpHeader.HTTPS.equals(uri.getScheme())) {
+                errors.add(AlertReferenceError.Cause.NOT_HTTPS.create(reference, ""));
+            } else if (false) {
+                fetchUrl(uri, reference, errors);
+            }
+        }
+
+        assertThat(errors.toString(), errors, is(empty()));
+    }
+
+    private static void fetchUrl(URI uri, String reference, List<AlertReferenceError> errors) {
+        try {
+            HttpMessage message = new HttpMessage(uri);
+            new HttpSender(0).sendAndReceive(message);
+            var responseHeader = message.getResponseHeader();
+            int statusCode = responseHeader.getStatusCode();
+            if (statusCode != HttpStatusCode.OK) {
+                errors.add(
+                        AlertReferenceError.Cause.UNEXPECTED_STATUS_CODE.create(
+                                reference, statusCode));
+            }
+        } catch (IOException e) {
+            errors.add(AlertReferenceError.Cause.IO_EXCEPTION.create(reference, e));
+        }
+    }
+
+    private static Set<String> getAllReferences(Object scanRule) {
+        Set<String> references = new TreeSet<>();
+        if (scanRule instanceof ExampleAlertProvider) {
+            Optional.ofNullable(((ExampleAlertProvider) scanRule).getExampleAlerts())
+                    .orElse(List.of())
+                    .stream()
+                    .map(Alert::getReference)
+                    .map(ScanRuleTests::convertReferences)
+                    .flatMap(Function.identity())
+                    .forEach(references::add);
+        }
+        if (scanRule instanceof Plugin) {
+            convertReferences(((Plugin) scanRule).getReference()).forEach(references::add);
+        }
+
+        return references;
+    }
+
+    private static Stream<String> convertReferences(String refs) {
+        return Arrays.stream(Optional.ofNullable(refs).orElse("").split("\\r?\\n"))
+                .map(String::trim)
+                .filter(e -> !e.isEmpty());
+    }
+}


### PR DESCRIPTION
Do the following validations:
 - Valid URI;
 - Uses HTTPS scheme.

Enable the validation for two rules and make them pass by removing "N/A" references/data.

Part of zaproxy/zaproxy#5364.