### PR TITLE
network: fix concurrency issue handling requests

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Do not pass-through requests to the local proxies themselves (e.g. ZAP domain, aliases).
+- Correctly handle concurrent requests (Issue 7838).
 
 ## [0.7.0] - 2023-04-04
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServerHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServerHandler.java
@@ -57,13 +57,14 @@ public class LocalServerHandler extends MainProxyHandler {
     }
 
     @Override
-    protected HandlerResult processMessage(HttpMessage msg) {
+    protected HandlerResult processMessage(
+            DefaultHttpMessageHandlerContext handlerContext, HttpMessage msg) {
         boolean excluded = isExcluded(msg);
         handlerContext.setExcluded(excluded);
 
         Object semaphore = !excluded && serialiseState.isSerialise() ? SEMAPHORE_SINGLETON : this;
         synchronized (semaphore) {
-            return super.processMessage(msg);
+            return super.processMessage(handlerContext, msg);
         }
     }
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainServerHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainServerHandler.java
@@ -56,7 +56,6 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
 
     protected final Executor executor;
     protected final List<HttpMessageHandler> pipeline;
-    protected final DefaultHttpMessageHandlerContext handlerContext;
 
     /**
      * Constructs a {@code MainServerHandler} with the given handlers.
@@ -68,7 +67,6 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
     public MainServerHandler(Executor executor, List<HttpMessageHandler> handlers) {
         this.executor = executor;
         this.pipeline = Objects.requireNonNull(handlers);
-        this.handlerContext = new DefaultHttpMessageHandlerContext();
     }
 
     @Override
@@ -89,11 +87,11 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
     }
 
     private void process(ChannelHandlerContext ctx, HttpMessage msg) {
-        handlerContext.reset();
         Channel channel = ctx.channel();
+        DefaultHttpMessageHandlerContext handlerContext = new DefaultHttpMessageHandlerContext();
         handlerContext.setRecursive(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get());
 
-        if (processMessage(msg) == HandlerResult.CLOSE) {
+        if (processMessage(handlerContext, msg) == HandlerResult.CLOSE) {
             close(ctx);
             return;
         }
@@ -127,15 +125,16 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
         return (Map<String, Object>) userObject;
     }
 
-    protected HandlerResult processMessage(HttpMessage msg) {
-        HandlerResult result = notifyMessageHandlers(msg);
+    protected HandlerResult processMessage(
+            DefaultHttpMessageHandlerContext handlerContext, HttpMessage msg) {
+        HandlerResult result = notifyMessageHandlers(handlerContext, msg);
         if (result != HandlerResult.CONTINUE) {
             return result;
         }
 
         handlerContext.handlingResponse();
 
-        result = notifyMessageHandlers(msg);
+        result = notifyMessageHandlers(handlerContext, msg);
         if (result != HandlerResult.CONTINUE) {
             return result;
         }
@@ -143,7 +142,8 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
         return HandlerResult.CONTINUE;
     }
 
-    private HandlerResult notifyMessageHandlers(HttpMessage msg) {
+    private HandlerResult notifyMessageHandlers(
+            DefaultHttpMessageHandlerContext handlerContext, HttpMessage msg) {
         for (HttpMessageHandler handler : pipeline) {
             try {
                 handler.handleMessage(handlerContext, msg);


### PR DESCRIPTION
Use a context for each request otherwise the state of one request could affect the other, e.g. causing responses to not be fetched.

Fix zaproxy/zaproxy#7838.