### PR TITLE
pscanrulesAlpha: add scan rule for fetch metadata request headers

### DIFF
--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java
@@ -1,0 +1,277 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpHeaderField;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class FetchMetadataRequestHeadersScanRule extends PluginPassiveScanner {
+    private static final String FETCH_METADATA_REQUEST_MESSAGE_PREFIX =
+            "pscanalpha.metadata-request-headers.";
+    private static final String MISSING_VULN_TYPE = "missing.";
+    private static final String INVALID_VALUES_VULN_TYPE = "invalid-values.";
+    private static final String INVALID_VALUE = "invalid";
+    private static final int PLUGIN_ID = 90005;
+    private final List<FetchMetaDataRequestHeaders> rules =
+            List.of(
+                    new SecFetchSite(this::newAlert),
+                    new SecFetchMode(this::newAlert),
+                    new SecFetchDest(this::newAlert),
+                    new SecFetchUser(this::newAlert));
+
+    private static final Map<String, String> ALERT_TAGS =
+            CommonAlertTag.toMap(CommonAlertTag.WSTG_V42_SESS_05_CSRF);
+
+    @Override
+    public void scanHttpRequestSend(HttpMessage msg, int id) {
+        rules.forEach(
+                rule ->
+                        rule.build(msg.getRequestHeader(), rule.getHeader(), rule.getValidValues())
+                                .forEach(AlertBuilder::raise));
+    }
+
+    @Override
+    public int getPluginId() {
+        return PLUGIN_ID;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(FETCH_METADATA_REQUEST_MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        List<Alert> alerts = new ArrayList<>();
+
+        alerts.addAll(
+                rules.stream().map(s -> s.getMissingAlert().build()).collect(Collectors.toList()));
+        alerts.addAll(
+                rules.stream()
+                        .map(s -> s.getInvalidValuesAlert(INVALID_VALUE).build())
+                        .collect(Collectors.toList()));
+
+        return alerts;
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return ALERT_TAGS;
+    }
+
+    abstract static class FetchMetaDataRequestHeaders {
+        private final Supplier<AlertBuilder> newAlert;
+        private final String alertRef;
+
+        FetchMetaDataRequestHeaders(Supplier<AlertBuilder> newAlert, String alertReference) {
+            this.newAlert = newAlert;
+            this.alertRef = PLUGIN_ID + alertReference;
+        }
+
+        protected abstract String getHeader();
+
+        protected abstract String getString(String param);
+
+        protected abstract List<String> getValidValues();
+
+        protected AlertBuilder getMissingAlert() {
+            return alert(MISSING_VULN_TYPE, "");
+        }
+
+        protected AlertBuilder getInvalidValuesAlert(String evidence) {
+            return alert(INVALID_VALUES_VULN_TYPE, evidence);
+        }
+
+        List<AlertBuilder> build(
+                HttpRequestHeader httpRequestHeaders, String header, List<String> valid_values) {
+            List<AlertBuilder> alert = new ArrayList<>();
+            List<HttpHeaderField> httpHeaderFields = httpRequestHeaders.getHeaders();
+
+            boolean hasHeader =
+                    httpHeaderFields.stream()
+                            .anyMatch(
+                                    httpHeaderField ->
+                                            httpHeaderField.getName().equalsIgnoreCase(header));
+
+            if (!hasHeader) {
+                alert.add(this.getMissingAlert());
+            } else {
+                List<String> value = httpRequestHeaders.getHeaderValues(header);
+                if (!valid_values.contains(value.get(0))) {
+                    alert.add(this.getInvalidValuesAlert(value.get(0)));
+                }
+            }
+            return alert;
+        };
+
+        protected AlertBuilder alert(String vulnType, String evidence) {
+            return newAlert.get()
+                    .setRisk(Alert.RISK_INFO)
+                    .setConfidence(Alert.CONFIDENCE_HIGH)
+                    .setParam(getHeader())
+                    .setName(getString(vulnType + "name"))
+                    .setDescription(getString(vulnType + "desc"))
+                    .setSolution(getString(vulnType + "soln"))
+                    .setReference(getString(vulnType + "refs"))
+                    .setAlertRef(alertRef)
+                    .setCweId(352)
+                    .setWascId(9)
+                    .setEvidence(evidence);
+        }
+    }
+
+    static class SecFetchSite extends FetchMetaDataRequestHeaders {
+        public static final String HEADER = "Sec-Fetch-Site";
+        private static final String SFS_PREFIX_MESSAGE =
+                FETCH_METADATA_REQUEST_MESSAGE_PREFIX + "sfs.";
+        private static final List<String> VALID_VALUES =
+                List.of("same-origin", "same-site", "cross-site", "none");
+
+        SecFetchSite(Supplier<AlertBuilder> newAlert) {
+            super(newAlert, "-1");
+        }
+
+        @Override
+        protected String getHeader() {
+            return HEADER;
+        }
+
+        @Override
+        protected String getString(String param) {
+            return Constant.messages.getString(SFS_PREFIX_MESSAGE + param);
+        }
+
+        @Override
+        protected List<String> getValidValues() {
+            return VALID_VALUES;
+        }
+    }
+
+    static class SecFetchMode extends FetchMetaDataRequestHeaders {
+        public static final String HEADER = "Sec-Fetch-Mode";
+        private static final String SFM_PREFIX_MESSAGE =
+                FETCH_METADATA_REQUEST_MESSAGE_PREFIX + "sfm.";
+        private static final List<String> VALID_VALUES =
+                List.of("cors", "no-cors", "navigate", "same-origin", "websocket");
+
+        SecFetchMode(Supplier<AlertBuilder> newAlert) {
+            super(newAlert, "-2");
+        }
+
+        @Override
+        protected String getHeader() {
+            return HEADER;
+        }
+
+        @Override
+        protected String getString(String param) {
+            return Constant.messages.getString(SFM_PREFIX_MESSAGE + param);
+        }
+
+        @Override
+        protected List<String> getValidValues() {
+            return VALID_VALUES;
+        }
+    }
+
+    static class SecFetchDest extends FetchMetaDataRequestHeaders {
+        public static final String HEADER = "Sec-Fetch-Dest";
+        private static final String SFD_PREFIX_MESSAGE =
+                FETCH_METADATA_REQUEST_MESSAGE_PREFIX + "sfd.";
+        private static final List<String> VALID_VALUES =
+                List.of(
+                        "audio",
+                        "audioworklet",
+                        "document",
+                        "embed",
+                        "empty",
+                        "font",
+                        "frame",
+                        "iframe",
+                        "image",
+                        "manifest",
+                        "object",
+                        "paintworklet",
+                        "report",
+                        "script",
+                        "serviceworker",
+                        "sharedworker",
+                        "style",
+                        "track",
+                        "video",
+                        "worker",
+                        "xslt");
+
+        SecFetchDest(Supplier<AlertBuilder> newAlert) {
+            super(newAlert, "-3");
+        }
+
+        @Override
+        protected String getHeader() {
+            return HEADER;
+        }
+
+        @Override
+        protected String getString(String param) {
+            return Constant.messages.getString(SFD_PREFIX_MESSAGE + param);
+        }
+
+        @Override
+        protected List<String> getValidValues() {
+            return VALID_VALUES;
+        }
+    }
+
+    static class SecFetchUser extends FetchMetaDataRequestHeaders {
+        public static final String HEADER = "Sec-Fetch-User";
+        private static final String SFU_PREFIX_MESSAGE =
+                FETCH_METADATA_REQUEST_MESSAGE_PREFIX + "sfu.";
+        private static final List<String> VALID_VALUES = List.of("?1");
+
+        SecFetchUser(Supplier<AlertBuilder> newAlert) {
+            super(newAlert, "-4");
+        }
+
+        @Override
+        protected String getHeader() {
+            return HEADER;
+        }
+
+        @Override
+        protected String getString(String param) {
+            return Constant.messages.getString(SFU_PREFIX_MESSAGE + param);
+        }
+
+        @Override
+        protected List<String> getValidValues() {
+            return VALID_VALUES;
+        }
+    }
+}

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -79,5 +79,51 @@ NOTE: Ignores CSS, JavaScript, images, and font files.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a>
 
+<H2>Fetch Metadata Request Headers Scan Rule</H2>
+Fetch Metadata Request headers are HTTP request headers that provide additional information about a request's origin.
+This additional information helps the server to implement resource isolation policy, allowing external sites to request only
+those resources that are intended for sharing, and that are used appropriately. This approach can help mitigate common
+cross-site web vulnerabilities such as CSRF, Cross-site Script Inclusion, timing attacks, and cross-origin information leaks.
+The Fetch Metadata Request headers are:
+<ul>
+ <li>Sec-Fetch-Site</li>
+ <li>Sec-Fetch-Mode</li>
+ <li>Sec-Fetch-Dest</li>
+ <li>Sec-Fetch-User</li>
+</ul>
+(from <a href="https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header">Fetch Metadata Headers</a>)
+
+<p>
+Sec-Fetch-Site indicates the relationship between a request initiator's origin and the origin of requested resource.
+(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site">Sec-Fetch-Site</a>)
+
+<p>
+Sec-Fetch-Mode allows the server to distinguish between requests originating from a user navigating between HTML
+pages and requests to load images and other resources.
+(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode">Sec-Fetch-Mode</a>)
+
+<p>
+Sec-Fetch-Dest indicates where and how the requested resource will be used.
+(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest">Sec-Fetch-Dest</a>)
+
+<p>
+Sec-Fetch-User is only sent for requests initiated by user activation.
+(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User">Sec-Fetch-User</a>)
+
+<p>
+ Alerts generated:
+<ul>
+ <li><b>Sec-Fetch-Site Header is Missing</b></li>
+ <li><b>Sec-Fetch-Site Header Has an Invalid Value</b></li>
+ <li><b>Sec-Fetch-Mode Header is Missing</b></li>
+ <li><b>Sec-Fetch-Mode Header Has an Invalid Value</b></li>
+ <li><b>Sec-Fetch-Dest Header is Missing</b></li>
+ <li><b>Sec-Fetch-Dest Header Has an Invalid Value</b></li>
+ <li><b>Sec-Fetch-User Header is Missing</b></li>
+ <li><b>Sec-Fetch-User Header Has an Invalid Value</b></li>
+</ul>
+<p>
+ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java">FetchMetadataRequestHeadersScanRule.java</a>
+
 </BODY>
 </HTML>

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -22,6 +22,48 @@ pscanalpha.examplefile.other = This is for information that doesn't fit in any o
 pscanalpha.examplefile.refs = https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/
 pscanalpha.examplefile.soln = A general description of how to solve the problem.
 
+pscanalpha.metadata-request-headers.name = Fetch Metadata Request Headers
+pscanalpha.metadata-request-headers.sfd.invalid-values.desc = Specifies how and where the data would be used. For instance, if the value is audio, then the requested resource must be audio data and not any other type of resource.
+
+pscanalpha.metadata-request-headers.sfd.invalid-values.name = Sec-Fetch-Dest Header Has an Invalid Value
+pscanalpha.metadata-request-headers.sfd.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest
+pscanalpha.metadata-request-headers.sfd.invalid-values.soln = Sec-Fetch-Dest header must have one of the following values: audio, audioworklet, document, embed, empty, font, frame, iframe, image, manifest, object, paintworklet, report, script, serviceworker, sharedworker, style, track, video, worker, xslt.
+pscanalpha.metadata-request-headers.sfd.missing.desc = Specifies how and where the data would be used. For instance, if the value is audio, then the requested resource must be audio data and not any other type of resource.
+
+pscanalpha.metadata-request-headers.sfd.missing.name = Sec-Fetch-Dest Header is Missing
+pscanalpha.metadata-request-headers.sfd.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest
+pscanalpha.metadata-request-headers.sfd.missing.soln = Ensure that Sec-Fetch-Dest header is included in request headers.
+pscanalpha.metadata-request-headers.sfm.invalid-values.desc = Allows to differentiate between requests for navigating between HTML pages and requests for loading resources like images, audio etc.
+
+pscanalpha.metadata-request-headers.sfm.invalid-values.name = Sec-Fetch-Mode Header Has an Invalid Value
+pscanalpha.metadata-request-headers.sfm.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode
+pscanalpha.metadata-request-headers.sfm.invalid-values.soln = Sec-Fetch-Mode header must have one of the following values: cors, no-cors, navigate, same-origin, or websocket.
+pscanalpha.metadata-request-headers.sfm.missing.desc = Allows to differentiate between requests for navigating between HTML pages and requests for loading resources like images, audio etc.
+
+pscanalpha.metadata-request-headers.sfm.missing.name = Sec-Fetch-Mode Header is Missing
+pscanalpha.metadata-request-headers.sfm.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode
+pscanalpha.metadata-request-headers.sfm.missing.soln = Ensure that Sec-Fetch-Mode header is included in request headers.
+pscanalpha.metadata-request-headers.sfs.invalid-values.desc = Specifies the relationship between request initiator's origin and target's origin.
+
+pscanalpha.metadata-request-headers.sfs.invalid-values.name = Sec-Fetch-Site Header Has an Invalid Value
+pscanalpha.metadata-request-headers.sfs.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site
+pscanalpha.metadata-request-headers.sfs.invalid-values.soln = Sec-Fetch-Site header must have one of the following values: same-origin, same-site, cross-origin, or none.
+pscanalpha.metadata-request-headers.sfs.missing.desc = Specifies the relationship between request initiator's origin and target's origin.
+
+pscanalpha.metadata-request-headers.sfs.missing.name = Sec-Fetch-Site Header is Missing
+pscanalpha.metadata-request-headers.sfs.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site
+pscanalpha.metadata-request-headers.sfs.missing.soln = Ensure that Sec-Fetch-Site header is included in request headers.
+pscanalpha.metadata-request-headers.sfu.invalid-values.desc = Specifies if a navigation request was initiated by a user.
+
+pscanalpha.metadata-request-headers.sfu.invalid-values.name = Sec-Fetch-User Header Has an Invalid Value
+pscanalpha.metadata-request-headers.sfu.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User
+pscanalpha.metadata-request-headers.sfu.invalid-values.soln = Sec-Fetch-User header must have the value set to ?1.
+pscanalpha.metadata-request-headers.sfu.missing.desc = Specifies if a navigation request was initiated by a user.
+
+pscanalpha.metadata-request-headers.sfu.missing.name = Sec-Fetch-User Header is Missing
+pscanalpha.metadata-request-headers.sfu.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User
+pscanalpha.metadata-request-headers.sfu.missing.soln = Ensure that Sec-Fetch-User header is included in user initiated requests.
+
 pscanalpha.name = Passive Scan Rules - alpha
 
 pscanalpha.site-isolation.coep.desc = Cross-Origin-Embedder-Policy header is a response header that prevents a document from loading any cross-origin resources that don't explicitly grant the document permission (using CORP or CORS).

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRuleTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRuleTest.java
@@ -1,0 +1,261 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+
+class FetchMetadataRequestHeadersScanRuleTest
+        extends PassiveScannerTest<FetchMetadataRequestHeadersScanRule> {
+    private static final String HTTP_METHOD = "GET / HTTP/1.1\r\n";
+    private static final String SFS_VALID_HEADER = "Sec-Fetch-Site: same-origin\r\n";
+    private static final String SFS_INVALID_HEADER = "Sec-Fetch-Site: same\r\n";
+    private static final String SFM_VALID_HEADER = "Sec-Fetch-Mode: navigate\r\n";
+    private static final String SFM_INVALID_HEADER = "Sec-Fetch-Mode: socket\r\n";
+    private static final String SFD_VALID_HEADER = "Sec-Fetch-Dest: audio\r\n";
+    private static final String SFD_INVALID_HEADER = "Sec-Fetch-Dest: doc\r\n";
+    private static final String SFU_VALID_HEADER = "Sec-Fetch-User: ?1\r\n";
+    private static final String SFU_INVALID_HEADER = "Sec-Fetch-User: none\r\n";
+
+    @Test
+    void shouldRaiseSfsAlertGivenRequestDoesntSendSfsHeader() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForMissingCase("Sec-Fetch-Site"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(FetchMetadataRequestHeadersScanRule.SecFetchSite.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo(""));
+    }
+
+    @Test
+    void shouldRaiseSfmAlertGivenRequestDoesntSendSfmHeader() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForMissingCase("Sec-Fetch-Mode"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(FetchMetadataRequestHeadersScanRule.SecFetchMode.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo(""));
+    }
+
+    @Test
+    void shouldRaiseSfdAlertGivenRequestDoesntSendSfdHeader() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForMissingCase("Sec-Fetch-Dest"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(FetchMetadataRequestHeadersScanRule.SecFetchDest.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo(""));
+    }
+
+    @Test
+    void shouldRaiseSfuAlertGivenRequestDoesntSendSfuHeader() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForMissingCase("Sec-Fetch-User"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(FetchMetadataRequestHeadersScanRule.SecFetchUser.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo(""));
+    }
+
+    @Test
+    void shouldNotRaiseAlertGivenAllHeadersArePresentAndValid() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForMissingCase("none"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    void shouldRaiseSfsAlertGivenRequestSendsInvalidSfsHeaderValue() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForInvalidCase("Sec-Fetch-Site"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(FetchMetadataRequestHeadersScanRule.SecFetchSite.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("same"));
+    }
+
+    @Test
+    void shouldRaiseSfmAlertGivenRequestSendsInvalidSfmHeaderValue() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForInvalidCase("Sec-Fetch-Mode"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(FetchMetadataRequestHeadersScanRule.SecFetchMode.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("socket"));
+    }
+
+    @Test
+    void shouldRaiseSfdAlertGivenRequestSendsInvalidSfdHeaderValue() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForInvalidCase("Sec-Fetch-Dest"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(FetchMetadataRequestHeadersScanRule.SecFetchDest.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("doc"));
+    }
+
+    @Test
+    void shouldRaiseSfuAlertGivenRequestSendsInvalidSfuHeaderValue() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForInvalidCase("Sec-Fetch-User"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(FetchMetadataRequestHeadersScanRule.SecFetchUser.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("none"));
+    }
+
+    @Test
+    void shouldNotRaiseAlertGivenAllHeadersAreInLowerCase() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(generateRequestForInvalidCase("none"));
+
+        // When
+        scanHttpRequestSend(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Override
+    protected FetchMetadataRequestHeadersScanRule createScanner() {
+        return new FetchMetadataRequestHeadersScanRule();
+    }
+
+    private String generateRequestForMissingCase(String missingHeader) {
+        switch (missingHeader) {
+            case "Sec-Fetch-Site":
+                return HTTP_METHOD + SFM_VALID_HEADER + SFD_VALID_HEADER + SFU_VALID_HEADER;
+            case "Sec-Fetch-Mode":
+                return HTTP_METHOD + SFS_VALID_HEADER + SFD_VALID_HEADER + SFU_VALID_HEADER;
+            case "Sec-Fetch-Dest":
+                return HTTP_METHOD + SFS_VALID_HEADER + SFM_VALID_HEADER + SFU_VALID_HEADER;
+            case "Sec-Fetch-User":
+                return HTTP_METHOD + SFS_VALID_HEADER + SFM_VALID_HEADER + SFD_VALID_HEADER;
+            default:
+                return HTTP_METHOD
+                        + SFS_VALID_HEADER
+                        + SFM_VALID_HEADER
+                        + SFD_VALID_HEADER
+                        + SFU_VALID_HEADER;
+        }
+    }
+
+    private String generateRequestForInvalidCase(String invalidHeader) {
+        switch (invalidHeader) {
+            case "Sec-Fetch-Site":
+                return HTTP_METHOD
+                        + SFS_INVALID_HEADER
+                        + SFM_VALID_HEADER
+                        + SFD_VALID_HEADER
+                        + SFU_VALID_HEADER;
+            case "Sec-Fetch-Mode":
+                return HTTP_METHOD
+                        + SFS_VALID_HEADER
+                        + SFM_INVALID_HEADER
+                        + SFD_VALID_HEADER
+                        + SFU_VALID_HEADER;
+            case "Sec-Fetch-Dest":
+                return HTTP_METHOD
+                        + SFS_VALID_HEADER
+                        + SFM_VALID_HEADER
+                        + SFD_INVALID_HEADER
+                        + SFU_VALID_HEADER;
+            case "Sec-Fetch-User":
+                return HTTP_METHOD
+                        + SFS_VALID_HEADER
+                        + SFM_VALID_HEADER
+                        + SFD_VALID_HEADER
+                        + SFU_INVALID_HEADER;
+            default:
+                return HTTP_METHOD
+                        + "sec-fetch-site: same-origin\r\n"
+                        + "sec-fetch-mode: navigate\r\n"
+                        + "sec-fetch-dest: audio\r\n"
+                        + "sec-fetch-user: ?1\r\n";
+        }
+    }
+}


### PR DESCRIPTION
Fixes zaproxy/zaproxy#6955. Let me know if this is the right approach or I need to make changes. Otherwise, I'll proceed with the test cases.