### PR TITLE
network: allow to log client side traffic

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Allow to log client side HTTP traffic for debug purposes, using the name `org.zaproxy.addon.network.http`.
+
 ### Fixed
 - Do not pass-through requests to the local proxies themselves (e.g. ZAP domain, aliases).
 - Correctly handle concurrent requests (Issue 7838).

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/HttpServerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/HttpServerUnitTest.java
@@ -212,6 +212,7 @@ class HttpServerUnitTest {
         // Then
         inOrder.verify(pipeline).remove("timeout");
         inOrder.verify(pipeline).remove("http.decoder");
+        inOrder.verify(pipeline).remove("logging");
         ArgumentCaptor<HttpToHttp2ConnectionHandler> connectionHandlerCaptor =
                 ArgumentCaptor.forClass(HttpToHttp2ConnectionHandler.class);
         inOrder.verify(pipeline)


### PR DESCRIPTION
Add logging handlers to allow to log HTTP traffic, to make it easier to debug client side issues.