### PR TITLE
network: prevent reuse of WebSocket/SSE conns

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not pass-through requests to the local proxies themselves (e.g. ZAP domain, aliases).
 - Correctly handle concurrent requests (Issue 7838).
 - Close connection on recursive request after notifying all handlers to still allow custom local proxies to serve or rewrite the request.
+- Ensure WebSocket and SSE connections are not incorrectly reused (Issue 7730).
 
 ## [0.7.0] - 2023-04-04
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/SocketDelegate.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/SocketDelegate.java
@@ -1,0 +1,278 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.SocketOption;
+import java.nio.channels.SocketChannel;
+import java.util.Set;
+
+class SocketDelegate extends Socket {
+
+    private final Socket delegate;
+    private final Closeable closeable;
+
+    SocketDelegate(Socket delegate, Closeable closeable) {
+        this.delegate = delegate;
+        this.closeable = closeable;
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return delegate.equals(obj);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint) throws IOException {
+        delegate.connect(endpoint);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        delegate.connect(endpoint, timeout);
+    }
+
+    @Override
+    public void bind(SocketAddress bindpoint) throws IOException {
+        delegate.bind(bindpoint);
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+        return delegate.getInetAddress();
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return delegate.getLocalAddress();
+    }
+
+    @Override
+    public int getPort() {
+        return delegate.getPort();
+    }
+
+    @Override
+    public int getLocalPort() {
+        return delegate.getLocalPort();
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        return delegate.getRemoteSocketAddress();
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        return delegate.getLocalSocketAddress();
+    }
+
+    @Override
+    public SocketChannel getChannel() {
+        return delegate.getChannel();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return delegate.getInputStream();
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return delegate.getOutputStream();
+    }
+
+    @Override
+    public void setTcpNoDelay(boolean on) throws SocketException {
+        delegate.setTcpNoDelay(on);
+    }
+
+    @Override
+    public boolean getTcpNoDelay() throws SocketException {
+        return delegate.getTcpNoDelay();
+    }
+
+    @Override
+    public void setSoLinger(boolean on, int linger) throws SocketException {
+        delegate.setSoLinger(on, linger);
+    }
+
+    @Override
+    public int getSoLinger() throws SocketException {
+        return delegate.getSoLinger();
+    }
+
+    @Override
+    public void sendUrgentData(int data) throws IOException {
+        delegate.sendUrgentData(data);
+    }
+
+    @Override
+    public void setOOBInline(boolean on) throws SocketException {
+        delegate.setOOBInline(on);
+    }
+
+    @Override
+    public boolean getOOBInline() throws SocketException {
+        return delegate.getOOBInline();
+    }
+
+    @Override
+    public synchronized void setSoTimeout(int timeout) throws SocketException {
+        delegate.setSoTimeout(timeout);
+    }
+
+    @Override
+    public synchronized int getSoTimeout() throws SocketException {
+        return delegate.getSoTimeout();
+    }
+
+    @Override
+    public synchronized void setSendBufferSize(int size) throws SocketException {
+        delegate.setSendBufferSize(size);
+    }
+
+    @Override
+    public synchronized int getSendBufferSize() throws SocketException {
+        return delegate.getSendBufferSize();
+    }
+
+    @Override
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
+        delegate.setReceiveBufferSize(size);
+    }
+
+    @Override
+    public synchronized int getReceiveBufferSize() throws SocketException {
+        return delegate.getReceiveBufferSize();
+    }
+
+    @Override
+    public void setKeepAlive(boolean on) throws SocketException {
+        delegate.setKeepAlive(on);
+    }
+
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+        return delegate.getKeepAlive();
+    }
+
+    @Override
+    public void setTrafficClass(int tc) throws SocketException {
+        delegate.setTrafficClass(tc);
+    }
+
+    @Override
+    public int getTrafficClass() throws SocketException {
+        return delegate.getTrafficClass();
+    }
+
+    @Override
+    public void setReuseAddress(boolean on) throws SocketException {
+        delegate.setReuseAddress(on);
+    }
+
+    @Override
+    public boolean getReuseAddress() throws SocketException {
+        return delegate.getReuseAddress();
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        try {
+            closeable.close();
+        } catch (Exception e) {
+            // Nothing to do.
+        }
+        delegate.close();
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        delegate.shutdownInput();
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        delegate.shutdownOutput();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return delegate.isConnected();
+    }
+
+    @Override
+    public boolean isBound() {
+        return delegate.isBound();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return delegate.isClosed();
+    }
+
+    @Override
+    public boolean isInputShutdown() {
+        return delegate.isInputShutdown();
+    }
+
+    @Override
+    public boolean isOutputShutdown() {
+        return delegate.isOutputShutdown();
+    }
+
+    @Override
+    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+        delegate.setPerformancePreferences(connectionTime, latency, bandwidth);
+    }
+
+    @Override
+    public <T> Socket setOption(SocketOption<T> name, T value) throws IOException {
+        return delegate.setOption(name, value);
+    }
+
+    @Override
+    public <T> T getOption(SocketOption<T> name) throws IOException {
+        return delegate.getOption(name);
+    }
+
+    @Override
+    public Set<SocketOption<?>> supportedOptions() {
+        return delegate.supportedOptions();
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapHttpRequestExecutor.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapHttpRequestExecutor.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.network.internal.client.apachev5;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.Locale;
+import org.apache.hc.client5.http.classic.ExecRuntime;
 import org.apache.hc.client5.http.io.ManagedHttpClientConnection;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -50,6 +51,9 @@ public class ZapHttpRequestExecutor extends HttpRequestExecutor {
     public static final String CONNECTION = "zap.connection";
     public static final String CONNECTION_SOCKET = "zap.connection.socket";
     public static final String CONNECTION_INPUT_STREAM = "zap.connection.inputstream";
+
+    public static final String EXEC_RUNTIME = "zap.exec.runtime";
+    public static final String CONNECTION_STREAM = "zap.connection.stream";
 
     public ZapHttpRequestExecutor() {
         super(DEFAULT_WAIT_FOR_CONTINUE, null, null);
@@ -89,10 +93,15 @@ public class ZapHttpRequestExecutor extends HttpRequestExecutor {
                     || isEventStream(response)) {
                 if (conn instanceof ManagedHttpClientConnection) {
                     HttpClientContext clientContext = HttpClientContext.adapt(context);
-                    clientContext.setUserToken("zap.connection.stream");
+                    clientContext.setUserToken(CONNECTION_STREAM);
 
                     Socket socket = ((ManagedHttpClientConnection) conn).getSocket();
-                    context.setAttribute(CONNECTION_SOCKET, socket);
+                    context.setAttribute(
+                            CONNECTION_SOCKET,
+                            new SocketDelegate(
+                                    socket,
+                                    ((ExecRuntime) context.getAttribute(EXEC_RUNTIME))
+                                            ::discardEndpoint));
 
                     ClassicHttpResponse r =
                             DefaultClassicHttpResponseFactory.INSTANCE.newHttpResponse(200);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapPoolingHttpClientConnectionManager.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapPoolingHttpClientConnectionManager.java
@@ -51,7 +51,7 @@ public class ZapPoolingHttpClientConnectionManager extends PoolingHttpClientConn
                 null,
                 connectionFactory);
 
-        setDefaultMaxPerRoute(100);
+        setDefaultMaxPerRoute(1000);
         setMaxTotal(getDefaultMaxPerRoute() * 100);
     }
 }


### PR DESCRIPTION
Do not release WebSocket/SSE connections back to the pool, instead discard them when the underlying connection is closed.
Also, increase the number of concurrent connections allowed per route.

Fix zaproxy/zaproxy#7730.