### PR TITLE
ascanrules: correct resource message

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Fix typo in ASP payload of Server Side Code Injection scan rule.
+- Include complete solution of Server Side Include scan rule.
 
 ## [54] - 2023-05-03
 ### Changed

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -1,4 +1,3 @@
-Refer = to manual to disable Sever Side Include.\nUse least privilege to run your web server or application server.\nFor Apache, disable the following:\nOptions Indexes FollowSymLinks Includes\nAddType application/x-httpd-cgi .cgi\nAddType text/x-server-parsed-html .html
 
 ascanrules.bufferoverflow.desc = Buffer overflow errors are characterized by the overwriting of memory spaces of the background web process, which should have never been modified intentionally or unintentionally. Overwriting values of the IP (Instruction Pointer), BP (Base Pointer) and other registers causes exceptions, segmentation faults, and other process errors to occur. Usually these errors end execution of the application in an unexpected way. 
 ascanrules.bufferoverflow.name = Buffer Overflow
@@ -131,7 +130,7 @@ ascanrules.remotefileinclude.name = Remote File Inclusion
 ascanrules.serversideinclude.desc = Certain parameters may cause Server Side Include commands to be executed.  This may allow database connection or arbitrary code to be executed.
 ascanrules.serversideinclude.name = Server Side Include
 ascanrules.serversideinclude.refs = http://www.carleton.ca/~dmcfet/html/ssi.html
-ascanrules.serversideinclude.soln = Do not trust client side input and enforce a tight check in the server side.  Disable server side includes.\n
+ascanrules.serversideinclude.soln = Do not trust client side input and enforce a tight check in the server side. Disable server side includes.\nRefer to manual to disable Sever Side Include.\nUse least privilege to run your web server or application server.\nFor Apache, disable the following:\nOptions Indexes FollowSymLinks Includes\nAddType application/x-httpd-cgi .cgi\nAddType text/x-server-parsed-html .html
 
 ascanrules.sourcecodedisclosurecve-2012-1823.desc = Some PHP versions, when configured to run using CGI, do not correctly handle query strings that lack an unescaped "=" character, enabling PHP source code disclosure, and arbitrary code execution. In this case, the contents of the PHP file were served directly to the web browser. This output will typically contain PHP, although it may also contain straight HTML.
 ascanrules.sourcecodedisclosurecve-2012-1823.name = Source Code Disclosure - CVE-2012-1823


### PR DESCRIPTION
Move text to be under the correct key.