### PR TITLE
network: do not close client conn if not required

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Do not close the client connection when the server closes it, if not required, to keep the client connection in good state and be used longer.
 
 ## [0.8.0] - 2023-05-03
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainServerHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainServerHandler.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.concurrent.Executor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.network.internal.ChannelAttributes;
@@ -97,7 +98,7 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
 
         writeResponse(ctx, msg);
 
-        if (isClosed(msg)) {
+        if (isCloseRequired(msg)) {
             close(ctx);
             return;
         }
@@ -111,8 +112,9 @@ public class MainServerHandler extends SimpleChannelInboundHandler<HttpMessage> 
         }
     }
 
-    private static boolean isClosed(HttpMessage msg) {
-        return Boolean.TRUE.equals(getProperties(msg).get("connection.closed"));
+    private static boolean isCloseRequired(HttpMessage msg) {
+        return Boolean.TRUE.equals(getProperties(msg).get("connection.closed"))
+                && msg.getResponseHeader().getHeader(HttpHeader.CONTENT_LENGTH) == null;
     }
 
     @SuppressWarnings("unchecked")

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainServerHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainServerHandlerUnitTest.java
@@ -449,10 +449,58 @@ class MainServerHandlerUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"1.0", "1.1"})
-    void shouldCloseChannelIfUserObjectContainsConnectionClosed(String httpVersion) {
+    void shouldCloseChannelIfUserObjectContainsConnectionClosedAndResponseHasNoContentLength(
+            String httpVersion) {
         // Given
         String request = "GET / HTTP/" + httpVersion + "\r\nConnection: keep-alive\r\n\r\n";
         String response = "HTTP/" + httpVersion + " 200\r\nConnection: keep-alive\r\n\r\n";
+        handler1.addAction(
+                0,
+                (ctx, msg) -> {
+                    msg.setResponseHeader(response);
+                    msg.setUserObject(Collections.singletonMap("connection.closed", Boolean.TRUE));
+                });
+        // When
+        written(request);
+        // Then
+        assertThat(exceptionsThrown, hasSize(0));
+        assertChannelActive(false);
+        assertResponse(response);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.0", "1.1"})
+    void
+            shouldNotCloseChannelIfUserObjectContainsConnectionClosedAndResponseHasKeepAliveAndContentLength(
+                    String httpVersion) {
+        // Given
+        String request = "GET / HTTP/" + httpVersion + "\r\nConnection: keep-alive\r\n\r\n";
+        String response =
+                "HTTP/"
+                        + httpVersion
+                        + " 200\r\nConnection: keep-alive\r\nContent-Length: 0\r\n\r\n";
+        handler1.addAction(
+                0,
+                (ctx, msg) -> {
+                    msg.setResponseHeader(response);
+                    msg.setUserObject(Collections.singletonMap("connection.closed", Boolean.TRUE));
+                });
+        // When
+        written(request);
+        // Then
+        assertThat(exceptionsThrown, hasSize(0));
+        assertChannelActive(true);
+        assertResponse(response);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.0", "1.1"})
+    void shouldCloseChannelIfUserObjectContainsConnectionClosedAndResponseHasCloseAndContentLength(
+            String httpVersion) {
+        // Given
+        String request = "GET / HTTP/" + httpVersion + "\r\nConnection: keep-alive\r\n\r\n";
+        String response =
+                "HTTP/" + httpVersion + " 200\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
         handler1.addAction(
                 0,
                 (ctx, msg) -> {


### PR DESCRIPTION
Do not close the client connection when the server closes it, if not required (i.e. response has content-length), to keep the client connection in good state and be used longer.