### PR TITLE
openapi: update swagger dependencies

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [33] - 2023-04-04
 ### Changed

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -77,8 +77,8 @@ dependencies {
     compileOnly(parent!!.childProjects.get("formhandler")!!)
     compileOnly(parent!!.childProjects.get("spider")!!)
 
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.13")
-    implementation("io.swagger:swagger-compat-spec-parser:1.0.65") {
+    implementation("io.swagger.parser.v3:swagger-parser:2.1.14")
+    implementation("io.swagger:swagger-compat-spec-parser:1.0.66") {
         // Not needed:
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")


### PR DESCRIPTION
Use latest version of `swagger-parser` and `swagger-compat-spec-parse`.