### PR TITLE
reports: include ZAP version in Traditional HTML report

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Add Zap version to html and pdf exports
+
 ### Fixed
 - Validate that `outputSummary`'s job field `summaryFile` has a parent directory.
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -371,7 +371,6 @@ public class ExtensionReports extends ExtensionAdaptor {
             context.setVariable("alertTree", reportData.getAlertTreeRootNode());
             context.setVariable("reportTitle", reportData.getTitle());
             context.setVariable("description", reportData.getDescription());
-            context.setVariable("owaspZapVersion", "2.12.0");
             context.setVariable("helper", new ReportHelper());
             context.setVariable(
                     "alertCounts", getAlertCountsByRisk(reportData.getAlertTreeRootNode()));

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -371,6 +371,7 @@ public class ExtensionReports extends ExtensionAdaptor {
             context.setVariable("alertTree", reportData.getAlertTreeRootNode());
             context.setVariable("reportTitle", reportData.getTitle());
             context.setVariable("description", reportData.getDescription());
+            context.setVariable("owaspZapVersion", "2.12.0");
             context.setVariable("helper", new ReportHelper());
             context.setVariable(
                     "alertCounts", getAlertCountsByRisk(reportData.getAlertTreeRootNode()));

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
@@ -124,6 +124,8 @@ reports.report.confidence.4 = User Confirmed
 
 reports.report.generated = Generated on {0}
 
+reports.report.owaspZapVersion = ZAP Version: {0}
+
 reports.report.risk.-1 = \t\t\t\tFalse Positives:
 reports.report.risk.0 = Informational
 reports.report.risk.1 = Low

--- a/addOns/reports/src/main/zapHomeFiles/reports/high-level-report/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/high-level-report/report.html
@@ -45,6 +45,12 @@
 				th:class="'text-right'"></em>
 
 		</div>
+		<div class="row">
+			<em
+					th:text="#{report.owaspZapVersion(${zapVersion})}"
+					th:class="'text-right'">OWASP Version</em>
+
+		</div>
 	</div>
 	<p></p>
 

--- a/addOns/reports/src/main/zapHomeFiles/reports/modern/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/modern/report.html
@@ -61,6 +61,10 @@
 					<th:block
 						th:text="#{report.generated(${#dates.format(new java.util.Date(), 'EEE, d MMM yyyy HH:mm:ss')})}">Date, time</th:block>
 				</h3>
+				<h3>
+					<th:block
+							th:text="#{report.owaspZapVersion(${zapVersion})}">OWASP ZAP Version</th:block>
+				</h3>
 
 				<th:block th:if="${reportData.isIncludeSection('chart')}">
 					<!--  Hidden divs just to allow us to get hold of the right CSS colors -->

--- a/addOns/reports/src/main/zapHomeFiles/reports/risk-confidence-html/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/risk-confidence-html/report.html
@@ -26,6 +26,8 @@
 				data-th-text="${#dates.format(new java.util.Date(), #messages.msg('report.template.generatedDatetime'))}">on
 				date, at time</span>
 		</p>
+		<p data-th-text="#{report.owaspZapVersion(${zapVersion})}">OWASP ZAP Version</th:block>
+		</p>
 	</header>
 
 	<main

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
@@ -46,6 +46,10 @@
 		<th:block
 			th:text="#{report.generated(${#dates.format(new java.util.Date(), 'EEE, d MMM yyyy HH:mm:ss')})}">Date, time</th:block>
 	</h3>
+	<h3>
+		<th:block
+				th:text="#{report.owaspZapVersion(${zapVersion})}">OWASP ZAP Version</th:block>
+	</h3>
 	<th:block th:if="${reportData.isIncludeSection('chart')}">
 		<canvas id="summaryChart" width="550" height="300"
 			style="border: 1px solid"></canvas>

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html/report.html
@@ -138,7 +138,7 @@ td {
 	</h3>
 	<h3>
 		<th:block
-				th:text="#{report.owaspZapVersion(${owaspZapVersion})}">OWASP ZAP Version</th:block>
+				th:text="#{report.owaspZapVersion(${zapVersion})}">OWASP ZAP Version</th:block>
 	</h3>
 	<th:block th:if="${reportData.isIncludeSection('alertcount')}">
 		<h3 th:text="#{report.alerts.summary}" class="left-header">Summary

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html/report.html
@@ -136,7 +136,10 @@ td {
 		<th:block
 			th:text="#{report.generated(${#dates.format(new java.util.Date(), 'EEE, d MMM yyyy HH:mm:ss')})}">Date, time</th:block>
 	</h3>
-
+	<h3>
+		<th:block
+				th:text="#{report.owaspZapVersion(${owaspZapVersion})}">OWASP ZAP Version</th:block>
+	</h3>
 	<th:block th:if="${reportData.isIncludeSection('alertcount')}">
 		<h3 th:text="#{report.alerts.summary}" class="left-header">Summary
 			of Alerts</h3>

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-pdf/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-pdf/report.html
@@ -140,6 +140,10 @@ td {
 		<th:block
 			th:text="#{report.generated(${#dates.format(new java.util.Date(), 'EEE, d MMM yyyy HH:mm:ss')})}">Date, time</th:block>
 	</h3>
+	<h3>
+		<th:block
+				th:text="#{report.owaspZapVersion(${zapVersion})}">OWASP ZAP Version</th:block>
+	</h3>
 
 	<th:block th:if="${reportData.isIncludeSection('alertcount')}">
 		<h3 th:text="#{report.alerts.summary}" class="left-header">Summary


### PR DESCRIPTION
When looking at historical reports, you don't know which version of Owasp Zap was run with the report if you've updated. This enhancement will resolve that issue