### PR TITLE
spiderAjax: configure own logging

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Configure logging of dependencies directly, instead of relying on core.
 
 ## [23.13.1] - 2023-04-05
 ### Fixed

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("network")!!)
+    compileOnly("org.apache.logging.log4j:log4j-core:2.19.0")
+
     implementation(files("lib/crawljax-core-3.7.jar"))
     implementation("commons-math:commons-math:1.2")
     implementation("com.codahale.metrics:metrics-core:3.0.2")
@@ -80,9 +82,11 @@ dependencies {
         exclude(group = "log4j", module = "log4j")
     }
     implementation("xmlunit:xmlunit:1.6")
+
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("selenium")!!)
+    testImplementation("org.apache.logging.log4j:log4j-core:2.19.0")
     testImplementation(project(":testutils"))
 }

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjaxUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjaxUnitTest.java
@@ -1,0 +1,106 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.spiderAjax;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/** Unit test for {@link ExtensionAjax}. */
+class ExtensionAjaxUnitTest {
+
+    private ExtensionAjax extension;
+
+    @BeforeEach
+    void setup() throws Exception {
+        resetLogConfig();
+
+        extension = new ExtensionAjax();
+    }
+
+    private void resetLogConfig() throws Exception {
+        Configurator.reconfigure(getClass().getResource("/log4j2-test.properties").toURI());
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        resetLogConfig();
+    }
+
+    @ParameterizedTest
+    @MethodSource("chattyCrawljaxClassesWithDefaultLevel")
+    void shouldHaveCrawljaxChattyClassesSetToAppropriateLevel(
+            String classname, Level defaultLevel) {
+        // Given
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = ctx.getConfiguration();
+        // When
+        extension.init();
+        // Then
+        LoggerConfig loggerConfig = configuration.getLoggerConfig(classname);
+        assertThat(loggerConfig, is(notNullValue()));
+        assertThat(loggerConfig.getLevel(), is(equalTo(defaultLevel)));
+    }
+
+    static Stream<Arguments> chattyCrawljaxClassesWithDefaultLevel() {
+        return Stream.of(
+                arguments("com.crawljax.core.Crawler", Level.WARN),
+                arguments("com.crawljax.core.state.StateMachine", Level.WARN),
+                arguments("com.crawljax.core.UnfiredCandidateActions", Level.WARN));
+    }
+
+    @ParameterizedTest
+    @MethodSource("chattyCrawljaxClassesWithDefaultLevel")
+    void shouldNotChangeCrawljaxChattyClassesIfAlreadyConfigured(String classname) {
+        // Given
+        Level customLevel = Level.DEBUG;
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = ctx.getConfiguration();
+        configuration.addLogger(
+                classname,
+                LoggerConfig.newBuilder()
+                        .withLoggerName(classname)
+                        .withLevel(customLevel)
+                        .withConfig(configuration)
+                        .build());
+        ctx.updateLoggers();
+        // When
+        extension.init();
+        // Then
+        LoggerConfig loggerConfig = configuration.getLoggerConfig(classname);
+        assertThat(loggerConfig, is(notNullValue()));
+        assertThat(loggerConfig.getLevel(), is(equalTo(customLevel)));
+    }
+}


### PR DESCRIPTION
Do not rely on core to configure logging of own dependencies.

Part of zaproxy/zaproxy#7817.