### PR TITLE
DOM-XSS Disable JSON view in Firefox

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Disable JSON view in Firefox to prevent hangs when the "Save As" option is invoked.
+
 ## [14] - 2022-10-27
 ### Changed
 - Update minimum ZAP version to 2.12.0.

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -22,7 +22,7 @@ zapAddOn {
                     version.set(">=0.1.0")
                 }
                 register("selenium") {
-                    version.set("15.*")
+                    version.set(">= 15.12.0")
                 }
                 register("commonlib") {
                     version.set(">= 1.6.0 & < 2.0.0")

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -53,6 +53,7 @@ import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
@@ -259,13 +260,15 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
     private WebDriver createWebDriver() {
         WebDriver webDriver =
                 ExtensionSelenium.getWebDriver(
+                        HttpSender.ACTIVE_SCANNER_INITIATOR,
                         browser,
                         "127.0.0.1",
                         proxyPort,
                         capabilities ->
                                 capabilities.setCapability(
                                         CapabilityType.UNEXPECTED_ALERT_BEHAVIOUR,
-                                        UnexpectedAlertBehaviour.IGNORE));
+                                        UnexpectedAlertBehaviour.IGNORE),
+                        false);
 
         webDriver.manage().timeouts().pageLoadTimeout(10, TimeUnit.SECONDS);
         webDriver.manage().timeouts().setScriptTimeout(10, TimeUnit.SECONDS);

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Disable JSON view in Firefox for DOM XSS rule to prevent hangs when the "Save As" option is invoked.
+
 ## [15.11.0] - 2022-10-27
 ### Changed
 - Update minimum ZAP version to 2.12.0.

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -905,8 +905,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
             String proxyAddress,
             int proxyPort,
             Consumer<MutableCapabilities> consumer) {
-        validateProxyAddressPort(proxyAddress, proxyPort);
-
         return getWebDriver(browser, proxyAddress, proxyPort, consumer, false);
     }
 
@@ -918,8 +916,21 @@ public class ExtensionSelenium extends ExtensionAdaptor {
             boolean enableExtensions) {
         validateProxyAddressPort(proxyAddress, proxyPort);
 
+        return getWebDriver(-1, browser, proxyAddress, proxyPort, consumer, enableExtensions);
+    }
+
+    public static WebDriver getWebDriver(
+            int requester,
+            Browser browser,
+            String proxyAddress,
+            int proxyPort,
+            Consumer<MutableCapabilities> consumer,
+            boolean enableExtensions) {
+        validateProxyAddressPort(proxyAddress, proxyPort);
+
         WebDriver wd =
-                getWebDriverImpl(-1, browser, proxyAddress, proxyPort, consumer, enableExtensions);
+                getWebDriverImpl(
+                        requester, browser, proxyAddress, proxyPort, consumer, enableExtensions);
         webDrivers.add(wd);
         updateStats(browser);
         return wd;
@@ -1022,8 +1033,11 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                 // also useful for other launched browsers.
                 firefoxOptions.addPreference("network.captive-portal-service.enabled", false);
 
-                if (requester == HttpSender.AJAX_SPIDER_INITIATOR) {
-                    // Disable JSON viewer, otherwise AJAX Spider will crawl it.
+                if (requester == HttpSender.AJAX_SPIDER_INITIATOR
+                        || requester == HttpSender.ACTIVE_SCANNER_INITIATOR) {
+                    // Disable JSON viewer, otherwise AJAX Spider or scan rules will use it,
+                    // potentially invoking the "Save As" dialog which will hang waiting for the
+                    // user to click on a button.
                     // https://developer.mozilla.org/en-US/docs/Tools/JSON_viewer
                     firefoxOptions.addPreference("devtools.jsonview.enabled", false);
                 }


### PR DESCRIPTION
To prevent hangs when the "Save As" option is invoked.