### PR TITLE
spiderAjax: restore and fix automation job tests

### DIFF
--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -1,5 +1,19 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
+plugins {
+    id("eclipse")
+}
+
+eclipse {
+    classpath {
+        minusConfigurations.plusAssign(
+            configurations.detachedConfiguration(
+                dependencies.create("net.bytebuddy:byte-buddy:1.8.15"),
+            ),
+        )
+    }
+}
+
 description = "Allows you to spider sites that make heavy use of JavaScript using Crawljax"
 
 zapAddOn {


### PR DESCRIPTION
Configure Eclipse classpath to not include older version of Byte Buddy which was causing JAR hell when running the tests.
Update tests to match the latest code and expectations.