### PR TITLE
authhelper: fix example alert

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Prefer username fields with known id/name strings.
 
+### Fixed
+- Correct example alert of Session Management Response Identified scan rule.
+
 ## [0.7.0] - 2023-05-23
 ### Added
 - Authentication tester dialog.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -191,7 +191,7 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
         List<SessionToken> tokens = new ArrayList<>();
         tokens.add(new SessionToken(SessionToken.HEADER_SOURCE, HttpHeader.AUTHORIZATION, ""));
         SessionManagementRequestDetails smDetails =
-                new SessionManagementRequestDetails(null, null, Alert.CONFIDENCE_MEDIUM);
+                new SessionManagementRequestDetails(null, tokens, Alert.CONFIDENCE_MEDIUM);
         alerts.add(this.getAlert(smDetails).build());
         return alerts;
     }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/SessionDetectionScanRuleUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/SessionDetectionScanRuleUnitTest.java
@@ -1,0 +1,29 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper;
+
+/** Unit test for {@link SessionDetectionScanRule}. */
+class SessionDetectionScanRuleUnitTest extends PassiveScannerTest<SessionDetectionScanRule> {
+
+    @Override
+    protected SessionDetectionScanRule createScanner() {
+        return new SessionDetectionScanRule();
+    }
+}

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/VerificationDetectionScanRuleUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/VerificationDetectionScanRuleUnitTest.java
@@ -1,0 +1,30 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper;
+
+/** Unit test for {@link VerificationDetectionScanRule}. */
+class VerificationDetectionScanRuleUnitTest
+        extends PassiveScannerTest<VerificationDetectionScanRule> {
+
+    @Override
+    protected VerificationDetectionScanRule createScanner() {
+        return new VerificationDetectionScanRule();
+    }
+}


### PR DESCRIPTION
Use the `tokens` for the example alert to prevent a NPE.
Add test classes for the scan rules to verify the example alerts are generated.