### PR TITLE
selenium: install Firefox exts with WebDriver

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Install Firefox extensions without using a profile (Issue 7878).
 
 ## [15.12.0] - 2023-05-23
 ### Changed


### PR DESCRIPTION
Use the WebDriver to install the extensions instead of using a profile, the latter does not always work.

Fix zaproxy/zaproxy#7878.