### PR TITLE
automation: clear Output tab on plan set

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Test taking into account previous statistic values.
+- Clear Output tab on new plan.
 
 ## [0.28.0] - 2023-05-04
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
@@ -600,6 +600,7 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
 
     public void setCurrentPlan(AutomationPlan plan) {
         currentPlan = plan;
+        getOutputArea().setText("");
         getTreeModel().setPlan(currentPlan);
         getRunPlanButton().setEnabled(currentPlan != null);
         getAddJobButton().setEnabled(currentPlan != null);


### PR DESCRIPTION
Clear the Output tab when a plan is set to avoid output from previous plan to still be shown when a new plan is created.