### PR TITLE
automation: test stats with previous values

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Statistic name to test summary.
 
+### Fixed
+- Test taking into account previous statistic values.
+
 ## [0.28.0] - 2023-05-04
 ### Added
 - Support for verification type of "autodetect" (post 2.12).

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/tests/AutomationStatisticTest.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/tests/AutomationStatisticTest.java
@@ -150,6 +150,13 @@ public class AutomationStatisticTest extends AbstractAutomationTest {
     }
 
     @Override
+    public void reset() {
+        super.reset();
+
+        stat = getStatistic();
+    }
+
+    @Override
     public boolean runTest(AutomationProgress progress) throws RuntimeException {
         if (this.getData().getValue() == null) {
             progress.error(
@@ -158,10 +165,7 @@ public class AutomationStatisticTest extends AbstractAutomationTest {
             return false;
         }
 
-        stat =
-                getStatistic(
-                        this.getData().getStatistic(),
-                        this.getJob().getEnv().replaceVars(this.getData().getSite()));
+        stat = getStatistic() - stat;
 
         switch (getOperator(this.getData().getOperator())) {
             case LESS:
@@ -188,7 +192,10 @@ public class AutomationStatisticTest extends AbstractAutomationTest {
                 .get();
     }
 
-    private long getStatistic(String stat, String site) {
+    private long getStatistic() {
+        String stat = getData().getStatistic();
+        String site = getJob().getEnv().replaceVars(getData().getSite());
+
         InMemoryStats inMemoryStats =
                 Control.getSingleton()
                         .getExtensionLoader()

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/tests/AutomationStatisticTestUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/tests/AutomationStatisticTestUnitTest.java
@@ -143,6 +143,28 @@ class AutomationStatisticTestUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldTestTakingIntoAccountPreviousStatValue() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        String key = "stats.job.something";
+        AutomationStatisticTest test =
+                new AutomationStatisticTest(
+                        key, "name", "==", 2, "warn", new ActiveScanJob(), progress);
+        test.getJob().setEnv(new AutomationEnvironment(progress));
+        when(extStats.getInMemoryStats().getStat(key)).thenReturn(16L, 18L);
+
+        // When
+        test.reset();
+        test.logToProgress(progress);
+
+        // Then
+        assertThat(progress.getInfos().size(), is(7));
+        assertThat(progress.getInfos().get(6), is("!automation.tests.pass!"));
+        assertThat(test.hasRun(), is(true));
+        assertThat(test.hasPassed(), is(true));
+    }
+
+    @Test
     void shouldResetTestStatus() {
         // Given
         AutomationProgress progress = new AutomationProgress();


### PR DESCRIPTION
Take into account the previous value when testing the statistics otherwise previous values would lead to wrong results.
For example, running the spider several times would test more URLs each time, as it would use the total value rather than the value since the last run.