### PR TITLE
network: adjust log level of client-side traffic

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Use `TRACE` level (instead of `DEBUG`) to log client side HTTP traffic to avoid accidentally enabling it when debugging other add-ons.
+
 ### Fixed
 - Do not close the client connection when the server closes it, if not required, to keep the client connection in good state and be used longer.
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
@@ -145,7 +145,7 @@ public class HttpServer extends BaseServer {
                         TIMEOUT_HANDLER_NAME,
                         new ReadTimeoutHandler(ConnectionOptions.DEFAULT_TIMEOUT, TimeUnit.SECONDS))
                 .addLast("tls.upgrade", new TlsProtocolHandler())
-                .addLast(LOGGING_HANDLER_NAME, new LoggingHandler(LOGGER_NAME))
+                .addLast(LOGGING_HANDLER_NAME, new LoggingHandler(LOGGER_NAME, LogLevel.TRACE))
                 .addLast(HTTP_DECODER_HANDLER_NAME, new HttpRequestDecoder())
                 .addLast(HTTP_ENCODER_HANDLER_NAME, HttpResponseEncoder.getInstance())
                 .addLast(CommonMessagePropertiesHandler.getInstance())
@@ -176,7 +176,7 @@ public class HttpServer extends BaseServer {
                         "http2.codec",
                         HttpToHttp2ConnectionHandler.create(
                                 new InboundHttp2ToHttpAdapter(connection),
-                                new Http2FrameLogger(LogLevel.DEBUG, LOGGER_NAME),
+                                new Http2FrameLogger(LogLevel.TRACE, LOGGER_NAME),
                                 connection,
                                 tlsUpgraded ? HttpHeader.HTTPS : HttpHeader.HTTP));
                 break;


### PR DESCRIPTION
Use `TRACE` instead of `DEBUG` to avoid accidentally enabling it when debugging other add-ons.