### PR TITLE
pscanrules: Suspicious Comment example alert and custom payloads tag

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Added 'DEBUG' to list of suspicious comments.
-- Added custom payload support (via Custom Payloads add-on) to 'Information Disclosure Suspicious Comments' scan rule.
-- Removed suspicious-comments.txt file in favor of payload editing via Custom Payloads add-on.
+- The Information Disclosure Suspicious Comments scan rule:
+    - Now includes example alert functionality for documentation generation purposes (Issue 6119).
+    - Now has a Alert Tag with a OWASP WSTG reference.
+    - Added 'DEBUG' to list of suspicious comments.
+    - Added custom payload support (via Custom Payloads add-on).
+    - Removed suspicious-comments.txt file in favor of payload editing via Custom Payloads add-on.
 
 ### Fixed
 - Ensure Custom Payloads support can be properly unloaded.

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,6 +32,7 @@ import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -77,7 +79,7 @@ class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
         // Then
         assertThat(cwe, is(equalTo(200)));
         assertThat(wasc, is(equalTo(13)));
-        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),
                 is(equalTo(true)));
@@ -85,11 +87,17 @@ class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
                 tags.containsKey(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()),
                 is(equalTo(true)));
         assertThat(
+                tags.containsKey(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getTag()),
+                is(equalTo(true)));
+        assertThat(
                 tags.get(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getValue())));
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getValue())));
+        assertThat(
+                tags.get(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getTag()),
+                is(equalTo(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getValue())));
     }
 
     @Test
@@ -327,6 +335,31 @@ class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
 
         // Then
         assertEquals(0, alertsRaised.size());
+    }
+
+    @Test
+    void shouldHaveExpectedExample() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(
+                alert.getOtherInfo(),
+                is(
+                        equalTo(
+                                Constant.messages.getString(
+                                        "pscanrules.informationdisclosuresuspiciouscomments.otherinfo",
+                                        "\\bFIXME\\b",
+                                        "<!-- FixMe: cookie: root=true; Secure -->"))));
+        assertThat(alert.getEvidence(), is(equalTo("FixMe")));
+        Map<String, String> tags = alert.getTags();
+        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
     }
 
     private static String wrapEvidenceOtherInfo(String evidence, String info, int count) {


### PR DESCRIPTION
- CHANGELOG > Added change notes.
- InformationDisclosureSuspiciousCommentsScanRule > Added example alert functionality, and  WSTG_V42_INFO_05_CONTENT_LEAK tag.
- InformationDisclosureSuspiciousCommentsScanRuleUnitTest > Add unit test to assert the new example.

A follow-up item in zaproxy/zaproxy#5708