### PR TITLE
ascanrules and pscanrulesBeta: add payloader unit tests

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix typo in ASP payload of Server Side Code Injection scan rule.
 - Include complete solution of Server Side Include scan rule.
+- Ensure Custom Payloads support can be properly unloaded.
 
 ## [54] - 2023-05-03
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/payloader/ExtensionPayloader.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/payloader/ExtensionPayloader.java
@@ -82,6 +82,8 @@ public class ExtensionPayloader extends ExtensionAdaptor {
     public void unload() {
         UserAgentScanRule.setPayloadProvider(null);
         ecp.removePayloadCategory(uaCategory);
+        HiddenFilesScanRule.setPayloadProvider(null);
+        ecp.removePayloadCategory(hfCategory);
     }
 
     @Override

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/payloader/ExtensionPayloaderUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/payloader/ExtensionPayloaderUnitTest.java
@@ -1,0 +1,112 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules.payloader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.ascanrules.ExtensionAscanRules;
+import org.zaproxy.zap.extension.ascanrules.HiddenFilesScanRule;
+import org.zaproxy.zap.extension.ascanrules.UserAgentScanRule;
+import org.zaproxy.zap.extension.custompayloads.ExtensionCustomPayloads;
+import org.zaproxy.zap.extension.custompayloads.PayloadCategory;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class ExtensionPayloaderUnitTest extends TestUtils {
+
+    @Test
+    void shouldHaveAName() {
+        // Given
+        ExtensionPayloader ep = new ExtensionPayloader();
+        mockMessages(new ExtensionAscanRules());
+        // When / Then
+        assertThat(ep.getName(), is(equalTo("ExtensionPayloaderAscanRules")));
+        assertThat(ep.getUIName(), is(equalTo("Active Scan Rules Custom Payloads")));
+    }
+
+    @Test
+    void shouldBeUnloadable() {
+        // Given
+        ExtensionPayloader ep = new ExtensionPayloader();
+        // When / Then
+        assertThat(ep.canUnload(), is(equalTo(true)));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    void shouldHandleExpectedCategoriesOnHookAndUnload() {
+        // Given
+        Model model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        ExtensionLoader extensionLoader = mock(ExtensionLoader.class);
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        ExtensionPayloader ep = new ExtensionPayloader();
+        ExtensionHook eh = mock(ExtensionHook.class);
+        ExtensionCustomPayloads ecp = mock(ExtensionCustomPayloads.class);
+        given(extensionLoader.getExtension(ExtensionCustomPayloads.class)).willReturn(ecp);
+        ArgumentCaptor<PayloadCategory> inCategories =
+                ArgumentCaptor.forClass(PayloadCategory.class);
+        ArgumentCaptor<PayloadCategory> outCategories =
+                ArgumentCaptor.forClass(PayloadCategory.class);
+        MockedStatic<UserAgentScanRule> uaRule = mockStatic(UserAgentScanRule.class);
+        MockedStatic<HiddenFilesScanRule> hffRule = mockStatic(HiddenFilesScanRule.class);
+        ArgumentCaptor<Supplier> uaSuppliers = ArgumentCaptor.forClass(Supplier.class);
+        ArgumentCaptor<Supplier> hffSuppliers = ArgumentCaptor.forClass(Supplier.class);
+        // When
+        ep.hook(eh);
+        ep.unload();
+        // Then
+        uaRule.verify(() -> UserAgentScanRule.setPayloadProvider(uaSuppliers.capture()), times(2));
+        // The supplier should be set null on unload, second invocation
+        Supplier<?> outUaSupplier = uaSuppliers.getAllValues().get(1);
+        assertThat(outUaSupplier, is(equalTo(null)));
+
+        hffRule.verify(
+                () -> HiddenFilesScanRule.setPayloadProvider(hffSuppliers.capture()), times(2));
+        // The supplier should be set null on unload, second invocation
+        Supplier<?> outHffSupplier = hffSuppliers.getAllValues().get(1);
+        assertThat(outHffSupplier, is(equalTo(null)));
+
+        verify(ecp, times(2)).addPayloadCategory(inCategories.capture());
+        PayloadCategory inCategory1 = inCategories.getAllValues().get(0);
+        PayloadCategory inCategory2 = inCategories.getAllValues().get(1);
+
+        verify(ecp, times(2)).removePayloadCategory(outCategories.capture());
+        PayloadCategory outCategory1 = outCategories.getAllValues().get(0);
+        PayloadCategory outCategory2 = outCategories.getAllValues().get(1);
+
+        assertThat(inCategory1.getName(), is(equalTo(outCategory1.getName())));
+        assertThat(inCategory2.getName(), is(equalTo(outCategory2.getName())));
+    }
+}

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Maintenance changes.
 
 ## [33] - 2023-05-03
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/payloader/ExtensionPayloader.java
@@ -33,7 +33,7 @@ import org.zaproxy.zap.extension.pscanrulesBeta.JsFunctionScanRule;
 
 public class ExtensionPayloader extends ExtensionAdaptor {
 
-    public static final String NAME = "ExtensionPayloaderPscanRulesBetaRelease";
+    public static final String NAME = "ExtensionPayloaderPscanRulesBeta";
     private static final List<Class<? extends Extension>> DEPENDENCIES;
     private static ExtensionCustomPayloads ecp;
     private PayloadCategory jsFuncCategory;

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/payloader/ExtensionPayloaderUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/payloader/ExtensionPayloaderUnitTest.java
@@ -1,0 +1,100 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesBeta.payloader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.custompayloads.ExtensionCustomPayloads;
+import org.zaproxy.zap.extension.custompayloads.PayloadCategory;
+import org.zaproxy.zap.extension.pscanrulesBeta.ExtensionPscanRulesBeta;
+import org.zaproxy.zap.extension.pscanrulesBeta.JsFunctionScanRule;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class ExtensionPayloaderUnitTest extends TestUtils {
+
+    @Test
+    void shouldHaveAName() {
+        // Given
+        ExtensionPayloader ep = new ExtensionPayloader();
+        mockMessages(new ExtensionPscanRulesBeta());
+        // When / Then
+        assertThat(ep.getName(), is(equalTo("ExtensionPayloaderPscanRulesBeta")));
+        assertThat(ep.getUIName(), is(equalTo("Passive Scan Rules Beta Custom Payloads")));
+    }
+
+    @Test
+    void shouldBeUnloadable() {
+        // Given
+        ExtensionPayloader ep = new ExtensionPayloader();
+        // When / Then
+        assertThat(ep.canUnload(), is(equalTo(true)));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    void shouldHandleExpectedCategoriesOnHookAndUnload() {
+        // Given
+        Model model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        ExtensionLoader extensionLoader = mock(ExtensionLoader.class);
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        ExtensionPayloader ep = new ExtensionPayloader();
+        ExtensionHook eh = mock(ExtensionHook.class);
+        ExtensionCustomPayloads ecp = mock(ExtensionCustomPayloads.class);
+        given(extensionLoader.getExtension(ExtensionCustomPayloads.class)).willReturn(ecp);
+        ArgumentCaptor<PayloadCategory> inCategories =
+                ArgumentCaptor.forClass(PayloadCategory.class);
+        ArgumentCaptor<PayloadCategory> outCategories =
+                ArgumentCaptor.forClass(PayloadCategory.class);
+        MockedStatic<JsFunctionScanRule> jsRule = mockStatic(JsFunctionScanRule.class);
+        ArgumentCaptor<Supplier> jsSuppliers = ArgumentCaptor.forClass(Supplier.class);
+        // When
+        ep.hook(eh);
+        ep.unload();
+        // Then
+        jsRule.verify(() -> JsFunctionScanRule.setPayloadProvider(jsSuppliers.capture()), times(2));
+        // The supplier should be set null on unload, second invocation
+        Supplier<?> outJsSupplier = jsSuppliers.getAllValues().get(1);
+        assertThat(outJsSupplier, is(equalTo(null)));
+
+        verify(ecp, times(1)).addPayloadCategory(inCategories.capture());
+        PayloadCategory inCategory1 = inCategories.getAllValues().get(0);
+
+        verify(ecp, times(1)).removePayloadCategory(outCategories.capture());
+        PayloadCategory outCategory1 = outCategories.getAllValues().get(0);
+
+        assertThat(inCategory1.getName(), is(equalTo(outCategory1.getName())));
+    }
+}


### PR DESCRIPTION
- CHANGELOG > Added change notes.
- ExtensionPayloader > Ensured things unload properly and were named more consistently.
- ExpensionPayloaderUnitTest > Implement tests for extension payloader.

Related to: zaproxy/zap-extensions#4611