### PR TITLE
spiderAjax: handle no params in automation job

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Handle job with no parameters when reading Excluded Elements (Issue 7889).
 
 ## [23.14.0] - 2023-05-31
 ### Added

--- a/addOns/spiderAjax/gradle.properties
+++ b/addOns/spiderAjax/gradle.properties
@@ -1,2 +1,2 @@
-version=23.15.0
+version=23.14.1
 release=false

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
@@ -91,7 +91,6 @@ public class AjaxSpiderJob extends AutomationJob {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void verifyParameters(AutomationProgress progress) {
         Map<?, ?> jobData = this.getJobData();
         if (jobData == null) {
@@ -104,6 +103,24 @@ public class AjaxSpiderJob extends AutomationJob {
                 this.getName(),
                 new String[] {PARAM_EXCLUDED_ELEMENTS},
                 progress);
+
+        readExcludedElements(progress, parametersData);
+
+        if (this.getParameters().getWarnIfFoundUrlsLessThan() != null
+                || this.getParameters().getFailIfFoundUrlsLessThan() != null) {
+            progress.warn(
+                    Constant.messages.getString(
+                            "automation.error.spider.failIfUrlsLessThan.deprecated",
+                            getName(),
+                            "automation.spiderAjax.urls.added"));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readExcludedElements(AutomationProgress progress, Map<?, ?> parametersData) {
+        if (parametersData == null) {
+            return;
+        }
 
         try {
             var eeData = (List<Map<String, ?>>) parametersData.get(PARAM_EXCLUDED_ELEMENTS);
@@ -123,15 +140,6 @@ public class AjaxSpiderJob extends AutomationJob {
             progress.error(
                     Constant.messages.getString(
                             "spiderajax.automation.error.excludedelements.format", getName(), e));
-        }
-
-        if (this.getParameters().getWarnIfFoundUrlsLessThan() != null
-                || this.getParameters().getFailIfFoundUrlsLessThan() != null) {
-            progress.warn(
-                    Constant.messages.getString(
-                            "automation.error.spider.failIfUrlsLessThan.deprecated",
-                            getName(),
-                            "automation.spiderAjax.urls.added"));
         }
     }
 

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.spiderAjax.automation;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -195,6 +196,22 @@ class AjaxSpiderJobUnitTest {
         public AjaxSpiderParam getAjaxSpiderParam() {
             return new AjaxSpiderParam();
         }
+    }
+
+    @Test
+    void shouldVerifyWithoutParameters() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        AjaxSpiderJob job = new AjaxSpiderJob();
+        job.setJobData(null);
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.getErrors(), is(empty()));
     }
 
     @Test


### PR DESCRIPTION
Check that parameters are available when reading the excluded elements.

Fix zaproxy/zaproxy#7889.