### PR TITLE
ascanrules: Add Blazor WASM Config file to Hidden File Finder

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix typo in ASP payload of Server Side Code Injection scan rule.
 - Include complete solution of Server Side Include scan rule.
 
+### Added
+- The Hidden File Finder scan rule now check for Blazor WASM config files.
+
 ## [54] - 2023-05-03
 ### Changed
 - Maintenance changes.

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
@@ -203,7 +203,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
                 .setRisk(risk)
                 .setConfidence(confidence)
                 .setName(getAlertName())
-                .setOtherInfo(getOtherInfo(file.getType()))
+                .setOtherInfo(getOtherInfo(file))
                 .setEvidence(msg.getResponseHeader().getPrimeHeader())
                 .setReference(getReferences(file))
                 .setMessage(msg);
@@ -291,8 +291,14 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
         return Constant.messages.getString(MESSAGE_PREFIX + "alert.name");
     }
 
-    private static String getOtherInfo(String type) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo", type);
+    private static String getOtherInfo(HiddenFile file) {
+        String otherInfo =
+                Constant.messages.getString(MESSAGE_PREFIX + "otherinfo", file.getType());
+        String extra = file.getExtra();
+        if (!extra.isBlank()) {
+            otherInfo += "\n\n" + extra;
+        }
+        return otherInfo;
     }
 
     private List<HiddenFile> readFromJsonFile() {
@@ -315,6 +321,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
                                 getOptionalString(hiddenFileObject, "binary"),
                                 getOptionalList(hiddenFileObject, "links"),
                                 getOptionalString(hiddenFileObject, "type"),
+                                getOptionalString(hiddenFileObject, "extra"),
                                 false);
                 hiddenFiles.add(hiddenFile);
 
@@ -435,6 +442,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
         private final String binary;
         private final List<String> links;
         private final String type;
+        private final String extra;
         private final boolean custom;
 
         public HiddenFile(
@@ -445,6 +453,18 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
                 List<String> links,
                 String type,
                 boolean custom) {
+            this(path, content, not_content, binary, links, type, "", custom);
+        }
+
+        public HiddenFile(
+                String path,
+                List<String> content,
+                List<String> not_content,
+                String binary,
+                List<String> links,
+                String type,
+                String extra,
+                boolean custom) {
             super();
             this.path = path;
             this.content = content;
@@ -452,6 +472,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
             this.binary = binary;
             this.links = links;
             this.type = type;
+            this.extra = extra;
             this.custom = custom;
         }
 
@@ -481,6 +502,10 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
 
         public boolean isCustom() {
             return custom;
+        }
+
+        public String getExtra() {
+            return extra;
         }
     }
 }

--- a/addOns/ascanrules/src/main/zapHomeFiles/json/hidden_files.json
+++ b/addOns/ascanrules/src/main/zapHomeFiles/json/hidden_files.json
@@ -284,6 +284,14 @@
       "links":["https://www.acunetix.com/vulnerabilities/web/wpengine-_wpeprivate-config-json-information-disclosure/","https://twitter.com/nav1n0x/status/1575171517893079043"],
       "type":"wordpress/WPEngine",
       "source":"nav1n0x"
+    },
+    {
+      "path":"/_framework/blazor.boot.json",
+      "content":["Blazor"],
+      "links":["https://twitter.com/_Freakyclown_/status/1660737687178072064", "https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly"],
+      "type":"Blazor",
+      "source":"freakyclown",
+      "extra": "This Blazor config file often lists DLLs which in turn may contain credentials or other sensitive details."
     }
   ]
 } 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
@@ -145,7 +145,14 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         List<String> links = Arrays.asList("https://example.org");
         HiddenFile hiddenFile =
                 new HiddenFile(
-                        testPath, contents, Collections.emptyList(), "", links, "test_php", false);
+                        testPath,
+                        contents,
+                        Collections.emptyList(),
+                        "",
+                        links,
+                        "test_php",
+                        "This file leaks info",
+                        false);
 
         this.nano.addHandler(new OkResponse(servePath));
         this.nano.addHandler(
@@ -166,7 +173,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_HIGH, alertsRaised.get(0).getConfidence());
-        assertEquals(hiddenFile.getType(), alert.getOtherInfo());
+        assertEquals(hiddenFile.getType() + "\n\n" + hiddenFile.getExtra(), alert.getOtherInfo());
         assertEquals(
                 rule.getReference() + '\n' + hiddenFile.getLinks().get(0), alert.getReference());
     }


### PR DESCRIPTION
- CHANGELOG > Add note.
- hidden_files.json > Add new entry.
- HiddenFileScanRule > Add handling for optional extra info to be appended to "Other Info".
- HiddenFileScanRuleUnitTest > Update one of the success test cases to include the new Extra/Other Info handling.

Hat tip to @freakyclown:
- https://twitter.com/_Freakyclown_/status/1660737687178072064
- https://github.com/freakyclown/Nuclei_templates/blob/main/blazor_server.yaml