### PR TITLE
openapi: fix NPE with parameter without schema

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Dependency updates.
 
+### Fixed
+- Fix exception when generating data for parameters without schema.
+
 ## [33] - 2023-04-04
 ### Changed
 - Dependency updates.

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -132,7 +132,7 @@ public class DataGenerator {
             return getExampleValue(parameter);
         }
 
-        if (isArray(parameter.getSchema().getType())) {
+        if (isArray(getType(parameter.getSchema()))) {
             return generateArrayValue(name, parameter);
         }
 
@@ -144,6 +144,10 @@ public class DataGenerator {
         }
 
         return getExampleValue(parameter);
+    }
+
+    private static String getType(Schema<?> schema) {
+        return schema == null ? null : schema.getType();
     }
 
     private String generateArrayValue(String name, Parameter parameter) {
@@ -211,7 +215,7 @@ public class DataGenerator {
 
     private String getExampleValue(Parameter parameter) {
         String in = parameter.getIn();
-        String type = parameter.getSchema().getType();
+        String type = getType(parameter.getSchema());
         if ("cookie".equals(in) && "string".equals(type)) {
             return "JohnDoe";
         }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/DataGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/DataGeneratorUnitTest.java
@@ -59,6 +59,18 @@ class DataGeneratorUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldGenerateEmptyValueForParameterWithoutSchema() throws IOException {
+        // Given
+        OpenAPI openAPI = parseResource("defn-with-query-params.yml");
+        Parameter parameter =
+                openAPI.getPaths().get("/without-schema").getGet().getParameters().get(0);
+        // When
+        String data = generator.generate(parameter.getName(), parameter);
+        // Then
+        assertEquals("", data);
+    }
+
+    @Test
     void shouldUseContentInParameter() throws IOException {
         // Given
         OpenAPI openAPI = parseResource("defn-with-query-params.yml");

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/generators/defn-with-query-params.yml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/generators/defn-with-query-params.yml
@@ -18,6 +18,17 @@ paths:
         '200':
           description: OK
 
+  /without-schema:
+    get:
+      parameters:
+        - name: param
+          in: query
+          content:
+            text/xyz: {}
+      responses:
+        '200':
+          description: OK
+
 components:
   schemas:
     Tag:


### PR DESCRIPTION
Check that the schema of the parameter is available before getting the type to prevent the `NullPointerException`.

---
From OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/LqtILRKX8Jc/m/xREEz8VwAAAJ