### PR TITLE
automation: address NPE when creating a context

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Address exception when creating a new context through the UI.
 
 ## [0.29.0] - 2023-06-06
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.automation.ContextWrapper;
+import org.zaproxy.addon.automation.TechnologyData;
 import org.zaproxy.addon.automation.TechnologyUtils;
 import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -63,6 +64,7 @@ public class ContextDialog extends StandardFieldsDialog {
         this.envDialog = owner;
         if (context == null) {
             context = new ContextWrapper.Data();
+            context.setTechnology(new TechnologyData());
             this.isNew = true;
         }
         this.context = context;


### PR DESCRIPTION
Initialise the `TechnologyData` when creating the `ContextWrapper.Data` so it's able to set the techs when saving the dialogue.

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/mwRHFwP43Ko/m/mF5fb7mnBAAJ