### PR TITLE
reports: fix SARIF's Base64 encoder

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Change SARIF's Base64 encoder to not rely on the default character encoding.
 
 ## [0.21.0] - 2023-06-06
 ### Added

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/sarif/SarifBase64Encoder.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/sarif/SarifBase64Encoder.java
@@ -29,7 +29,6 @@ public class SarifBase64Encoder {
         if (bytes == null) {
             return null;
         }
-        byte[] encoded = Base64.getEncoder().encode(bytes);
-        return new String(encoded);
+        return Base64.getEncoder().encodeToString(bytes);
     }
 }

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/sarif/SarifBase64EncoderUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/sarif/SarifBase64EncoderUnitTest.java
@@ -21,6 +21,8 @@ package org.zaproxy.addon.reports.sarif;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,14 +53,15 @@ class SarifBase64EncoderUnitTest {
     @Test
     void emojThinkingFaceCanBeEncodedToBase64() {
         /* prepare */
+        Charset charset = StandardCharsets.UTF_8;
         String content = "🤔 Thinking Face";
 
         /* execute */
-        String encoded = toTest.encodeBytesToBase64(content.getBytes());
+        String encoded = toTest.encodeBytesToBase64(content.getBytes(charset));
 
         /* test */
         byte[] backwardCheck = Base64.getDecoder().decode(encoded);
-        assertEquals(content, new String(backwardCheck));
+        assertEquals(content, new String(backwardCheck, charset));
         assertEquals("8J+klCBUaGlua2luZyBGYWNl", encoded);
     }
 


### PR DESCRIPTION
Do not rely on the default charset when creating the string from the Base64 encoded data, ensure it's used always the expected, ISO-8859-1.
Correct the tests to also not rely on the default charset when converting the string to/from bytes.