### PR TITLE
pscanrules: Add Example Alert XBackendServerInformationLeakScanRule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+- The X-Backend-Server Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [49] - 2023-06-06
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
 - The X-Backend-Server Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [49] - 2023-06-06

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRule.java
@@ -58,19 +58,22 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner 
             // It is set so lets check it. Should only be one but it's a vector so iterate to be
             // sure.
             for (String xbsDirective : xbsOption) {
-                newAlert()
-                        .setRisk(Alert.RISK_LOW)
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setDescription(getDescription())
-                        .setSolution(getSolution())
-                        .setReference(getReference())
-                        .setEvidence(xbsDirective)
-                        .setCweId(200)
-                        .setWascId(13)
-                        .raise();
+                createAlert(xbsDirective).raise();
             }
         }
         LOGGER.debug("\tScan of record {} took {}ms", id, System.currentTimeMillis() - start);
+    }
+
+    private AlertBuilder createAlert(String evidence) {
+        return newAlert()
+                .setRisk(Alert.RISK_LOW)
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setDescription(getDescription())
+                .setSolution(getSolution())
+                .setReference(getReference())
+                .setEvidence(evidence)
+                .setCweId(200)
+                .setWascId(13);
     }
 
     @Override
@@ -98,5 +101,10 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner 
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(createAlert("developer1.webapp.scl3.mozilla.com").build());
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRuleUnitTest.java
@@ -23,10 +23,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
@@ -97,5 +100,24 @@ class XBackendServerInformationLeakScanRuleUnitTest
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_INFO_02_FINGERPRINT_WEB_SERVER.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_INFO_02_FINGERPRINT_WEB_SERVER.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        String MESSAGE_PREFIX = "pscanrules.xbackendserver.";
+
+        List<Alert> alerts = rule.getExampleAlerts();
+
+        Alert alert = alerts.get(0);
+        assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(
+                alert.getReference(),
+                equalTo(Constant.messages.getString(MESSAGE_PREFIX + "refs")));
+        assertThat(alert.getEvidence(), equalTo(HEADER_VALUE));
+        assertThat(
+                alert.getSolution(), equalTo(Constant.messages.getString(MESSAGE_PREFIX + "soln")));
+        assertThat(
+                alert.getDescription(),
+                equalTo(Constant.messages.getString(MESSAGE_PREFIX + "desc")));
     }
 }


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/6119

Changes:
- Add example alert functionality.
- Add unit tests for example alerts functionality.
- Add note to changelog.