### PR TITLE
ascanrules: Format string rule only needs a single example alert

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
@@ -310,9 +310,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
 
     @Override
     public List<Alert> getExampleAlerts() {
-        return List.of(
-                createInitialAttackAlert("%n%s%n%s%n%s%n%s\n", "name", null).build(),
-                createSecondaryAttackAlert("%s%s%s%s%s%s%s", "query", null).build(),
-                createMicrosoftAttackAlert("%p %p %p %p %p %p", "q", null).build());
+        // Although there are different 'tests' there is really only one alert
+        return List.of(createInitialAttackAlert("%n%s%n%s%n%s%n%s\n", "name", null).build());
     }
 }

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRuleUnitTest.java
@@ -88,15 +88,13 @@ class FormatStringScanRuleUnitTest extends ActiveScannerTest<FormatStringScanRul
     void shouldReturnExpectedExampleAlert() {
         List<Alert> alerts = rule.getExampleAlerts();
 
-        assertThat(alerts.size(), is(equalTo(3)));
-
-        for (Alert alert : alerts) {
-            Map<String, String> tags = alert.getTags();
-            assertThat(tags.size(), is(equalTo(2)));
-            assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()));
-            assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()));
-            assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
-            assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        }
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        Map<String, String> tags = alert.getTags();
+        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 }


### PR DESCRIPTION
Yes I agree with https://developercertificate.org/. I did this edit in github.dev and am unable to --signoff.

Related to: https://github.com/zaproxy/zaproxy-website/pull/1889#issuecomment-1594119445