### PR TITLE
ascanrules: Correct Blazor HFF entry

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - The Format String Error scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
+- Corrected Hidden File Finder scan rule Blazor WASM config file path.
 
 ## [55] - 2023-06-06
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
@@ -72,6 +72,8 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
                     CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG,
                     CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE);
     static final String PAYLOADS_FILE_PATH = "json/hidden_files.json";
+    static final String DEFAULT_PAYLOAD_PATH =
+            Constant.getZapHome() + File.separator + PAYLOADS_FILE_PATH;
 
     private static final List<String> HIDDEN_FILES =
             Arrays.asList(
@@ -94,7 +96,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
 
     @Override
     public void init() {
-        hfList = readFromJsonFile();
+        hfList = readFromJsonFile(DEFAULT_PAYLOAD_PATH);
         for (String payload : getHiddenFilePayloads().get()) {
             hfList.add(
                     new HiddenFile(
@@ -301,8 +303,8 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
         return otherInfo;
     }
 
-    private List<HiddenFile> readFromJsonFile() {
-        String jsonTxt = readPayloadsFile();
+    List<HiddenFile> readFromJsonFile(String path) {
+        String jsonTxt = readPayloadsFile(path);
         if (jsonTxt.isEmpty()) {
             return new ArrayList<>();
         }
@@ -372,8 +374,8 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
         return newList;
     }
 
-    private String readPayloadsFile() {
-        File f = new File(Constant.getZapHome() + File.separator + PAYLOADS_FILE_PATH);
+    private String readPayloadsFile(String path) {
+        File f = new File(path);
         if (!f.exists()) {
             LOGGER.error("No such file: {}", f.getAbsolutePath());
             return "";

--- a/addOns/ascanrules/src/main/zapHomeFiles/json/hidden_files.json
+++ b/addOns/ascanrules/src/main/zapHomeFiles/json/hidden_files.json
@@ -286,7 +286,7 @@
       "source":"nav1n0x"
     },
     {
-      "path":"/_framework/blazor.boot.json",
+      "path":"_framework/blazor.boot.json",
       "content":["Blazor"],
       "links":["https://twitter.com/_Freakyclown_/status/1660737687178072064", "https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly"],
       "type":"Blazor",


### PR DESCRIPTION
The path shouldn't have a leading slash otherwise the generated path duplicates it.