### PR TITLE
network: remove task no longer needed

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -1343,8 +1343,6 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
         }
 
         Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
-        // TODO needs https://github.com/bcgit/bc-java/issues/1254
-        // ThreadUtils.findThreadsByName("BC Entropy Daemon").forEach(Thread::interrupt);
 
         if (hasView()) {
             OptionsDialog optionsDialog = View.getSingleton().getOptionsDialog("");


### PR DESCRIPTION
The possible clean up is no longer needed, the Bouncy Castle version in use no longer uses a daemon thread by default.