### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update Zest library to 0.17.0:
+- Update Zest library to 0.18.0:
   - Update Selenium to version 4.
   - jBrowserDriver (JBD), Opera, and PhantomJS are no longer supported (no longer being actively maintained).
+  - Add client statements for Scroll, MouseOver, and Window Resize events.
 - Maintenance changes.
 
 ## [38] - 2023-01-03

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -38,7 +38,7 @@ zapAddOn {
 dependencies {
     compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
-    implementation("org.zaproxy:zest:0.17.0") {
+    implementation("org.zaproxy:zest:0.18.0") {
         // Provided by Selenium add-on.
         exclude(group = "org.seleniumhq.selenium")
         // Provided by ZAP.


### PR DESCRIPTION
Update Zest library to 0.18.0:
 - Add client statements for Scroll, MouseOver, and Window Resize events.
 - Update Selenium to version 4.10.0.