### PR TITLE
openapi: Increase definition column size

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix exception when generating data for parameters without schema.
+- An exception which might occur on large definition imports (Issue 7876).
 
 ## [33] - 2023-04-04
 ### Changed


### PR DESCRIPTION
- TableOpenApi.java > Increased "definition" column from 16M to 64M. If a session is opened with an existing table then the column definition is adjusted. If a definition greater than 64M is imported then it simply won't persist, but should not fail.
- CHANGELOG.md > Added fix note.

Part of zaproxy/zaproxy#7876