### PR TITLE
ascanrulesBeta: add example alerts to Source Code Disclosure - File Inclusion

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- The Source Code Disclosure - File Inclusion now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [46] - 2023-05-03
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
@@ -332,28 +333,12 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
 
                             // if we get to here, is is very likely that we have source file
                             // inclusion attack. alert it.
-                            newAlert()
-                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setDescription(
-                                            Constant.messages.getString(
-                                                    "ascanbeta.sourcecodedisclosure.desc"))
-                                    .setUri(getBaseMsg().getRequestHeader().getURI().toString())
-                                    .setParam(paramname)
-                                    .setAttack(prefixedUrlfilename)
-                                    .setOtherInfo(
-                                            Constant.messages.getString(
-                                                    "ascanbeta.sourcecodedisclosure.lfibased.extrainfo",
-                                                    prefixedUrlfilename,
-                                                    NON_EXISTANT_FILENAME,
-                                                    randomversussourcefilenamematchpercentage,
-                                                    this.thresholdPercentage))
-                                    .setSolution(
-                                            Constant.messages.getString(
-                                                    "ascanbeta.sourcecodedisclosure.lfibased.soln"))
-                                    .setEvidence(
-                                            Constant.messages.getString(
-                                                    "ascanbeta.sourcecodedisclosure.lfibased.evidence"))
-                                    .setMessage(sourceattackmsg)
+                            createAlert(
+                                            paramname,
+                                            prefixedUrlfilename,
+                                            randomversussourcefilenamematchpercentage,
+                                            sourceattackmsg,
+                                            getBaseMsg().getRequestHeader().getURI().toString())
                                     .raise();
                             // All done on this parameter
                             return;
@@ -429,28 +414,12 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
 
                             // if we get to here, is is very likely that we have source file
                             // inclusion attack. alert it.
-                            newAlert()
-                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setDescription(
-                                            Constant.messages.getString(
-                                                    "ascanbeta.sourcecodedisclosure.desc"))
-                                    .setUri(getBaseMsg().getRequestHeader().getURI().toString())
-                                    .setParam(paramname)
-                                    .setAttack(prefixedUrlfilename)
-                                    .setOtherInfo(
-                                            Constant.messages.getString(
-                                                    "ascanbeta.sourcecodedisclosure.lfibased.extrainfo",
-                                                    prefixedUrlfilename,
-                                                    NON_EXISTANT_FILENAME,
-                                                    randomversussourcefilenamematchpercentage,
-                                                    this.thresholdPercentage))
-                                    .setSolution(
-                                            Constant.messages.getString(
-                                                    "ascanbeta.sourcecodedisclosure.lfibased.soln"))
-                                    .setEvidence(
-                                            Constant.messages.getString(
-                                                    "ascanbeta.sourcecodedisclosure.lfibased.evidence"))
-                                    .setMessage(sourceattackmsg)
+                            createAlert(
+                                            paramname,
+                                            prefixedUrlfilename,
+                                            randomversussourcefilenamematchpercentage,
+                                            sourceattackmsg,
+                                            getBaseMsg().getRequestHeader().getURI().toString())
                                     .raise();
 
                             // All done. No need to look for vulnerabilities on subsequent
@@ -546,5 +515,40 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
         if (a == 0 || b == 0) return 0;
 
         return (int) ((((double) Math.min(a, b)) / Math.max(a, b)) * 100);
+    }
+
+    private AlertBuilder createAlert(
+            String paramname,
+            String prefixedUrlfilename,
+            Integer randomversussourcefilenamematchpercentage,
+            HttpMessage sourceattackmsg,
+            String uri) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setDescription(Constant.messages.getString("ascanbeta.sourcecodedisclosure.desc"))
+                .setUri(uri)
+                .setParam(paramname)
+                .setAttack(prefixedUrlfilename)
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                "ascanbeta.sourcecodedisclosure.lfibased.extrainfo",
+                                prefixedUrlfilename,
+                                NON_EXISTANT_FILENAME,
+                                randomversussourcefilenamematchpercentage,
+                                this.thresholdPercentage))
+                .setSolution(
+                        Constant.messages.getString("ascanbeta.sourcecodedisclosure.lfibased.soln"))
+                .setEvidence(
+                        Constant.messages.getString(
+                                "ascanbeta.sourcecodedisclosure.lfibased.evidence"))
+                .setMessage(sourceattackmsg);
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        String exampleUri = "https://example.com";
+        return List.of(
+                createAlert("name", "../config/database.php", 48, getBaseMsg(), exampleUri).build(),
+                createAlert("name", "../secrets/passwords", 31, getBaseMsg(), exampleUri).build());
     }
 }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -547,8 +547,6 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
     @Override
     public List<Alert> getExampleAlerts() {
         String exampleUri = "https://example.com";
-        return List.of(
-                createAlert("name", "../config/database.php", 48, getBaseMsg(), exampleUri).build(),
-                createAlert("name", "../secrets/passwords", 31, getBaseMsg(), exampleUri).build());
+        return List.of(createAlert("name", "../config/database.php", 48, null, exampleUri).build());
     }
 }

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
@@ -66,7 +66,7 @@ class SourceCodeDisclosureFileInclusionScanRuleUnitTest
     void shouldReturnExpectedExampleAlert() {
         List<Alert> alerts = rule.getExampleAlerts();
 
-        assertThat(alerts.size(), is(equalTo(2)));
+        assertThat(alerts.size(), is(equalTo(1)));
 
         for (Alert alert : alerts) {
             Map<String, String> tags = alert.getTags();

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
@@ -21,10 +21,13 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 
 class SourceCodeDisclosureFileInclusionScanRuleUnitTest
@@ -57,5 +60,21 @@ class SourceCodeDisclosureFileInclusionScanRuleUnitTest
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        List<Alert> alerts = rule.getExampleAlerts();
+
+        assertThat(alerts.size(), is(equalTo(2)));
+
+        for (Alert alert : alerts) {
+            Map<String, String> tags = alert.getTags();
+            assertThat(tags.size(), is(equalTo(2)));
+            assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
+            assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
+            assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+            assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        }
     }
 }


### PR DESCRIPTION
## Overview
Added example alerts for [Source Code Disclosure - File Inclusion](https://www.zaproxy.org/docs/alerts/43/).

## Related Issues
[#6119](https://github.com/zaproxy/zaproxy/issues/6119)

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
