### PR TITLE
pscanrules: add examples alerts to X Chrome logger

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- The X-Backend-Server Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).
-- The X-ChromeLogger-Data Header information Leak Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).
-
+- The following now include example alert functionality for documentation generation purposes (Issue 6119):
+    - X-Backend-Server Scan Rule
+    - X-ChromeLogger-Data Header Information Leak Scan Rule
 ## [49] - 2023-06-06
 ### Changed
 - The X-AspNet-Version Response Header Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - The X-Backend-Server Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).
+- The X-ChromeLogger-Data Header information Leak Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [49] - 2023-06-06
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The following now include example alert functionality for documentation generation purposes (Issue 6119):
     - X-Backend-Server Scan Rule
     - X-ChromeLogger-Data Header Information Leak Scan Rule
+
 ## [49] - 2023-06-06
 ### Changed
 - The X-AspNet-Version Response Header Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java
@@ -70,17 +70,7 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner {
 
         if (!loggerHeaders.isEmpty()) { // Header(s) Found
             for (String xcldField : loggerHeaders) {
-                newAlert()
-                        .setRisk(Alert.RISK_MEDIUM)
-                        .setConfidence(Alert.CONFIDENCE_HIGH)
-                        .setDescription(getDescription())
-                        .setOtherInfo(getOtherInfo(xcldField))
-                        .setSolution(getSolution())
-                        .setReference(getReference())
-                        .setEvidence(xcldField)
-                        .setCweId(200)
-                        .setWascId(13)
-                        .raise();
+                createAlert(xcldField).raise();
             }
         }
         LOGGER.debug("\tScan of record {} took {}ms", id, System.currentTimeMillis() - start);
@@ -124,5 +114,34 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner {
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
+    }
+
+    private AlertBuilder createAlert(String xcldField) {
+        return newAlert()
+                .setRisk(Alert.RISK_MEDIUM)
+                .setConfidence(Alert.CONFIDENCE_HIGH)
+                .setDescription(getDescription())
+                .setOtherInfo(getOtherInfo(xcldField))
+                .setSolution(getSolution())
+                .setReference(getReference())
+                .setEvidence(xcldField)
+                .setCweId(200)
+                .setWascId(13);
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                createAlert(
+                                "eyJ2ZXJzaW9uIjoiNC4wIiwiY29sdW"
+                                        + "1ucyI6WyJsYWJlbCIsImxvZyIsImJhY2t0cmFjZSIsInR5cGUiXSwicm93cyI"
+                                        + "6W1sicmVxdWVzdCIsIk1hdGNoZWQgcm91dGUgXCJhcHBfc2VjdXJpdHlfbG9n"
+                                        + "aW5cIiAocGFyYW1ldGVyczogXCJfY29udHJvbGxlclwiOiBcIkJhY2tFbmRcX"
+                                        + "EFwcEJ1bmRsZVxcQ29udHJvbGxlclxcU2VjdXJpdHlDb250cm9sbGVyOjpsb2"
+                                        + "dpbkFjdGlvblwiLCBcIl9yb3V0ZVwiOiBcImFwcF9zZWN1cml0eV9sb2dpblw"
+                                        + "iKSIsInVua25vd24iLCJpbmZvIl0sWyJzZWN1cml0eSIsIlBvcHVsYXRlZCBT"
+                                        + "ZWN1cml0eUNvbnRleHQgd2l0aCBhbiBhbm9ueW1vdXMgVG9rZW4iLCJ1bmtub"
+                                        + "3duIiwiaW5mbyJdXSwicmVxdWVzdF91cmkiOiJcL2xvZ2luIn0=")
+                        .build());
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
@@ -26,10 +26,12 @@ import static org.hamcrest.Matchers.is;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
@@ -149,5 +151,25 @@ class XChromeLoggerDataInfoLeakScanRuleUnitTest
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+
+        Alert alert = alerts.get(0);
+        Map<String, String> tags1 = alert.getTags();
+        assertThat(tags1.size(), is(equalTo(3)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_HIGH)));
+        assertThat(
+                tags1.containsKey(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()),
+                is(equalTo(true)));
+        assertThat(
+                tags1.containsKey(CommonAlertTag.OWASP_2021_A04_INSECURE_DESIGN.getTag()),
+                is(equalTo(true)));
     }
 }


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/6119

Changes:
- Add example alert functionality
- Add unit tests for example alert functionality
- Add note to changelog