### PR TITLE
pscanrules: add example alert to Cache Control Scan Rule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - The following now include example alert functionality for documentation generation purposes (Issue 6119):
+    - Re-examine Cache-control Directives Scan Rule
     - X-Backend-Server Scan Rule
     - X-ChromeLogger-Data Header Information Leak Scan Rule
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRuleUnitTest.java
@@ -26,10 +26,12 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -402,5 +404,26 @@ class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheControlScanRu
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        String MESSAGE_PREFIX = "pscanrules.cachecontrol.";
+
+        List<Alert> alerts = rule.getExampleAlerts();
+
+        Alert alert = alerts.get(0);
+        assertThat(alert.getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(
+                alert.getReference(),
+                equalTo(Constant.messages.getString(MESSAGE_PREFIX + "refs")));
+        assertThat(
+                alert.getSolution(), equalTo(Constant.messages.getString(MESSAGE_PREFIX + "soln")));
+        assertThat(
+                alert.getDescription(),
+                equalTo(Constant.messages.getString(MESSAGE_PREFIX + "desc")));
+        assertThat(alert.getEvidence(), equalTo("no-store, must-revalidate"));
+        assertThat(alert.getParam(), equalTo(HttpHeader.CACHE_CONTROL));
     }
 }


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/6119

Changes:
- Add example alert functionality.
- Add unit tests for example alerts functionality.
- Add note to changelog.