### PR TITLE
postman: Add importing through the API

### DIFF
--- a/addOns/postman/postman.gradle.kts
+++ b/addOns/postman/postman.gradle.kts
@@ -8,6 +8,11 @@ zapAddOn {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/postman-support/")
     }
+
+    apiClientGen {
+        api.set("org.zaproxy.addon.postman.PostmanApi")
+        messages.set(file("src/main/resources/org/zaproxy/addon/postman/resources/Messages.properties"))
+    }
 }
 
 crowdin {

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/ExtensionPostman.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/ExtensionPostman.java
@@ -61,6 +61,7 @@ public class ExtensionPostman extends ExtensionAdaptor implements CommandLineLis
             extensionHook.getHookMenu().addImportMenuItem(getMenuImportUrlPostman());
             extensionHook.addSessionListener(new SessionChangedListenerImpl());
         }
+        extensionHook.addApiImplementor(new PostmanApi());
         extensionHook.addCommandLine(getCommandLineArguments());
     }
 

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanApi.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanApi.java
@@ -1,0 +1,68 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.postman;
+
+import net.sf.json.JSONObject;
+import org.zaproxy.zap.extension.api.ApiAction;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
+
+public class PostmanApi extends ApiImplementor {
+    private static final String PREFIX = "postman";
+    private static final String ACTION_IMPORT_FILE = "importFile";
+    private static final String ACTION_IMPORT_URL = "importUrl";
+    private static final String PARAM_URL = "url";
+    private static final String PARAM_FILE = "file";
+    private static final String PARAM_ENDPOINT_URL = "endpointUrl";
+
+    public PostmanApi() {
+        this.addApiAction(
+                new ApiAction(
+                        ACTION_IMPORT_FILE,
+                        new String[] {PARAM_FILE},
+                        new String[] {PARAM_ENDPOINT_URL}));
+        this.addApiAction(
+                new ApiAction(
+                        ACTION_IMPORT_URL,
+                        new String[] {PARAM_URL},
+                        new String[] {PARAM_ENDPOINT_URL}));
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
+        switch (name) {
+            case ACTION_IMPORT_FILE:
+            case ACTION_IMPORT_URL:
+                break;
+
+            default:
+                throw new ApiException(ApiException.Type.BAD_ACTION);
+        }
+
+        return ApiResponseElement.OK;
+    }
+}

--- a/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/postman.html
+++ b/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/postman.html
@@ -16,6 +16,13 @@ This add-on will allow you to spider and import Postman definitions. It is curre
 <li>Import a Postman definition from a URL</li>
 </ul>
 
+<H2>API</H2>
+The following operations are added to the API:
+<ul>
+<li>ACTION importFile (file, endpointUrl)</li>
+<li>ACTION importUrl (url, endpointUrl)</li>
+</ul>
+
 <H2>Command Line</H2>
 The following Command Line options are added:
 <ul>


### PR DESCRIPTION
## Overview

The following operations are added to the API:
- ACTION importFile (file, endpointUrl)
- ACTION importUrl (url, endpointUrl)

## Related Issues
https://github.com/zaproxy/zaproxy/issues/6960

## Checklist
- [x] Update help
- [x] Update changelog (N/A)
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests (N/A)
- [x] Check code coverage (N/A)
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
