### PR TITLE
network: keep stack trace of original exceptions

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update dependencies.
 - Update default user-agents.
 
+### Fixed
+- Keep the original stack trace of timeout and unknown host exceptions.
+
 ## [0.9.0] - 2023-06-06
 ### Changed
 - Use `TRACE` level (instead of `DEBUG`) to log client side HTTP traffic to avoid accidentally enabling it when debugging other add-ons.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/common/ZapSocketTimeoutException.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/common/ZapSocketTimeoutException.java
@@ -38,11 +38,30 @@ public class ZapSocketTimeoutException extends SocketTimeoutException {
      *
      * @param msg the detail message.
      * @param timeout the value of the timeout.
+     * @deprecated (0.10.0) Use {@link #ZapSocketTimeoutException(SocketTimeoutException, int)}
+     *     instead.
      */
+    @Deprecated(since = "0.10.0", forRemoval = true)
     public ZapSocketTimeoutException(String msg, int timeout) {
         super(msg);
 
         this.timeout = timeout;
+    }
+
+    /**
+     * Constructs a {@code ZapSocketTimeoutException} with the given exception and the value of the
+     * timeout.
+     *
+     * @param e the original exception.
+     * @param timeout the value of the timeout.
+     * @throws NullPointerException if the given exception is {@code null}.
+     * @since 0.10.0
+     */
+    public ZapSocketTimeoutException(SocketTimeoutException e, int timeout) {
+        super(e.getMessage());
+
+        this.timeout = timeout;
+        setStackTrace(e.getStackTrace());
     }
 
     /**

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/common/ZapUnknownHostException.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/common/ZapUnknownHostException.java
@@ -39,11 +39,31 @@ public class ZapUnknownHostException extends UnknownHostException {
      * @param host the name of the host.
      * @param fromOutgoingProxy {@code true} if failed to resolve the outgoing proxy's host, {@code
      *     false} otherwise.
+     * @deprecated (0.10.0) Use {@link #ZapUnknownHostException(UnknownHostException, boolean)}
+     *     instead.
      */
+    @Deprecated(since = "0.10.0", forRemoval = true)
     public ZapUnknownHostException(String host, boolean fromOutgoingProxy) {
         super(host);
 
         this.fromOutgoingProxy = fromOutgoingProxy;
+    }
+
+    /**
+     * Constructs a {@code ZapUnknownHostException} with the given exception and whether the host is
+     * the outgoing proxy.
+     *
+     * @param e the original exception.
+     * @param fromOutgoingProxy {@code true} if failed to resolve the outgoing proxy's host, {@code
+     *     false} otherwise.
+     * @throws NullPointerException if the given exception is {@code null}.
+     * @since 0.10.0
+     */
+    public ZapUnknownHostException(UnknownHostException e, boolean fromOutgoingProxy) {
+        super(e.getMessage());
+
+        this.fromOutgoingProxy = fromOutgoingProxy;
+        setStackTrace(e.getStackTrace());
     }
 
     /**

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -362,10 +362,10 @@ public class HttpSenderApache
             sendImpl0(ctx, requestContext, message, responseBodyConsumer);
         } catch (SocketTimeoutException e) {
             LOGGER.debug("A timeout occurred while sending the request:", e);
-            throw new ZapSocketTimeoutException(e.getMessage(), options.getTimeoutInSecs());
+            throw new ZapSocketTimeoutException(e, options.getTimeoutInSecs());
         } catch (UnknownHostException e) {
             LOGGER.debug("An unknown host exception occurred while sending the request:", e);
-            throw new ZapUnknownHostException(e.getMessage(), isProxyHost(e.getMessage()));
+            throw new ZapUnknownHostException(e, isProxyHost(e.getMessage()));
         } catch (IOException e) {
             LOGGER.debug("An I/O error occurred while sending the request:", e);
             throw e;

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
@@ -40,6 +40,7 @@ import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 import fi.iki.elonen.NanoHTTPD.Response.Status;
 import java.net.MalformedURLException;
+import java.net.UnknownHostException;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -573,7 +574,7 @@ class SpiderJobUnitTest extends TestUtils {
         given(env.replaceVars(url)).willReturn(url);
 
         HttpSender httpSender = mock(HttpSender.class);
-        doThrow(new ZapUnknownHostException("", true))
+        doThrow(new ZapUnknownHostException(new UnknownHostException(), true))
                 .when(httpSender)
                 .sendAndReceive(any(), anyBoolean());
 


### PR DESCRIPTION
Keep the original stack trace when creating the custom timeout and unknown host exceptions.