### PR TITLE
Update content-length in auth template scripts

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Updated encode-decode script templates to conform to the latest method signatures.
+- Update the content-length header field after setting the request body in the authentication templates.
 
 ## [0.3.0] - 2022-10-27
 ### Changed

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/authentication/Authentication default template GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/authentication/Authentication default template GraalJS.js
@@ -20,6 +20,11 @@ function authenticate(helper, paramsValues, credentials) {
 	
 	// TODO: Process message to match the authentication needs
 
+	// For example, add a request payload
+	// msg.setRequestBody("a payload with user credentials")
+	// And set/update the content-length header field accordingly.
+	// msg.getRequestHeader().setContentLength(msg.getRequestBody().length())
+
 	// Configurations on how the messages are sent/handled:
 	// Set to follow redirects when sending messages (default is false).
 	// helper.getHttpSender().setFollowRedirect(true)

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/authentication/BodgeIt Store Authentication GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/authentication/BodgeIt Store Authentication GraalJS.js
@@ -32,6 +32,7 @@ function authenticate(helper, paramsValues, credentials) {
 	var msg=helper.prepareMessage();
 	msg.setRequestHeader(new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10));
 	msg.setRequestBody(requestBody);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/authentication/Simple Form-Based Authentication GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/authentication/Simple Form-Based Authentication GraalJS.js
@@ -42,6 +42,7 @@ function authenticate(helper, paramsValues, credentials) {
 	var msg = helper.prepareMessage();
 	msg.setRequestHeader(new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10));
 	msg.setRequestBody(requestBody);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/authentication/Wordpress Authentication GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/authentication/Wordpress Authentication GraalJS.js
@@ -49,6 +49,7 @@ function authenticate(helper, paramsValues, credentials) {
 	var msg = helper.prepareMessage();
 	msg.setRequestHeader(requestHeader);
 	msg.setRequestBody(requestBody);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.12.0.
 
+### Fixed
+- Update the content-length header field after setting the request body in the authentication template.
+
 ## [8] - 2021-10-07
 ### Changed
 - Update links to zaproxy repo.

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/authentication/Simple Form-Based Authentication.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/authentication/Simple Form-Based Authentication.rb
@@ -39,6 +39,7 @@ def authenticate(helper, paramsValues, credentials)
 	msg=helper.prepareMessage();
 	msg.setRequestHeader(HttpRequestHeader.new(requestMethod, requestUri, HttpHeader::HTTP10));
 	msg.setRequestBody(requestBody);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 	# Send the authentication message and return it
 	helper.sendAndReceive(msg);

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Updated encode-decode script templates to conform to the latest method signatures.
+- Update the content-length header field after setting the request body in the authentication template.
 
 ## [12] - 2021-10-07
 ### Added

--- a/addOns/jython/src/main/zapHomeFiles/scripts/templates/authentication/Simple Form-Based Authentication.py
+++ b/addOns/jython/src/main/zapHomeFiles/scripts/templates/authentication/Simple Form-Based Authentication.py
@@ -38,6 +38,7 @@ def authenticate(helper, paramsValues, credentials):
 	msg = helper.prepareMessage();
 	msg.setRequestHeader(HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10));
 	msg.setRequestBody(requestBody);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 	# Send the authentication message and return it
 	print "Sending %s request to %s with body: %s" % (requestMethod, requestUri, requestBody);


### PR DESCRIPTION
Change the authentication template scripts to update the content-length header field after setting the request body.

Related to zaproxy/zaproxy#7936.