### PR TITLE
graphql: handle invalid enum when loading options

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   "Import a GraphQL schema".
 - The Import dialog shows the values used in the previous import when reopened.
 
+### Fixed
+- Handle invalid values when reading the options.
+
 ## [0.17.0] - 2023-06-19
 ### Added
 - It is now possible to disable the query generator completely.

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
@@ -295,13 +295,25 @@ public class GraphQlParam extends VersionedAbstractParam {
                 getInt(PARAM_MAX_ADDITIONAL_QUERY_DEPTH, DEFAULT_MAX_ADDITIONAL_QUERY_DEPTH);
         maxArgsDepth = getInt(PARAM_MAX_ARGS_DEPTH, DEFAULT_MAX_ARGS_DEPTH);
         optionalArgsEnabled = getBoolean(PARAM_OPTIONAL_ARGS, DEFAULT_OPTIONAL_ARGS);
-        argsType = ArgsTypeOption.valueOf(getString(PARAM_ARGS_TYPE, DEFAULT_ARGS_TYPE.toString()));
+        argsType = getEnum(ArgsTypeOption.class, PARAM_ARGS_TYPE, DEFAULT_ARGS_TYPE);
         querySplitType =
-                QuerySplitOption.valueOf(
-                        getString(PARAM_QUERY_SPLIT_TYPE, DEFAULT_QUERY_SPLIT_TYPE.toString()));
+                getEnum(QuerySplitOption.class, PARAM_QUERY_SPLIT_TYPE, DEFAULT_QUERY_SPLIT_TYPE);
         requestMethod =
-                RequestMethodOption.valueOf(
-                        getString(PARAM_REQUEST_METHOD, DEFAULT_REQUEST_METHOD.toString()));
+                getEnum(RequestMethodOption.class, PARAM_REQUEST_METHOD, DEFAULT_REQUEST_METHOD);
+    }
+
+    private <T extends Enum<T>> T getEnum(Class<T> enumType, String key, T defaultValue) {
+        String value = getString(key, defaultValue.toString());
+        try {
+            return Enum.valueOf(enumType, value);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn(
+                    "Using default {}, {}. Failed to convert from: {}",
+                    enumType.getSimpleName(),
+                    defaultValue,
+                    value);
+        }
+        return defaultValue;
     }
 
     @Override

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParamUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParamUnitTest.java
@@ -1,0 +1,125 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.zaproxy.addon.graphql.GraphQlParam.ArgsTypeOption;
+import org.zaproxy.addon.graphql.GraphQlParam.QuerySplitOption;
+import org.zaproxy.addon.graphql.GraphQlParam.RequestMethodOption;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link GraphQlParam}. */
+class GraphQlParamUnitTest {
+
+    private static final String PARAM_ARGS_TYPE = "graphql.argsType";
+    private static final String PARAM_QUERY_SPLIT_TYPE = "graphql.querySplitType";
+    private static final String PARAM_REQUEST_METHOD = "graphql.requestMethod";
+
+    private ZapXmlConfiguration config;
+    private GraphQlParam options;
+
+    @BeforeEach
+    void setUp() {
+        options = new GraphQlParam();
+        config = new ZapXmlConfiguration();
+        options.load(config);
+    }
+
+    @Test
+    void shouldHaveConfigVersionKey() {
+        assertThat(options.getConfigVersionKey(), is(equalTo("graphql[@version]")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ArgsTypeOption.class)
+    void shouldLoadConfigWithArgsTypeOption(ArgsTypeOption value) {
+        // Given
+        options = new GraphQlParam();
+        config.setProperty(PARAM_ARGS_TYPE, value.toString());
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getArgsType(), is(equalTo(value)));
+    }
+
+    @Test
+    void shouldUseDefaultWithInvalidArgsTypeOption() {
+        // Given
+        options = new GraphQlParam();
+        config.setProperty(PARAM_ARGS_TYPE, "Not Valid");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getArgsType(), is(equalTo(ArgsTypeOption.BOTH)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(QuerySplitOption.class)
+    void shouldLoadConfigWithQuerySplitOption(QuerySplitOption value) {
+        // Given
+        options = new GraphQlParam();
+        config.setProperty(PARAM_QUERY_SPLIT_TYPE, value.toString());
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getQuerySplitType(), is(equalTo(value)));
+    }
+
+    @Test
+    void shouldUseDefaultWithInvalidQuerySplitOption() {
+        // Given
+        options = new GraphQlParam();
+        config.setProperty(PARAM_QUERY_SPLIT_TYPE, "Not Valid");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getQuerySplitType(), is(equalTo(QuerySplitOption.LEAF)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(RequestMethodOption.class)
+    void shouldLoadConfigWithRequestMethodOption(RequestMethodOption value) {
+        // Given
+        options = new GraphQlParam();
+        config.setProperty(PARAM_REQUEST_METHOD, value.toString());
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getRequestMethod(), is(equalTo(value)));
+    }
+
+    @Test
+    void shouldUseDefaultWithInvalidRequestMethodOption() {
+        // Given
+        options = new GraphQlParam();
+        config.setProperty(PARAM_REQUEST_METHOD, "Not Valid");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getRequestMethod(), is(equalTo(RequestMethodOption.POST_JSON)));
+    }
+}


### PR DESCRIPTION
Handle the exception when creating invalid enum values.

--- 
From ZAP Developer Group: https://groups.google.com/g/zaproxy-develop/c/MBlbdGoL0TI/m/1LpCzjdJAgAJ