### PR TITLE
commonlib: update dependencies

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [1.14.0] - 2023-02-24
 ### Fixed

--- a/addOns/commonlib/commonlib.gradle.kts
+++ b/addOns/commonlib/commonlib.gradle.kts
@@ -26,8 +26,8 @@ crowdin {
 }
 
 dependencies {
-    implementation("commons-io:commons-io:2.11.0")
-    implementation("org.apache.commons:commons-csv:1.9.0")
+    implementation("commons-io:commons-io:2.13.0")
+    implementation("org.apache.commons:commons-csv:1.10.0")
     implementation("org.apache.commons:commons-collections4:4.4")
 
     testImplementation(project(":testutils"))

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/binlist/BinList.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/binlist/BinList.java
@@ -66,7 +66,7 @@ public final class BinList {
         Trie<String, BinRecord> trie = new PatriciaTrie<>();
         Iterable<CSVRecord> records;
         try (InputStream in = BinList.class.getResourceAsStream(BINLIST_FILE);
-                BOMInputStream bomStream = new BOMInputStream(in);
+                BOMInputStream bomStream = BOMInputStream.builder().setInputStream(in).get();
                 InputStreamReader inStream =
                         new InputStreamReader(bomStream, StandardCharsets.UTF_8)) {
 

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/binlist/BinListUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/binlist/BinListUnitTest.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.binlist;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link BinList}. */
+class BinListUnitTest {
+
+    @Test
+    void shouldCreateBinList() {
+        // Given / When
+        BinList binList = assertDoesNotThrow(() -> BinList.getSingleton());
+        // Then
+        assertThat(binList, is(notNullValue()));
+    }
+
+    @Test
+    void shouldGetValidBinRecord() {
+        // Given
+        String candidate = "324000";
+        // When
+        BinRecord record = BinList.getSingleton().get(candidate);
+        // Then
+        assertThat(record, is(notNullValue()));
+        assertThat(record.getBin(), is(equalTo("324000")));
+    }
+
+    @Test
+    void shouldNotGetInvalidBinRecord() {
+        // Given
+        String candidate = "Not a bin";
+        // When
+        BinRecord record = BinList.getSingleton().get(candidate);
+        // Then
+        assertThat(record, is(nullValue()));
+    }
+}


### PR DESCRIPTION
Update:
 - Commons IO to 2.13.0.
 - Commons CSV to 1.10.0.

Address deprecation.
Add test to verify that the BIN list is still properly loaded.