### PR TITLE
Update codebase to ZAP 2.13

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [8] - 2022-10-28

--- a/addOns/accessControl/accessControl.gradle.kts
+++ b/addOns/accessControl/accessControl.gradle.kts
@@ -2,7 +2,6 @@ description = "Adds a set of tools for testing access control in web application
 
 zapAddOn {
     addOnName.set("Access Control Testing")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -146,12 +146,19 @@ subprojects {
         }
     }
 
-    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.12.0"))
+    val zapGav = "org.zaproxy:zap:2.13.0-SNAPSHOT"
+    dependencies {
+        "zap"(zapGav)
+    }
+
+    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create(zapGav))
 
     zapAddOn {
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })
 
         manifest {
+            zapVersion.set("2.13.0")
+
             changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
             repo.set("https://github.com/zaproxy/zap-extensions/")
         }

--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.13.0.
+
 ### Fixed
 - Allow to filter Directory Browsing (ID 0) alerts through the Automation Framework job, previously would report as a missing ID.
 

--- a/addOns/alertFilters/alertFilters.gradle.kts
+++ b/addOns/alertFilters/alertFilters.gradle.kts
@@ -5,7 +5,6 @@ description = "Allows you to automate the changing of alert risk levels."
 zapAddOn {
     addOnName.set("Alert Filters")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/allinonenotes/CHANGELOG.md
+++ b/addOns/allinonenotes/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/allinonenotes/allinonenotes.gradle.kts
+++ b/addOns/allinonenotes/allinonenotes.gradle.kts
@@ -2,7 +2,6 @@ description = "A simple extension to view all notes in one pane."
 
 zapAddOn {
     addOnName.set("All In One Notes")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("David Vassallo")

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Server Side Template Injection (Blind)
   - XPath Injection
 
+### Changed
+- Update minimum ZAP version to 2.13.0.
+
 ## [55] - 2023-06-06
 ### Changed
 - The Parameter Tamper Scan rule now includes example alert functionality for documentation generation purposes (Issue 6119)

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -5,7 +5,6 @@ description = "The release status Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ### Removed

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -2,7 +2,6 @@ description = "The alpha status Active Scanner rules"
 
 zapAddOn {
     addOnName.set("Active scanner rules (alpha)")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Server Side Request Forgery
   - Text4shell (CVE-2022-42889)
 
+### Changed
+- Update minimum ZAP version to 2.13.0.
+
 ### Removed
 - The following scan rules were removed, having been promoted to Release:
   - Log4Shell

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -5,7 +5,6 @@ description = "The beta status Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules (beta)")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Direct support for handling browser based authentication in the AJAX spider.
 - Support for cookie based session management.
 
+### Changed
+- Update minimum ZAP version to 2.13.0.
+
 ## [0.8.0] - 2023-06-06
 ### Changed
 - Prefer username fields with known id/name strings.

--- a/addOns/authhelper/authhelper.gradle.kts
+++ b/addOns/authhelper/authhelper.gradle.kts
@@ -5,7 +5,6 @@ description = "Helps identify and set up authentication handling"
 zapAddOn {
     addOnName.set("Authentication Helper")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -195,12 +195,12 @@ class AuthUtilsUnitTest extends TestUtils {
         // Then
         assertThat(tokens.size(), is(equalTo(1)));
 
-        assertThat(tokens.get("header:Authorization"), is(notNullValue()));
+        assertThat(tokens.get("header:authorization"), is(notNullValue()));
         assertThat(
-                tokens.get("header:Authorization").getSource(),
+                tokens.get("header:authorization").getSource(),
                 is(equalTo(SessionToken.HEADER_SOURCE)));
         assertThat(
-                tokens.get("header:Authorization").getKey(), is(equalTo(HttpHeader.AUTHORIZATION)));
+                tokens.get("header:authorization").getKey(), is(equalTo(HttpHeader.AUTHORIZATION)));
     }
 
     @Test
@@ -390,7 +390,7 @@ class AuthUtilsUnitTest extends TestUtils {
         // Then
         assertThat(headerTokens.size(), is(equalTo(2)));
         assertThat(headerTokens.get(0).first, is(equalTo(HttpHeader.AUTHORIZATION)));
-        assertThat(headerTokens.get(0).second, is(equalTo("Bearer {%header:Authorization%}")));
+        assertThat(headerTokens.get(0).second, is(equalTo("Bearer {%header:authorization%}")));
         assertThat(headerTokens.get(1).first, is(equalTo(HttpHeader.COOKIE)));
         assertThat(headerTokens.get(1).second, is(equalTo("{%json:set.cookie%}; SameSite=Strict")));
     }
@@ -422,7 +422,7 @@ class AuthUtilsUnitTest extends TestUtils {
         // Then
         assertThat(headerTokens.size(), is(equalTo(1)));
         assertThat(headerTokens.get(0).first, is(equalTo(HttpHeader.AUTHORIZATION)));
-        assertThat(headerTokens.get(0).second, is(equalTo("Bearer {%header:Authorization%}")));
+        assertThat(headerTokens.get(0).second, is(equalTo("Bearer {%header:authorization%}")));
     }
 
     @Test
@@ -480,8 +480,8 @@ class AuthUtilsUnitTest extends TestUtils {
         assertThat(stArray[2].getSource(), is(equalTo(SessionToken.HEADER_SOURCE)));
 
         assertThat(stArray[0].getToken(), is(equalTo("cookie:id")));
-        assertThat(stArray[1].getToken(), is(equalTo("header:Authorization")));
-        assertThat(stArray[2].getToken(), is(equalTo("header:Authorization")));
+        assertThat(stArray[1].getToken(), is(equalTo("header:authorization")));
+        assertThat(stArray[2].getToken(), is(equalTo("header:authorization")));
 
         assertThat(stArray[0].getValue(), is(equalTo(token2)));
         assertThat(stArray[1].getValue(), is(equalTo(token3)));

--- a/addOns/authstats/CHANGELOG.md
+++ b/addOns/authstats/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [2] - 2021-10-07

--- a/addOns/authstats/authstats.gradle.kts
+++ b/addOns/authstats/authstats.gradle.kts
@@ -2,7 +2,6 @@ description = "Records logged in/out statistics for all contexts in scope."
 
 zapAddOn {
     addOnName.set("Authentication Statistics")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Dependency updates.
 
 ### Fixed

--- a/addOns/automation/automation.gradle.kts
+++ b/addOns/automation/automation.gradle.kts
@@ -5,7 +5,6 @@ description = "Automation Framework."
 zapAddOn {
     addOnName.set("Automation Framework")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
@@ -31,6 +31,7 @@ This job supports <a href="test-monitor.html">monitor</a> tests.
       injectPluginIdInHeader:          # Bool: If set then the relevant rule Id will be injected into the X-ZAP-Scan-ID header of each request, default: false
       scanHeadersAllRequests:          # Bool: If set then the headers of requests that do not include any parameters will be scanned, default: false
       threadPerHost:                   # Int: The max number of threads per host, default: 2
+      maxAlertsPerRule:                # Int: Maximum number of alerts to raise per rule, default: 0 unlimited
     policyDefinition:                  # The policy definition - only used if the 'policy' is not set
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-max.yaml
@@ -12,6 +12,7 @@
       injectPluginIdInHeader:          # Bool: If set then the relevant rule Id will be injected into the X-ZAP-Scan-ID header of each request, default: false
       scanHeadersAllRequests:          # Bool: If set then the headers of requests that do not include any parameters will be scanned, default: false
       threadPerHost:                   # Int: The max number of threads per host, default: 2
+      maxAlertsPerRule:                # Int: Maximum number of alerts to raise per rule, default: 0 unlimited
     policyDefinition:                  # The policy definition - only used if the 'policy' is not set
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -191,7 +191,7 @@ class ActiveScanJobUnitTest {
                 job.getConfigParameters(new ScannerParamWrapper(), job.getParamMethodName());
 
         // Then
-        assertThat(params.size(), is(equalTo(10)));
+        assertThat(params.size(), is(equalTo(11)));
 
         assertThat(params.containsKey("addQueryParam"), is(equalTo(true)));
         assertThat(params.containsKey("defaultPolicy"), is(equalTo(true)));
@@ -203,6 +203,7 @@ class ActiveScanJobUnitTest {
         assertThat(params.containsKey("scanHeadersAllRequests"), is(equalTo(true)));
         assertThat(params.containsKey("threadPerHost"), is(equalTo(true)));
         assertThat(params.containsKey("scanNullJsonValues"), is(equalTo(true)));
+        assertThat(params.containsKey("maxAlertsPerRule"), is(equalTo(true)));
     }
 
     @Test
@@ -216,7 +217,6 @@ class ActiveScanJobUnitTest {
                 job.getConfigParameters(new ScannerParamWrapper(), job.getParamMethodName());
 
         // Then
-        assertThat(params.size(), is(equalTo(10)));
         assertThat(params.containsKey("threadPerHost"), is(equalTo(true)));
         assertTrue(Integer.parseInt(params.get("threadPerHost")) > 0);
     }
@@ -233,7 +233,9 @@ class ActiveScanJobUnitTest {
     private static class ScannerParamWrapper {
         @SuppressWarnings("unused")
         public ScannerParam getScannerParam() {
-            return new ScannerParam();
+            ScannerParam param = new ScannerParam();
+            param.load(new ZapXmlConfiguration());
+            return param;
         }
     }
 

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -106,6 +106,7 @@ jobs:
       injectPluginIdInHeader:          # Bool: If set then the relevant rule Id will be injected into the X-ZAP-Scan-ID header of each request, default: false
       scanHeadersAllRequests:          # Bool: If set then the headers of requests that do not include any parameters will be scanned, default: false
       threadPerHost:                   # Int: The max number of threads per host, default: 2
+      maxAlertsPerRule:                # Int: Maximum number of alerts to raise per rule, default: 0 unlimited
     policyDefinition:                  # The policy definition - only used if the 'policy' is not set
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium

--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Dependency updates.
 
 ## [7] - 2021-10-07

--- a/addOns/beanshell/beanshell.gradle.kts
+++ b/addOns/beanshell/beanshell.gradle.kts
@@ -5,7 +5,6 @@ description = "Provides a BeanShell Console"
 zapAddOn {
     addOnName.set("BeanShell Console")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/browserView/CHANGELOG.md
+++ b/addOns/browserView/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [6] - 2023-03-13
 ### Added

--- a/addOns/browserView/browserView.gradle.kts
+++ b/addOns/browserView/browserView.gradle.kts
@@ -12,7 +12,6 @@ javafx {
 
 zapAddOn {
     addOnName.set("Browser View")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [13] - 2023-06-06
 ### Changed

--- a/addOns/bruteforce/bruteforce.gradle.kts
+++ b/addOns/bruteforce/bruteforce.gradle.kts
@@ -5,7 +5,6 @@ description = "Forced browsing of files and directories using code from the OWAS
 zapAddOn {
     addOnName.set("Forced Browse")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [4] - 2022-09-23

--- a/addOns/bugtracker/bugtracker.gradle.kts
+++ b/addOns/bugtracker/bugtracker.gradle.kts
@@ -2,7 +2,6 @@ description = "Bug Tracker extension."
 
 zapAddOn {
     addOnName.set("Bug Tracker")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/callgraph/CHANGELOG.md
+++ b/addOns/callgraph/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [5] - 2021-10-07
 ### Added

--- a/addOns/callgraph/callgraph.gradle.kts
+++ b/addOns/callgraph/callgraph.gradle.kts
@@ -2,7 +2,6 @@ description = "Allows the user to view a call graph of the selected resources"
 
 zapAddOn {
     addOnName.set("Call Graph")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Colm O'Flaherty")

--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [0.6.0] - 2022-12-02
 ### Fixed

--- a/addOns/callhome/callhome.gradle.kts
+++ b/addOns/callhome/callhome.gradle.kts
@@ -5,7 +5,6 @@ description = "Handles all of the calls to ZAP services."
 zapAddOn {
     addOnName.set("Call Home")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
@@ -372,6 +372,7 @@ public class ExtensionCallHome extends ExtensionAdaptor
         return os;
     }
 
+    @SuppressWarnings("deprecation")
     private HttpSender getHttpSender() {
         if (httpSender == null) {
             httpSender = new HttpSender(HttpSender.CHECK_FOR_UPDATES_INITIATOR);

--- a/addOns/client/client.gradle.kts
+++ b/addOns/client/client.gradle.kts
@@ -3,7 +3,6 @@ description = "Exposes client (browser) side information in ZAP using Firefox an
 
 zapAddOn {
     addOnName.set("Client Side Integration")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/codedx/CHANGELOG.md
+++ b/addOns/codedx/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Dependency updates.
 - Maintenance changes.
 

--- a/addOns/codedx/codedx.gradle.kts
+++ b/addOns/codedx/codedx.gradle.kts
@@ -2,7 +2,6 @@ description = "Includes request and response data in XML reports and provides th
 
 zapAddOn {
     addOnName.set("Code Dx Extension")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Code Dx, Inc.")

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Dependency updates.
 
 ## [1.14.0] - 2023-02-24

--- a/addOns/commonlib/commonlib.gradle.kts
+++ b/addOns/commonlib/commonlib.gradle.kts
@@ -5,7 +5,6 @@ description = "A common library, for use by other add-ons."
 zapAddOn {
     addOnName.set("Common Library")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/coreLang/CHANGELOG.md
+++ b/addOns/coreLang/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [15] - 2022-02-14
 ### Changed

--- a/addOns/coreLang/coreLang.gradle.kts
+++ b/addOns/coreLang/coreLang.gradle.kts
@@ -5,7 +5,6 @@ description = "Translations of the core language files"
 zapAddOn {
     addOnName.set("Core Language Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [0.12.0] - 2022-09-23

--- a/addOns/custompayloads/custompayloads.gradle.kts
+++ b/addOns/custompayloads/custompayloads.gradle.kts
@@ -2,7 +2,6 @@ description = "Ability to add, edit or remove payloads that are used i.e. by act
 
 zapAddOn {
     addOnName.set("Custom Payloads")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/database/CHANGELOG.md
+++ b/addOns/database/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Dependency updates.
 
 ## [0.1.0] - 2022-10-27

--- a/addOns/database/database.gradle.kts
+++ b/addOns/database/database.gradle.kts
@@ -12,7 +12,6 @@ configurations.api { extendsFrom(sqlite) }
 zapAddOn {
     addOnName.set("Database")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Auth page which uses one request and one cookie
 - Auth page which uses multiple requests and multiple cookies
 
+### Changed
+- Update minimum ZAP version to 2.13.0.
+
 ## [0.2.0] - 2023-05-09
 
 ### Added

--- a/addOns/dev/dev.gradle.kts
+++ b/addOns/dev/dev.gradle.kts
@@ -2,7 +2,6 @@ description = "An add-on to help with development of ZAP."
 
 zapAddOn {
     addOnName.set("Dev Add-on")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/diff/CHANGELOG.md
+++ b/addOns/diff/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [12] - 2022-10-27

--- a/addOns/diff/diff.gradle.kts
+++ b/addOns/diff/diff.gradle.kts
@@ -5,7 +5,6 @@ description = "Displays a dialog showing the differences between 2 requests or r
 zapAddOn {
     addOnName.set("Diff")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv1/CHANGELOG.md
+++ b/addOns/directorylistv1/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [5] - 2021-10-06
 ### Changed

--- a/addOns/directorylistv1/directorylistv1.gradle.kts
+++ b/addOns/directorylistv1/directorylistv1.gradle.kts
@@ -5,7 +5,6 @@ description = "List of directory names to be used with Forced Browse or Fuzzer a
 zapAddOn {
     addOnName.set("Directory List v1.0")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv2_3/CHANGELOG.md
+++ b/addOns/directorylistv2_3/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/directorylistv2_3/directorylistv2_3.gradle.kts
+++ b/addOns/directorylistv2_3/directorylistv2_3.gradle.kts
@@ -5,7 +5,6 @@ description = "Lists of directory names to be used with Forced Browse or Fuzzer 
 zapAddOn {
     addOnName.set("Directory List v2.3")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv2_3_lc/CHANGELOG.md
+++ b/addOns/directorylistv2_3_lc/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/directorylistv2_3_lc/directorylistv2_3_lc.gradle.kts
+++ b/addOns/directorylistv2_3_lc/directorylistv2_3_lc.gradle.kts
@@ -5,7 +5,6 @@ description = "Lists of lower case directory names to be used with Forced Browse
 zapAddOn {
     addOnName.set("Directory List v2.3 LC")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Depend on newer version of Selenium add-on.
 
 ### Fixed

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -5,7 +5,6 @@ description = "DOM XSS Active scanner rule"
 zapAddOn {
     addOnName.set("DOM XSS Active scanner rule")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Aabha Biyani, ZAP Dev Team")

--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [1.1.0] - 2023-03-13
 ### Changed

--- a/addOns/encoder/encoder.gradle.kts
+++ b/addOns/encoder/encoder.gradle.kts
@@ -5,7 +5,6 @@ description = "Adds encode/decode/hash dialog and support for scripted processor
 zapAddOn {
     addOnName.set("Encoder")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/evalvillain/CHANGELOG.md
+++ b/addOns/evalvillain/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [0.2.0] - 2023-04-04
 ### Changed

--- a/addOns/evalvillain/evalvillain.gradle.kts
+++ b/addOns/evalvillain/evalvillain.gradle.kts
@@ -2,7 +2,6 @@ description = "Adds the Eval Villain extension to Firefox when launched from ZAP
 
 zapAddOn {
     addOnName.set("Eval Villain")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Dennis Goodlett and the ZAP Dev Team")

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [0.5.0] - 2023-04-04
 ### Changed

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -5,7 +5,6 @@ description = "Import and Export functionality"
 zapAddOn {
     addOnName.set("Import/Export")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team & thatsn0tmysite")

--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [6.3.0] - 2023-06-02
 ### Changed

--- a/addOns/formhandler/formhandler.gradle.kts
+++ b/addOns/formhandler/formhandler.gradle.kts
@@ -5,7 +5,6 @@ description = "This Value Generator Add-on allows a user to define field names a
 zapAddOn {
     addOnName.set("Value Generator")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/frontendscanner/frontendscanner.gradle.kts
+++ b/addOns/frontendscanner/frontendscanner.gradle.kts
@@ -2,7 +2,6 @@ description = "Scan modern web applications relying heavily on Javascript."
 
 zapAddOn {
     addOnName.set("Front-end Scanner")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 - Default number of threads to 2 * processor count.
 

--- a/addOns/fuzz/fuzz.gradle.kts
+++ b/addOns/fuzz/fuzz.gradle.kts
@@ -5,7 +5,6 @@ description = "Advanced fuzzer for manual testing"
 zapAddOn {
     addOnName.set("Fuzzer")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/fuzzdb/CHANGELOG.md
+++ b/addOns/fuzzdb/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [9] - 2022-09-23
 ### Changed

--- a/addOns/fuzzdb/fuzzdb.gradle.kts
+++ b/addOns/fuzzdb/fuzzdb.gradle.kts
@@ -16,7 +16,6 @@ description = "FuzzDB files which can be used with the ZAP fuzzer"
 zapAddOn {
     addOnName.set("FuzzDB Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/gettingStarted/gettingStarted.gradle.kts
+++ b/addOns/gettingStarted/gettingStarted.gradle.kts
@@ -5,12 +5,9 @@ description = "A short Getting Started with ZAP Guide"
 zapAddOn {
     addOnName.set("Getting Started with ZAP Guide")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/getting-started-guide/")
-
-        notBeforeVersion.set("2.13.0")
     }
 }

--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info URL.
 
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 
 ### Fixed

--- a/addOns/graaljs/graaljs.gradle.kts
+++ b/addOns/graaljs/graaljs.gradle.kts
@@ -5,7 +5,6 @@ description = "Provides the GraalVM JavaScript engine for ZAP scripting."
 zapAddOn {
     addOnName.set("GraalVM JavaScript")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - The "Import a GraphQL Schema from a File" and "Import a GraphQL schema from a URL" menu items were merged into one,
   "Import a GraphQL schema".
 - The Import dialog shows the values used in the previous import when reopened.

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -2,7 +2,6 @@ description = "Inspect and attack GraphQL endpoints."
 
 zapAddOn {
     addOnName.set("GraphQL Support")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 - Dependency updates.
 

--- a/addOns/groovy/groovy.gradle.kts
+++ b/addOns/groovy/groovy.gradle.kts
@@ -5,7 +5,6 @@ description = "Adds Groovy support to ZAP"
 zapAddOn {
     addOnName.set("Groovy Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/highlighter/CHANGELOG.md
+++ b/addOns/highlighter/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [8] - 2021-10-07
 ### Added

--- a/addOns/highlighter/highlighter.gradle.kts
+++ b/addOns/highlighter/highlighter.gradle.kts
@@ -2,7 +2,6 @@ description = "Allows you to highlight strings in the request and response tabs.
 
 zapAddOn {
     addOnName.set("Highlighter")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [4] - 2022-09-23

--- a/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
+++ b/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
@@ -5,7 +5,6 @@ description = "Image Location and Privacy Passive Scanner"
 zapAddOn {
     addOnName.set("Image Location and Privacy Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Jay Ball (veggiespam) and the ZAP Dev Team")

--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [12] - 2022-10-27

--- a/addOns/invoke/invoke.gradle.kts
+++ b/addOns/invoke/invoke.gradle.kts
@@ -5,7 +5,6 @@ description = "Invoke external applications passing context related information 
 zapAddOn {
     addOnName.set("Invoke Applications")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ### Fixed
 - Update the content-length header field after setting the request body in the authentication template.

--- a/addOns/jruby/jruby.gradle.kts
+++ b/addOns/jruby/jruby.gradle.kts
@@ -5,7 +5,6 @@ description = "Allows Ruby to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Ruby Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/jsonview/CHANGELOG.md
+++ b/addOns/jsonview/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/jsonview/jsonview.gradle.kts
+++ b/addOns/jsonview/jsonview.gradle.kts
@@ -2,7 +2,6 @@ description = "Adds a view that shows JSON messages nicely formatted"
 
 zapAddOn {
     addOnName.set("JSON View")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Juha Kivekäs")

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 
 ### Fixed

--- a/addOns/jython/jython.gradle.kts
+++ b/addOns/jython/jython.gradle.kts
@@ -5,7 +5,6 @@ description = "Allows Python to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Python Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [1.1.0] - 2021-10-07
 ### Changed

--- a/addOns/kotlin/kotlin.gradle.kts
+++ b/addOns/kotlin/kotlin.gradle.kts
@@ -5,7 +5,6 @@ description = "Allows Kotlin to be used for ZAP scripting"
 zapAddOn {
     addOnName.set("Kotlin Support")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("StackHawk Engineering")

--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On weekly releases and versions after 2.12 allow to manage global exclusions, supersedes core functionality.
 
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Update dependencies.
 - Update default user-agents.
 

--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -11,7 +11,6 @@ configurations.implementation { extendsFrom(hc) }
 zapAddOn {
     addOnName.set("Network")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSender.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSender.java
@@ -65,6 +65,9 @@ import org.zaproxy.zap.utils.Pair;
 public abstract class BaseHttpSender<T1 extends BaseHttpSenderContext, T2, T3>
         implements CloseableHttpSenderImpl<T1> {
 
+    @SuppressWarnings("deprecation")
+    protected static final int CHECK_FOR_UPDATES_INITIATOR = HttpSender.CHECK_FOR_UPDATES_INITIATOR;
+
     protected static final byte[] EMPTY_BODY = {};
 
     private static final String CONTEXTS_FIELD = "contexts";
@@ -222,6 +225,13 @@ public abstract class BaseHttpSender<T1 extends BaseHttpSenderContext, T2, T3>
     protected abstract byte[] getBytes(T3 body) throws IOException;
 
     protected abstract T2 createRequestContext(T1 ctx, HttpRequestConfig requestConfig);
+
+    @Override
+    public void sendAndReceive(
+            HttpSender parent, HttpRequestConfig config, HttpMessage msg, Path file)
+            throws IOException {
+        sendAndReceive(getContext(parent), config, msg, file);
+    }
 
     @Override
     public void sendAndReceive(T1 ctx, HttpRequestConfig config, HttpMessage msg, Path file)
@@ -396,7 +406,7 @@ public abstract class BaseHttpSender<T1 extends BaseHttpSenderContext, T2, T3>
             HttpMessage message,
             ResponseBodyConsumer<T3> responseBodyConsumer)
             throws IOException {
-        if (ctx.getInitiator() != HttpSender.CHECK_FOR_UPDATES_INITIATOR) {
+        if (ctx.getInitiator() != CHECK_FOR_UPDATES_INITIATOR) {
             rateLimiter.throttle(message, ctx.getInitiator());
         }
         sendImpl(ctx, requestCtx, requestConfig, message, responseBodyConsumer);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CloseableHttpSenderImpl.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CloseableHttpSenderImpl.java
@@ -19,12 +19,7 @@
  */
 package org.zaproxy.addon.network.internal.client;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.network.internal.ratelimit.RateLimiter;
-import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.network.HttpSenderContext;
 import org.zaproxy.zap.network.HttpSenderImpl;
 
@@ -37,22 +32,6 @@ public interface CloseableHttpSenderImpl<T extends HttpSenderContext> extends Ht
 
     /** Close the sender implementation. */
     void close();
-
-    default T getContext(HttpSender httpSender) {
-        return null;
-    }
-
-    default void sendAndReceive(
-            HttpSender parent, HttpRequestConfig config, HttpMessage msg, Path file)
-            throws IOException {
-        sendAndReceive(getContext(parent), config, msg, file);
-    }
-
-    default Object saveState() {
-        return null;
-    }
-
-    default void restoreState(Object implState) {}
 
     default void setRateLimiter(RateLimiter rateLimiter) {}
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -283,7 +283,7 @@ public class HttpSenderApache
             HttpSenderContextApache ctx, HttpRequestConfig requestConfig) {
         ZapHttpClientContext context = new ZapHttpClientContext();
 
-        if (ctx.getInitiator() != HttpSender.CHECK_FOR_UPDATES_INITIATOR) {
+        if (ctx.getInitiator() != CHECK_FOR_UPDATES_INITIATOR) {
             context.setAttribute(SslConnectionSocketFactory.LAX_ATTR_NAME, Boolean.TRUE);
         }
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -88,6 +88,7 @@ import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -118,6 +119,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 class ExtensionNetworkUnitTest extends TestUtils {
 
     private MockedStatic<ZAP> zap;
+    private Session session;
     private Model model;
     private OptionsParam optionsParam;
     private ExtensionLoader extensionLoader;
@@ -140,6 +142,8 @@ class ExtensionNetworkUnitTest extends TestUtils {
         given(optionsParam.getProxyParam())
                 .willReturn(mock(org.parosproxy.paros.core.proxy.ProxyParam.class));
         given(model.getOptionsParam()).willReturn(optionsParam);
+        session = mock(Session.class);
+        given(model.getSession()).willReturn(session);
 
         extension = new ExtensionNetwork();
         extension.init();
@@ -317,7 +321,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook, times(5)).addOptionsParamSet(argument.capture());
+        verify(extensionHook, times(6)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), hasItem(instanceOf(ServerCertificatesOptions.class)));
         assertThat(
                 extension.getServerCertificatesOptions(),
@@ -354,6 +358,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
+    @SuppressWarnings("removal")
     void shouldAddLegacyProxyListenerHandlerOnHookAlways() {
         // Given
         ExtensionHook extensionHook = mock(ExtensionHook.class);
@@ -377,7 +382,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook, times(5)).addOptionsParamSet(argument.capture());
+        verify(extensionHook, times(6)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), hasItem(instanceOf(LocalServersOptions.class)));
         assertThat(extension.getLocalServersOptions(), is(equalTo(argument.getAllValues().get(1))));
     }
@@ -468,7 +473,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook, times(5)).addOptionsParamSet(argument.capture());
+        verify(extensionHook, times(6)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), hasItem(instanceOf(ConnectionOptions.class)));
     }
 
@@ -490,7 +495,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.hook(extensionHook);
         // Then
         ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
-        verify(extensionHook, times(5)).addOptionsParamSet(argument.capture());
+        verify(extensionHook, times(6)).addOptionsParamSet(argument.capture());
         assertThat(argument.getAllValues(), hasItem(instanceOf(ClientCertificatesOptions.class)));
         assertThat(extension.getClientCertificatesOptions(), is(notNullValue()));
     }
@@ -780,7 +785,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
 
     @Test
     void shouldNotBeUnloadable() {
-        assertThat(extension.canUnload(), is(false));
+        assertThat(extension.canUnload(), is(true));
     }
 
     @Test
@@ -791,9 +796,11 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.unload();
         // Then
         assertThat(Security.getProvider(BouncyCastleProvider.PROVIDER_NAME), is(nullValue()));
+        verify(session).setGlobalExcludedUrlRegexsSupplier(null);
     }
 
     @Test
+    @SuppressWarnings("removal")
     void shouldUnloadLegacyProxyListenerHandlerAlways() {
         // Given
         extension.hook(mock(ExtensionHook.class));

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
@@ -248,7 +248,7 @@ class HttpSenderImplUnitTest {
 
     static Stream<Arguments> noBodyKeepAliveResponseAndSendAndReceiveMethods() {
         return Stream.of("1.0", "1.1")
-                .map(version -> "HTTP/" + version + " 200 OK\r\nConnection: keep-alive\r\n\r\n")
+                .map(version -> "HTTP/" + version + " 200 OK\r\nconnection: keep-alive\r\n\r\n")
                 .flatMap(response -> sendAndReceiveMethods().map(sm -> arguments(response, sm)));
     }
 
@@ -258,7 +258,7 @@ class HttpSenderImplUnitTest {
                         version ->
                                 "HTTP/"
                                         + version
-                                        + " 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n")
+                                        + " 200 OK\r\ncontent-length: 0\r\nconnection: keep-alive\r\n\r\n")
                 .flatMap(response -> sendAndReceiveMethods().map(sm -> arguments(response, sm)));
     }
 
@@ -270,7 +270,7 @@ class HttpSenderImplUnitTest {
                 "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
         void shouldNotBeThrottledForCfuInitiator(SenderMethod method) throws Exception {
             // Given
-            httpSender.setInitiator(HttpSender.CHECK_FOR_UPDATES_INITIATOR);
+            httpSender.setInitiator(BaseHttpSender.CHECK_FOR_UPDATES_INITIATOR);
             HttpRequestHeader requestHeader = message.getRequestHeader();
             requestHeader.setHeader("Host", "localhost:" + serverPort);
             requestHeader.setContentLength(0);
@@ -421,10 +421,10 @@ class HttpSenderImplUnitTest {
                                     "GET "
                                             + getServerUri("/")
                                             + " HTTP/1.1\r\n"
-                                            + "Host: localhost:"
+                                            + "host: localhost:"
                                             + serverPort
                                             + "\r\n"
-                                            + "Content-Length: 0\r\n"
+                                            + "content-length: 0\r\n"
                                             + "\r\n")));
             assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
         }
@@ -449,10 +449,10 @@ class HttpSenderImplUnitTest {
                                     "GET "
                                             + getServerUri("/")
                                             + " HTTP/1.1\r\n"
-                                            + "Host: localhost:"
+                                            + "host: localhost:"
                                             + serverPort
                                             + "\r\n"
-                                            + "Content-Length: 0\r\n"
+                                            + "content-length: 0\r\n"
                                             + "\r\n")));
             assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
         }
@@ -475,7 +475,7 @@ class HttpSenderImplUnitTest {
                                     "GET "
                                             + getServerUri("/")
                                             + " HTTP/1.1\r\n"
-                                            + "Host: localhost:"
+                                            + "host: localhost:"
                                             + serverPort
                                             + "\r\n\r\n")));
             assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
@@ -501,10 +501,10 @@ class HttpSenderImplUnitTest {
                                     "GET "
                                             + getServerUri("/")
                                             + " HTTP/1.1\r\n"
-                                            + "Host: localhost:"
+                                            + "host: localhost:"
                                             + serverPort
                                             + "\r\n"
-                                            + "Content-Length: 42\r\n"
+                                            + "content-length: 42\r\n"
                                             + "\r\n")));
             assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
         }
@@ -525,7 +525,7 @@ class HttpSenderImplUnitTest {
                     "GET "
                             + getServerUri("/")
                             + " HTTP/1.1\r\n"
-                            + "Host: localhost:"
+                            + "host: localhost:"
                             + serverPort
                             + "\r\n"
                             + "content-length: 0\r\n"
@@ -585,7 +585,7 @@ class HttpSenderImplUnitTest {
         void shouldHaveDataReceived(SenderMethod method) throws Exception {
             // Given
             String responseHeader =
-                    "HTTP/1.1 500 Reason\r\nHeader1: HeaderValue\r\nX: y\r\nContent-Length: 13\r\n\r\n";
+                    "HTTP/1.1 500 Reason\r\nheader1: HeaderValue\r\nx: y\r\ncontent-length: 13\r\n\r\n";
             String responseBody = "Response Body";
             server.setHttpMessageHandler(
                     (ctx, msg) -> {
@@ -623,7 +623,7 @@ class HttpSenderImplUnitTest {
                 throws Exception {
             // Given
             String responseHeader =
-                    "HTTP/1.1 200 OK\r\nContent-Length: 420\r\nConnection: close\r\n\r\n";
+                    "HTTP/1.1 200 OK\r\ncontent-length: 420\r\nConnection: close\r\n\r\n";
             String responseBody = "Response Body";
             server.setHttpMessageHandler(
                     (ctx, msg) -> {
@@ -643,7 +643,7 @@ class HttpSenderImplUnitTest {
                 "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
         void shouldPreserveNonAsciiCharactersInHeader(SenderMethod method) throws Exception {
             // Given
-            String responseHeader = "HTTP/1.1 200 OK\r\nJ/ψ:  → VP\r\nContent-Length: 0\r\n\r\n";
+            String responseHeader = "HTTP/1.1 200 OK\r\nJ/ψ:  → VP\r\ncontent-length: 0\r\n\r\n";
             server.setHttpMessageHandler((ctx, msg) -> msg.setResponseHeader(responseHeader));
             // When
             method.sendWith(httpSender, message);
@@ -661,7 +661,7 @@ class HttpSenderImplUnitTest {
                     (ctx, msg) -> {
                         ByteBuf out = ctx.alloc().buffer();
                         ByteBufUtil.writeAscii(
-                                out, "HTTP/1.1 200 OK\r\nContent-Length: " + size + "\r\n\r\n");
+                                out, "HTTP/1.1 200 OK\r\ncontent-length: " + size + "\r\n\r\n");
                         ctx.write(out);
 
                         out = ctx.alloc().buffer(10);
@@ -1800,10 +1800,10 @@ class HttpSenderImplUnitTest {
                                         + " "
                                         + getServerUri("/")
                                         + " HTTP/1.1\r\n"
-                                        + "Content-Length: "
+                                        + "content-length: "
                                         + requestBody.getBytes(StandardCharsets.US_ASCII).length
                                         + "\r\n"
-                                        + "Host: localhost:"
+                                        + "host: localhost:"
                                         + serverPort
                                         + "\r\n"
                                         + "\r\n")));

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpMessageDecoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpMessageDecoderUnitTest.java
@@ -114,7 +114,7 @@ abstract class HttpMessageDecoderUnitTest {
         assertThat(message, is(notNullValue()));
         HttpHeader header = extractHeader(message);
         assertThat(header.getHeaders(), hasSize(2));
-        checkHeader(header, 0, "Content-Length", "0");
+        checkHeader(header, 0, "content-length", "0");
         checkHeader(header, 1, "Y", "x");
         assertThat(extractBody(message).toString(), is(equalTo("")));
         assertChannelState();
@@ -124,7 +124,7 @@ abstract class HttpMessageDecoderUnitTest {
     void shouldReadFixedLengthBody() {
         // Given
         String body = "0123456789012345";
-        String content = getPrimeHeader() + "Content-Length: 16\r\n\r\n" + body;
+        String content = getPrimeHeader() + "content-length: 16\r\n\r\n" + body;
         // When
         written(content, true);
         // Then
@@ -132,7 +132,7 @@ abstract class HttpMessageDecoderUnitTest {
         assertThat(message, is(notNullValue()));
         HttpHeader header = extractHeader(message);
         assertThat(header.getHeaders(), hasSize(1));
-        checkHeader(header, 0, "Content-Length", "16");
+        checkHeader(header, 0, "content-length", "16");
         assertThat(extractBody(message).toString(), is(equalTo(body)));
         assertChannelState();
     }
@@ -143,7 +143,7 @@ abstract class HttpMessageDecoderUnitTest {
         int numberOfRequests = 2;
         String content =
                 StringUtils.repeat(
-                        getPrimeHeader() + "Content-Length: 1\r\n\r\nA", numberOfRequests);
+                        getPrimeHeader() + "content-length: 1\r\n\r\nA", numberOfRequests);
         // When
         written(content, true);
         // Then
@@ -151,7 +151,7 @@ abstract class HttpMessageDecoderUnitTest {
             HttpMessage message = channel.readInbound();
             assertThat(message, is(notNullValue()));
             HttpHeader header = extractHeader(message);
-            checkHeader(header, 0, "Content-Length", "1");
+            checkHeader(header, 0, "content-length", "1");
             assertThat(extractBody(message).toString(), is(equalTo("A")));
         }
         assertChannelState();
@@ -160,7 +160,7 @@ abstract class HttpMessageDecoderUnitTest {
     @Test
     void shouldProduceMessageWithExceptionIfChannelClosedBeforeSendingFullFixedLengthBody() {
         // Given / When
-        written(getPrimeHeader() + "Content-Length: 5\r\n\r\n123", false);
+        written(getPrimeHeader() + "content-length: 5\r\n\r\n123", false);
         channel.close();
         // Then
         HttpMessage message = channel.readInbound();
@@ -175,7 +175,7 @@ abstract class HttpMessageDecoderUnitTest {
         // Given
         String body = "0123456789012345";
         String content =
-                getPrimeHeader() + "Content-Length: 4\r\nContent-Length: 16\r\n\r\n" + body;
+                getPrimeHeader() + "content-length: 4\r\ncontent-length: 16\r\n\r\n" + body;
         // When
         written(content, true);
         // Then
@@ -183,7 +183,7 @@ abstract class HttpMessageDecoderUnitTest {
         assertThat(message, is(notNullValue()));
         HttpHeader header = extractHeader(message);
         assertThat(header.getHeaders(), hasSize(2));
-        checkHeader(header, 0, "Content-Length", "4", "16");
+        checkHeader(header, 0, "content-length", "4", "16");
         assertThat(extractBody(message).toString(), is(equalTo(body)));
         assertChannelState();
     }
@@ -200,7 +200,7 @@ abstract class HttpMessageDecoderUnitTest {
         assertThat(message, is(notNullValue()));
         HttpHeader header = extractHeader(message);
         assertThat(header.getHeaders(), hasSize(1));
-        checkHeader(header, 0, "Content-Length", "7");
+        checkHeader(header, 0, "content-length", "7");
         assertThat(extractBody(message).toString(), is(equalTo("Abcwxyz")));
         assertChannelState();
     }
@@ -218,7 +218,7 @@ abstract class HttpMessageDecoderUnitTest {
         assertThat(message, is(notNullValue()));
         HttpHeader header = extractHeader(message);
         assertThat(header.getHeaders(), hasSize(1));
-        checkHeader(header, 0, "Content-Length", "7");
+        checkHeader(header, 0, "content-length", "7");
         assertThat(extractBody(message).toString(), is(equalTo("Abcwxyz")));
         assertChannelState();
     }
@@ -239,7 +239,7 @@ abstract class HttpMessageDecoderUnitTest {
         assertThat(message, is(notNullValue()));
         HttpHeader header = extractHeader(message);
         assertThat(header.getHeaders(), hasSize(1));
-        checkHeader(header, 0, "Content-Length", "3");
+        checkHeader(header, 0, "content-length", "3");
         assertThat(extractBody(message).toString(), is(equalTo("Abc")));
         assertChannelState();
     }
@@ -270,7 +270,7 @@ abstract class HttpMessageDecoderUnitTest {
         assertThat(message, is(notNullValue()));
         HttpHeader header = extractHeader(message);
         assertThat(header.getHeaders(), hasSize(1));
-        checkHeader(header, 0, "Content-Length", "7");
+        checkHeader(header, 0, "content-length", "7");
         assertThat(extractBody(message).toString(), is(equalTo("Abcwxyz")));
         assertChannelState();
     }
@@ -303,7 +303,7 @@ abstract class HttpMessageDecoderUnitTest {
         assertThat(header.getHeaders(), hasSize(3));
         checkHeader(header, 0, "A", "b");
         checkHeader(header, 1, "X", "y");
-        checkHeader(header, 2, "Content-Length", "0");
+        checkHeader(header, 2, "content-length", "0");
         assertThat(extractBody(message).toString(), is(equalTo("")));
         assertChannelState();
     }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoderUnitTest.java
@@ -91,13 +91,13 @@ class HttpRequestDecoderUnitTest extends HttpMessageDecoderUnitTest {
 
     static Stream<String> headersDifferentSeparators() {
         return Stream.of(
-                "GET / HTTP/1.1\r\nContent-Length: 0\r\nY: x\r\n\r\n",
-                "GET / HTTP/1.1\nContent-Length: 0\nY: x\n\n",
-                "GET / HTTP/1.1\nContent-Length: 0\r\nY: x\r\n\n");
+                "GET / HTTP/1.1\r\ncontent-length: 0\r\nY: x\r\n\r\n",
+                "GET / HTTP/1.1\ncontent-length: 0\nY: x\n\n",
+                "GET / HTTP/1.1\ncontent-length: 0\r\nY: x\r\n\n");
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "\r\nContent-Length: 0"})
+    @ValueSource(strings = {"", "\r\ncontent-length: 0"})
     void shouldReadEmptyBody(String contentLength) {
         // Given
         String content = "POST / HTTP/1.1" + contentLength + "\r\n\r\n";

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpResponseDecoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpResponseDecoderUnitTest.java
@@ -81,9 +81,9 @@ class HttpResponseDecoderUnitTest extends HttpMessageDecoderUnitTest {
 
     static Stream<String> headersDifferentSeparators() {
         return Stream.of(
-                "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nY: x\r\n\r\n",
-                "HTTP/1.1 200 OK\nContent-Length: 0\nY: x\n\n",
-                "HTTP/1.1 200 OK\nContent-Length: 0\r\nY: x\r\n\n");
+                "HTTP/1.1 200 OK\r\ncontent-length: 0\r\nY: x\r\n\r\n",
+                "HTTP/1.1 200 OK\ncontent-length: 0\nY: x\n\n",
+                "HTTP/1.1 200 OK\ncontent-length: 0\r\nY: x\r\n\n");
     }
 
     @Test
@@ -107,7 +107,7 @@ class HttpResponseDecoderUnitTest extends HttpMessageDecoderUnitTest {
         String content =
                 "HTTP/1.1 "
                         + statusCode
-                        + "\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nABC";
+                        + "\r\n\r\nHTTP/1.1 200 OK\r\ncontent-length: 3\r\n\r\nABC";
         // When
         written(content, true);
         // Then
@@ -144,7 +144,7 @@ class HttpResponseDecoderUnitTest extends HttpMessageDecoderUnitTest {
         String content =
                 "HTTP/1.1 101\r\nUpgrade: "
                         + httpVersion
-                        + "\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nABC";
+                        + "\r\n\r\nHTTP/1.1 200 OK\r\ncontent-length: 3\r\n\r\nABC";
         // When
         written(content, true);
         // Then

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 
 ## [0.15.0] - 2023-03-13

--- a/addOns/oast/oast.gradle.kts
+++ b/addOns/oast/oast.gradle.kts
@@ -7,7 +7,6 @@ description = "Allows you to exploit out-of-band vulnerabilities"
 zapAddOn {
     addOnName.set("OAST Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/onlineMenu/CHANGELOG.md
+++ b/addOns/onlineMenu/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [10] - 2022-10-27
 ### Changed

--- a/addOns/onlineMenu/onlineMenu.gradle.kts
+++ b/addOns/onlineMenu/onlineMenu.gradle.kts
@@ -5,7 +5,6 @@ description = "ZAP Online menu items"
 zapAddOn {
     addOnName.set("Online menus")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Dependency updates.
 
 ## [34] - 2023-06-27

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -5,7 +5,6 @@ description = "Imports and spiders OpenAPI definitions."
 zapAddOn {
     addOnName.set("OpenAPI Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak, Marcin Spiewak, and SDA SE Open Industry Solutions")

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/HeadersGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/HeadersGenerator.java
@@ -35,7 +35,7 @@ import org.zaproxy.zap.extension.openapi.converter.swagger.OperationModel;
 
 public class HeadersGenerator {
 
-    private static final String ACCEPT = "Accept";
+    private static final String ACCEPT = "accept";
     private static final String HEADER = "header";
     private static final String COOKIE = "cookie";
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/HeadersGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/HeadersGeneratorUnitTest.java
@@ -70,7 +70,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateContentTypeHeaders(operation, headers, "");
         // Then
-        assertThat(headers, not(contains(header("Content-Type"))));
+        assertThat(headers, not(contains(header("content-type"))));
     }
 
     @Test
@@ -82,7 +82,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateContentTypeHeaders(operation, headers, "");
         // Then
-        assertThat(headers, not(contains(header("Content-Type"))));
+        assertThat(headers, not(contains(header("content-type"))));
     }
 
     @ParameterizedTest
@@ -95,7 +95,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateContentTypeHeaders(operation, headers, "");
         // Then
-        assertThat(headers, not(contains(header("Content-Type"))));
+        assertThat(headers, not(contains(header("content-type"))));
     }
 
     @ParameterizedTest
@@ -108,7 +108,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateContentTypeHeaders(operation, headers, "");
         // Then
-        assertThat(headers, contains(header("Content-Type", mediaType)));
+        assertThat(headers, contains(header("content-type", mediaType)));
     }
 
     @ParameterizedTest
@@ -122,7 +122,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateContentTypeHeaders(operation, headers, "");
         // Then
-        assertThat(headers, contains(header("Content-Type", mediaType)));
+        assertThat(headers, contains(header("content-type", mediaType)));
     }
 
     @ParameterizedTest
@@ -140,7 +140,7 @@ class HeadersGeneratorUnitTest {
                 headers,
                 contains(
                         header(
-                                "Content-Type",
+                                "content-type",
                                 mediaType + "; boundary=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")));
     }
 
@@ -153,7 +153,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateContentTypeHeaders(operation, headers, "{\"a\":\"b\"}");
         // Then
-        assertThat(headers, contains(header("Content-Type", "application/json")));
+        assertThat(headers, contains(header("content-type", "application/json")));
     }
 
     @Test
@@ -166,7 +166,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateAcceptHeaders(operation, headers);
         // Then
-        assertThat(headers, contains(header("Accept", "*/*")));
+        assertThat(headers, contains(header("accept", "*/*")));
     }
 
     @Test
@@ -178,7 +178,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateAcceptHeaders(operation, headers);
         // Then
-        assertThat(headers, contains(header("Accept", "*/*")));
+        assertThat(headers, contains(header("accept", "*/*")));
     }
 
     @Test
@@ -190,7 +190,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateAcceptHeaders(operation, headers);
         // Then
-        assertThat(headers, contains(header("Accept", "text/plain")));
+        assertThat(headers, contains(header("accept", "text/plain")));
     }
 
     @Test
@@ -202,7 +202,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateAcceptHeaders(operation, headers);
         // Then
-        assertThat(headers, contains(header("Accept", "text/x, text/y")));
+        assertThat(headers, contains(header("accept", "text/x, text/y")));
     }
 
     @Test
@@ -218,7 +218,7 @@ class HeadersGeneratorUnitTest {
         // Then
         assertThat(
                 headers,
-                contains(header("Accept", "text/a1, text/b1, text/b2, text/c1, text/c2, text/c3")));
+                contains(header("accept", "text/a1, text/b1, text/b2, text/c1, text/c2, text/c3")));
     }
 
     @Test
@@ -231,7 +231,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateAcceptHeaders(operation, headers);
         // Then
-        assertThat(headers, contains(header("Accept", "text/plain")));
+        assertThat(headers, contains(header("accept", "text/plain")));
     }
 
     @Test
@@ -323,7 +323,7 @@ class HeadersGeneratorUnitTest {
         // When
         headersGenerator.generateCustomHeader(operation, headers);
         // Then
-        assertThat(headers, contains(header("Cookie", cookieName + "=" + cookieValue)));
+        assertThat(headers, contains(header("cookie", cookieName + "=" + cookieValue)));
     }
 
     @Test
@@ -347,7 +347,7 @@ class HeadersGeneratorUnitTest {
                 headers,
                 contains(
                         header(
-                                "Cookie",
+                                "cookie",
                                 cookieName1
                                         + "="
                                         + cookieValue1
@@ -390,10 +390,10 @@ class HeadersGeneratorUnitTest {
         assertThat(
                 headers,
                 contains(
-                        header("Accept", "text/plain"),
-                        header("Content-Type", "application/json"),
+                        header("accept", "text/plain"),
+                        header("content-type", "application/json"),
                         header(headerName, headerValue),
-                        header("Cookie", cookieName + "=" + cookieValue)));
+                        header("cookie", cookieName + "=" + cookieValue)));
     }
 
     private static ApiResponse mockResponseWithMediaTypes(String... types) {

--- a/addOns/packpentester/CHANGELOG.md
+++ b/addOns/packpentester/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [0.1.0] - 2022-05-12
 

--- a/addOns/packpentester/packpentester.gradle.kts
+++ b/addOns/packpentester/packpentester.gradle.kts
@@ -5,7 +5,6 @@ description = "A collection of add-ons ideal for pentesters"
 zapAddOn {
     addOnName.set("Collection: Pentester Pack")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/packscanrules/CHANGELOG.md
+++ b/addOns/packscanrules/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [0.0.1] - 2022-05-13
 

--- a/addOns/packscanrules/packscanrules.gradle.kts
+++ b/addOns/packscanrules/packscanrules.gradle.kts
@@ -5,7 +5,6 @@ description = "All of the add-ons just containing release, beta and alpha status
 zapAddOn {
     addOnName.set("Collection: Scan Rules Pack")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/paramdigger/CHANGELOG.md
+++ b/addOns/paramdigger/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [0.2.0] - 2023-06-06
 ### Fixed

--- a/addOns/paramdigger/paramdigger.gradle.kts
+++ b/addOns/paramdigger/paramdigger.gradle.kts
@@ -2,7 +2,6 @@ description = "Identify hidden, unlinked parameters. Useful for finding web cach
 
 zapAddOn {
     addOnName.set("Parameter Digger")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team and Arkaprabha Chakraborty")

--- a/addOns/plugnhack/CHANGELOG.md
+++ b/addOns/plugnhack/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent exception if no display (Issue 3978).
 
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [13] - 2022-10-27

--- a/addOns/plugnhack/plugnhack.gradle.kts
+++ b/addOns/plugnhack/plugnhack.gradle.kts
@@ -5,7 +5,6 @@ description = "Supports the Mozilla Plug-n-Hack standard: https://developer.mozi
 zapAddOn {
     addOnName.set("Plug-n-Hack Configuration")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/portscan/CHANGELOG.md
+++ b/addOns/portscan/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 - Default number of threads to 2 * processor count.
 

--- a/addOns/portscan/portscan.gradle.kts
+++ b/addOns/portscan/portscan.gradle.kts
@@ -5,7 +5,6 @@ description = "Allows to port scan a target server"
 zapAddOn {
     addOnName.set("Port Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/postman/postman.gradle.kts
+++ b/addOns/postman/postman.gradle.kts
@@ -2,7 +2,6 @@ description = "Imports and spiders Postman definitions."
 
 zapAddOn {
     addOnName.set("Postman Support")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - X-Backend-Server Scan Rule
     - X-ChromeLogger-Data Header Information Leak Scan Rule
 
+### Changed
+- Update minimum ZAP version to 2.13.0.
+
 ## [49] - 2023-06-06
 ### Changed
 - The X-AspNet-Version Response Header Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -5,7 +5,6 @@ description = "The release status Passive Scanner rules"
 zapAddOn {
     addOnName.set("Passive scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRuleUnitTest.java
@@ -104,7 +104,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat("Cookie without SameSite Attribute", equalTo(alertsRaised.get(0).getName()));
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     @Test
@@ -130,7 +130,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         Alert alert = alertsRaised.get(0);
         assertEquals("Cookie with SameSite Attribute None", alert.getName());
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     @Test
@@ -174,7 +174,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     @Test
@@ -186,7 +186,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     @Test
@@ -200,7 +200,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     @Test
@@ -214,7 +214,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     @Test
@@ -260,7 +260,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     @Test
@@ -278,7 +278,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     @Test
@@ -310,7 +310,7 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("set-cookie: test"));
     }
 
     private static HttpMessage createMessage() throws HttpMalformedHeaderException {

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Fetch Metadata Request Headers scan rule (Issue 6955).
 
+### Changed
+- Update minimum ZAP version to 2.13.0.
+
 ### Removed
 - The following scan rules were removed, having been promoted to Beta:
   - Insufficient Site Isolation Against Spectre Vulnerability

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -2,7 +2,6 @@ description = "The alpha status Passive Scanner rules"
 
 zapAddOn {
     addOnName.set("Passive scanner rules (alpha)")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Source Code Disclosure
 
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [33] - 2023-05-03

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -5,7 +5,6 @@ description = "The beta status Passive Scanner rules"
 zapAddOn {
     addOnName.set("Passive scanner rules (beta)")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [37] - 2023-03-13
 ### Changed

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -5,7 +5,6 @@ description = "Provides a tab which allows you to quickly test a target applicat
 zapAddOn {
     addOnName.set("Quick Start")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/regextester/regextester.gradle.kts
+++ b/addOns/regextester/regextester.gradle.kts
@@ -2,7 +2,6 @@ description = "Allows to test Regular Expressions"
 
 zapAddOn {
     addOnName.set("Regular Expression Tester")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [12] - 2023-01-03

--- a/addOns/replacer/replacer.gradle.kts
+++ b/addOns/replacer/replacer.gradle.kts
@@ -5,7 +5,6 @@ description = "Easy way to replace strings in requests and responses."
 zapAddOn {
     addOnName.set("Replacer")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.replacer;
 
 import java.util.List;
 import java.util.regex.Pattern;
-import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.utils.Enableable;
 
 public class ReplacerParamRule extends Enableable {
@@ -215,9 +214,6 @@ public class ReplacerParamRule extends Enableable {
     }
 
     public boolean appliesToInitiator(int initiator) {
-        if (initiator == HttpSender.CHECK_FOR_UPDATES_INITIATOR) {
-            return false;
-        }
         return appliesToAllInitiators() || initiators.contains(initiator);
     }
 

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Reduce add-on size.
 - Dependency updates.
 

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -10,7 +10,6 @@ description = "Official ZAP Reports."
 zapAddOn {
     addOnName.set("Report Generation")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -817,7 +817,7 @@ class ExtensionReportsUnitTest {
                 instances.getJSONObject(i).getString("request-header"),
                 is(
                         equalTo(
-                                "GET http://example.com/example_3 HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\r\nPragma: no-cache\r\nCache-Control: no-cache\r\n\r\n")));
+                                "GET http://example.com/example_3 HTTP/1.1\r\nhost: example.com\r\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\r\npragma: no-cache\r\ncache-control: no-cache\r\n\r\n")));
         assertThat(
                 instances.getJSONObject(i).getString("request-body"),
                 is(equalTo("Test Request Body")));
@@ -1074,7 +1074,7 @@ class ExtensionReportsUnitTest {
                     instanceChildNodes.item(y).getTextContent(),
                     is(
                             equalTo(
-                                    "GET http://example.com/example_3 HTTP/1.1\nHost: example.com\nUser-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\nPragma: no-cache\nCache-Control: no-cache\n\n")));
+                                    "GET http://example.com/example_3 HTTP/1.1\nhost: example.com\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\npragma: no-cache\ncache-control: no-cache\n\n")));
             y++;
             assertThat(instanceChildNodes.item(y).getNodeName(), is(equalTo("#text"))); // Filler
             y++;

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportApiUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportApiUnitTest.java
@@ -410,11 +410,12 @@ class ReportApiUnitTest {
                         () -> reportApi.handleApiAction(ReportApi.ACTION_GENERATE, params));
 
         // Then
-        assertThat(exception.getMessage(), is("illegal_parameter"));
+        assertThat(
+                exception.getMessage(), is("ILLEGAL_PARAMETER (!reports.api.error.badSections!)"));
         assertThat(
                 exception.toString(true),
                 is(
-                        "Provided parameter has illegal or unrecognized value (illegal_parameter) : !reports.api.error.badSections!"));
+                        "Provided parameter has illegal or unrecognized value (illegal_parameter): !reports.api.error.badSections!"));
     }
 
     @Test

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html-plus.html
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html-plus.html
@@ -271,16 +271,16 @@
 									GET http://example.com/example_3 HTTP/1.1
 									<br />
 								
-									Host: example.com
+									host: example.com
 									<br />
 								
-									User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
+									user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
 									<br />
 								
-									Pragma: no-cache
+									pragma: no-cache
 									<br />
 								
-									Cache-Control: no-cache
+									cache-control: no-cache
 									<br />
 								
 									
@@ -382,16 +382,16 @@
 									GET http://example.com/example_3 HTTP/1.1
 									<br />
 								
-									Host: example.com
+									host: example.com
 									<br />
 								
-									User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
+									user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
 									<br />
 								
-									Pragma: no-cache
+									pragma: no-cache
 									<br />
 								
-									Cache-Control: no-cache
+									cache-control: no-cache
 									<br />
 								
 									

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json-plus.json
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json-plus.json
@@ -26,7 +26,7 @@
                             "attack": "Test \"Attack\\\"",
                             "evidence": "Test <p>Evidence",
                             "otherinfo": "Test 'Other\\",
-                            "request-header": "GET http://example.com/example_3 HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\r\nPragma: no-cache\r\nCache-Control: no-cache\r\n\r\n",
+                            "request-header": "GET http://example.com/example_3 HTTP/1.1\r\nhost: example.com\r\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\r\npragma: no-cache\r\ncache-control: no-cache\r\n\r\n",
                             "request-body": "Test Request Body",
                             "response-header": "HTTP/1.0 0\r\n\r\n",
                             "response-body": "Test Response Body"
@@ -38,7 +38,7 @@
                             "attack": "Test \"Attack\\\"",
                             "evidence": "Test <p>Evidence",
                             "otherinfo": "Test Another 'Other\\",
-                            "request-header": "GET http://example.com/example_3 HTTP/1.1\r\nHost: example.com\r\nUser-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\r\nPragma: no-cache\r\nCache-Control: no-cache\r\n\r\n",
+                            "request-header": "GET http://example.com/example_3 HTTP/1.1\r\nhost: example.com\r\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\r\npragma: no-cache\r\ncache-control: no-cache\r\n\r\n",
                             "request-body": "Test Request Body",
                             "response-header": "HTTP/1.0 0\r\n\r\n",
                             "response-body": "Test Response Body"

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml-plus.xml
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml-plus.xml
@@ -24,10 +24,10 @@
 									<evidence>Test &lt;p&gt;Evidence</evidence>
 									<otherinfo>Test &apos;Other\</otherinfo>
 									<requestheader>GET http://example.com/example_3 HTTP/1.1
-Host: example.com
-User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
-Pragma: no-cache
-Cache-Control: no-cache
+host: example.com
+user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
+pragma: no-cache
+cache-control: no-cache
 
 </requestheader>
 									<requestbody>Test Request Body</requestbody>
@@ -45,10 +45,10 @@ Cache-Control: no-cache
 									<evidence>Test &lt;p&gt;Evidence</evidence>
 									<otherinfo>Test Another &apos;Other\</otherinfo>
 									<requestheader>GET http://example.com/example_3 HTTP/1.1
-Host: example.com
-User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
-Pragma: no-cache
-Cache-Control: no-cache
+host: example.com
+user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
+pragma: no-cache
+cache-control: no-cache
 
 </requestheader>
 									<requestbody>Test Request Body</requestbody>

--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [7.2.0] - 2023-03-23
 ### Changed

--- a/addOns/requester/requester.gradle.kts
+++ b/addOns/requester/requester.gradle.kts
@@ -6,7 +6,6 @@ description = "Allows to manually edit and send messages."
 zapAddOn {
     addOnName.set("Requester")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Surikato and the ZAP Dev Team")

--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [0.5.0] - 2023-01-03

--- a/addOns/retest/retest.gradle.kts
+++ b/addOns/retest/retest.gradle.kts
@@ -2,7 +2,6 @@ description = "An add-on to retest for presence/absence of previously generated 
 
 zapAddOn {
     addOnName.set("Retest")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Updated with upstream retire.js pattern changes.
 
 

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -5,7 +5,6 @@ description = "Retire.js"
 zapAddOn {
     addOnName.set("Retire.js")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Nikita Mundhada and the ZAP Dev Team")

--- a/addOns/reveal/CHANGELOG.md
+++ b/addOns/reveal/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [5] - 2022-10-27

--- a/addOns/reveal/reveal.gradle.kts
+++ b/addOns/reveal/reveal.gradle.kts
@@ -5,7 +5,6 @@ description = "Show hidden fields and enable disabled fields"
 zapAddOn {
     addOnName.set("Reveal")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/revisit/revisit.gradle.kts
+++ b/addOns/revisit/revisit.gradle.kts
@@ -2,7 +2,6 @@ description = "Revisit a site at any time in the past using the session history"
 
 zapAddOn {
     addOnName.set("Revisit")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/saml/CHANGELOG.md
+++ b/addOns/saml/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [10] - 2022-10-28

--- a/addOns/saml/saml.gradle.kts
+++ b/addOns/saml/saml.gradle.kts
@@ -2,7 +2,6 @@ description = "Detect, Show, Edit, Fuzz SAML requests"
 
 zapAddOn {
     addOnName.set("SAML Support")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [38] - 2023-03-29
 ### Fixed

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -5,7 +5,6 @@ description = "Supports all JSR 223 scripting languages"
 zapAddOn {
     addOnName.set("Script Console")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Update Selenium to version 4.
 
 ### Removed

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -5,7 +5,6 @@ description = "WebDriver provider and includes HtmlUnit browser"
 zapAddOn {
     addOnName.set("Selenium")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ### Fixed
 - Prevent exception if no display (Issue 3978).

--- a/addOns/sequence/sequence.gradle.kts
+++ b/addOns/sequence/sequence.gradle.kts
@@ -2,7 +2,6 @@ description = "Gives the possibility of defining a sequence of requests to be sc
 
 zapAddOn {
     addOnName.set("Sequence")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/simpleexample/simpleexample.gradle.kts
+++ b/addOns/simpleexample/simpleexample.gradle.kts
@@ -2,7 +2,6 @@ description = "A simple extension example."
 
 zapAddOn {
     addOnName.set("Simple Example")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Dependency updates.
 
 ## [17] - 2023-02-09

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -5,7 +5,6 @@ description = "Imports and scans WSDL files containing SOAP endpoints."
 zapAddOn {
     addOnName.set("SOAP Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Alberto (albertov91) + ZAP Dev Team")

--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [0.4.0] - 2023-05-03
 ### Fixed

--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -5,7 +5,6 @@ description = "Spider used for automatically finding URIs on a site."
 zapAddOn {
     addOnName.set("Spider")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for authentication handlers.
 
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Depend on newer version of Selenium add-on.
 - Update Crawljax to 3.7.1, to use the newer version of Selenium.
 

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -19,7 +19,6 @@ description = "Allows you to spider sites that make heavy use of JavaScript usin
 zapAddOn {
     addOnName.set("Ajax Spider")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [15] - 2021-10-20

--- a/addOns/sqliplugin/sqliplugin.gradle.kts
+++ b/addOns/sqliplugin/sqliplugin.gradle.kts
@@ -5,7 +5,6 @@ description = "An advanced active injection bundle for SQLi (derived by SQLMap)"
 zapAddOn {
     addOnName.set("Advanced SQLInjection Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Andrea Pompili (Yhawke)")

--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [12] - 2022-10-28

--- a/addOns/sse/sse.gradle.kts
+++ b/addOns/sse/sse.gradle.kts
@@ -2,7 +2,6 @@ description = "Allows you to view Server-Sent Events (SSE) communication."
 
 zapAddOn {
     addOnName.set("Server-Sent Events")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/svndigger/CHANGELOG.md
+++ b/addOns/svndigger/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/svndigger/svndigger.gradle.kts
+++ b/addOns/svndigger/svndigger.gradle.kts
@@ -11,7 +11,6 @@ val processFiles by tasks.registering(ProcessSvnDiggerFiles::class) {
 zapAddOn {
     addOnName.set("SVN Digger Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/tips/CHANGELOG.md
+++ b/addOns/tips/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 
 ## [10] - 2022-10-27

--- a/addOns/tips/tips.gradle.kts
+++ b/addOns/tips/tips.gradle.kts
@@ -5,7 +5,6 @@ description = "Display ZAP Tips and Tricks"
 zapAddOn {
     addOnName.set("Tips and Tricks")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/todo/todo.gradle.kts
+++ b/addOns/todo/todo.gradle.kts
@@ -2,7 +2,6 @@ description = "Provides a tab which allows you to view the list of test cases"
 
 zapAddOn {
     addOnName.set("ToDo-List")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("vishesh, ZAP Dev Team")

--- a/addOns/tokengen/CHANGELOG.md
+++ b/addOns/tokengen/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [15] - 2021-10-07
 ### Changed

--- a/addOns/tokengen/tokengen.gradle.kts
+++ b/addOns/tokengen/tokengen.gradle.kts
@@ -5,7 +5,6 @@ description = "Allows you to generate and analyze pseudo random tokens, such as 
 zapAddOn {
     addOnName.set("Token Generation and Analysis")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/treetools/CHANGELOG.md
+++ b/addOns/treetools/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [8] - 2021-10-07
 ### Added

--- a/addOns/treetools/treetools.gradle.kts
+++ b/addOns/treetools/treetools.gradle.kts
@@ -5,7 +5,6 @@ description = "Tools to add functionality to the tree view."
 zapAddOn {
     addOnName.set("TreeTools")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Carl Sampson")

--- a/addOns/viewstate/CHANGELOG.md
+++ b/addOns/viewstate/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.12.0.
+- Update minimum ZAP version to 2.13.0.
 
 ## [3] - 2021-10-07
 ### Changed

--- a/addOns/viewstate/viewstate.gradle.kts
+++ b/addOns/viewstate/viewstate.gradle.kts
@@ -2,7 +2,6 @@ description = "ASP/JSF ViewState Decoder and Editor"
 
 zapAddOn {
     addOnName.set("ViewState")
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("Calum Hutton")

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Updated with upstream Wappalyzer icon and pattern changes.
 
 

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -5,7 +5,6 @@ description = "Technology detection using Wappalyzer: wappalyzer.com"
 zapAddOn {
     addOnName.set("Wappalyzer - Technology Detection")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -4,50 +4,37 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [56] - 2023-06-01
 ### Changed
 - Update ChromeDriver to 114.0.5735.90.
 
-
-
 ## [55] - 2023-05-04
 ### Changed
 - Update ChromeDriver to 113.0.5672.63.
-
-
 
 ## [54] - 2023-04-06
 ### Changed
 - Update ChromeDriver to 112.0.5615.49.
 
-
-
 ## [53] - 2023-04-04
 ### Changed
 - Update geckodriver to 0.33.0.
 
-
-
 ## [52] - 2023-03-09
 ### Changed
 - Update ChromeDriver to 111.0.5563.64.
-
-
 
 ## [51] - 2023-02-08
 ### Changed
 - Update geckodriver to 0.32.2.
 - Update ChromeDriver to 110.0.5481.77.
 
-
-
 ## [50] - 2023-02-02
 ### Changed
 - Update geckodriver to 0.32.1.
-
-
 
 ## [49] - 2023-01-26
 ### Added
@@ -57,38 +44,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update ChromeDriver to 109.0.5414.74.
 
-
-
 ## [47] - 2022-12-01
 ### Changed
 - Update ChromeDriver to 108.0.5359.71.
-
-
 
 ## [46] - 2022-10-27
 ### Changed
 - Update minimum ZAP version to 2.12.0.
 - Update ChromeDriver to 107.0.5304.62.
 
-
-
 ## [45] - 2022-10-14
 ### Changed
 - Update geckodriver to 0.32.0.
-
-
 
 ## [44] - 2022-09-29
 ### Changed
 - Update ChromeDriver to 106.0.5249.61.
 
-
-
 ## [43] - 2022-09-01
 ### Changed
 - Update ChromeDriver to 105.0.5195.52.
-
-
 
 ## [42] - 2022-08-04
 ### Changed

--- a/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
+++ b/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
@@ -8,7 +8,6 @@ extra["targetOs"] = DownloadWebDriver.OS.LINUX
 zapAddOn {
     addOnName.set("Linux WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -4,87 +4,62 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [56] - 2023-06-01
 ### Changed
 - Update ChromeDriver to 114.0.5735.90.
 
-
-
 ## [55] - 2023-05-04
 ### Changed
 - Update ChromeDriver to 113.0.5672.63.
-
-
 
 ## [54] - 2023-04-06
 ### Changed
 - Update ChromeDriver to 112.0.5615.49.
 
-
-
 ## [53] - 2023-04-04
 ### Changed
 - Update geckodriver to 0.33.0.
 
-
-
 ## [52] - 2023-03-09
 ### Changed
 - Update ChromeDriver to 111.0.5563.64.
-
-
 
 ## [51] - 2023-02-08
 ### Changed
 - Update geckodriver to 0.32.2.
 - Update ChromeDriver to 110.0.5481.77.
 
-
-
 ## [50] - 2023-02-02
 ### Changed
 - Update geckodriver to 0.32.1.
-
-
 
 ## [49] - 2023-01-12
 ### Changed
 - Update ChromeDriver to 109.0.5414.74.
 
-
-
 ## [48] - 2022-12-01
 ### Changed
 - Update ChromeDriver to 108.0.5359.71.
-
-
 
 ## [47] - 2022-10-27
 ### Changed
 - Update minimum ZAP version to 2.12.0.
 - Update ChromeDriver to 107.0.5304.62.
 
-
-
 ## [46] - 2022-10-14
 ### Changed
 - Update geckodriver to 0.32.0.
-
-
 
 ## [45] - 2022-09-29
 ### Changed
 - Update ChromeDriver to 106.0.5249.61.
 
-
-
 ## [44] - 2022-09-01
 ### Changed
 - Update ChromeDriver to 105.0.5195.52.
-
-
 
 ## [43] - 2022-08-04
 ### Changed
@@ -114,7 +89,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [37] - 2022-03-29
 ### Added
 - Add aarch64/arm64 WebDrivers.
-
 
 ## [36] - 2022-03-04
 ### Changed

--- a/addOns/webdrivers/webdrivermacos/webdrivermacos.gradle.kts
+++ b/addOns/webdrivers/webdrivermacos/webdrivermacos.gradle.kts
@@ -8,7 +8,6 @@ extra["targetOs"] = DownloadWebDriver.OS.MAC
 zapAddOn {
     addOnName.set("MacOS WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -4,87 +4,62 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.13.0.
 
 ## [55] - 2023-06-01
 ### Changed
 - Update ChromeDriver to 114.0.5735.90.
 
-
-
 ## [54] - 2023-05-04
 ### Changed
 - Update ChromeDriver to 113.0.5672.63.
-
-
 
 ## [53] - 2023-04-06
 ### Changed
 - Update ChromeDriver to 112.0.5615.49.
 
-
-
 ## [52] - 2023-04-04
 ### Changed
 - Update geckodriver to 0.33.0.
 
-
-
 ## [51] - 2023-03-09
 ### Changed
 - Update ChromeDriver to 111.0.5563.64.
-
-
 
 ## [50] - 2023-02-08
 ### Changed
 - Update geckodriver to 0.32.2.
 - Update ChromeDriver to 110.0.5481.77.
 
-
-
 ## [49] - 2023-02-02
 ### Changed
 - Update geckodriver to 0.32.1.
-
-
 
 ## [48] - 2023-01-12
 ### Changed
 - Update ChromeDriver to 109.0.5414.74.
 
-
-
 ## [47] - 2022-12-01
 ### Changed
 - Update ChromeDriver to 108.0.5359.71.
-
-
 
 ## [46] - 2022-10-27
 ### Changed
 - Update minimum ZAP version to 2.12.0.
 - Update ChromeDriver to 107.0.5304.62.
 
-
-
 ## [45] - 2022-10-14
 ### Changed
 - Update geckodriver to 0.32.0.
-
-
 
 ## [44] - 2022-09-29
 ### Changed
 - Update ChromeDriver to 106.0.5249.61.
 
-
-
 ## [43] - 2022-09-01
 ### Changed
 - Update ChromeDriver to 105.0.5195.52.
-
-
 
 ## [42] - 2022-08-04
 ### Changed

--- a/addOns/webdrivers/webdriverwindows/webdriverwindows.gradle.kts
+++ b/addOns/webdrivers/webdriverwindows/webdriverwindows.gradle.kts
@@ -8,7 +8,6 @@ extra["targetOs"] = DownloadWebDriver.OS.WIN
 zapAddOn {
     addOnName.set("Windows WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Maintenance changes.
 - Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 

--- a/addOns/websocket/websocket.gradle.kts
+++ b/addOns/websocket/websocket.gradle.kts
@@ -5,7 +5,6 @@ description = "Allows you to inspect WebSocket communication."
 zapAddOn {
     addOnName.set("WebSockets")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dialogs for scroll, scrollTo, window resize and mouse over.
 
 ### Changed
+- Update minimum ZAP version to 2.13.0.
 - Update Zest library to 0.18.0:
   - Update Selenium to version 4.
   - jBrowserDriver (JBD), Opera, and PhantomJS are no longer supported (no longer being actively maintained).

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -16,7 +16,6 @@ description = "A graphical security scripting language, ZAPs macro language on s
 zapAddOn {
     addOnName.set("Zest - Graphical Security Scripting Language")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.12.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,9 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 
     spotless {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -15,9 +15,9 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.12.0")
+    compileOnly("org.zaproxy:zap:2.13.0-SNAPSHOT")
     implementation(parent!!.childProjects.get("addOns")!!.childProjects.get("network")!!)
-    implementation("org.apache.httpcomponents.client5:httpclient5:5.2-beta1")
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 
     api("org.hamcrest:hamcrest-library:2.2")
     api("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")


### PR DESCRIPTION
Change all add-ons and `testutils` to use 2.13 (SNAPSHOT).
Update code accordingly (e.g. address deprecations).
Update tests to assert with the headers lower case.
Add `maxAlertsPerRule` to active scan job/plans, required as it's a new core active scan property.