### PR TITLE
network: correct API parameter name declaration

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Correct declaration of mandatory parameters of the API endpoint `setRateLimitRuleEnabled`.
 
 ## [0.10.0] - 2023-07-11
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
@@ -287,7 +287,7 @@ public class NetworkApi extends ApiImplementor {
         this.addApiAction(
                 new ApiAction(
                         ACTION_SET_RATE_LIMIT_RULE_ENABLED,
-                        Arrays.asList(PARAM_DESCRIPTION, PARAM_DESCRIPTION)));
+                        Arrays.asList(PARAM_DESCRIPTION, PARAM_ENABLED)));
     }
 
     @Override

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
@@ -1527,19 +1527,20 @@ class NetworkApiUnitTest extends TestUtils {
         verify(rateLimitOptions).removeRule("example.org");
     }
 
-    @Test
-    void shouldReturnOkForChangedRateLimitRule() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldReturnOkForChangedRateLimitRule(boolean enabled) throws Exception {
         // Given
         String name = "setRateLimitRuleEnabled";
         JSONObject params = new JSONObject();
         params.put("description", "example.org");
-        params.put("enabled", "false");
+        params.put("enabled", enabled);
         given(rateLimitOptions.setEnabled(any(), anyBoolean())).willReturn(true);
         // When
         ApiResponse response = networkApi.handleApiAction(name, params);
         // Then
         assertThat(response, is(equalTo(ApiResponseElement.OK)));
-        verify(rateLimitOptions).setEnabled("example.org", false);
+        verify(rateLimitOptions).setEnabled("example.org", enabled);
     }
 
     @Test


### PR DESCRIPTION
Correct the declaration of the parameter, use `enabled` instead of `description` (the latter being duplicated).