### PR TITLE
graphql, spider: use core method to read enums

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## Unreleased
 ### Changed
 - Dependency updates.
+- Maintenance changes.
 
 ## [0.18.0] - 2023-07-11
 ### Changed

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
@@ -295,25 +295,9 @@ public class GraphQlParam extends VersionedAbstractParam {
                 getInt(PARAM_MAX_ADDITIONAL_QUERY_DEPTH, DEFAULT_MAX_ADDITIONAL_QUERY_DEPTH);
         maxArgsDepth = getInt(PARAM_MAX_ARGS_DEPTH, DEFAULT_MAX_ARGS_DEPTH);
         optionalArgsEnabled = getBoolean(PARAM_OPTIONAL_ARGS, DEFAULT_OPTIONAL_ARGS);
-        argsType = getEnum(ArgsTypeOption.class, PARAM_ARGS_TYPE, DEFAULT_ARGS_TYPE);
-        querySplitType =
-                getEnum(QuerySplitOption.class, PARAM_QUERY_SPLIT_TYPE, DEFAULT_QUERY_SPLIT_TYPE);
-        requestMethod =
-                getEnum(RequestMethodOption.class, PARAM_REQUEST_METHOD, DEFAULT_REQUEST_METHOD);
-    }
-
-    private <T extends Enum<T>> T getEnum(Class<T> enumType, String key, T defaultValue) {
-        String value = getString(key, defaultValue.toString());
-        try {
-            return Enum.valueOf(enumType, value);
-        } catch (IllegalArgumentException e) {
-            LOGGER.warn(
-                    "Using default {}, {}. Failed to convert from: {}",
-                    enumType.getSimpleName(),
-                    defaultValue,
-                    value);
-        }
-        return defaultValue;
+        argsType = getEnum(PARAM_ARGS_TYPE, DEFAULT_ARGS_TYPE);
+        querySplitType = getEnum(PARAM_QUERY_SPLIT_TYPE, DEFAULT_QUERY_SPLIT_TYPE);
+        requestMethod = getEnum(PARAM_REQUEST_METHOD, DEFAULT_REQUEST_METHOD);
     }
 
     @Override

--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.5.0] - 2023-07-11
 ### Changed

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderParam.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderParam.java
@@ -335,11 +335,7 @@ public class SpiderParam extends VersionedAbstractParam {
         this.skipURL = getString(SPIDER_SKIP_URL, "");
         parseSkipURL(this.skipURL);
 
-        handleParametersVisited =
-                HandleParametersOption.valueOf(
-                        getString(
-                                SPIDER_HANDLE_PARAMETERS,
-                                HandleParametersOption.USE_ALL.toString()));
+        handleParametersVisited = getEnum(SPIDER_HANDLE_PARAMETERS, HandleParametersOption.USE_ALL);
 
         this.handleODataParametersVisited = getBoolean(SPIDER_HANDLE_ODATA_PARAMETERS, false);
 


### PR DESCRIPTION
Use the core method to read the enums, avoids duplication and properly handles invalid values.