### PR TITLE
fuzz: reset message after edits

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Show actual contents of the message after edits (Issue 7947).
 
 ## [13.10.0] - 2023-07-11
 ### Changed

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzerDialog.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzerDialog.java
@@ -150,6 +150,8 @@ public class FuzzerDialog<
                 fuzzLocationsPanel.reset();
             } else {
                 fuzzMessagePanel.saveData();
+                // Reset the message to show any automatic changes.
+                fuzzMessagePanel.setMessage(getMessage());
                 Stats.incCounter(ExtensionFuzz.MESSAGES_EDITED_STATS);
             }
             this.fuzzMessagePanel.setEditable(editable);


### PR DESCRIPTION
Ensure the message panel shows the actual contents of the message and what is being selected to fuzz, the message might be modified when saved (e.g. URL normalization).

Fix zaproxy/zaproxy#7947.