### PR TITLE
automation: support max alerts per rule in ascan

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Add support for max alerts per rule in the Active Scan job (Issue 7784).
 
 ## [0.30.0] - 2023-07-11
 ### Changed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
@@ -61,6 +61,8 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
     private static final String POLICY_PARAM = "automation.dialog.ascan.policy";
     private static final String MAX_RULE_DURATION_PARAM = "automation.dialog.ascan.maxruleduration";
     private static final String MAX_SCAN_DURATION_PARAM = "automation.dialog.ascan.maxscanduration";
+    private static final String MAX_ALERTS_PER_RULE_PARAM =
+            "automation.dialog.ascan.maxalertsperrule";
     private static final String FIELD_ADVANCED = "automation.dialog.ascan.advanced";
 
     private static final String DEFAULT_THRESHOLD_PARAM =
@@ -115,6 +117,12 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
                 0,
                 Integer.MAX_VALUE,
                 JobUtils.unBox(JobUtils.unBox(job.getParameters().getMaxScanDurationInMins())));
+        addNumberField(
+                0,
+                MAX_ALERTS_PER_RULE_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(job.getParameters().getMaxAlertsPerRule()));
         this.addCheckBoxField(0, FIELD_ADVANCED, advOptionsSet());
         this.addFieldListener(FIELD_ADVANCED, e -> setAdvancedTabs(getBoolValue(FIELD_ADVANCED)));
 
@@ -221,6 +229,7 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
         this.job
                 .getParameters()
                 .setMaxScanDurationInMins(this.getIntValue(MAX_SCAN_DURATION_PARAM));
+        job.getParameters().setMaxAlertsPerRule(getIntValue(MAX_ALERTS_PER_RULE_PARAM));
 
         this.job
                 .getData()

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -556,6 +556,7 @@ public class ActiveScanJob extends AutomationJob {
         private Boolean injectPluginIdInHeader;
         private Boolean scanHeadersAllRequests;
         private Integer threadPerHost;
+        private Integer maxAlertsPerRule;
 
         public Parameters() {}
 
@@ -657,6 +658,14 @@ public class ActiveScanJob extends AutomationJob {
 
         public void setThreadPerHost(Integer threadPerHost) {
             this.threadPerHost = threadPerHost;
+        }
+
+        public Integer getMaxAlertsPerRule() {
+            return maxAlertsPerRule;
+        }
+
+        public void setMaxAlertsPerRule(Integer maxAlertsPerRule) {
+            this.maxAlertsPerRule = maxAlertsPerRule;
         }
     }
 }

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -68,6 +68,7 @@ automation.dialog.ascan.defaultthreshold = Default Threshold:
 automation.dialog.ascan.delayinms = Delay In MS:
 automation.dialog.ascan.handleanticsrf = Handle Anti CSRF Tokens:
 automation.dialog.ascan.injectid = Inject Plugin Id:
+automation.dialog.ascan.maxalertsperrule = Max Alerts Per Rule:
 automation.dialog.ascan.maxruleduration = Max Rule Duration (in mins):
 automation.dialog.ascan.maxscanduration = Max Scan Duration (in mins):
 automation.dialog.ascan.policy = Policy:

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -141,7 +141,11 @@ class ActiveScanJobUnitTest {
     @Test
     void shouldApplyCustomConfigParams() {
         // Given
-        String yamlStr = "parameters:\n" + "  maxScanDurationInMins: 12\n" + "  policy: testPolicy";
+        String yamlStr =
+                "parameters:\n"
+                        + "  maxScanDurationInMins: 12\n"
+                        + "  maxAlertsPerRule: 5\n"
+                        + "  policy: testPolicy";
         AutomationProgress progress = new AutomationProgress();
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
@@ -154,6 +158,7 @@ class ActiveScanJobUnitTest {
 
         // Then
         assertThat(job.getParameters().getMaxScanDurationInMins(), is(equalTo(12)));
+        assertThat(job.getParameters().getMaxAlertsPerRule(), is(equalTo(5)));
         assertThat(job.getParameters().getPolicy(), is(equalTo("testPolicy")));
         assertThat(progress.hasErrors(), is(equalTo(false)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));


### PR DESCRIPTION
Allow to configure and use the max alerts per scan rule in the Active Scan job.

Fix zaproxy/zaproxy#7784.