### PR TITLE
ascanrulesBeta: add example alerts to HttpOnlySiteScanRule

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- The HTTP Only Site scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [47] - 2023-07-20
 ### Added

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRuleUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import javax.net.ssl.SSLException;
 import org.apache.commons.httpclient.URI;
@@ -147,6 +149,25 @@ class HttpOnlySiteScanRuleUnitTest extends ActiveScannerTest<HttpOnlySiteScanRul
             assertThat(alertsRaised, hasSize(0));
             assertThat(httpMessagesSent, hasSize(1));
         }
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        List<Alert> alerts = rule.getExampleAlerts();
+
+        assertThat(alerts.size(), is(equalTo(1)));
+
+        Alert alert = alerts.get(0);
+
+        Map<String, String> tags = alert.getTags();
+        assertThat(tags.size(), is(equalTo(3)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_SESS_02_COOKIE_ATTRS.getTag()));
+        assertThat(alert.getUri(), is(equalTo("http://example.com")));
+        assertThat(alert.getOtherInfo(), containsString("https://example.com"));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
     private static HttpMessage getHttpMessage(int port) throws Exception {


### PR DESCRIPTION
## Overview
Added example alerts for [HttpOnlySiteScanRule](https://www.zaproxy.org/docs/alerts/10106/).

## Related Issues
[#6119](https://github.com/zaproxy/zaproxy/issues/6119)

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
