### PR TITLE
formhandler: tweak space position in help content

### DIFF
--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Tweak help for proper rendering in the website.
 
 ## [6.4.0] - 2023-07-11
 ### Changed

--- a/addOns/formhandler/src/main/javahelp/org/zaproxy/zap/extension/formhandler/resources/help/contents/FormHandlerHelp.html
+++ b/addOns/formhandler/src/main/javahelp/org/zaproxy/zap/extension/formhandler/resources/help/contents/FormHandlerHelp.html
@@ -10,7 +10,7 @@
 				This Value Generator extension allows for the custom configuration of values used in sites/apps based on field/input names.
 			</p>
 			<p>
-				<strong>Note: </strong>The word "Field" is used throughout this help documentation interchangeably with parameter or input.
+				<strong>Note:</strong> The word "Field" is used throughout this help documentation interchangeably with parameter or input.
 			</p>
 
 		<H2>Description</H2>


### PR DESCRIPTION
Add the space after the tag for proper conversion/rendering in the website (currently shown as `**Note:**The`).