### PR TITLE
ascanrulesBeta: Tweak for SourceCodeDisclosureFileInclusionScanRule alert details

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- The Source Code Disclosure - File Inclusion alerts now consistently leverage the description and solution from the associated vulnerability details.
+
 ## [47] - 2023-07-20
 ### Added
 - The Source Code Disclosure - File Inclusion now includes example alert functionality for documentation generation purposes (Issue 6119).

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -525,7 +525,6 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
             String uri) {
         return newAlert()
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(Constant.messages.getString("ascanbeta.sourcecodedisclosure.desc"))
                 .setUri(uri)
                 .setParam(paramname)
                 .setAttack(prefixedUrlfilename)
@@ -536,11 +535,6 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
                                 NON_EXISTANT_FILENAME,
                                 randomversussourcefilenamematchpercentage,
                                 this.thresholdPercentage))
-                .setSolution(
-                        Constant.messages.getString("ascanbeta.sourcecodedisclosure.lfibased.soln"))
-                .setEvidence(
-                        Constant.messages.getString(
-                                "ascanbeta.sourcecodedisclosure.lfibased.evidence"))
                 .setMessage(sourceattackmsg);
     }
 

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -218,15 +218,12 @@ ascanbeta.shellshock.ref = http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2
 ascanbeta.shellshock.soln = Update Bash on the server to the latest version
 ascanbeta.shellshock.timingbased.evidence = Using the attack, a delay of [{0}] milliseconds was induced and detected
 
-ascanbeta.sourcecodedisclosure.desc = The source code for the current page was disclosed by the web server
+ascanbeta.sourcecodedisclosure.desc = The source code for the current page was disclosed by the web server.
 ascanbeta.sourcecodedisclosure.gitbased.evidence = The source code for [{0}] was extracted using [{1}]
-ascanbeta.sourcecodedisclosure.gitbased.extrainfo = 
 ascanbeta.sourcecodedisclosure.gitbased.name = Source Code Disclosure - Git 
 ascanbeta.sourcecodedisclosure.gitbased.soln = Ensure that Git metadata files are not deployed to the web server or application server
-ascanbeta.sourcecodedisclosure.lfibased.evidence = 
 ascanbeta.sourcecodedisclosure.lfibased.extrainfo = The output for the source code filename [{0}] differs sufficiently from that of the random parameter [{1}], at [{2}%], compared to a threshold of [{3}%]
 ascanbeta.sourcecodedisclosure.lfibased.name = Source Code Disclosure - File Inclusion
-ascanbeta.sourcecodedisclosure.lfibased.soln = Ensure that arbitrary files specified by the user are not included in the output
 ascanbeta.sourcecodedisclosure.svnbased.extrainfo = The source code for [{0}] was found at [{1}]
 ascanbeta.sourcecodedisclosure.svnbased.name = Source Code Disclosure - SVN
 ascanbeta.sourcecodedisclosure.svnbased.soln = Ensure that SVN metadata files are not deployed to the web server or application server

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.model.Vulnerabilities;
+import org.zaproxy.zap.model.Vulnerability;
 
 class SourceCodeDisclosureFileInclusionScanRuleUnitTest
         extends ActiveScannerTest<SourceCodeDisclosureFileInclusionScanRule> {
@@ -64,17 +66,22 @@ class SourceCodeDisclosureFileInclusionScanRuleUnitTest
 
     @Test
     void shouldReturnExpectedExampleAlert() {
+        // Given
+        Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_33");
+        // When
         List<Alert> alerts = rule.getExampleAlerts();
-
+        // Then
         assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
 
-        for (Alert alert : alerts) {
-            Map<String, String> tags = alert.getTags();
-            assertThat(tags.size(), is(equalTo(2)));
-            assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
-            assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
-            assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
-            assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        }
+        Map<String, String> tags = alert.getTags();
+        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
+
+        assertThat(alert.getDescription(), is(equalTo(vuln.getDescription())));
+        assertThat(alert.getSolution(), is(equalTo(vuln.getSolution())));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 }


### PR DESCRIPTION
## Overview
- CHANGELOG > Add maint note.
- Message.properties > Removed unused resource keys/values.
- SourceCodeDisclosureFileInclusionScanRule > Tweaked so that the example alerts use the same details as the plugin itself (which were based on vulnerabilities.xml content).

## Related Issues
https://github.com/zaproxy/zaproxy-website/pull/2007

## Checklist
- [ ] Update help - N/A
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage - N/A
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title