### PR TITLE
replacer: update docs and disable field

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Document that Token Processing applies just to string match types and disable the field in
+the dialogue when other match types are selected.
 
 ## [13] - 2023-07-11
 ### Changed

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
@@ -88,16 +88,19 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
         this.addTextField(0, URL_FIELD, "");
         this.addComboField(0, MATCH_TYPE_FIELD, getMatchTypes(), selectedStr);
 
+        boolean stringMatchType = true;
         if (ReplacerParamRule.MatchType.REQ_HEADER.equals(selectedMatchType)) {
             this.addComboField(0, MATCH_STR_FIELD, getDefaultRequestHeaders(), "", true);
             this.addCheckBoxField(0, REGEX_FIELD, false);
             // Only support exact matches with headers
             this.getField(REGEX_FIELD).setEnabled(false);
+            stringMatchType = false;
         } else if (ReplacerParamRule.MatchType.RESP_HEADER.equals(selectedMatchType)) {
             this.addComboField(0, MATCH_STR_FIELD, getDefaultResponseHeaders(), "", true);
             this.addCheckBoxField(0, REGEX_FIELD, false);
             // Only support exact matches with headers
             this.getField(REGEX_FIELD).setEnabled(false);
+            stringMatchType = false;
         } else {
             this.addTextField(0, MATCH_STR_FIELD, "");
             this.addCheckBoxField(0, REGEX_FIELD, false);
@@ -107,6 +110,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
         this.addReadOnlyField(0, INIT_TYPE_SUMMARY_FIELD, "", false);
         this.addCheckBoxField(0, ENABLE_FIELD, false);
         this.addCheckBoxField(0, ENABLE_TOKEN_PROCESSING, false);
+        getField(ENABLE_TOKEN_PROCESSING).setEnabled(stringMatchType);
         this.addPadding(0);
 
         this.addCheckBoxField(1, INIT_TYPE_ALL_FIELD, true);

--- a/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
+++ b/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
@@ -96,6 +96,14 @@ When enabled, the Replacement String may contain a single token which is replace
 		<td>Unix epoch milliseconds using <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#currentTimeMillis--">System.currentTimeMillis()</a></td>
 	</tr>
 </table> 
+<p>
+<strong>Note:</strong> This option applies only to the following Match Types:
+<ul>
+	<li>Request Header String</li>
+	<li>Request Body String</li>
+	<li>Response Header String</li>
+	<li>Response Body String</li>
+</ul>
 
 <h3>Initiators tab</h3>
 Allows you to specify which 'initiators' the rule should apply to.


### PR DESCRIPTION
Document that Token Processing applies just to string match types and disable the field in the dialogue when other match types are selected.

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/D2BKRS8J900/m/yNSbehPTBQAJ and direct reply.