### PR TITLE
postman: Implement item deserialization

### DIFF
--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/AbstractItemDeserializer.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/AbstractItemDeserializer.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.postman;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.zaproxy.addon.postman.models.AbstractItem;
+
+public class AbstractItemDeserializer extends JsonDeserializer<List<AbstractItem>> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public List<AbstractItem> deserialize(JsonParser jsonParser, DeserializationContext ctxt)
+            throws IOException {
+        JsonNode itemsNode = jsonParser.getCodec().readTree(jsonParser);
+
+        if (itemsNode.isArray()) {
+            return deserializeArray(itemsNode);
+        } else if (itemsNode.isObject()) {
+            return deserializeObject(itemsNode);
+        }
+
+        return List.of();
+    }
+
+    private List<AbstractItem> deserializeArray(JsonNode itemsNode) {
+        List<AbstractItem> items = new ArrayList<AbstractItem>();
+        for (JsonNode itemNode : itemsNode) {
+            AbstractItem item = deserializeItem(itemNode);
+            if (item != null) {
+                items.add(item);
+            }
+        }
+        return Collections.unmodifiableList(items);
+    }
+
+    private List<AbstractItem> deserializeObject(JsonNode itemNode) {
+        AbstractItem item = deserializeItem(itemNode);
+        return (item != null) ? List.of(item) : List.of();
+    }
+
+    private AbstractItem deserializeItem(JsonNode itemNode) {
+        try {
+            return mapper.treeToValue(itemNode, AbstractItem.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
@@ -29,6 +29,7 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.io.FileUtils;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.postman.models.PostmanCollection;
 
 public class PostmanParser {
 

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/AbstractItem.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/AbstractItem.java
@@ -1,0 +1,29 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.postman.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({@JsonSubTypes.Type(Item.class), @JsonSubTypes.Type(ItemGroup.class)})
+public abstract class AbstractItem {}

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/Item.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/Item.java
@@ -1,0 +1,40 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.postman.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents an item in the Postman format which is the basic building block of a collection.
+ *
+ * @see https://learning.postman.com/collection-format/reference/item/
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Item extends AbstractItem {
+    private Object request;
+
+    public Object getRequest() {
+        return request;
+    }
+
+    public void setRequest(Object request) {
+        this.request = request;
+    }
+}

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/ItemGroup.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/ItemGroup.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.postman.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
+import org.zaproxy.addon.postman.AbstractItemDeserializer;
+
+/**
+ * Represents an item-group in the Postman format which can contain both item and item-group
+ * elements.
+ *
+ * @see https://learning.postman.com/collection-format/reference/item-group/
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ItemGroup extends AbstractItem {
+    @JsonDeserialize(using = AbstractItemDeserializer.class)
+    private List<AbstractItem> item;
+
+    public List<AbstractItem> getItem() {
+        return item;
+    }
+
+    public void setItem(List<AbstractItem> item) {
+        this.item = item;
+    }
+}

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/PostmanCollection.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/PostmanCollection.java
@@ -17,21 +17,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.addon.postman;
+package org.zaproxy.addon.postman.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
+import org.zaproxy.addon.postman.AbstractItemDeserializer;
 
+/**
+ * Represents a collection in the Postman format.
+ *
+ * @see https://learning.postman.com/collection-format/reference/collection/
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PostmanCollection {
 
-    private Object item;
+    @JsonDeserialize(using = AbstractItemDeserializer.class)
+    private List<AbstractItem> item;
+
     private Object variable;
 
-    public Object getItem() {
+    public List<AbstractItem> getItem() {
         return item;
     }
 
-    public void setItem(Object item) {
+    public void setItem(List<AbstractItem> item) {
         this.item = item;
     }
 


### PR DESCRIPTION
## Overview
This PR implements deserialization of items of a postman definition into `SingleItem` or `ItemGroup` model classes which are the subclasses of `Item`. The deserializer will ignore the items which doesn't fit into these model classes.


## Related Issues
https://github.com/zaproxy/zaproxy/issues/6960

## Checklist
- [x] Update help (N/A)
- [x] Update changelog (N/A)
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title


