### PR TITLE
automation: address error with active scan job

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Address error logged when using the Active Scan job.
+
 ## [0.30.0] - 2023-07-11
 ### Changed
 - Update minimum ZAP version to 2.13.0.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -53,6 +53,7 @@ public class ActiveScanJob extends AutomationJob {
 
     private static final String PARAM_CONTEXT = "context";
     private static final String PARAM_POLICY = "policy";
+    private static final String PARAM_USER = "user";
 
     private static final String RULES_ELEMENT_NAME = "rules";
 
@@ -186,7 +187,7 @@ public class ActiveScanJob extends AutomationJob {
                 this.parameters,
                 JobUtils.getJobOptions(this, progress),
                 this.getName(),
-                new String[] {PARAM_POLICY, PARAM_CONTEXT},
+                new String[] {PARAM_POLICY, PARAM_CONTEXT, PARAM_USER},
                 progress,
                 this.getPlan().getEnv());
     }


### PR DESCRIPTION
Ignore the user property when applying the parameters to the active scan options, the user is handled differently.
This prevents an error from being logged when using the active scan job.

---
```
[ZAP-Automation] ERROR org.zaproxy.addon.automation.jobs.JobUtils - Automation Framework failed to find method setUser on org.parosproxy.paros.core.scanner.ScannerParam
```
e.g. https://groups.google.com/g/zaproxy-users/c/wIf-djwYT9U/m/zk17SwTvAAAJ