### PR TITLE
ascanrulesAlpha: remove `oast` dependency

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Remove the dependency on OAST add-on, no longer required.
 
 ## [43] - 2023-07-20
 ### Changed

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -12,9 +12,6 @@ zapAddOn {
                 register("commonlib") {
                     version.set(">= 1.13.0 & < 2.0.0")
                 }
-                register("oast") {
-                    version.set(">= 0.14.0")
-                }
             }
         }
     }
@@ -22,11 +19,7 @@ zapAddOn {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("oast")!!)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("database")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
-    testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))
 }


### PR DESCRIPTION
The `oast` add-on is no longer a dependency, with the promotion of the scan rules that use it.