### PR TITLE
Remove redundant test dependencies

### DIFF
--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
     testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))
-    testImplementation("org.apache.commons:commons-lang3:3.12")
 }
 
 spotless {

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
-    testImplementation("org.apache.commons:commons-lang3:3.12.0")
 }
 
 spotless {


### PR DESCRIPTION
The dependency is already in the test compile/runtime classpaths as it is provided by ZAP core.