### PR TITLE
Reports: Add Other Info handling

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- The following reports now include "Other Info" for alerts:
+    - Traditional Markdown Report
+    - Traditional PDF Report
 
 ## [0.23.0] - 2023-07-11
 ### Changed

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-markdown.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-markdown.html
@@ -75,16 +75,19 @@ CSRF has primarily been used to perform an action against a target site using th
   * Parameter: ``
   * Attack: ``
   * Evidence: `&lt;form id="advanced" name="advanced" method="POST" onsubmit="return validateForm(this);false;"&gt;`
+  * Other Info: ``
 * URL: http://localhost:8080/bodgeit/advanced.jsp
   * Method: `GET`
   * Parameter: ``
   * Attack: ``
   * Evidence: `&lt;form id="query" name="advanced" method="POST"&gt;`
+  * Other Info: ``
 * URL: http://localhost:8080/bodgeit/basket.jsp
   * Method: `GET`
   * Parameter: ``
   * Attack: ``
   * Evidence: `&lt;form action="basket.jsp" method="post"&gt;`
+  * Other Info: ``
 
 </pre>
 

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
@@ -96,6 +96,7 @@ reports.report.alerts.detail.description = Description
 reports.report.alerts.detail.evidence = Evidence
 reports.report.alerts.detail.instances = Instances
 reports.report.alerts.detail.method = Method
+reports.report.alerts.detail.otherinfo = Other Info
 reports.report.alerts.detail.param = Parameter
 reports.report.alerts.detail.pluginid = Plugin Id
 reports.report.alerts.detail.reference = Reference

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-md/report.md
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-md/report.md
@@ -40,6 +40,7 @@
   * [(#{report.alerts.detail.param})]: `[(${instance.userObject.param})]`
   * [(#{report.alerts.detail.attack})]: `[(${instance.userObject.attack})]`
   * [(#{report.alerts.detail.evidence})]: `[(${instance.userObject.evidence})]`
+  * [(#{report.alerts.detail.otherinfo})]: `[(${instance.userObject.otherinfo})]`
 [/th:block]
 [(#{report.alerts.detail.instances})]: [(${alert.childCount})]
 

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-pdf/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-pdf/report.html
@@ -232,6 +232,12 @@ td {
 							class="indent2">Evidence</td>
 						<td th:text="${instance.userObject.evidence}" width="80%">Evidence</td>
 					</tr>
+					<tr>
+						<td th:text="#{report.alerts.detail.otherinfo}" width="20%"
+							class="indent2">Other Info</td>
+						<td th:text="${instance.userObject.otherinfo}" width="80%">Other
+							Info</td>
+					</tr>
 				</th:block>
 				<tr>
 					<td th:text="#{report.alerts.detail.instances}" width="20%">Instances</td>

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-md.md
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-md.md
@@ -41,11 +41,13 @@ XSS Description
   * !reports.report.alerts.detail.param!: `Test Param`
   * !reports.report.alerts.detail.attack!: `Test "Attack\"`
   * !reports.report.alerts.detail.evidence!: `Test <p>Evidence`
+  * !reports.report.alerts.detail.otherinfo!: `Test 'Other\`
 * !reports.report.alerts.detail.url!: http://example.com/example_3
   * !reports.report.alerts.detail.method!: `GET`
   * !reports.report.alerts.detail.param!: `Test Param`
   * !reports.report.alerts.detail.attack!: `Test "Attack\"`
   * !reports.report.alerts.detail.evidence!: `Test <p>Evidence`
+  * !reports.report.alerts.detail.otherinfo!: `Test Another 'Other\`
 
 !reports.report.alerts.detail.instances!: 2
 


### PR DESCRIPTION
## Overview
I have added `Other info` handling for traditional-pdf and traditional-md reports. Am I going in the right direction? And looking at the structure of the high-level report, I don't think 'Other info` is needed, per instance?

## Related Issues
Fixes zaproxy/zaproxy#7717

Also see: https://github.com/zaproxy/zap-extensions/pull/4435

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting ➡ N/A
- [x] Write tests ➡ N/A
- [x] Check code coverage ➡ N/A
- [x] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title ➡ N/A