### PR TITLE
Simplify declaration of add-on dependencies

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -144,6 +144,16 @@ subprojects {
             exclude(group = "log4j")
             exclude(group = "org.apache.logging.log4j", module = "log4j-1.2-api")
         }
+
+        val zapAddOn by creating
+
+        "compileOnly" {
+            extendsFrom(zapAddOn)
+        }
+
+        "testImplementation" {
+            extendsFrom(zapAddOn)
+        }
     }
 
     val zapGav = "org.zaproxy:zap:2.13.0"

--- a/addOns/alertFilters/alertFilters.gradle.kts
+++ b/addOns/alertFilters/alertFilters.gradle.kts
@@ -32,7 +32,7 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
+    zapAddOn("automation")
+
     testImplementation(project(":testutils"))
-    testImplementation(parent!!.childProjects.get("automation")!!)
 }

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -42,19 +42,15 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("custompayloads")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
-    compileOnly(parent!!.childProjects.get("oast")!!)
+    zapAddOn("commonlib")
+    zapAddOn("custompayloads")
+    zapAddOn("network")
+    zapAddOn("oast")
+
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     implementation("org.bitbucket.mstrobel:procyon-compilertools:0.6.0")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
-    testImplementation(parent!!.childProjects.get("custompayloads")!!)
-    testImplementation(parent!!.childProjects.get("database")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
-    testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -18,8 +18,7 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -30,19 +30,15 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("database")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
-    compileOnly(parent!!.childProjects.get("oast")!!)
+    zapAddOn("commonlib")
+    zapAddOn("database")
+    zapAddOn("network")
+    zapAddOn("oast")
 
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     implementation("org.jsoup:jsoup:1.14.3")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
-    testImplementation(parent!!.childProjects.get("database")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
-    testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/authhelper/authhelper.gradle.kts
+++ b/addOns/authhelper/authhelper.gradle.kts
@@ -48,12 +48,10 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
-    compileOnly(parent!!.childProjects.get("selenium")!!)
-    compileOnly(parent!!.childProjects.get("spiderAjax")!!)
+    zapAddOn("commonlib")
+    zapAddOn("network")
+    zapAddOn("selenium")
+    zapAddOn("spiderAjax")
+
     testImplementation(project(":testutils"))
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
-    testImplementation(parent!!.childProjects.get("selenium")!!)
 }

--- a/addOns/automation/automation.gradle.kts
+++ b/addOns/automation/automation.gradle.kts
@@ -34,12 +34,13 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
+
     val jacksonVersion = "2.15.2"
     api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
     api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     api("org.snakeyaml:snakeyaml-engine:2.6")
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
+
     testImplementation(project(":testutils"))
 }

--- a/addOns/bruteforce/bruteforce.gradle.kts
+++ b/addOns/bruteforce/bruteforce.gradle.kts
@@ -21,9 +21,8 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/client/client.gradle.kts
+++ b/addOns/client/client.gradle.kts
@@ -29,8 +29,8 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("selenium")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
+    zapAddOn("selenium")
+    zapAddOn("network")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/dev/dev.gradle.kts
+++ b/addOns/dev/dev.gradle.kts
@@ -18,6 +18,5 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("network")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
+    zapAddOn("network")
 }

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -32,12 +32,10 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
-    compileOnly(parent!!.childProjects.get("selenium")!!)
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
-    testImplementation(parent!!.childProjects.get("selenium")!!)
+    zapAddOn("commonlib")
+    zapAddOn("network")
+    zapAddOn("selenium")
+
     testImplementation("io.github.bonigarcia:webdrivermanager:5.0.3")
     testImplementation(project(":testutils"))
 }

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -51,12 +51,11 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("automation")
+    zapAddOn("commonlib")
+
     implementation(files("lib/org.jwall.web.audit-0.2.15.jar"))
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
-    testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/fuzz/fuzz.gradle.kts
+++ b/addOns/fuzz/fuzz.gradle.kts
@@ -20,7 +20,8 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
+
     implementation("com.natpryce:snodge:2.1.2.2")
     implementation("org.owasp.jbrofuzz:jbrofuzz-core:2.5.1") {
         // Only "jbrofuzz-core" is needed.
@@ -28,6 +29,5 @@ dependencies {
     }
     implementation("com.github.mifmif:generex:1.0.2")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -71,17 +71,14 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("formhandler")!!)
-    compileOnly(parent!!.childProjects.get("spider")!!)
+    zapAddOn("automation")
+    zapAddOn("commonlib")
+    zapAddOn("formhandler")
+    zapAddOn("spider")
+
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("com.graphql-java:graphql-java:21.0")
 
-    testImplementation(parent!!.childProjects.get("automation")!!)
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("formhandler")!!)
-    testImplementation(parent!!.childProjects.get("spider")!!)
     testImplementation(project(":testutils"))
     testImplementation(libs.log4j.core)
 }

--- a/addOns/groovy/groovy.gradle.kts
+++ b/addOns/groovy/groovy.gradle.kts
@@ -16,5 +16,5 @@ dependencies {
     implementation("org.codehaus.groovy:groovy-all:3.0.14")
 
     testImplementation(project(":testutils"))
-    testImplementation(parent!!.childProjects.get("websocket")!!)
+    testImplementation(project(":addOns:websocket"))
 }

--- a/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
+++ b/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
@@ -21,12 +21,11 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
 
     implementation("com.adobe.xmp:xmpcore:6.0.6")
     implementation("com.drewnoakes:metadata-extractor:2.13.0")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/oast/oast.gradle.kts
+++ b/addOns/oast/oast.gradle.kts
@@ -57,10 +57,9 @@ datanucleus {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects["database"]!!)
-    compileOnly(parent!!.childProjects["graaljs"]!!)
-    compileOnly(parent!!.childProjects["network"]!!)
+    zapAddOn("database")
+    zapAddOn("graaljs")
+    zapAddOn("network")
 
     testImplementation(project(":testutils"))
-    testImplementation(parent!!.childProjects["network"]!!)
 }

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -71,10 +71,10 @@ configurations {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("formhandler")!!)
-    compileOnly(parent!!.childProjects.get("spider")!!)
+    zapAddOn("automation")
+    zapAddOn("commonlib")
+    zapAddOn("formhandler")
+    zapAddOn("spider")
 
     implementation("io.swagger.parser.v3:swagger-parser:2.1.16")
     implementation("io.swagger:swagger-compat-spec-parser:1.0.67") {
@@ -87,11 +87,7 @@ dependencies {
         exclude(group = "org.apache.logging.log4j")
     }
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(libs.log4j.core)
-    testImplementation(parent!!.childProjects.get("automation")!!)
-    testImplementation(parent!!.childProjects.get("formhandler")!!)
-    testImplementation(parent!!.childProjects.get("spider")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/paramdigger/paramdigger.gradle.kts
+++ b/addOns/paramdigger/paramdigger.gradle.kts
@@ -18,9 +18,8 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/plugnhack/plugnhack.gradle.kts
+++ b/addOns/plugnhack/plugnhack.gradle.kts
@@ -41,6 +41,6 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("network")!!)
-    compileOnly(parent!!.childProjects.get("requester")!!)
+    zapAddOn("network")
+    zapAddOn("requester")
 }

--- a/addOns/portscan/portscan.gradle.kts
+++ b/addOns/portscan/portscan.gradle.kts
@@ -24,10 +24,8 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
+    zapAddOn("commonlib")
+    zapAddOn("network")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -39,11 +39,9 @@ dependencies {
     implementation("com.google.re2j:re2j:1.6")
     implementation("com.shapesecurity:salvation2:3.0.1")
 
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("custompayloads")!!)
+    zapAddOn("commonlib")
+    zapAddOn("custompayloads")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -17,8 +17,7 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -35,10 +35,8 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("custompayloads")!!)
+    zapAddOn("commonlib")
+    zapAddOn("custompayloads")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -80,10 +80,10 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("callhome")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
-    compileOnly(parent!!.childProjects.get("reports")!!)
-    compileOnly(parent!!.childProjects.get("selenium")!!)
-    compileOnly(parent!!.childProjects.get("spider")!!)
-    compileOnly(parent!!.childProjects.get("spiderAjax")!!)
+    zapAddOn("callhome")
+    zapAddOn("network")
+    zapAddOn("reports")
+    zapAddOn("selenium")
+    zapAddOn("spider")
+    zapAddOn("spiderAjax")
 }

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -45,7 +45,8 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
+    zapAddOn("automation")
+
     implementation("org.thymeleaf:thymeleaf:3.1.1.RELEASE")
     implementation("org.xhtmlrenderer:flying-saucer-pdf:9.1.22")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2")
@@ -56,7 +57,6 @@ dependencies {
         exclude(group = "org.apache.logging.log4j")
     }
 
-    testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/retest/retest.gradle.kts
+++ b/addOns/retest/retest.gradle.kts
@@ -30,7 +30,7 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
-    testImplementation(parent!!.childProjects.get("automation")!!)
+    zapAddOn("automation")
+
     testImplementation(project(":testutils"))
 }

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -36,10 +36,9 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
 
     implementation("com.google.code.gson:gson:2.8.8")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -39,8 +39,8 @@ spotless {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
+    zapAddOn("automation")
+
     testImplementation(project(":testutils"))
-    testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation("org.snakeyaml:snakeyaml-engine:2.3")
 }

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -40,8 +40,7 @@ dependencies {
         exclude(group = "org.apache.logging.log4j")
     }
 
-    compileOnly(parent!!.childProjects.get("network")!!)
+    zapAddOn("network")
 
-    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -67,10 +67,11 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("formhandler")!!)
-    compileOnly(parent!!.childProjects.get("spider")!!)
+    zapAddOn("automation")
+    zapAddOn("commonlib")
+    zapAddOn("formhandler")
+    zapAddOn("spider")
+
     implementation("com.predic8:soa-model-core:2.0.1")
     implementation("com.sun.xml.messaging.saaj:saaj-impl:3.0.0")
     implementation("jakarta.xml.soap:jakarta.xml.soap-api:3.0.0")
@@ -79,9 +80,5 @@ dependencies {
         exclude(group = "org.apache.logging.log4j")
     }
 
-    testImplementation(parent!!.childProjects.get("automation")!!)
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("formhandler")!!)
-    testImplementation(parent!!.childProjects.get("spider")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -66,19 +66,14 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("database")!!)
-    compileOnly(parent!!.childProjects.get("formhandler")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
+    zapAddOn("automation")
+    zapAddOn("commonlib")
+    zapAddOn("database")
+    zapAddOn("formhandler")
+    zapAddOn("network")
 
     implementation("io.kaitai:kaitai-struct-runtime:0.10")
 
-    testImplementation(parent!!.childProjects.get("automation")!!)
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("database")!!)
-    testImplementation(parent!!.childProjects.get("formhandler")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -69,10 +69,11 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("selenium")!!)
-    compileOnly(parent!!.childProjects.get("automation")!!)
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
-    compileOnly(parent!!.childProjects.get("network")!!)
+    zapAddOn("selenium")
+    zapAddOn("automation")
+    zapAddOn("commonlib")
+    zapAddOn("network")
+
     compileOnly(libs.log4j.core)
 
     implementation(files("lib/crawljax-core-3.7.1.jar"))
@@ -93,10 +94,6 @@ dependencies {
     }
     implementation("xmlunit:xmlunit:1.6")
 
-    testImplementation(parent!!.childProjects.get("automation")!!)
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
-    testImplementation(parent!!.childProjects.get("network")!!)
-    testImplementation(parent!!.childProjects.get("selenium")!!)
     testImplementation(libs.log4j.core)
     testImplementation(project(":testutils"))
 }

--- a/addOns/sqliplugin/sqliplugin.gradle.kts
+++ b/addOns/sqliplugin/sqliplugin.gradle.kts
@@ -32,7 +32,7 @@ crowdin {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("commonlib")
 
     implementation("org.jdom:jdom:2.0.2")
 }

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -39,8 +39,8 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("automation")!!)
-    compileOnly(parent!!.childProjects.get("commonlib")!!)
+    zapAddOn("automation")
+    zapAddOn("commonlib")
 
     implementation("com.google.re2j:re2j:1.6")
 
@@ -53,6 +53,5 @@ dependencies {
 
     implementation("org.jsoup:jsoup:1.14.3")
 
-    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/websocket/websocket.gradle.kts
+++ b/addOns/websocket/websocket.gradle.kts
@@ -48,8 +48,8 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("fuzz")!!)
-    compileOnly(parent!!.childProjects.get("requester")!!)
+    zapAddOn("fuzz")
+    zapAddOn("requester")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -35,8 +35,9 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly(parent!!.childProjects.get("network")!!)
-    compileOnly(parent!!.childProjects.get("selenium")!!)
+    zapAddOn("network")
+    zapAddOn("selenium")
+
     implementation("org.zaproxy:zest:0.18.0") {
         // Provided by Selenium add-on.
         exclude(group = "org.seleniumhq.selenium")
@@ -49,6 +50,4 @@ dependencies {
     }
 
     testImplementation(project(":testutils"))
-    testImplementation(parent!!.childProjects.get("network")!!)
-    testImplementation(parent!!.childProjects.get("selenium")!!)
 }

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -1,6 +1,7 @@
 import com.diffplug.gradle.spotless.JavaExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.DependencyHandler
 
 /**
  * Configures the java extension with all Java files except the given ones and configures
@@ -35,3 +36,12 @@ fun SpotlessExtension.javaWith3rdPartyFormatted(project: Project, files: List<St
  */
 fun JavaExtension.googleJavaFormatAosp() =
     googleJavaFormat("1.7").aosp()
+
+/**
+ * Adds an add-on project as a dependency.
+ */
+fun DependencyHandler.zapAddOn(addOnId: String) {
+    add("zapAddOn", project(mapOf("path" to ":addOns:$addOnId")))
+
+    add("testRuntimeOnly", project(mapOf("path" to ":addOns:$addOnId", "configuration" to "zapAddOn")))
+}

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -16,7 +16,7 @@ configurations {
 
 dependencies {
     compileOnly("org.zaproxy:zap:2.13.0")
-    implementation(parent!!.childProjects.get("addOns")!!.childProjects.get("network")!!)
+    implementation(project(":addOns:network"))
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 
     api("org.hamcrest:hamcrest-library:2.2")


### PR DESCRIPTION
Automatically declare the add-on dependency as compile only, test implementation, and test runtime with transitive to closely simulate how they are available when running in ZAP.