### PR TITLE
scripts: remove unnecessary test dependency

### DIFF
--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -42,5 +42,4 @@ dependencies {
     zapAddOn("automation")
 
     testImplementation(project(":testutils"))
-    testImplementation("org.snakeyaml:snakeyaml-engine:2.3")
 }


### PR DESCRIPTION
The dependency is not necessary to compile or run the tests (in any case it would be exposed by a dependency add-on if needed).