### PR TITLE
jsonview: fix JSON formatting

### DIFF
--- a/addOns/jsonview/CHANGELOG.md
+++ b/addOns/jsonview/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Update minimum ZAP version to 2.13.0.
+- Depend on Common Library add-on to reuse libraries (Issue 7961).
+
+### Fixed
+- Use other library to format the JSON bodies (Issue 7798).
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/jsonview/jsonview.gradle.kts
+++ b/addOns/jsonview/jsonview.gradle.kts
@@ -11,6 +11,14 @@ zapAddOn {
             baseName.set("help%LC%.helpset")
             localeToken.set("%LC%")
         }
+
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">= 1.16.0 & < 2.0.0")
+                }
+            }
+        }
     }
 }
 
@@ -19,4 +27,10 @@ crowdin {
         file.set(file("$rootDir/gradle/crowdin-help-only.yml"))
         tokens.put("%helpPath%", "")
     }
+}
+
+dependencies {
+    zapAddOn("commonlib")
+
+    testImplementation(project(":testutils"))
 }

--- a/addOns/jsonview/src/main/java/org/zaproxy/zap/extension/jsonview/internal/JsonFormatter.java
+++ b/addOns/jsonview/src/main/java/org/zaproxy/zap/extension/jsonview/internal/JsonFormatter.java
@@ -1,0 +1,81 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jsonview.internal;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+public final class JsonFormatter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectWriter PRETTY_PRINTER =
+            OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
+
+    private JsonFormatter() {}
+
+    /**
+     * Tells whether or not the given data is JSON.
+     *
+     * @param data the data to check.
+     * @return {@code true} if the given data is JSON, {@code false} otherwise.
+     */
+    public static boolean isJson(String data) {
+        if (isBlank(data)) {
+            return true;
+        }
+
+        try {
+            parse(data);
+            return true;
+        } catch (JacksonException e) {
+            return false;
+        }
+    }
+
+    private static boolean isBlank(String data) {
+        return data == null || data.isBlank();
+    }
+
+    private static Object parse(String data) throws JacksonException {
+        return OBJECT_MAPPER.readValue(data, Object.class);
+    }
+
+    /**
+     * Formats the given JSON.
+     *
+     * <p>If not valid JSON it is returned without any modifications.
+     *
+     * @param data the JSON to format.
+     * @return the formatted JSON, or the given data if not JSON.
+     */
+    public static String toFormattedJson(String data) {
+        if (isBlank(data)) {
+            return data;
+        }
+
+        try {
+            var object = parse(data);
+            return PRETTY_PRINTER.writeValueAsString(object);
+        } catch (Exception e) {
+            return data;
+        }
+    }
+}

--- a/addOns/jsonview/src/test/java/org/zaproxy/zap/extension/jsonview/internal/JsonFormatterUnitTest.java
+++ b/addOns/jsonview/src/test/java/org/zaproxy/zap/extension/jsonview/internal/JsonFormatterUnitTest.java
@@ -1,0 +1,124 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jsonview.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Unit test for {@link JsonFormatter}. */
+class JsonFormatterUnitTest {
+
+    static Stream<String> invalidJson() {
+        return Stream.of(
+                "\t notliteral \t",
+                "\t +1 \t",
+                "\t 1E/1 \t",
+                "\t { not object } \t",
+                "\t [ not array ] \t");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidJson")
+    void shouldNotBeJsonIfInvalidJson(String original) {
+        // Given / When
+        boolean json = JsonFormatter.isJson(original);
+        // Then
+        assertThat(json, is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"false", "null", "true", "1", "[]", "{}"})
+    void shouldBeJsonIfValidJsonOrNullOrEmpty(String original) {
+        // Given / When
+        boolean json = JsonFormatter.isJson(original);
+        // Then
+        assertThat(json, is(equalTo(true)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"'\t false ',false", "'\t null ',null", "'\t true ',true"})
+    void shouldFormatLiteralNames(String original, String expected) {
+        testFormattedValue(original, expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'\t -1 ',-1",
+        "'\t 1 ',1",
+        "'\t 1.2 ',1.2",
+        "'\t 1E1 ',10.0",
+        "'\t 1E+1 ',10.0",
+        "'\t 1E-1 ',0.1",
+        "'\t 0.2E+2 ',20.0",
+        "'\t 0.2E-1 ',0.02"
+    })
+    void shouldFormatNumbers(String original, String expected) {
+        testFormattedValue(original, expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                "'\t \"\" ',\"\"",
+                "'\t  \"escaped chars \\t \\n \\\"  \"   \t','\"escaped chars \\t \\n \\\"  \"'"
+            })
+    void shouldFormatStrings(String original, String expected) {
+        testFormattedValue(original, expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"'\t [] ',[ ]", "'\t  [1, null, {}, \"\"]','[ 1, null, { }, \"\" ]'"})
+    void shouldFormatArrays(String original, String expected) {
+        testFormattedValue(original, expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                "'\t {} ','{ }'",
+                "'\t  {\"a\": {}, \"b\":\"{}\"}','{\n  \"a\" : { },\n  \"b\" : \"{}\"\n}'"
+            })
+    void shouldFormatObjects(String original, String expected) {
+        testFormattedValue(original, expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @MethodSource("invalidJson")
+    void shouldNotFormatInvalidJson(String original) {
+        testFormattedValue(original, original);
+    }
+
+    private static void testFormattedValue(String original, String expected) {
+        // Given / When
+        String formatted = JsonFormatter.toFormattedJson(original);
+        // Then
+        assertThat(formatted, is(equalTo(expected)));
+    }
+}


### PR DESCRIPTION
Use Jackson to format instead of `json-lib`, the latter library might inadvertently change the JSON structure/content while formatting.
Depend on the `commonlib` add-on to reuse the library.

Part of zaproxy/zaproxy#7798.
Related to zaproxy/zaproxy#7961.