### PR TITLE
commonlib: provide Jackson lib

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Provide Jackson parsing library, to reuse the library in other add-ons (Issue 7961).
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/commonlib/commonlib.gradle.kts
+++ b/addOns/commonlib/commonlib.gradle.kts
@@ -25,6 +25,10 @@ crowdin {
 }
 
 dependencies {
+    api(platform("com.fasterxml.jackson:jackson-bom:2.15.2"))
+    api("com.fasterxml.jackson.core:jackson-databind")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+
     implementation("commons-io:commons-io:2.13.0")
     implementation("org.apache.commons:commons-csv:1.10.0")
     implementation("org.apache.commons:commons-collections4:4.4")

--- a/addOns/postman/postman.gradle.kts
+++ b/addOns/postman/postman.gradle.kts
@@ -6,6 +6,14 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/postman-support/")
+
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">= 1.16.0 & < 2.0.0")
+                }
+            }
+        }
     }
 
     apiClientGen {
@@ -23,7 +31,7 @@ crowdin {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.12.5")
+    zapAddOn("commonlib")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The following reports now include "Other Info" for alerts:
     - Traditional Markdown Report
     - Traditional PDF Report
+- Depend on Common Library add-on to reuse libraries (Issue 7961).
 
 ## [0.23.0] - 2023-07-11
 ### Changed

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -14,6 +14,15 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/report-generation/")
+
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">= 1.16.0 & < 2.0.0")
+                }
+            }
+        }
+
         extensions {
             register("org.zaproxy.addon.reports.automation.ExtensionReportAutomation") {
                 classnames {
@@ -46,12 +55,10 @@ crowdin {
 
 dependencies {
     zapAddOn("automation")
+    zapAddOn("commonlib")
 
     implementation("org.thymeleaf:thymeleaf:3.1.1.RELEASE")
     implementation("org.xhtmlrenderer:flying-saucer-pdf:9.1.22")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
-    implementation("org.snakeyaml:snakeyaml-engine:2.6")
     implementation(libs.log4j.slf4j2) {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")


### PR DESCRIPTION
Change `commonlib` to provide the Jackson library since it's used by several add-ons.
Change `postman` and `reports` to depend on `commonlib` and no longer include the Jackson dependencies.

Fix zaproxy/zaproxy#7961.