### PR TITLE
testutils: use random server port directly

### DIFF
--- a/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -192,7 +192,7 @@ public abstract class TestUtils {
      * @see #stopServer()
      */
     protected void startServer() throws IOException {
-        startServer(getRandomPort());
+        startServer(0);
     }
 
     /**


### PR DESCRIPTION
Let the server pick a random port instead of manually getting one first as the latter might cause binding failures on some systems.