### PR TITLE
network: update names in generated certs

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Update names of generated root CA certificate and issued server certificates.
 
 ### Fixed
 - Correct declaration of mandatory parameters of the API endpoint `setRateLimitRuleEnabled`.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptionsPanel.java
@@ -61,10 +61,9 @@ class ServerCertificatesOptionsPanel extends AbstractParamPanel {
 
     private static final Logger LOGGER = LogManager.getLogger(ServerCertificatesOptionsPanel.class);
 
-    private static final String OWASP_ZAP_ROOT_CA_NAME = "owasp_zap_root_ca";
-    private static final String OWASP_ZAP_ROOT_CA_FILE_EXT = ".cer";
-    private static final String OWASP_ZAP_ROOT_CA_FILENAME =
-            OWASP_ZAP_ROOT_CA_NAME + OWASP_ZAP_ROOT_CA_FILE_EXT;
+    private static final String ZAP_ROOT_CA_NAME = "zap_root_ca";
+    private static final String ZAP_ROOT_CA_FILE_EXT = ".cer";
+    private static final String ZAP_ROOT_CA_FILENAME = ZAP_ROOT_CA_NAME + ZAP_ROOT_CA_FILE_EXT;
 
     private static final String CONFIGURATION_FILENAME = Constant.FILE_CONFIG_NAME;
 
@@ -305,7 +304,7 @@ class ServerCertificatesOptionsPanel extends AbstractParamPanel {
                     new WritableFileChooser(new File(System.getProperty("user.home")));
             fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
             fileChooser.setMultiSelectionEnabled(false);
-            fileChooser.setSelectedFile(new File(OWASP_ZAP_ROOT_CA_FILENAME));
+            fileChooser.setSelectedFile(new File(ZAP_ROOT_CA_FILENAME));
             if (fileChooser.showSaveDialog(panel) != JFileChooser.APPROVE_OPTION) {
                 return;
             }
@@ -486,7 +485,7 @@ class ServerCertificatesOptionsPanel extends AbstractParamPanel {
         private void viewRootCaCert() {
             Path file;
             try {
-                file = Files.createTempFile(OWASP_ZAP_ROOT_CA_NAME, OWASP_ZAP_ROOT_CA_FILE_EXT);
+                file = Files.createTempFile(ZAP_ROOT_CA_NAME, ZAP_ROOT_CA_FILE_EXT);
                 writePem(file);
             } catch (IOException e) {
                 LOGGER.error("An error occured while creating the temporary file", e);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
@@ -164,13 +164,13 @@ public final class CertificateUtils {
         // using the hash code of the user's name and home path, keeps anonymity
         // but also gives user a chance to distinguish between each other
         X500NameBuilder nameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
-        nameBuilder.addRDN(BCStyle.CN, "OWASP Zed Attack Proxy Root CA");
+        nameBuilder.addRDN(BCStyle.CN, "Zed Attack Proxy Root CA");
         nameBuilder.addRDN(
                 BCStyle.L,
                 Integer.toHexString(System.getProperty("user.name").hashCode())
                         + Integer.toHexString(System.getProperty("user.home").hashCode()));
-        nameBuilder.addRDN(BCStyle.O, "OWASP Root CA");
-        nameBuilder.addRDN(BCStyle.OU, "OWASP ZAP Root CA");
+        nameBuilder.addRDN(BCStyle.O, "ZAP Root CA");
+        nameBuilder.addRDN(BCStyle.OU, "ZAP Root CA");
         nameBuilder.addRDN(BCStyle.C, "xx");
 
         X500Name name = nameBuilder.build();
@@ -284,7 +284,7 @@ public final class CertificateUtils {
             namebld.addRDN(BCStyle.CN, certData.getCommonName());
         }
         namebld.addRDN(BCStyle.OU, "Zed Attack Proxy Project");
-        namebld.addRDN(BCStyle.O, "OWASP");
+        namebld.addRDN(BCStyle.O, "ZAP");
         namebld.addRDN(BCStyle.C, "xx");
         namebld.addRDN(BCStyle.EmailAddress, "zaproxy-develop@googlegroups.com");
 

--- a/addOns/network/src/main/javahelp/help/contents/options/servercertificates.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/servercertificates.html
@@ -10,7 +10,7 @@
 	This screens allows to manage and configure the root CA certificate and issued certificates.
 
 	<p>
-	OWASP ZAP allows you to transparently decrypt SSL connections.
+	ZAP allows you to transparently decrypt SSL connections.
 	For doing so, ZAP has to encrypt each request before sending
 	to the server and decrypt each response, which comes back.
 	But, this is already done by the browser.
@@ -75,10 +75,10 @@
 	</p>
 	<p style="padding-left: 20pt;">
 		<code>
-		CN = OWASP Zed Attack Proxy Root CA<br>
+		CN = Zed Attack Proxy Root CA<br>
 		L = 87b77fe834b0a301<br>
-		O = OWASP Root CA<br>
-		OU = OWASP ZAP Root CA<br>
+		O = ZAP Root CA<br>
+		OU = ZAP Root CA<br>
 		C = XX<br>
 		</code>
 	</p>
@@ -92,9 +92,9 @@
 	<h3>Import</h3>
 	<p>
 		When you're using multiple ZAP installation and you want to use the same
-		Root CA certificate, so you can import it. Simply use one installation of OWASP ZAP
+		Root CA certificate, so you can import it. Simply use one installation of ZAP
 		to generate one Root CA certificate.<br>
-		Copy the file 'OWASP ZAP/config.xml' from your users home directory to
+		Copy the file 'config.xml' from ZAP's home directory to
 		the PC, where you want to use the same certificate and press 'import' to import it.
 	</p>
 	<p>
@@ -178,9 +178,9 @@
 	<p style="padding-left: 20pt;">
 		<code>
 		CN = www.example.com<br>
-		E = owasp-zed-attack-proxy@lists.owasp.org<br>
+		E = zaproxy-develop@googlegroups.com<br>
 		C = XX<br>
-		O = OWASP<br>
+		O = ZAP<br>
 		OU = Zed Attack Proxy Project<br>
 		</code>
 	</p>
@@ -240,7 +240,7 @@
 
 	<h2><a name="install">Install ZAP Root CA certificate</a></h2>
 	<p>
-		Any HTTPS client you want to use, has to know the OWASP Root CA certificate
+		Any HTTPS client you want to use, has to know the ZAP Root CA certificate
 		as 'trusted root certificate'. Typically you have to install manually the
 		ZAP certificate into your browser's list of trusted root certificates.
 	</p>
@@ -263,7 +263,7 @@
 		<li>Tab Content</li>
 		<li>Click certificates</li>
 		<li>Click tab trusted root certificates</li>
-		<li>The OWASP ZAP Root CA should be there</li>
+		<li>The ZAP Root CA should be there</li>
 		</ol>
 
 	<h3>Mozilla Firefox</h3>
@@ -278,7 +278,7 @@
 		<li>Tab Cryptography/Certificates</li>
 		<li>Click View Certificates</li>
 		<li>Click Authorities tab</li>
-		<li>Click Import and choose the saved <tt>owasp_zap_root_ca.cer</tt> file</li>
+		<li>Click Import and choose the saved <tt>zap_root_ca.cer</tt> file</li>
 		<li>In the wizard choose to trust this certificate to identify web sites (check on the boxes)</li>
 		<li>Finalize the wizard</li>
 		</ol>


### PR DESCRIPTION
Update the names of the root CA cert and issued server certificates, rename also related code constants.
Update the help to reflect the changes.