### PR TITLE
Remove Java 11 requirement for `buildSrc`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,13 +34,3 @@ dependencies {
     }
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.20.0")
 }
-
-java {
-    val javaVersion = JavaVersion.VERSION_11
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
-}
-
-kotlin {
-    jvmToolchain(11)
-}


### PR DESCRIPTION
It's not necessary and avoids the need to have/download other JDK, when using newer Java versions.