### PR TITLE
encoder: do not rely on default charset

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Do not rely on the default charset in Full URL and ASCII Hex encoders/decoders.
+
 ## [1.2.0] - 2023-07-11
 ### Changed
 - Update minimum ZAP version to 2.13.0.

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/FullUrlEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/FullUrlEncoder.java
@@ -20,6 +20,7 @@
 package org.zaproxy.addon.encoder.processors.predefined;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class FullUrlEncoder extends DefaultEncodeDecodeProcessor {
 
@@ -27,7 +28,7 @@ public class FullUrlEncoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws IOException {
-        return HexStringEncoder.getPercentHexString(value.getBytes());
+        return HexStringEncoder.getPercentHexString(value.getBytes(StandardCharsets.UTF_8));
     }
 
     public static FullUrlEncoder getSingleton() {

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HexStringDecoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HexStringDecoder.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.addon.encoder.processors.predefined;
 
+import java.nio.charset.StandardCharsets;
+
 public class HexStringDecoder extends DefaultEncodeDecodeProcessor {
 
     private static final HexStringDecoder INSTANCE = new HexStringDecoder();
@@ -42,7 +44,7 @@ public class HexStringDecoder extends DefaultEncodeDecodeProcessor {
                 offset += 2;
                 rawToByte[i] = (byte) (Integer.parseInt(chunk, 16) & 0x000000FF);
             }
-            decodedText = new String(rawToByte);
+            decodedText = new String(rawToByte, StandardCharsets.UTF_8);
         }
         return decodedText;
     }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HexStringEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HexStringEncoder.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.encoder.processors.predefined;
 
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
 public class HexStringEncoder extends DefaultEncodeDecodeProcessor {
@@ -27,7 +28,7 @@ public class HexStringEncoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) {
-        return getHexString(value.getBytes());
+        return getHexString(value.getBytes(StandardCharsets.UTF_8));
     }
 
     protected static String getHexString(byte[] buf) {


### PR DESCRIPTION
Change Full URL and ASCII Hex encoders/decoders to always use UTF-8 to not rely on the default charset, which would lead to different results depending in which OS is ZAP running.