### PR TITLE
Use newer API endpoint for ChromeDriver

### DIFF
--- a/.github/workflows/create_webdriver_update.yml
+++ b/.github/workflows/create_webdriver_update.yml
@@ -40,7 +40,7 @@ jobs:
         CHROME_INPUT=${CHROME_INPUT:-"cxx" }
         echo $CHROME_INPUT
         if [ $CHROME_INPUT == "cxx" ]; then
-          CHROME_VERS=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+          CHROME_VERS=$(curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json|jq -r .channels.Stable.version)
         else
           CHROME_VERS=${{ github.event.inputs.chrome_version }}
         fi

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,7 +29,7 @@ tasks.withType<JavaCompile>().configureEach {
 
 dependencies {
     implementation("commons-codec:commons-codec:1.15")
-    implementation("io.github.bonigarcia:webdrivermanager:5.1.0") {
+    implementation("io.github.bonigarcia:webdrivermanager:5.4.1") {
         exclude("com.fasterxml.jackson.core")
     }
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.20.0")


### PR DESCRIPTION
Use new JSON API endpoint to get the ChromeDriver version in the workflow.
Update the WebDriverManager to use the newer endpoints for the actual download.

Fix zaproxy/zaproxy#7955.