### PR TITLE
automation: remove unused API dependency

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Removed
+- The SnakeYAML Engine dependency was removed.
+
 ### Fixed
 - Address error logged when using the Active Scan job.
 

--- a/addOns/automation/automation.gradle.kts
+++ b/addOns/automation/automation.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
     api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    api("org.snakeyaml:snakeyaml-engine:2.6")
 
     testImplementation(project(":testutils"))
 }


### PR DESCRIPTION
The SnakeYAML Engine is not used, it is used SnakeYAML instead, which is already a (transitive) API dependency.