### PR TITLE
pscanrulesBeta: update URLs of alert references

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Use HTTPS and resolve redirections in the alert references.
 
 ## [34] - 2023-07-20
 ### Added

--- a/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -13,7 +13,7 @@ pscanbeta.jsfunction.soln = See the references for security advice on the use of
 
 pscanbeta.jso.desc = Java Serialization seems to be in use. If not correctly validated, an attacker can send a specially crafted object. This can lead to a dangerous "Remote Code Execution". A magic sequence identifying JSO has been detected (Base64: rO0AB, Raw: 0xac, 0xed, 0x00, 0x05).
 pscanbeta.jso.name = Java Serialization Object
-pscanbeta.jso.refs = https://www.oracle.com/technetwork/java/seccodeguide-139067.html#8
+pscanbeta.jso.refs = https://www.oracle.com/java/technologies/javase/seccodeguide.html#8
 pscanbeta.jso.soln = Deserialization of untrusted data is inherently dangerous and should be avoided.
 
 pscanbeta.name = Passive Scan Rules - beta
@@ -21,7 +21,7 @@ pscanbeta.name = Passive Scan Rules - beta
 pscanbeta.nonstorable.desc = The response contents are not storable by caching components such as proxy servers. If the response does not contain sensitive, personal or user-specific information, it may benefit from being stored and cached, to improve performance.
 pscanbeta.nonstorable.extrainfo = {0}
 pscanbeta.nonstorable.name = Non-Storable Content
-pscanbeta.nonstorable.refs = https://tools.ietf.org/html/rfc7234\nhttps://tools.ietf.org/html/rfc7231\nhttp://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html (obsoleted by rfc7234)
+pscanbeta.nonstorable.refs = https://datatracker.ietf.org/doc/html/rfc7234\nhttps://datatracker.ietf.org/doc/html/rfc7231\nhttps://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 pscanbeta.nonstorable.soln = The content may be marked as storable by ensuring that the following conditions are satisfied:\nThe request method must be understood by the cache and defined as being cacheable ("GET", "HEAD", and "POST" are currently defined as cacheable)\nThe response status code must be understood by the cache (one of the 1XX, 2XX, 3XX, 4XX, or 5XX response classes are generally understood)\nThe "no-store" cache directive must not appear in the request or response header fields\nFor caching by "shared" caches such as "proxy" caches, the "private" response directive must not appear in the response\nFor caching by "shared" caches such as "proxy" caches, the "Authorization" header field must not appear in the request, unless the response explicitly allows it (using one of the "must-revalidate", "public", or "s-maxage" Cache-Control response directives)\nIn addition to the conditions above, at least one of the following conditions must also be satisfied by the response:\nIt must contain an "Expires" header field\nIt must contain a "max-age" response directive\nFor "shared" caches such as "proxy" caches, it must contain a "s-maxage" response directive\nIt must contain a "Cache Control Extension" that allows it to be cached\nIt must have a status code that is defined as cacheable by default (200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501).   
 
 pscanbeta.payloader.desc = Provides support for custom payloads in scan rules.
@@ -29,16 +29,16 @@ pscanbeta.payloader.name = Passive Scan Rules Beta Custom Payloads
 
 pscanbeta.permissionspolicymissing.deprecated.desc = The header has now been renamed to Permissions-Policy. 
 pscanbeta.permissionspolicymissing.deprecated.name = Deprecated Feature Policy Header Set
-pscanbeta.permissionspolicymissing.deprecated.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy\nhttps://scotthelme.co.uk/goodbye-feature-policy-and-hello-permissions-policy/
+pscanbeta.permissionspolicymissing.deprecated.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy\nhttps://scotthelme.co.uk/goodbye-feature-policy-and-hello-permissions-policy/
 pscanbeta.permissionspolicymissing.deprecated.soln = Ensure that your web server, application server, load balancer, etc. is configured to set the Permissions-Policy header instead of the Feature-Policy header.
 pscanbeta.permissionspolicymissing.desc = Permissions Policy Header is an added layer of security that helps to restrict from unauthorized access or usage of browser/client features by web resources. This policy ensures the user privacy by limiting or specifying the features of the browsers can be used by the web resources. Permissions Policy provides a set of standard HTTP headers that allow website owners to limit which features of browsers can be used by the page such as camera, microphone, location, full screen etc.
 pscanbeta.permissionspolicymissing.name = Permissions Policy Header Not Set
-pscanbeta.permissionspolicymissing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy\nhttps://developers.google.com/web/updates/2018/06/feature-policy\nhttps://scotthelme.co.uk/a-new-security-header-feature-policy/\nhttps://w3c.github.io/webappsec-feature-policy/\nhttps://www.smashingmagazine.com/2018/12/feature-policy/
+pscanbeta.permissionspolicymissing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy\nhttps://developer.chrome.com/blog/feature-policy/\nhttps://scotthelme.co.uk/a-new-security-header-feature-policy/\nhttps://w3c.github.io/webappsec-feature-policy/\nhttps://www.smashingmagazine.com/2018/12/feature-policy/
 pscanbeta.permissionspolicymissing.soln = Ensure that your web server, application server, load balancer, etc. is configured to set the Permissions-Policy header.
 
 pscanbeta.servletparameterpollution.desc = Unspecified form action: HTTP parameter override attack potentially possible. This is a known problem with Java Servlets but other platforms may also be vulnerable.
 pscanbeta.servletparameterpollution.name = HTTP Parameter Override
-pscanbeta.servletparameterpollution.refs = http://download.oracle.com/javaee-archive/servlet-spec.java.net/jsr340-experts/att-0317/OnParameterPollutionAttacks.pdf
+pscanbeta.servletparameterpollution.refs = https://download.oracle.com/javaee-archive/servlet-spec.java.net/jsr340-experts/att-0317/OnParameterPollutionAttacks.pdf
 pscanbeta.servletparameterpollution.soln = All forms must specify the action URL.
 
 pscanbeta.site-isolation.coep.desc = Cross-Origin-Embedder-Policy header is a response header that prevents a document from loading any cross-origin resources that don't explicitly grant the document permission (using CORP or CORS).
@@ -51,20 +51,20 @@ pscanbeta.site-isolation.coop.refs = https://developer.mozilla.org/en-US/docs/We
 pscanbeta.site-isolation.coop.soln = Ensure that the application/web server sets the Cross-Origin-Opener-Policy header appropriately, and that it sets the Cross-Origin-Opener-Policy header to 'same-origin' for documents.\n'same-origin-allow-popups' is considered as less secured and should be avoided.\nIf possible, ensure that the end user uses a standards-compliant and modern web browser that supports the Cross-Origin-Opener-Policy header (https://caniuse.com/mdn-http_headers_cross-origin-opener-policy).
 pscanbeta.site-isolation.corp.desc = Cross-Origin-Resource-Policy header is an opt-in header designed to counter side-channels attacks like Spectre. Resource should be specifically set as shareable amongst different origins.
 pscanbeta.site-isolation.corp.name = Cross-Origin-Resource-Policy Header Missing or Invalid
-pscanbeta.site-isolation.corp.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
+pscanbeta.site-isolation.corp.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy
 pscanbeta.site-isolation.corp.soln = Ensure that the application/web server sets the Cross-Origin-Resource-Policy header appropriately, and that it sets the Cross-Origin-Resource-Policy header to 'same-origin' for all web pages.\n'same-site' is considered as less secured and should be avoided.\nIf resources must be shared, set the header to 'cross-origin'.\nIf possible, ensure that the end user uses a standards-compliant and modern web browser that supports the Cross-Origin-Resource-Policy header (https://caniuse.com/mdn-http_headers_cross-origin-resource-policy).
 pscanbeta.site-isolation.name = Insufficient Site Isolation Against Spectre Vulnerability
 
 pscanbeta.sourcecodedisclosure.desc = Application Source Code was disclosed by the web server
 pscanbeta.sourcecodedisclosure.extrainfo = {0}
 pscanbeta.sourcecodedisclosure.name = Source Code Disclosure
-pscanbeta.sourcecodedisclosure.refs = http://blogs.wsj.com/cio/2013/10/08/adobe-source-code-leak-is-bad-news-for-u-s-government/
+pscanbeta.sourcecodedisclosure.refs = https://www.wsj.com/articles/BL-CIOB-2999
 pscanbeta.sourcecodedisclosure.soln = Ensure that application Source Code is not available with alternative extensions, and ensure that source code is not present within other files or data deployed to the web server, or served by the web server. 
 
 pscanbeta.sri-integrity.desc = The integrity attribute is missing on a script or link tag served by an external server. The integrity tag prevents an attacker who have gained access to this server from injecting a malicious content. 
 pscanbeta.sri-integrity.name = Sub Resource Integrity Attribute Missing
 pscanbeta.sri-integrity.otherinfo = The following hash was calculated (using base64 encoding of the output of the hash algorithm: SHA-384) for the script in question {0}
-pscanbeta.sri-integrity.refs = https://developer.mozilla.org/en/docs/Web/Security/Subresource_Integrity
+pscanbeta.sri-integrity.refs = https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
 pscanbeta.sri-integrity.soln = Provide a valid integrity attribute to the tag.
 
 pscanbeta.storabilitycacheability.name = Content Cacheability
@@ -74,11 +74,11 @@ pscanbeta.storablecacheable.extrainfo = {0}
 pscanbeta.storablecacheable.name = Storable and Cacheable Content
 pscanbeta.storablecacheable.otherinfo.liberallifetimeheuristic = In the absence of an explicitly specified caching lifetime directive in the response, a liberal lifetime heuristic of 1 year was assumed. This is permitted by rfc7234.
 pscanbeta.storablecacheable.otherinfo.staleretrievenotblocked = The response is stale, and stale responses are not configured to be re-validated or blocked, using the 'must-revalidate', 'proxy-revalidate', 's-maxage', or 'max-age' response 'Cache-Control' directives.
-pscanbeta.storablecacheable.refs = https://tools.ietf.org/html/rfc7234\nhttps://tools.ietf.org/html/rfc7231\nhttp://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html (obsoleted by rfc7234)
+pscanbeta.storablecacheable.refs = https://datatracker.ietf.org/doc/html/rfc7234\nhttps://datatracker.ietf.org/doc/html/rfc7231\nhttps://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 pscanbeta.storablecacheable.soln = Validate that the response does not contain sensitive, personal or user-specific information.  If it does, consider the use of the following HTTP response headers, to limit, or prevent the content being stored and retrieved from the cache by another user:\nCache-Control: no-cache, no-store, must-revalidate, private\nPragma: no-cache\nExpires: 0\nThis configuration directs both HTTP 1.0 and HTTP 1.1 compliant caching servers to not store the response, and to not retrieve the response (without validation) from the cache, in response to a similar request. 
 
 pscanbeta.storablenoncacheable.desc = The response contents are storable by caching components such as proxy servers, but will not be retrieved directly from the cache, without validating the request upstream, in response to similar requests from other users. 
 pscanbeta.storablenoncacheable.extrainfo = {0}}
 pscanbeta.storablenoncacheable.name = Storable but Non-Cacheable Content
-pscanbeta.storablenoncacheable.refs = https://tools.ietf.org/html/rfc7234\nhttps://tools.ietf.org/html/rfc7231\nhttp://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html (obsoleted by rfc7234)
+pscanbeta.storablenoncacheable.refs = https://datatracker.ietf.org/doc/html/rfc7234\nhttps://datatracker.ietf.org/doc/html/rfc7231\nhttps://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 pscanbeta.storablenoncacheable.soln = 


### PR DESCRIPTION
Use HTTPS and use the final URL (in case of redirections).
Remove leading text in some URLs as that's not expected.