### PR TITLE
pscanrules: add example alert to scan rule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- The following now include example alert functionality for documentation generation purposes (Issue 6119):
+  - Loosely Scoped Cookie scan rule.
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -77,7 +77,7 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner {
 
         // raise alert if have found any loosely scoped cookies
         if (looselyScopedCookies.size() > 0) {
-            raiseAlert(msg, id, host, looselyScopedCookies);
+            buildAlert(host, looselyScopedCookies).raise();
         }
     }
 
@@ -158,8 +158,7 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner {
         return true;
     }
 
-    private void raiseAlert(
-            HttpMessage msg, int id, String host, List<HttpCookie> looselyScopedCookies) {
+    private AlertBuilder buildAlert(String host, List<HttpCookie> looselyScopedCookies) {
 
         StringBuilder sbCookies = new StringBuilder();
         for (HttpCookie cookie : looselyScopedCookies) {
@@ -167,7 +166,7 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner {
                     Constant.messages.getString(MESSAGE_PREFIX + "extrainfo.cookie", cookie));
         }
 
-        newAlert()
+        return newAlert()
                 .setRisk(getRisk())
                 .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(getDescription())
@@ -176,8 +175,16 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner {
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setCweId(getCweId())
-                .setWascId(getWascId())
-                .raise();
+                .setWascId(getWascId());
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildAlert(
+                                "subdomain.example.com",
+                                HttpCookie.parse("name=value; domain=example.com"))
+                        .build());
     }
 
     @Override

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
@@ -21,15 +21,18 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.quality.Strictness;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -76,6 +79,10 @@ class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLoose
         assertThat(cwe, is(equalTo(565)));
         assertThat(wasc, is(equalTo(15)));
         assertThat(tags.size(), is(equalTo(3)));
+        assertAlertTags(tags);
+    }
+
+    private static void assertAlertTags(Map<String, String> tags) {
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A08_INTEGRITY_FAIL.getTag()),
                 is(equalTo(true)));
@@ -94,6 +101,20 @@ class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLoose
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_SESS_02_COOKIE_ATTRS.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_SESS_02_COOKIE_ATTRS.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts, hasSize(1));
+        Alert alert = alerts.get(0);
+        assertAlertTags(alert.getTags());
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));
+        assertThat(alert.getCweId(), is(equalTo(565)));
+        assertThat(alert.getWascId(), is(equalTo(15)));
     }
 
     @Test


### PR DESCRIPTION
Change `CookieLooselyScopedScanRule` to provide the example alerts.

Part of zaproxy/zaproxy#6119.