### PR TITLE
pscanrulesAlpha: update URLs of alert references

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Use HTTPS and resolve redirections in the alert references.
 
 ## [40] - 2023-07-20
 ### Added

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -1,17 +1,17 @@
 pscanalpha.base64disclosure.desc = Base64 encoded data was disclosed by the application/web server. Note: in the interests of performance not all base64 strings in the response were analyzed individually, the entire response should be looked at by the analyst/security team/developer(s).
 pscanalpha.base64disclosure.extrainfo = {1}
 pscanalpha.base64disclosure.name = Base64 Disclosure
-pscanalpha.base64disclosure.refs = http://projects.webappsec.org/w/page/13246936/Information%20Leakage
+pscanalpha.base64disclosure.refs = https://projects.webappsec.org/w/page/13246936/Information%20Leakage
 pscanalpha.base64disclosure.soln = Manually confirm that the Base64 data does not leak sensitive information, and that the data cannot be aggregated/used to exploit other vulnerabilities.
 pscanalpha.base64disclosure.viewstate.desc = An ASP.NET ViewState was disclosed by the application/web server
 pscanalpha.base64disclosure.viewstate.extrainfo = {0}
 pscanalpha.base64disclosure.viewstate.name = ASP.NET ViewState Disclosure
-pscanalpha.base64disclosure.viewstate.refs = http://msdn.microsoft.com/en-us/library/bb386448.aspx\nhttp://projects.webappsec.org/w/page/13246936/Information%20Leakage
+pscanalpha.base64disclosure.viewstate.refs = https://learn.microsoft.com/en-us/previous-versions/bb386448(v=vs.140)\nhttps://projects.webappsec.org/w/page/13246936/Information%20Leakage
 pscanalpha.base64disclosure.viewstate.soln = Manually confirm that the ASP.NET ViewState does not leak sensitive information, and that the data cannot be aggregated/used to exploit other vulnerabilities.
 pscanalpha.base64disclosure.viewstatewithoutmac.desc = The application does not use a Message Authentication Code (MAC) to protect the integrity of the ASP.NET ViewState, which can be tampered with by a malicious client
 pscanalpha.base64disclosure.viewstatewithoutmac.extrainfo = {0}
 pscanalpha.base64disclosure.viewstatewithoutmac.name = ASP.NET ViewState Integrity
-pscanalpha.base64disclosure.viewstatewithoutmac.refs = http://msdn.microsoft.com/en-us/library/bb386448.aspx\nhttps://www.jardinesoftware.net/2012/02/06/asp-net-tampering-with-event-validation-part-1/
+pscanalpha.base64disclosure.viewstatewithoutmac.refs = https://learn.microsoft.com/en-us/previous-versions/bb386448(v=vs.140)\nhttps://www.jardinesoftware.net/2012/02/06/asp-net-tampering-with-event-validation-part-1/
 pscanalpha.base64disclosure.viewstatewithoutmac.soln = Ensure that all ASP.NET ViewStates are protected from tampering, by using a MAC, generated using a secure algorithm, and a secret key on the server side. This is the default configuration on modern ASP.NET installation, by may be over-ridden programmatically, or via the ASP.NET configuration.
 
 pscanalpha.desc = Alpha status passive scan rules


### PR DESCRIPTION
Use HTTPS and use the final URL (in case of redirections).