### PR TITLE
reports: include other info in HTML reports

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - The following reports now include "Other Info" for alerts:
+    - Traditional HTML Report
+    - Traditional HTML Report with requests and responses
     - Traditional Markdown Report
     - Traditional PDF Report
 - Depend on Common Library add-on to reuse libraries (Issue 7961).

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
@@ -360,6 +360,12 @@
 						<td th:text="${instance.userObject.evidence}" width="80%">Evidence</td>
 					</tr>
 					<tr>
+						<td th:text="#{report.alerts.detail.otherinfo}" width="20%"
+							class="indent2">Other Info</td>
+						<td th:text="${instance.userObject.otherinfo}" width="80%">Other
+							Info</td>
+					</tr>
+					<tr>
 						<td width="20%" class="indent2">
 							<div th:id="${'alert-' + instance.userObject.alertId}">
 								<a

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html/report.html
@@ -234,6 +234,12 @@ td {
 							class="indent2">Evidence</td>
 						<td th:text="${instance.userObject.evidence}" width="80%">Evidence</td>
 					</tr>
+					<tr>
+						<td th:text="#{report.alerts.detail.otherinfo}" width="20%"
+							class="indent2">Other Info</td>
+						<td th:text="${instance.userObject.otherinfo}" width="80%">Other
+							Info</td>
+					</tr>
 				</th:block>
 				<tr>
 					<td th:text="#{report.alerts.detail.instances}" width="20%">Instances</td>

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html-plus.html
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html-plus.html
@@ -251,6 +251,11 @@
 						<td width="80%">Test &lt;p&gt;Evidence</td>
 					</tr>
 					<tr>
+						<td width="20%"
+							class="indent2">!reports.report.alerts.detail.otherinfo!</td>
+						<td width="80%">Test &#39;Other\</td>
+					</tr>
+					<tr>
 						<td width="20%" class="indent2">
 							<div id="alert--1">
 								<a
@@ -360,6 +365,11 @@
 						<td width="20%"
 							class="indent2">!reports.report.alerts.detail.evidence!</td>
 						<td width="80%">Test &lt;p&gt;Evidence</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">!reports.report.alerts.detail.otherinfo!</td>
+						<td width="80%">Test Another &#39;Other\</td>
 					</tr>
 					<tr>
 						<td width="20%" class="indent2">

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html.html
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html.html
@@ -254,6 +254,11 @@ td {
 							class="indent2">!reports.report.alerts.detail.evidence!</td>
 						<td width="80%">Test &lt;p&gt;Evidence</td>
 					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">!reports.report.alerts.detail.otherinfo!</td>
+						<td width="80%">Test &#39;Other\</td>
+					</tr>
 					
 					<tr>
 						<td width="20%"
@@ -279,6 +284,11 @@ td {
 						<td width="20%"
 							class="indent2">!reports.report.alerts.detail.evidence!</td>
 						<td width="80%">Test &lt;p&gt;Evidence</td>
+					</tr>
+					<tr>
+						<td width="20%"
+							class="indent2">!reports.report.alerts.detail.otherinfo!</td>
+						<td width="80%">Test Another &#39;Other\</td>
 					</tr>
 					
 				<tr>


### PR DESCRIPTION
Include other info in `traditional-html` and `-plus`.

Part of zaproxy/zaproxy#7717.