### PR TITLE
Remove single parameter resource messages

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
@@ -292,8 +292,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
     }
 
     private static String getOtherInfo(HiddenFile file) {
-        String otherInfo =
-                Constant.messages.getString(MESSAGE_PREFIX + "otherinfo", file.getType());
+        String otherInfo = file.getType();
         String extra = file.getExtra();
         if (!extra.isBlank()) {
             otherInfo += "\n\n" + extra;

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -83,7 +83,6 @@ ascanrules.heartbleed.soln = Update to OpenSSL 1.0.1g or later. Re-issue HTTPS c
 ascanrules.hidden.files.alert.name = Hidden File Found
 ascanrules.hidden.files.desc = A sensitive file was identified as accessible or available. This may leak administrative, configuration, or credential information which can be leveraged by a malicious individual to further attack the system or conduct social engineering efforts.
 ascanrules.hidden.files.name = Hidden File Finder
-ascanrules.hidden.files.otherinfo = {0}
 ascanrules.hidden.files.refs = https://blog.hboeck.de/archives/892-Introducing-Snallygaster-a-Tool-to-Scan-for-Secrets-on-Web-Servers.html
 ascanrules.hidden.files.soln = Consider whether or not the component is actually required in production, if it isn't then disable it. If it is then ensure access to it requires appropriate authentication and authorization, or limit exposure to internal systems or specific source IPs, etc.
 

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -8,7 +8,6 @@ ascanalpha.examplefile.soln = A general description of how to solve the problem
 
 #ascanalpha.ldapinjection.alert.attack=[{0}] field [{1}] set to [{2}]
 ascanalpha.ldapinjection.alert.attack = parameter [{0}] set to [{1}]
-ascanalpha.ldapinjection.alert.evidence = {0}
 #ascanalpha.ldapinjection.alert.extrainfo=[{0}] field [{1}] on [{2}] [{3}] may be vulnerable to LDAP injection, using an attack with LDAP meta-characters [{4}], yielding known [{5}] error message [{6}], which was not present in the original response.
 ascanalpha.ldapinjection.alert.extrainfo = parameter [{0}] on [{1}] [{2}] may be vulnerable to LDAP injection, using an attack with LDAP meta-characters [{3}], yielding known [{4}] error message [{5}], which was not present in the original response.
 ascanalpha.ldapinjection.booleanbased.alert.attack = Equivalent LDAP expression: [{0}]. Random parameter: [{1}].

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- The alerts of the Hash Disclosure scan rule no longer have the evidence duplicated in the Other Info field.
 
 ## [50] - 2023-07-11
 ### Added

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
@@ -252,7 +252,6 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
                                 .setRisk(hashalert.getRisk())
                                 .setConfidence(hashalert.getConfidence())
                                 .setDescription(getDescription() + " - " + hashType)
-                                .setOtherInfo(getExtraInfo(msg, evidence))
                                 .setSolution(getSolution())
                                 .setReference(getReference())
                                 .setEvidence(evidence)
@@ -282,10 +281,6 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
 
     private String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getExtraInfo(HttpMessage msg, String arg0) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", arg0);
     }
 
     @Override

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -148,7 +148,6 @@ pscanrules.directorybrowsing.refs = https://cwe.mitre.org/data/definitions/548.h
 pscanrules.directorybrowsing.soln = Configure the web server to disable directory browsing.
 
 pscanrules.hashdisclosure.desc = A hash was disclosed by the web server.
-pscanrules.hashdisclosure.extrainfo = {0}
 pscanrules.hashdisclosure.name = Hash Disclosure
 pscanrules.hashdisclosure.refs = http://projects.webappsec.org/w/page/13246936/Information%20Leakage\nhttp://openwall.info/wiki/john/sample-hashes
 pscanrules.hashdisclosure.soln = Ensure that hashes that are used to protect credentials or other resources are not leaked by the web server or database. There is typically no requirement for password hashes to be accessible to the web browser.      
@@ -264,7 +263,6 @@ pscanrules.pii.name = PII Disclosure
 pscanrules.pii.soln = Check the response for the potential presence of personally identifiable information (PII), ensure nothing sensitive is leaked by the application.
 
 pscanrules.retrievedfromcache.desc = The content was retrieved from a shared cache. If the response data is sensitive, personal or user-specific, this may result in sensitive information being leaked. In some cases, this may even result in a user gaining complete control of the session of another user, depending on the configuration of the caching components in use in their environment. This is primarily an issue where caching servers such as "proxy" caches are configured on the local network. This configuration is typically found in corporate or educational environments, for instance. 
-pscanrules.retrievedfromcache.extrainfo = {0}
 pscanrules.retrievedfromcache.extrainfo.http11ageheader = The presence of the 'Age' header indicates that that a HTTP/1.1 compliant caching server is in use.
 pscanrules.retrievedfromcache.name = Retrieved from Cache
 pscanrules.retrievedfromcache.refs = https://tools.ietf.org/html/rfc7234\nhttps://tools.ietf.org/html/rfc7231\nhttp://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html (obsoleted by rfc7234)

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Use HTTPS and resolve redirections in the alert references.
+- The alerts ASP.NET ViewState Disclosure and ASP.NET ViewState Integrity no longer have the evidence duplicated in the Other Info field.
 
 ## [40] - 2023-07-20
 ### Added

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -335,9 +335,6 @@ public class Base64Disclosure extends PluginPassiveScanner {
                 .setName(Constant.messages.getString("pscanalpha.base64disclosure.viewstate.name"))
                 .setDescription(
                         Constant.messages.getString("pscanalpha.base64disclosure.viewstate.desc"))
-                .setOtherInfo(
-                        Constant.messages.getString(
-                                "pscanalpha.base64disclosure.viewstate.extrainfo", viewstatexml))
                 .setSolution(
                         Constant.messages.getString("pscanalpha.base64disclosure.viewstate.soln"))
                 .setReference(
@@ -354,10 +351,6 @@ public class Base64Disclosure extends PluginPassiveScanner {
                 .setDescription(
                         Constant.messages.getString(
                                 "pscanalpha.base64disclosure.viewstatewithoutmac.desc"))
-                .setOtherInfo(
-                        Constant.messages.getString(
-                                "pscanalpha.base64disclosure.viewstatewithoutmac.extrainfo",
-                                viewstatexml))
                 .setSolution(
                         Constant.messages.getString(
                                 "pscanalpha.base64disclosure.viewstatewithoutmac.soln"))
@@ -372,7 +365,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
     private AlertBuilder createBase64Alert(String evidence, byte[] data) {
         return createBasicAlert("-3")
                 .setDescription(getDescription())
-                .setOtherInfo(getExtraInfo(evidence, data))
+                .setOtherInfo(new String(data))
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(evidence);
@@ -406,10 +399,5 @@ public class Base64Disclosure extends PluginPassiveScanner {
 
     private static String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private static String getExtraInfo(String evidence, byte[] decodeddata) {
-        return Constant.messages.getString(
-                MESSAGE_PREFIX + "extrainfo", evidence, new String(decodeddata));
     }
 }

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -1,15 +1,12 @@
 pscanalpha.base64disclosure.desc = Base64 encoded data was disclosed by the application/web server. Note: in the interests of performance not all base64 strings in the response were analyzed individually, the entire response should be looked at by the analyst/security team/developer(s).
-pscanalpha.base64disclosure.extrainfo = {1}
 pscanalpha.base64disclosure.name = Base64 Disclosure
 pscanalpha.base64disclosure.refs = https://projects.webappsec.org/w/page/13246936/Information%20Leakage
 pscanalpha.base64disclosure.soln = Manually confirm that the Base64 data does not leak sensitive information, and that the data cannot be aggregated/used to exploit other vulnerabilities.
 pscanalpha.base64disclosure.viewstate.desc = An ASP.NET ViewState was disclosed by the application/web server
-pscanalpha.base64disclosure.viewstate.extrainfo = {0}
 pscanalpha.base64disclosure.viewstate.name = ASP.NET ViewState Disclosure
 pscanalpha.base64disclosure.viewstate.refs = https://learn.microsoft.com/en-us/previous-versions/bb386448(v=vs.140)\nhttps://projects.webappsec.org/w/page/13246936/Information%20Leakage
 pscanalpha.base64disclosure.viewstate.soln = Manually confirm that the ASP.NET ViewState does not leak sensitive information, and that the data cannot be aggregated/used to exploit other vulnerabilities.
 pscanalpha.base64disclosure.viewstatewithoutmac.desc = The application does not use a Message Authentication Code (MAC) to protect the integrity of the ASP.NET ViewState, which can be tampered with by a malicious client
-pscanalpha.base64disclosure.viewstatewithoutmac.extrainfo = {0}
 pscanalpha.base64disclosure.viewstatewithoutmac.name = ASP.NET ViewState Integrity
 pscanalpha.base64disclosure.viewstatewithoutmac.refs = https://learn.microsoft.com/en-us/previous-versions/bb386448(v=vs.140)\nhttps://www.jardinesoftware.net/2012/02/06/asp-net-tampering-with-event-validation-part-1/
 pscanalpha.base64disclosure.viewstatewithoutmac.soln = Ensure that all ASP.NET ViewStates are protected from tampering, by using a MAC, generated using a secure algorithm, and a secret key on the server side. This is the default configuration on modern ASP.NET installation, by may be over-ridden programmatically, or via the ASP.NET configuration.

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Use HTTPS and resolve redirections in the alert references.
+- The alerts of the Source Code Disclosure scan rule no longer have the evidence duplicated in the Other Info field.
 
 ## [34] - 2023-07-20
 ### Added

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
@@ -691,7 +691,6 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription() + " - " + programmingLanguage)
-                .setOtherInfo(getExtraInfo(evidence))
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(evidence)
@@ -724,9 +723,5 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
 
     private String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getExtraInfo(String evidence) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", evidence);
     }
 }

--- a/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -19,7 +19,6 @@ pscanbeta.jso.soln = Deserialization of untrusted data is inherently dangerous a
 pscanbeta.name = Passive Scan Rules - beta
 
 pscanbeta.nonstorable.desc = The response contents are not storable by caching components such as proxy servers. If the response does not contain sensitive, personal or user-specific information, it may benefit from being stored and cached, to improve performance.
-pscanbeta.nonstorable.extrainfo = {0}
 pscanbeta.nonstorable.name = Non-Storable Content
 pscanbeta.nonstorable.refs = https://datatracker.ietf.org/doc/html/rfc7234\nhttps://datatracker.ietf.org/doc/html/rfc7231\nhttps://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 pscanbeta.nonstorable.soln = The content may be marked as storable by ensuring that the following conditions are satisfied:\nThe request method must be understood by the cache and defined as being cacheable ("GET", "HEAD", and "POST" are currently defined as cacheable)\nThe response status code must be understood by the cache (one of the 1XX, 2XX, 3XX, 4XX, or 5XX response classes are generally understood)\nThe "no-store" cache directive must not appear in the request or response header fields\nFor caching by "shared" caches such as "proxy" caches, the "private" response directive must not appear in the response\nFor caching by "shared" caches such as "proxy" caches, the "Authorization" header field must not appear in the request, unless the response explicitly allows it (using one of the "must-revalidate", "public", or "s-maxage" Cache-Control response directives)\nIn addition to the conditions above, at least one of the following conditions must also be satisfied by the response:\nIt must contain an "Expires" header field\nIt must contain a "max-age" response directive\nFor "shared" caches such as "proxy" caches, it must contain a "s-maxage" response directive\nIt must contain a "Cache Control Extension" that allows it to be cached\nIt must have a status code that is defined as cacheable by default (200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501).   
@@ -56,7 +55,6 @@ pscanbeta.site-isolation.corp.soln = Ensure that the application/web server sets
 pscanbeta.site-isolation.name = Insufficient Site Isolation Against Spectre Vulnerability
 
 pscanbeta.sourcecodedisclosure.desc = Application Source Code was disclosed by the web server
-pscanbeta.sourcecodedisclosure.extrainfo = {0}
 pscanbeta.sourcecodedisclosure.name = Source Code Disclosure
 pscanbeta.sourcecodedisclosure.refs = https://www.wsj.com/articles/BL-CIOB-2999
 pscanbeta.sourcecodedisclosure.soln = Ensure that application Source Code is not available with alternative extensions, and ensure that source code is not present within other files or data deployed to the web server, or served by the web server. 
@@ -70,7 +68,6 @@ pscanbeta.sri-integrity.soln = Provide a valid integrity attribute to the tag.
 pscanbeta.storabilitycacheability.name = Content Cacheability
 
 pscanbeta.storablecacheable.desc = The response contents are storable by caching components such as proxy servers, and may be retrieved directly from the cache, rather than from the origin server by the caching servers, in response to similar requests from other users.  If the response data is sensitive, personal or user-specific, this may result in sensitive information being leaked. In some cases, this may even result in a user gaining complete control of the session of another user, depending on the configuration of the caching components in use in their environment. This is primarily an issue where "shared" caching servers such as "proxy" caches are configured on the local network. This configuration is typically found in corporate or educational environments, for instance.
-pscanbeta.storablecacheable.extrainfo = {0}
 pscanbeta.storablecacheable.name = Storable and Cacheable Content
 pscanbeta.storablecacheable.otherinfo.liberallifetimeheuristic = In the absence of an explicitly specified caching lifetime directive in the response, a liberal lifetime heuristic of 1 year was assumed. This is permitted by rfc7234.
 pscanbeta.storablecacheable.otherinfo.staleretrievenotblocked = The response is stale, and stale responses are not configured to be re-validated or blocked, using the 'must-revalidate', 'proxy-revalidate', 's-maxage', or 'max-age' response 'Cache-Control' directives.
@@ -78,7 +75,6 @@ pscanbeta.storablecacheable.refs = https://datatracker.ietf.org/doc/html/rfc7234
 pscanbeta.storablecacheable.soln = Validate that the response does not contain sensitive, personal or user-specific information.  If it does, consider the use of the following HTTP response headers, to limit, or prevent the content being stored and retrieved from the cache by another user:\nCache-Control: no-cache, no-store, must-revalidate, private\nPragma: no-cache\nExpires: 0\nThis configuration directs both HTTP 1.0 and HTTP 1.1 compliant caching servers to not store the response, and to not retrieve the response (without validation) from the cache, in response to a similar request. 
 
 pscanbeta.storablenoncacheable.desc = The response contents are storable by caching components such as proxy servers, but will not be retrieved directly from the cache, without validating the request upstream, in response to similar requests from other users. 
-pscanbeta.storablenoncacheable.extrainfo = {0}}
 pscanbeta.storablenoncacheable.name = Storable but Non-Cacheable Content
 pscanbeta.storablenoncacheable.refs = https://datatracker.ietf.org/doc/html/rfc7234\nhttps://datatracker.ietf.org/doc/html/rfc7231\nhttps://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 pscanbeta.storablenoncacheable.soln = 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRuleUnitTest.java
@@ -241,7 +241,7 @@ class SourceCodeDisclosureScanRuleUnitTest
         assertThat(alert.getName(), is(getLocalisedString("name") + " - " + language));
         assertThat(alert.getDescription(), is(getLocalisedString("desc") + " - " + language));
         assertThat(alert.getUri(), is(URI));
-        assertThat(alert.getOtherInfo(), is(getLocalisedString("extrainfo", evidence)));
+        assertThat(alert.getOtherInfo(), is(""));
         assertThat(alert.getSolution(), is(getLocalisedString("soln")));
         assertThat(alert.getReference(), is(getLocalisedString("refs")));
         assertThat(alert.getEvidence(), is(evidence));

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapUtils.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapUtils.java
@@ -137,7 +137,7 @@ public class ZestZapUtils {
 
         if (za instanceof ZestScript) {
             ZestScript zs = (ZestScript) za;
-            return indexStr + Constant.messages.getString("zest.element.script", zs.getTitle());
+            return indexStr + zs.getTitle();
         } else if (za instanceof ZestRequest) {
             ZestRequest zr = (ZestRequest) za;
             if (zr.getUrl() != null) {
@@ -151,8 +151,7 @@ public class ZestZapUtils {
             }
         } else if (za instanceof ZestResponse) {
             ZestResponse zr = (ZestResponse) za;
-            return indexStr
-                    + Constant.messages.getString("zest.element.response", zr.getStatusCode());
+            return indexStr + zr.getStatusCode();
 
         } else if (za instanceof ZestAssertion) {
             ZestAssertion zas = (ZestAssertion) za;

--- a/addOns/zest/src/main/resources/org/zaproxy/zap/extension/zest/resources/Messages.properties
+++ b/addOns/zest/src/main/resources/org/zaproxy/zap/extension/zest/resources/Messages.properties
@@ -519,8 +519,6 @@ zest.element.loop.regex.title = Loop Regex
 zest.element.loop.string = Loop For {0} in [{1}]
 zest.element.loop.string.title = Loop String
 zest.element.request = {0} : {1}
-zest.element.response = {0}
-zest.element.script = {0}
 zest.element.unknown = Unknown Element: {0}
 
 zest.expression.add.popup = Add Zest Expression


### PR DESCRIPTION
The single parameter resource messages are misleading as they don't provide any additional data.
Update code to use the parameter directly (some resource messages were not actually in use).
In some scan rules those messages were used as other info but since they were duplicating the evidence they were removed instead.