### PR TITLE
pscanrules: Update CSRF countermeasures rule to consider only html files

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- The CSRF Countermeasures scan rule now skips responses that are not HTML (Issue 7890)
 
 ## [51] - 2023-09-08
 ### Added

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Fixed
-- The CSRF Countermeasures scan rule now skips responses that are not HTML (Issue 7890)
+- The CSRF Countermeasures scan rule now skips responses that are not HTML (Issue 7890).
 
 ## [51] - 2023-09-08
 ### Added

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -85,8 +85,9 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
      */
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (AlertThreshold.HIGH.equals(getAlertThreshold()) && !msg.isInScope()) {
-            return; // At HIGH threshold return if the msg isn't in scope
+        if (AlertThreshold.HIGH.equals(getAlertThreshold()) && !msg.isInScope()
+                || !msg.getResponseHeader().isHtml()) {
+            return;
         }
 
         // need to do this if we are to be able to get an element's parent. Do it as early as
@@ -132,13 +133,12 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                 StringBuilder sbForm = new StringBuilder();
                 SortedSet<String> elementNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
                 ++numberOfFormsPassed;
-                // if the form has no parent, it is pretty likely invalid HTML (or Javascript!!!),
+                // if the form has no parent, it is pretty likely invalid HTML,
                 // so we will not report
                 // any alerts on it.
-                // ie. This logic is necessary to eliminate false positives on non-HTML files.
                 if (formElement.getParentElement() == null) {
                     LOGGER.debug(
-                            "Skipping HTML form because it has no parent. Likely not actually HTML.");
+                            "Skipping HTML form because it has no parent. Likely not actually valid HTML.");
                     continue; // do not report a missing anti-CSRF field on this form
                 }
                 if (formOnIgnoreList(formElement, ignoreList)) {

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -173,7 +173,8 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 
 <H2>CSRF Countermeasures</H2>
 This rule identifies "potential" vulnerabilities with the lack of known CSRF 
-countermeasures in pages with forms.<br>
+countermeasures in HTML pages with forms.<br>
+The rule does not scan messages that are not HTML pages.<br>
 At HIGH alert threshold only scans messages which are in scope.<br>
 Post 2.5.0 you can specify a comma separated list of identifiers in the 
 <code>rules.csrf.ignorelist</code> parameter via the Options 'Rule configuration' panel.

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -441,7 +441,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
                     }
                 };
         newMsg.getRequestHeader().setURI(new URI("http://", "localhost", "/", ""));
-        newMsg.getResponseHeader().setHeader("Content-type", "text/html");
+        newMsg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "text/html");
         newMsg.setResponseBody(
                 "<html><head></head><body>"
                         + "<form name=\"someName\" data-no-csrf><input type=\"text\" name=\"name\"/><input type=\"submit\"/></form>"

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -67,8 +68,13 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 
+        HttpResponseHeader responseHeader = new HttpResponseHeader();
+        responseHeader.setStatusCode(200);
+        responseHeader.setHeader("Content-type", "text/html");
+
         msg = new HttpMessage();
         msg.setRequestHeader(requestHeader);
+        msg.setResponseHeader(responseHeader);
     }
 
     @Override
@@ -422,6 +428,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
                     }
                 };
         newMsg.getRequestHeader().setURI(new URI("http://", "localhost", "/", ""));
+        newMsg.getResponseHeader().setHeader("Content-type", "text/html");
         newMsg.setResponseBody(
                 "<html><head></head><body>"
                         + "<form name=\"someName\" data-no-csrf><input type=\"text\" name=\"name\"/><input type=\"submit\"/></form>"

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
@@ -70,7 +71,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
 
         HttpResponseHeader responseHeader = new HttpResponseHeader();
         responseHeader.setStatusCode(200);
-        responseHeader.setHeader("Content-type", "text/html");
+        responseHeader.setHeader(HttpHeader.CONTENT_TYPE, "text/html");
 
         msg = new HttpMessage();
         msg.setRequestHeader(requestHeader);
@@ -109,6 +110,18 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_SESS_05_CSRF.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_SESS_05_CSRF.getValue())));
+    }
+
+    @Test
+    void shouldNotRaiseAlertIfContentTypeIsNotHTML() {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        msg.setResponseBody("no html");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(alertsRaised.size(), 0);
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -115,9 +115,8 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
     @Test
     void shouldNotRaiseAlertIfContentTypeIsNotHTML() {
         // Given
-        HttpMessage msg = new HttpMessage();
-        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "application/json");
-        msg.setResponseBody("no html");
+        msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        formWithoutAntiCsrfToken();
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -158,8 +157,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
     @Test
     void shouldRaiseAlertIfThereIsNoCSRFTokenFound() {
         // Given
-        msg.setResponseBody(
-                "<html><head></head><body><form id=\"no_csrf_token\"><input type=\"text\"/><input type=\"submit\"/></form></body></html>");
+        formWithoutAntiCsrfToken();
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -430,6 +428,11 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
+    }
+
+    void formWithoutAntiCsrfToken() {
+        msg.setResponseBody(
+                "<html><head></head><body><form id=\"no_csrf_token\"><input type=\"text\"/><input type=\"submit\"/></form></body></html>");
     }
 
     private HttpMessage createScopedMessage(boolean isInScope) throws URIException {


### PR DESCRIPTION
## Overview
Updated the passive scan CRSF countermeasures rule to consider only HTML files, as discussed in https://github.com/zaproxy/zaproxy/issues/7890

I know that it is currently assigned for @FiveOFive, but I saw this as an opportunity for my first contribution (hope that it is ok)

## Related Issues
https://github.com/zaproxy/zaproxy/issues/7890

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
