### PR TITLE
Use Jackson from `commonlib` for `automation`

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Depend on newer version of Automation Framework add-on for the automation job (Related to Issue 7961).
 
 ## [17] - 2023-07-11
 ### Changed

--- a/addOns/alertFilters/alertFilters.gradle.kts
+++ b/addOns/alertFilters/alertFilters.gradle.kts
@@ -17,8 +17,9 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.24.0")
+                            version.set(">=0.31.0")
                         }
+                        register("commonlib")
                     }
                 }
             }
@@ -33,6 +34,7 @@ zapAddOn {
 
 dependencies {
     zapAddOn("automation")
+    zapAddOn("commonlib")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Depend on newer version of Common Library add-on (Related to Issue 7961).
 
 ### Removed
 - The SnakeYAML Engine dependency was removed.

--- a/addOns/automation/automation.gradle.kts
+++ b/addOns/automation/automation.gradle.kts
@@ -13,7 +13,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.13.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }
@@ -35,11 +35,6 @@ crowdin {
 
 dependencies {
     zapAddOn("commonlib")
-
-    val jacksonVersion = "2.15.2"
-    api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion")
-    api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
-    api("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Provide Jackson datatype library for other add-ons (Issue 7961).
 
 ## [1.16.0] - 2023-08-14
 ### Added

--- a/addOns/commonlib/commonlib.gradle.kts
+++ b/addOns/commonlib/commonlib.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     api(platform("com.fasterxml.jackson:jackson-bom:2.15.2"))
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
 
     implementation("commons-io:commons-io:2.13.0")
     implementation("org.apache.commons:commons-csv:1.10.0")

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ## [0.6.0] - 2023-07-11
 ### Changed

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -22,7 +22,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.24.0")
+                            version.set(">=0.31.0")
                         }
                     }
                 }
@@ -31,7 +31,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.8.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Dependency updates.
 - Maintenance changes.
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ## [0.18.0] - 2023-07-11
 ### Changed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -9,7 +9,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.16.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }
@@ -21,7 +21,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.24.0")
+                            version.set(">=0.31.0")
                         }
                     }
                 }

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dependency updates.
 - The "Import an OpenAPI definition from the local file system" and "Import an OpenAPI definition from a URL" menu items
   were merged into one, "Import an OpenAPI Definition".
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ### Fixed
 - Importing empty or invalid OpenAPI definitions failed silently in some cases (Issue 7949).

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -17,7 +17,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.24.0")
+                            version.set(">=0.31.0")
                         }
                     }
                 }
@@ -50,7 +50,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.8.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ## [0.24.0] - 2023-08-17
 ### Changed

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -18,7 +18,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.16.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }
@@ -31,7 +31,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.24.0")
+                            version.set(">=0.31.0")
                         }
                     }
                 }

--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ## [0.6.0] - 2023-07-11
 ### Changed

--- a/addOns/retest/retest.gradle.kts
+++ b/addOns/retest/retest.gradle.kts
@@ -9,7 +9,10 @@ zapAddOn {
         dependencies {
             addOns {
                 register("automation") {
-                    version.set(">=0.20.0")
+                    version.set(">=0.31.0")
+                }
+                register("commonlib") {
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }
@@ -31,6 +34,7 @@ crowdin {
 
 dependencies {
     zapAddOn("automation")
+    zapAddOn("commonlib")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Allow to display script without focusing on it.
 - Maintenance changes.
+- Depend on newer version of Automation Framework add-on (Related to Issue 7961).
 
 ## [39] - 2023-07-11
 ### Changed

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -17,8 +17,9 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.24.0")
+                            version.set(">=0.31.0")
                         }
+                        register("commonlib")
                     }
                 }
             }
@@ -40,6 +41,7 @@ spotless {
 
 dependencies {
     zapAddOn("automation")
+    zapAddOn("commonlib")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   "Import a WSDL File". The merged dialog uses the shortcut `Ctrl+J` (`Cmd+J` on macOS).
 - The Import dialog shows the values used in the previous import when reopened.
 - Maintenance changes.
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ## [18] - 2023-07-11
 ### Changed

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -13,7 +13,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.5.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }
@@ -26,7 +26,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.24.0")
+                            version.set(">=0.31.0")
                         }
                     }
                 }

--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ## [0.5.0] - 2023-07-11
 ### Changed

--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -17,7 +17,7 @@ zapAddOn {
                     version.set(">=0.3.0")
                 }
                 register("commonlib") {
-                    version.set(">= 1.13.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }
@@ -30,7 +30,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.17.0")
+                            version.set(">=0.31.0")
                         }
                     }
                 }

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ## [23.15.0] - 2023-07-11
 ### Added

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -31,7 +31,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.17.0")
+                            version.set(">=0.31.0")
                         }
                     }
                 }
@@ -40,7 +40,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.13.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
                 register("network") {
                     version.set(">=0.1.0")

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
+
 ### Fixed
 - Ensure icons render when expected.
 

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -17,7 +17,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.4.0")
+                            version.set(">=0.31.0")
                         }
                     }
                 }
@@ -26,7 +26,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.7.0 & < 2.0.0")
+                    version.set(">= 1.17.0 & < 2.0.0")
                 }
             }
         }


### PR DESCRIPTION
Move Jackson datatype library from `automation` to `commonlib`.
Update versions of the add-ons to ensure the correct libraries are used.

Related to zaproxy/zaproxy#7961.