### PR TITLE
wappalyzer: Move from batik to jsvg

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Moved from Apache batik libraries to weisJ's jsvg library (thus reducing the size of the add-on).
 
 ## [21.24.0] - 2023-09-07
 ### Changed

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/ApplicationTestHolder.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/ApplicationTestHolder.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class WappalyzerApplicationTestHolder implements WappalyzerApplicationHolder {
+public class ApplicationTestHolder implements WappalyzerApplicationHolder {
 
     private List<Application> applications = new ArrayList<>();
     private Map<String, List<ApplicationMatch>> siteToApps = new HashMap<>();

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/AppsJsonParseUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/AppsJsonParseUnitTest.java
@@ -27,7 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class WappalyzerAppsJsonParseUnitTest {
+class AppsJsonParseUnitTest {
 
     @Test
     void test() throws IOException {

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/JsonParserUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/JsonParserUnitTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class WappalyzerJsonParserUnitTest {
+class JsonParserUnitTest {
 
     @Test
     void shouldParseExample() {

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/PassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/PassiveScannerUnitTest.java
@@ -39,14 +39,14 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
-class WappalyzerPassiveScannerUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveScanner> {
+class PassiveScannerUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveScanner> {
 
-    WappalyzerApplicationTestHolder defaultHolder;
+    ApplicationTestHolder defaultHolder;
 
-    public WappalyzerApplicationTestHolder getDefaultHolder() {
+    public ApplicationTestHolder getDefaultHolder() {
         if (defaultHolder == null) {
             try {
-                defaultHolder = new WappalyzerApplicationTestHolder();
+                defaultHolder = new ApplicationTestHolder();
                 WappalyzerJsonParser parser = new WappalyzerJsonParser();
                 WappalyzerData result =
                         parser.parse(

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -42,15 +42,10 @@ dependencies {
     zapAddOn("automation")
     zapAddOn("commonlib")
 
+    compileOnly(libs.log4j.core)
+
     implementation("com.google.re2j:re2j:1.7")
-
-    val batikVersion = "1.14"
-    implementation("org.apache.xmlgraphics:batik-anim:$batikVersion")
-    implementation("org.apache.xmlgraphics:batik-bridge:$batikVersion")
-    implementation("org.apache.xmlgraphics:batik-ext:$batikVersion")
-    implementation("org.apache.xmlgraphics:batik-gvt:$batikVersion")
-    implementation("org.apache.xmlgraphics:batik-util:$batikVersion")
-
+    implementation("com.github.weisj:jsvg:1.2.0")
     implementation("org.jsoup:jsoup:1.16.1")
 
     testImplementation(project(":testutils"))


### PR DESCRIPTION
## Overview
Size went from ~18MB to ~11MB for the built *.zap add-on.

- CHANGELOG.md > Added change note.
- ExtensionWappalyzer > Added logging configuration code to keep jsvg from being too verbose. (Changes similar to zaproxy/zap-extensions#4612)
- wappalyzer.gradle.kts > Change dependencies. (Reduce whitespace)
- WappalyzerJsonParser > Update SVG handling code.
- Maintenance changes - Dropped "Wappalyzer" from the start of all the UnitTest class names.

## Checklist
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
