### PR TITLE
openapi: Fix hanging import dialog

### DIFF
--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportDialog.java
@@ -303,7 +303,7 @@ public class ImportDialog extends AbstractDialog {
             var uri = new URI(definitionLocation, true);
             return extOpenApi.importOpenApiDefinition(
                             uri, getTargetField().getText(), true, getSelectedContextId())
-                    != null;
+                    == null;
         } catch (URIException | MalformedURLException | URISyntaxException ignored) {
             // Not a valid URI, try to import as a file
         } catch (InvalidUrlException e) {
@@ -334,7 +334,7 @@ public class ImportDialog extends AbstractDialog {
         try {
             return extOpenApi.importOpenApiDefinition(
                             file, getTargetField().getText(), true, getSelectedContextId())
-                    != null;
+                    == null;
         } catch (InvalidUrlException e) {
             ThreadUtils.invokeAndWaitHandled(
                     () -> {


### PR DESCRIPTION
## Overview
The import dialog was hanging on successful imports because of an incorrect return value from `ImportDialog#importDefinition`. We were supposed to check that no errors were returned, but we were doing the opposite.

## Related Issues
Fixes zaproxy/zaproxy#8011.

## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
