### PR TITLE
graaljs: update Graal JavaScript engine

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update Graal JavaScript engine.
 
 ## [0.4.0] - 2023-07-11
 ### Added

--- a/addOns/graaljs/graaljs.gradle.kts
+++ b/addOns/graaljs/graaljs.gradle.kts
@@ -28,7 +28,7 @@ crowdin {
 }
 
 dependencies {
-    val graalJsVersion = "20.2.0"
+    val graalJsVersion = "22.3.3"
     implementation("org.graalvm.js:js:$graalJsVersion")
     implementation("org.graalvm.js:js-scriptengine:$graalJsVersion")
     implementation("org.javadelight:delight-graaljs-sandbox:0.1.2")


### PR DESCRIPTION
Update to latest version (for Java 11) and set the add-on class loader directly to the context.

Related to zaproxy/zaproxy#7960.