### PR TITLE
graphql: Add example alerts

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- The add-on now includes example alert functionality for documentation generation purposes (Issue 6119).
+
 ### Changed
 - Dependency updates.
 - Maintenance changes.

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.Extension;
@@ -40,12 +41,13 @@ import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.commonlib.ExtensionCommonlib;
+import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionGraphQl extends ExtensionAdaptor
-        implements CommandLineListener, SessionChangedListener {
+        implements CommandLineListener, SessionChangedListener, ExampleAlertProvider {
 
     public static final String NAME = "ExtensionGraphQl";
 
@@ -284,5 +286,12 @@ public class ExtensionGraphQl extends ExtensionAdaptor
     public boolean handleFile(File file) {
         // Not supported
         return false;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                GraphQlParser.createIntrospectionAlert().build(),
+                GraphQlFingerprinter.createFingerprintingAlert("example").build());
     }
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlFingerprinter.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlFingerprinter.java
@@ -144,33 +144,37 @@ public class GraphQlFingerprinter {
         return false;
     }
 
+    static Alert.Builder createFingerprintingAlert(String engineId) {
+        final String enginePrefix = "graphql.engine." + engineId + ".";
+        return Alert.builder()
+                .setPluginId(ExtensionGraphQl.TOOL_ALERT_ID)
+                .setAlertRef(FINGERPRINTING_ALERT_REF)
+                .setName(Constant.messages.getString("graphql.fingerprinting.alert.name"))
+                .setDescription(
+                        Constant.messages.getString(
+                                "graphql.fingerprinting.alert.desc",
+                                Constant.messages.getString(enginePrefix + "name"),
+                                Constant.messages.getString(enginePrefix + "technologies")))
+                .setReference(Constant.messages.getString(enginePrefix + "docsUrl"))
+                .setConfidence(Alert.CONFIDENCE_HIGH)
+                .setRisk(Alert.RISK_INFO)
+                .setCweId(205)
+                .setWascId(45)
+                .setSource(Alert.Source.TOOL)
+                .setTags(FINGERPRINTING_ALERT_TAGS);
+    }
+
     private void raiseFingerprintingAlert(String engineId) {
         var extAlert =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
         if (extAlert == null) {
             return;
         }
-        final String enginePrefix = "graphql.engine." + engineId + ".";
         Alert alert =
-                Alert.builder()
-                        .setPluginId(ExtensionGraphQl.TOOL_ALERT_ID)
-                        .setAlertRef(FINGERPRINTING_ALERT_REF)
-                        .setName(Constant.messages.getString("graphql.fingerprinting.alert.name"))
-                        .setDescription(
-                                Constant.messages.getString(
-                                        "graphql.fingerprinting.alert.desc",
-                                        Constant.messages.getString(enginePrefix + "name"),
-                                        Constant.messages.getString(enginePrefix + "technologies")))
-                        .setReference(Constant.messages.getString(enginePrefix + "docsUrl"))
-                        .setConfidence(Alert.CONFIDENCE_HIGH)
-                        .setRisk(Alert.RISK_INFO)
+                createFingerprintingAlert(engineId)
+                        .setEvidence(matchedString)
                         .setMessage(lastQueryMsg)
                         .setUri(requestor.getEndpointUrl().toString())
-                        .setEvidence(matchedString)
-                        .setCweId(205)
-                        .setWascId(45)
-                        .setSource(Alert.Source.TOOL)
-                        .setTags(FINGERPRINTING_ALERT_TAGS)
                         .build();
         extAlert.alertFound(alert, null);
     }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -188,6 +188,22 @@ public class GraphQlParser {
         }
     }
 
+    static Alert.Builder createIntrospectionAlert() {
+        return Alert.builder()
+                .setPluginId(ExtensionGraphQl.TOOL_ALERT_ID)
+                .setAlertRef(INTROSPECTION_ALERT_REF)
+                .setName(Constant.messages.getString("graphql.introspection.alert.name"))
+                .setDescription(Constant.messages.getString("graphql.introspection.alert.desc"))
+                .setReference(Constant.messages.getString("graphql.introspection.alert.ref"))
+                .setSolution(Constant.messages.getString("graphql.introspection.alert.soln"))
+                .setConfidence(Alert.CONFIDENCE_HIGH)
+                .setRisk(Alert.RISK_INFO)
+                .setCweId(16)
+                .setWascId(15)
+                .setSource(Alert.Source.TOOL)
+                .setTags(INTROSPECTION_ALERT_TAGS);
+    }
+
     private void raiseIntrospectionAlert(HttpMessage msg) {
         var extAlert =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
@@ -195,22 +211,7 @@ public class GraphQlParser {
             return;
         }
         Alert alert =
-                Alert.builder()
-                        .setPluginId(ExtensionGraphQl.TOOL_ALERT_ID)
-                        .setAlertRef(INTROSPECTION_ALERT_REF)
-                        .setName(Constant.messages.getString("graphql.introspection.alert.name"))
-                        .setDescription(
-                                Constant.messages.getString("graphql.introspection.alert.desc"))
-                        .setReference(
-                                Constant.messages.getString("graphql.introspection.alert.ref"))
-                        .setSolution(
-                                Constant.messages.getString("graphql.introspection.alert.soln"))
-                        .setConfidence(Alert.CONFIDENCE_HIGH)
-                        .setRisk(Alert.RISK_INFO)
-                        .setCweId(16)
-                        .setWascId(15)
-                        .setSource(Alert.Source.TOOL)
-                        .setTags(INTROSPECTION_ALERT_TAGS)
+                createIntrospectionAlert()
                         .setHistoryRef(msg.getHistoryRef())
                         .setMessage(msg)
                         .build();

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -94,6 +94,10 @@ graphql.engine.directus.docsUrl = https://github.com/directus/directus
 graphql.engine.directus.name = Directus
 graphql.engine.directus.technologies = TypeScript
 
+graphql.engine.example.docsUrl = https://example.com/graphql-engine-reference
+graphql.engine.example.name = Example GraphQL Engine
+graphql.engine.example.technologies = "Example Technology 1" and "Example Technology 2"
+
 graphql.engine.gqlgen.docsUrl = https://github.com/99designs/gqlgen
 graphql.engine.gqlgen.name = gqlgen
 graphql.engine.gqlgen.technologies = Golang


### PR DESCRIPTION
## Overview
- The add-on now includes example alert functionality for documentation generation purposes.

## Related Issues
-  zaproxy/zaproxy#6119.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
