### PR TITLE
commonlib: add vulnerability classes

### DIFF
--- a/addOns/commonlib/commonlib.gradle.kts
+++ b/addOns/commonlib/commonlib.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
 
     api(platform("com.fasterxml.jackson:jackson-bom:2.15.2"))
     api("com.fasterxml.jackson.core:jackson-databind")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
 

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerabilities.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerabilities.java
@@ -1,0 +1,165 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.internal.vulns;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
+import org.zaproxy.zap.utils.LocaleUtils;
+
+public class DefaultVulnerabilities implements Vulnerabilities {
+
+    private static final Logger LOGGER = LogManager.getLogger(DefaultVulnerabilities.class);
+
+    private static final String FILE_NAME_PREFIX = "vulnerabilities";
+    private static final String FILE_NAME_EXTENSION = ".xml";
+
+    private static Vulnerabilities instance;
+
+    private final List<Vulnerability> list;
+    private final Map<String, Vulnerability> map;
+
+    /**
+     * Gets the instance.
+     *
+     * @return the instance, never {@code null}.
+     */
+    public static Vulnerabilities getInstance() {
+        if (instance == null) {
+            instance = new DefaultVulnerabilities();
+        }
+        return instance;
+    }
+
+    DefaultVulnerabilities() {
+        this(Constant.getLocale());
+    }
+
+    DefaultVulnerabilities(Locale locale) {
+        var result = loadVulnerabilities(locale);
+        list = result.getList();
+        map = result.getMap();
+    }
+
+    @Override
+    public List<Vulnerability> getAll() {
+        return list;
+    }
+
+    @Override
+    public Vulnerability get(String id) {
+        return map.get(id);
+    }
+
+    private LoadResult loadVulnerabilities(Locale locale) {
+        var extension = FILE_NAME_EXTENSION.substring(1);
+        var result =
+                LocaleUtils.findResource(
+                        FILE_NAME_PREFIX,
+                        extension,
+                        locale,
+                        candidateFilename -> {
+                            try (var is = getClass().getResourceAsStream(candidateFilename)) {
+                                if (is == null) {
+                                    return null;
+                                }
+
+                                LOGGER.debug(
+                                        "Loading vulnerabilities from {} for locale {}.",
+                                        candidateFilename,
+                                        locale);
+
+                                var persisted =
+                                        new XmlMapper()
+                                                .readValue(
+                                                        new BufferedInputStream(is),
+                                                        PersistedVulnerabilities.class);
+                                return new LoadResult(persisted);
+                            } catch (IOException e) {
+                                LOGGER.error(e.getMessage(), e);
+                                return null;
+                            }
+                        });
+
+        if (result != null) {
+            return result;
+        }
+        return new LoadResult(new PersistedVulnerabilities());
+    }
+
+    private static class LoadResult {
+
+        private static final int VULN_ITEM_PREFIX_LENGTH = "vuln_item_".length();
+
+        private final List<Vulnerability> list;
+        private final Map<String, Vulnerability> map;
+
+        LoadResult(PersistedVulnerabilities persisted) {
+            var vulnerabilities = persisted.getVulnerabilities();
+            list = vulnerabilities.values().stream().collect(Collectors.toUnmodifiableList());
+            map =
+                    vulnerabilities.entrySet().stream()
+                            .collect(
+                                    Collectors.toUnmodifiableMap(
+                                            e -> trimKeyPrefix(e),
+                                            e -> {
+                                                DefaultVulnerability value = e.getValue();
+                                                value.setId(trimKeyPrefix(e));
+                                                return value;
+                                            }));
+        }
+
+        private static String trimKeyPrefix(Entry<String, DefaultVulnerability> e) {
+            return e.getKey().substring(VULN_ITEM_PREFIX_LENGTH);
+        }
+
+        public List<Vulnerability> getList() {
+            return list;
+        }
+
+        public Map<String, Vulnerability> getMap() {
+            return map;
+        }
+    }
+
+    @JsonIgnoreProperties("vuln_items")
+    private static class PersistedVulnerabilities {
+
+        @JsonAnySetter
+        private Map<String, DefaultVulnerability> vulnerabilities = new LinkedHashMap<>();
+
+        public Map<String, DefaultVulnerability> getVulnerabilities() {
+            return vulnerabilities;
+        }
+    }
+}

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerability.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerability.java
@@ -1,0 +1,108 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.internal.vulns;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import java.util.List;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
+
+public class DefaultVulnerability implements Vulnerability {
+
+    private Integer wascId;
+
+    private String id;
+
+    @JsonProperty("alert")
+    private String name;
+
+    @JsonProperty("desc")
+    private String description;
+
+    private String solution;
+
+    @JsonProperty("reference")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    private List<String> references;
+
+    private String referencesAsString;
+
+    @Override
+    public int getWascId() {
+        if (wascId == null) {
+            wascId = -1;
+            String str = id.substring(5);
+            try {
+                wascId = Integer.parseInt(str);
+            } catch (NumberFormatException e) {
+                // Some have trailing alphabetic characters
+                try {
+                    wascId = Integer.parseInt(str.substring(0, str.length() - 1));
+                } catch (NumberFormatException e2) {
+                    // Ignore
+                }
+            }
+        }
+        return wascId;
+    }
+
+    void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getSolution() {
+        return solution;
+    }
+
+    @Override
+    public List<String> getReferences() {
+        return references;
+    }
+
+    void setReferences(List<String> references) {
+        this.references = references;
+    }
+
+    @Override
+    public String getReferencesAsString() {
+        if (referencesAsString == null) {
+            StringBuilder sb = new StringBuilder();
+            for (String ref : references) {
+                if (sb.length() > 0) {
+                    sb.append('\n');
+                }
+                sb.append(ref);
+            }
+            referencesAsString = sb.toString();
+        }
+        return referencesAsString;
+    }
+}

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/vulnerabilities/Vulnerabilities.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/vulnerabilities/Vulnerabilities.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.vulnerabilities;
+
+import java.util.List;
+import org.zaproxy.addon.commonlib.internal.vulns.DefaultVulnerabilities;
+
+/**
+ * The vulnerabilities.
+ *
+ * @since 1.17.0
+ */
+public interface Vulnerabilities {
+
+    /**
+     * Gets the default vulnerabilities.
+     *
+     * <p>The vulnerabilities might be localized.
+     *
+     * @return the default vulnerabilities.
+     */
+    static Vulnerabilities getDefault() {
+        return DefaultVulnerabilities.getInstance();
+    }
+
+    /**
+     * Gets an unmodifiable {@code List} containing all the {@code Vulnerability}.
+     *
+     * @return the {@code List} containing all the {@code Vulnerability}, never {@code null}.
+     */
+    List<Vulnerability> getAll();
+
+    /**
+     * Gets the {@code Vulnerability} for the given ID, or {@code null} if not available.
+     *
+     * <p>The ID is in the form: {@code wasc_#ID}, e.g. {@code wasc_1}, {@code wasc_2}.
+     *
+     * @param id the ID of the vulnerability.
+     * @return the {@code Vulnerability}, or {@code null} if not available.
+     */
+    Vulnerability get(String id);
+}

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/vulnerabilities/Vulnerability.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/vulnerabilities/Vulnerability.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.vulnerabilities;
+
+import java.util.List;
+
+/**
+ * The information of a vulnerability.
+ *
+ * @since 1.17.0
+ */
+public interface Vulnerability {
+
+    /**
+     * Gets the WASC ID of the vulnerability.
+     *
+     * @return the ID, or -1 if not known.
+     */
+    int getWascId();
+
+    /**
+     * Gets the name of the vulnerability.
+     *
+     * @return the name, never {@code null}.
+     */
+    String getName();
+
+    /**
+     * Gets the description of the vulnerability.
+     *
+     * @return the description, never {@code null}.
+     */
+    String getDescription();
+
+    /**
+     * Gets the solution of the vulnerability.
+     *
+     * @return the solution, never {@code null}.
+     */
+    String getSolution();
+
+    /**
+     * Gets the references of the vulnerability.
+     *
+     * @return the references, never {@code null}.
+     * @see #getReferencesAsString()
+     */
+    List<String> getReferences();
+
+    /**
+     * Gets the references of the vulnerability as a string, with each reference in its own line.
+     *
+     * @return the references, never {@code null}.
+     * @see #getReferences()
+     */
+    String getReferencesAsString();
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerabilitiesUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerabilitiesUnitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.internal.vulns;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
+
+/** Unit test for {@link DefaultVulnerabilities}. */
+class DefaultVulnerabilitiesUnitTest {
+
+    @Test
+    void shouldLoadDefaultVulnerabilities() {
+        // Given
+        Locale locale = Locale.ROOT;
+        // When
+        DefaultVulnerabilities vulnerabilities = new DefaultVulnerabilities(locale);
+        // Then
+        assertDefaults(vulnerabilities);
+    }
+
+    private static void assertDefaults(DefaultVulnerabilities vulnerabilities) {
+        assertThat(vulnerabilities.getAll(), hasSize(52));
+        assertVulnerability(vulnerabilities.get("wasc_1"), 1, 3);
+        assertVulnerability(vulnerabilities.get("wasc_11a"), 11, 2);
+        assertVulnerability(vulnerabilities.get("wasc_49"), 49, 2);
+    }
+
+    private static void assertVulnerability(
+            Vulnerability vulnerability, int id, int numberOfReferences) {
+        assertThat(vulnerability, is(notNullValue()));
+        assertThat(vulnerability.getWascId(), is(equalTo(id)));
+        assertThat(vulnerability.getName(), is(not(emptyString())));
+        assertThat(vulnerability.getDescription(), is(not(emptyString())));
+        assertThat(vulnerability.getSolution(), is(not(emptyString())));
+        assertThat(vulnerability.getReferences(), hasSize(numberOfReferences));
+    }
+
+    @Test
+    void shouldLoadDefaultVulnerabilitiesForUnknownLocale() {
+        // Given
+        Locale locale =
+                new Locale.Builder().setLanguage("XX").setRegion("YY").setScript("ZZZZ").build();
+        // When
+        DefaultVulnerabilities vulnerabilities = new DefaultVulnerabilities(locale);
+        // Then
+        assertDefaults(vulnerabilities);
+    }
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerabilityUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerabilityUnitTest.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.internal.vulns;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Unit test for {@link DefaultVulnerability}. */
+class DefaultVulnerabilityUnitTest {
+
+    private DefaultVulnerability vulnerability;
+
+    @BeforeEach
+    void setUp() {
+        vulnerability = new DefaultVulnerability();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"wasc_1, 1", "wasc_2a, 2", "not_wasc_id, -1"})
+    void shouldGetWascId(String id, int expectedWascId) {
+        // Given
+        vulnerability.setId(id);
+        // When
+        int wascId = vulnerability.getWascId();
+        // Then
+        assertThat(wascId, is(equalTo(expectedWascId)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"wasc_1, 1", "wasc_2a, 2", "not_wasc_id, -1"})
+    void shouldGetSameWascId(String id, int expectedWascId) {
+        // Given
+        vulnerability.setId(id);
+        // When
+        int wascId1st = vulnerability.getWascId();
+        int wascId2nd = vulnerability.getWascId();
+        // Then
+        assertThat(wascId1st, is(equalTo(wascId2nd)));
+    }
+
+    @Test
+    void shouldGetReferencesAsString() {
+        // Given
+        vulnerability.setReferences(List.of("Ref A", "Ref B"));
+        // When
+        String references = vulnerability.getReferencesAsString();
+        // Then
+        assertThat(references, is(equalTo("Ref A\nRef B")));
+    }
+
+    @Test
+    void shouldGetSameInstanceReferencesAsString() {
+        // Given
+        vulnerability.setReferences(List.of("Ref A", "Ref B"));
+        // When
+        String references1st = vulnerability.getReferencesAsString();
+        String references2nd = vulnerability.getReferencesAsString();
+        // Then
+        assertThat(references1st, is(sameInstance(references2nd)));
+    }
+}


### PR DESCRIPTION
Add classes to provide the vulnerabilities to other add-ons without the need to rely on core.
Add Jackson XML library to parse the vulnerabilities.xml files, make it also an API dependency to allow other add-ons to use it.

Fix zaproxy/zaproxy#8012.