### PR TITLE
Dev: Added OpenAPI (un)auth pages

### DIFF
--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Auth page where the return key does not submit the form
 - Auth page which uses one request and one cookie
 - Auth page which uses multiple requests and multiple cookies
+- OpenAPI auth and unauth pages
 
 ### Changed
 - Update minimum ZAP version to 2.13.0.

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestDirectory.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestDirectory.java
@@ -142,6 +142,10 @@ public class TestDirectory implements HttpMessageHandler {
                     contentType = "text/css";
                 } else if (name.endsWith(".js")) {
                     contentType = "text/javascript";
+                } else if (name.endsWith(".json")) {
+                    contentType = "application/json";
+                } else if (name.endsWith(".yaml")) {
+                    contentType = "application/yaml";
                 } else {
                     LOGGER.error("Unexpected tutorial file extension: {}", name);
                 }

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestProxyServer.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestProxyServer.java
@@ -29,6 +29,8 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.dev.api.openapi.simpleAuth.OpenApiSimpleAuthDir;
+import org.zaproxy.addon.dev.api.openapi.simpleUnauth.OpenApiSimpleUnauthDir;
 import org.zaproxy.addon.dev.auth.jsonMultipleCookies.JsonMultipleCookiesDir;
 import org.zaproxy.addon.dev.auth.nonStdJsonBearer.NonStdJsonBearerDir;
 import org.zaproxy.addon.dev.auth.passswordAddedNoSubmit.PasswordAddedNoSubmitDir;
@@ -78,7 +80,14 @@ public class TestProxyServer {
         authDir.addDirectory(new PasswordAddedNoSubmitDir(this, "password-added-json"));
         authDir.addDirectory(new JsonMultipleCookiesDir(this, "json-multiple-cookies"));
 
+        TestDirectory apiDir = new TestDirectory(this, "api");
+        TestDirectory openapiDir = new TestDirectory(this, "openapi");
+        apiDir.addDirectory(openapiDir);
+        openapiDir.addDirectory(new OpenApiSimpleAuthDir(this, "simple-auth"));
+        openapiDir.addDirectory(new OpenApiSimpleUnauthDir(this, "simple-unauth"));
+
         root.addDirectory(authDir);
+        root.addDirectory(apiDir);
     }
 
     private Server getServer() {

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleAuth/OpenApiLoginPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleAuth/OpenApiLoginPage.java
@@ -1,0 +1,70 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev.api.openapi.simpleAuth;
+
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.dev.TestPage;
+import org.zaproxy.addon.dev.TestProxyServer;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+public class OpenApiLoginPage extends TestPage {
+
+    private static final Logger LOGGER = LogManager.getLogger(OpenApiLoginPage.class);
+
+    public OpenApiLoginPage(TestProxyServer server) {
+        super(server, "login");
+    }
+
+    @Override
+    public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        String username = null;
+        String password = null;
+
+        if (msg.getRequestHeader().hasContentType("json")) {
+            String postData = msg.getRequestBody().toString();
+            JSONObject jsonObject;
+            try {
+                jsonObject = JSONObject.fromObject(postData);
+                username = jsonObject.getString("user");
+                password = jsonObject.getString("password");
+            } catch (JSONException e) {
+                LOGGER.debug("Unable to parse as JSON: {}", postData, e);
+            }
+        }
+
+        JSONObject response = new JSONObject();
+        if (getParent().isValid(username, password)) {
+            response.put("result", "OK");
+            response.put("accesstoken", getParent().getToken(username));
+        } else {
+            response.put("result", "FAIL");
+        }
+        this.getServer().setJsonResponse(response, msg);
+    }
+
+    @Override
+    public OpenApiSimpleAuthDir getParent() {
+        return (OpenApiSimpleAuthDir) super.getParent();
+    }
+}

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleAuth/OpenApiSimpleAuthDir.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleAuth/OpenApiSimpleAuthDir.java
@@ -1,0 +1,38 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev.api.openapi.simpleAuth;
+
+import org.zaproxy.addon.dev.TestAuthDirectory;
+import org.zaproxy.addon.dev.TestProxyServer;
+
+/**
+ * A directory which contains an OpenAPI spec. The spec is available unauthenticated but the
+ * endpoint it describes can only be accessed when a valid Authentication header is supplied. The
+ * login page uses one JSON request to login endpoint. The token is returned in a standard field.
+ */
+public class OpenApiSimpleAuthDir extends TestAuthDirectory {
+
+    public OpenApiSimpleAuthDir(TestProxyServer server, String name) {
+        super(server, name);
+        this.addPage(new OpenApiLoginPage(server));
+        this.addPage(new OpenApiVerificationPage(server));
+        this.addPage(new OpenApiTestApiPage(server));
+    }
+}

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleAuth/OpenApiTestApiPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleAuth/OpenApiTestApiPage.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev.api.openapi.simpleAuth;
+
+import net.sf.json.JSONObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.dev.TestPage;
+import org.zaproxy.addon.dev.TestProxyServer;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+public class OpenApiTestApiPage extends TestPage {
+
+    private static final Logger LOGGER = LogManager.getLogger(OpenApiTestApiPage.class);
+
+    public OpenApiTestApiPage(TestProxyServer server) {
+        super(server, "test-api");
+    }
+
+    @Override
+    public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        String token = msg.getRequestHeader().getHeader(HttpHeader.AUTHORIZATION);
+        String user = getParent().getUser(token);
+        LOGGER.debug("Token: {} user: {}", token, user);
+
+        JSONObject response = new JSONObject();
+        if (user != null) {
+            response.put("result", "Success");
+            this.getServer().setJsonResponse(TestProxyServer.STATUS_OK, response, msg);
+        } else {
+            response.put("result", "FAIL");
+            this.getServer().setJsonResponse(TestProxyServer.STATUS_FORBIDDEN, response, msg);
+        }
+    }
+
+    @Override
+    public OpenApiSimpleAuthDir getParent() {
+        return (OpenApiSimpleAuthDir) super.getParent();
+    }
+}

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleAuth/OpenApiVerificationPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleAuth/OpenApiVerificationPage.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev.api.openapi.simpleAuth;
+
+import net.sf.json.JSONObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.dev.TestPage;
+import org.zaproxy.addon.dev.TestProxyServer;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+public class OpenApiVerificationPage extends TestPage {
+
+    private static final Logger LOGGER = LogManager.getLogger(OpenApiVerificationPage.class);
+
+    public OpenApiVerificationPage(TestProxyServer server) {
+        super(server, "user");
+    }
+
+    @Override
+    public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        String token = msg.getRequestHeader().getHeader(HttpHeader.AUTHORIZATION);
+        String user = getParent().getUser(token);
+        LOGGER.debug("Token: {} user: {}", token, user);
+
+        JSONObject response = new JSONObject();
+        if (user != null) {
+            response.put("result", "OK");
+            response.put("user", user);
+        } else {
+            response.put("result", "FAIL");
+        }
+        this.getServer().setJsonResponse(response, msg);
+    }
+
+    @Override
+    public OpenApiSimpleAuthDir getParent() {
+        return (OpenApiSimpleAuthDir) super.getParent();
+    }
+}

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleUnauth/OpenApiSimpleUnauthDir.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/api/openapi/simpleUnauth/OpenApiSimpleUnauthDir.java
@@ -1,0 +1,31 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev.api.openapi.simpleUnauth;
+
+import org.zaproxy.addon.dev.TestDirectory;
+import org.zaproxy.addon.dev.TestProxyServer;
+
+/** A directory which contains an OpenAPI spec, no authentication. */
+public class OpenApiSimpleUnauthDir extends TestDirectory {
+
+    public OpenApiSimpleUnauthDir(TestProxyServer server, String name) {
+        super(server, name);
+    }
+}

--- a/addOns/dev/src/main/javahelp/org/zaproxy/addon/dev/resources/help/contents/dev.html
+++ b/addOns/dev/src/main/javahelp/org/zaproxy/addon/dev/resources/help/contents/dev.html
@@ -11,9 +11,12 @@ An add-on to help with development of ZAP.
 <p>
 It provides:
 
+<H2>API Pages</H2>
+Two simple OpenAPI specs, both of which require no authentication.
+One of the APIs described by the specs can only be accessed when authenticated.
+
 <H2>Authentication Pages</H2>
-One very simple authentication page, soon to be replaced with a set of more realistic ones.
-For use in testing ZAP authentication handling.
+A growing set of authentication pages, for use in testing ZAP authentication handling.
 
 </BODY>
 </HTML>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-auth/home.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-auth/home.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<h1>Simple Home Page</H1>
+<div class="roundContainer">
+	<div id="message"></div>
+</div>
+
+<script>
+function getuser() {
+	var xhr = new XMLHttpRequest();
+	var url = "user";
+	xhr.open("GET", url, true);
+	xhr.setRequestHeader("Authorization", sessionStorage.getItem("accesstoken"));
+	xhr.onreadystatechange = function () {
+	    if (xhr.readyState === 4 && xhr.status === 200) {
+	        var json = JSON.parse(xhr.responseText);
+	        
+	        if (json.result === "OK") {
+	        	const h2 = document.createElement("h2");
+	        	const textNode = document.createTextNode("Hello " + json.user);
+	        	h2.appendChild(textNode);
+	        	document.getElementById("message").appendChild(h2);
+	        } else {
+	        	window.location.replace("index.html");
+	        }
+	    }
+	};
+	xhr.send(null);
+}
+window.addEventListener("load", (event) => {
+	  getuser();
+	});
+
+</script>
+
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-auth/index.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-auth/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Simple OpenAPI Spec, with Authentication</H1>
+	<h2>Login</h2>
+	
+	<div id="result"></div>
+
+	<form>
+	<table style="border: none;">
+	<tr>
+		<td>Username:
+		<td><input id="user" name="user" type="text"></td>
+	</tr>
+	<tr>
+		<td>Password:
+		<td><input id="password" name="password" type="password"></td>
+	</tr>
+	<tr>
+		<td></td>
+		<td><button id="login" type="button" value="submit" onclick="submitform();">Login</button></td>
+	</tr>
+	</table>
+	</form>
+	<p>
+	Test credentials:
+	<ul>
+		<li>username = test@test.com
+		<li>password = password123
+	</ul>
+	The verification URL returns JSON with the username if valid, and a 200 response in all cases.
+	<p>
+	OpenAPI spec in openapi.json - no links, available unauthenticated but API only available with a valid Authorization header.
+	
+</div>
+<script>
+function submitform() {
+	// Remove previous messages
+	let element = document.getElementById("result");
+	while (element.firstChild) {
+		element.removeChild(element.firstChild);
+	}
+
+	// Make the login request
+	var xhr = new XMLHttpRequest();
+	var url = "login";
+	xhr.open("POST", url, true);
+	xhr.setRequestHeader("Content-Type", "application/json");
+	xhr.onreadystatechange = function () {
+	    if (xhr.readyState === 4 && xhr.status === 200) {
+	        var json = JSON.parse(xhr.responseText);
+	        
+	        if (json.result === "OK") {
+	        	sessionStorage.setItem("accesstoken", json.accesstoken);
+	        	window.location.replace("home.html");
+	        } else {
+	        	const h3 = document.createElement("h3");
+	        	const textNode = document.createTextNode("Username or password incorrect");
+	        	h3.appendChild(textNode);
+	        	document.getElementById("result").appendChild(h3);
+	        }
+	    }
+	};
+	var data = JSON.stringify({
+		"user": document.getElementById("user").value,
+		"password": document.getElementById("password").value});
+	xhr.send(data);
+}
+
+document.getElementById('password').onkeydown = function(e){
+	if (e.keyCode == 13) {
+		// Handle return key
+		submitform();
+	}
+};
+
+</script>
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-auth/openapi.json
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-auth/openapi.json
@@ -1,0 +1,42 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Simple OpenAPI Example",
+    "description": "A simple API that defines just one unauthenticated endpoint",
+    "contact": {
+      "name": "ZAP Core Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "localhost:9091",
+  "basePath": "/api/openapi/simple-auth",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/test-api": {
+      "get": {
+        "description": "A simple API endpoint",
+        "operationId": "test",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "API response"
+            }
+        }
+      }
+    }
+  }
+}

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-unauth/index.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-unauth/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Simple OpenAPI Spec, no Authentication</H1>
+	<p>
+	OpenAPI spec in openapi.yaml
+	<p>
+	
+</div>
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-unauth/openapi.yaml
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-unauth/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Example Spec
+  version: 1.0.0
+servers:
+  - url: http://localhost:9091
+paths:
+  /api/openapi/simple-unauth/api-test:
+    post:
+      summary: Example Endpoint
+      description: This is an example endpoint.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                foo: bar
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: { }

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-unauth/test-api
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/api/openapi/simple-unauth/test-api
@@ -1,0 +1,3 @@
+{
+  "result": "success"
+}


### PR DESCRIPTION
## Overview
Added OpenAPI auth and unauth test pages.
Plan to use these for integration testing (eg the packaged API scan) and authenticated OpenAPI import.

## Related Issues

Related to https://github.com/zaproxy/zaproxy/issues/8021

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
