### PR TITLE
automation: correct output of array values

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct output of array values set to the jobs.
 
 ## [0.31.0] - 2023-09-07
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -298,7 +298,7 @@ public class JobUtils {
                                             "automation.info.setparam",
                                             objectName, // TODO changed param
                                             key,
-                                            value));
+                                            toStringValue(value)));
                         } catch (Exception e) {
                             progress.error(
                                     Constant.messages.getString(
@@ -324,6 +324,13 @@ public class JobUtils {
                                 "automation.error.options.unknown", objectName, key));
             }
         }
+    }
+
+    private static Object toStringValue(Object value) {
+        if (value == null || !value.getClass().isArray()) {
+            return value;
+        }
+        return Arrays.toString((Object[]) value);
     }
 
     public static void applyObjectToObject(
@@ -471,7 +478,7 @@ public class JobUtils {
         } else if (List.class.equals(t)) {
             if (obj instanceof List) {
                 List<T> list = new ArrayList<>();
-                list.addAll((ArrayList) obj);
+                list.addAll((List) obj);
                 return (T) list;
             } else {
                 LOGGER.error("Unable to map to an List from {}", obj.getClass().getCanonicalName());


### PR DESCRIPTION
Convert the array to string beforehand as the array to string just shows the class name.
Fix cast of list, use interface instead of implementation.
Remove unnecessary stubbings.