### PR TITLE
Use vulnerability classes from `commonlib`

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.13.0.
 - Depend on Common Library add-on.
+- Use vulnerability data directly from Common Library add-on.
 - Maintenance changes.
 
 ## [8] - 2022-10-28

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
@@ -30,12 +30,12 @@ import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.extension.accessControl.AccessControlScannerThread.AccessControlNodeResult;
 import org.zaproxy.zap.extension.accessControl.AccessControlScannerThread.AccessControlResultEntry;
 import org.zaproxy.zap.extension.accessControl.AccessControlScannerThread.AccessControlScanStartOptions;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * The object that processes obtained scan results and raises {@link Alert Alerts}, if necessary.
@@ -45,10 +45,10 @@ import org.zaproxy.zap.model.Vulnerability;
 public class AccessControlAlertsProcessor {
     private static final Logger LOGGER = LogManager.getLogger(AccessControlAlertsProcessor.class);
 
-    private static Vulnerability vulnerabilityAuthentication =
-            Vulnerabilities.getVulnerability("wasc_1");
-    private static Vulnerability vulnerabilityAuthorization =
-            Vulnerabilities.getVulnerability("wasc_2");
+    private static final Vulnerability VULNERABILITY_AUTHENTICATION =
+            Vulnerabilities.getDefault().get("wasc_1");
+    private static final Vulnerability VULNERABILITY_AUTHORIZATION =
+            Vulnerabilities.getDefault().get("wasc_2");
 
     private static final String AUTHENTICATION_ALERT_TITLE =
             Constant.messages.getString("accessControl.alert.authentication.name");
@@ -120,15 +120,15 @@ public class AccessControlAlertsProcessor {
                 .setRisk(risk)
                 .setConfidence(Alert.CONFIDENCE_HIGH)
                 .setName(AUTHORIZATION_ALERT_TITLE)
-                .setDescription(Vulnerabilities.getDescription(vulnerabilityAuthorization))
+                .setDescription(VULNERABILITY_AUTHORIZATION.getDescription())
                 .setOtherInfo(
                         Constant.messages.getString(
                                 "accessControl.alert.authorization.otherinfo",
                                 userName,
                                 requestAuthorized,
                                 accessRule))
-                .setSolution(Vulnerabilities.getSolution(vulnerabilityAuthorization))
-                .setReference(Vulnerabilities.getReference(vulnerabilityAuthorization))
+                .setSolution(VULNERABILITY_AUTHORIZATION.getSolution())
+                .setReference(VULNERABILITY_AUTHORIZATION.getReferencesAsString())
                 .setCweId(205)
                 .setWascId(2)
                 .setUri(uri)
@@ -162,14 +162,14 @@ public class AccessControlAlertsProcessor {
                 .setRisk(risk)
                 .setConfidence(Alert.CONFIDENCE_HIGH)
                 .setName(AUTHENTICATION_ALERT_TITLE)
-                .setDescription(Vulnerabilities.getDescription(vulnerabilityAuthentication))
+                .setDescription(VULNERABILITY_AUTHENTICATION.getDescription())
                 .setOtherInfo(
                         Constant.messages.getString(
                                 "accessControl.alert.authentication.otherinfo",
                                 requestAuthorized,
                                 accessRule))
-                .setSolution(Vulnerabilities.getSolution(vulnerabilityAuthentication))
-                .setReference(Vulnerabilities.getReference(vulnerabilityAuthentication))
+                .setSolution(VULNERABILITY_AUTHENTICATION.getSolution())
+                .setReference(VULNERABILITY_AUTHENTICATION.getReferencesAsString())
                 .setCweId(287)
                 .setWascId(1)
                 .setUri(uri)

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Depend on newer version of Common Library add-on.
+- Use vulnerability data directly from Common Library add-on.
 
 ## [56] - 2023-07-11
 ### Added

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
@@ -42,12 +42,12 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.extension.ascanrules.timing.TimingUtils;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * Active scan rule for Command Injection testing and verification.
@@ -288,7 +288,7 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
     private static final Logger LOGGER = LogManager.getLogger(CommandInjectionScanRule.class);
 
     // Get WASC Vulnerability description
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_31");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_31");
 
     /** The number of seconds used in time-based attacks (i.e. sleep commands). */
     private int timeSleepSeconds = DEFAULT_TIME_SLEEP_SEC;
@@ -325,11 +325,7 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -39,10 +39,10 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.extension.ascanrules.httputils.HtmlContext;
 import org.zaproxy.zap.extension.ascanrules.httputils.HtmlContextAnalyser;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
 
@@ -89,7 +89,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
 
     private static final String HEADER_SPLITTING = "\n\r\n\r";
 
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_8");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_8");
     private static final Logger LOGGER = LogManager.getLogger(CrossSiteScriptingScanRule.class);
     private int currentParamType;
 
@@ -105,10 +105,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -118,25 +115,12 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
@@ -42,8 +42,8 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /**
  * Reviewed scan rule for External Redirect
@@ -112,7 +112,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
     };
 
     // Get WASC Vulnerability description
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_38");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_38");
 
     private static final Logger LOGGER = LogManager.getLogger(ExternalRedirectScanRule.class);
 
@@ -128,10 +128,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -141,28 +138,12 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-
-                sb.append(ref);
-            }
-
-            return sb.toString();
-        }
-
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     /**

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -40,10 +40,10 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.addon.network.common.ZapSocketTimeoutException;
 import org.zaproxy.zap.model.Tech;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /** A scan rule that looks for Path Traversal vulnerabilities. */
 public class PathTraversalScanRule extends AbstractAppParamPlugin {
@@ -177,7 +177,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
     /*
      * details of the vulnerability which we are attempting to find
      */
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_33");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_33");
 
     private static final Logger LOGGER = LogManager.getLogger(PathTraversalScanRule.class);
 
@@ -193,10 +193,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -206,26 +203,12 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     /**

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
@@ -37,10 +37,10 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.SourceSinkUtils;
 import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.extension.ascanrules.httputils.HtmlContext;
 import org.zaproxy.zap.extension.ascanrules.httputils.HtmlContextAnalyser;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 public class PersistentXssScanRule extends AbstractAppParamPlugin {
 
@@ -57,7 +57,7 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
     private static final List<Integer> GET_POST_TYPES =
             Arrays.asList(NameValuePair.TYPE_QUERY_STRING, NameValuePair.TYPE_POST_DATA);
 
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_8");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_8");
     private static final Logger LOGGER = LogManager.getLogger(PersistentXssScanRule.class);
     private int currentParamType;
 
@@ -78,10 +78,7 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -91,25 +88,12 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRule.java
@@ -33,10 +33,10 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * a scan rule that looks for, and exploits CVE-2012-1823 to perform Remote Code Execution on a
@@ -50,7 +50,7 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin {
      * details of the vulnerability which we are attempting to find WASC 20 = Improper Input
      * Handling
      */
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_20");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_20");
 
     /** the logger object */
     private static final Logger LOGGER =
@@ -101,10 +101,7 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -114,25 +111,12 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
@@ -34,8 +34,8 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /** a scanner that looks for Remote File Include vulnerabilities */
 public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
@@ -99,7 +99,7 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
     private static final int REQ_PER_PARAM_INSANE = REMOTE_FILE_TARGET_PREFIXES.length;
 
     /** details of the vulnerability which we are attempting to find */
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_5");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_5");
 
     /** the logger object */
     private static final Logger LOGGER = LogManager.getLogger(RemoteFileIncludeScanRule.class);
@@ -116,10 +116,7 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -129,25 +126,12 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRule.java
@@ -35,10 +35,10 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * a scan rule that looks for, and exploits CVE-2012-1823 to disclose PHP application source code
@@ -72,7 +72,7 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin {
      * details of the vulnerability which we are attempting to find WASC 20 = Improper Input
      * Handling
      */
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_20");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_20");
 
     private static final Logger LOGGER =
             LogManager.getLogger(SourceCodeDisclosureCve20121823ScanRule.class);
@@ -97,10 +97,7 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -110,25 +107,12 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -42,8 +42,8 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /**
  * a scanner that looks for Java classes disclosed via the WEB-INF folder and that decompiles them
@@ -91,7 +91,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
      * details of the vulnerability which we are attempting to find 34 = Predictable Resource
      * Location
      */
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_34");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_34");
 
     private static final Logger LOGGER =
             LogManager.getLogger(SourceCodeDisclosureWebInfScanRule.class);
@@ -108,10 +108,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -121,25 +118,12 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/XpathInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/XpathInjectionScanRule.java
@@ -29,8 +29,8 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /**
  * Active scan rule for Xpath Injection testing and verification. WASC Reference:
@@ -90,7 +90,7 @@ public class XpathInjectionScanRule extends AbstractAppParamPlugin {
                     CommonAlertTag.WSTG_V42_INPV_09_XPATH);
 
     // Get WASC Vulnerability description
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_39");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_39");
 
     // Logger instance
     private static final Logger LOGGER = LogManager.getLogger(XpathInjectionScanRule.class);
@@ -107,11 +107,7 @@ public class XpathInjectionScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -121,27 +117,12 @@ public class XpathInjectionScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/XxeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/XxeScanRule.java
@@ -34,9 +34,9 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.addon.oast.ExtensionOast;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing
@@ -49,7 +49,7 @@ public class XxeScanRule extends AbstractAppPlugin {
     private static final int PLUGIN_ID = 90023;
 
     // Get the correct vulnerability description from WASC
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_43");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_43");
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A03_INJECTION,
@@ -118,10 +118,7 @@ public class XxeScanRule extends AbstractAppPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -131,29 +128,12 @@ public class XxeScanRule extends AbstractAppPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-
-                sb.append(ref);
-            }
-
-            return sb.toString();
-        }
-
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Remove the dependency on OAST add-on, no longer required.
 - Depend on newer version of Common Library add-on.
+- Use vulnerability data directly from Common Library add-on.
 
 ## [43] - 2023-07-20
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanRule.java
@@ -28,10 +28,10 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * An example active scan rule, for more details see
@@ -42,7 +42,7 @@ import org.zaproxy.zap.model.Vulnerability;
 public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin {
 
     // wasc_10 is Denial of Service - well, its just an example ;)
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_10");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_10");
 
     private Random rnd = new Random();
 
@@ -60,10 +60,7 @@ public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         // Strip off the "Example Active Scan Rule: " part if implementing a real one ;)
-        if (vuln != null) {
-            return "Example Active Scan Rule: " + vuln.getAlert();
-        }
-        return "Example Active Scan Rule: Denial of Service";
+        return "Example Active Scan Rule: " + VULN.getName();
     }
 
     @Override
@@ -77,10 +74,7 @@ public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -90,25 +84,12 @@ public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append("\n");
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     /*

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Depend on newer version of Common Library add-on.
+- Use vulnerability data directly from Common Library add-on.
 
 ### Fixed
 - The Source Code Disclosure - File Inclusion alerts now consistently leverage the description and solution from the associated vulnerability details.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
@@ -35,8 +35,8 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /**
  * a scan rule that looks for backup files disclosed on the web server
@@ -284,7 +284,7 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
      * details of the vulnerability which we are attempting to find 34 = "Predictable Resource
      * Location"
      */
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_34");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_34");
 
     private static final Logger LOGGER = LogManager.getLogger(BackupFileDisclosureScanRule.class);
 
@@ -310,10 +310,7 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
@@ -42,10 +42,10 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.extension.httpsessions.HttpSessionsParam;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * CsrfTokenScanRule is an effort to improve the anti-CSRF token detection of ZAP It is based on
@@ -66,7 +66,7 @@ public class CsrfTokenScanRule extends AbstractAppPlugin {
     private String ignoreAttValue;
 
     // WASC Threat Classification (WASC-9)
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_9");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_9");
 
     private static final Logger LOGGER = LogManager.getLogger(CsrfTokenScanRule.class);
 
@@ -82,10 +82,7 @@ public class CsrfTokenScanRule extends AbstractAppPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -95,25 +92,12 @@ public class CsrfTokenScanRule extends AbstractAppPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append("\n");
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
@@ -52,8 +52,8 @@ import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /**
  * a scan rule that looks for known insecure HTTP methods enabled for the URL Note that HTTP methods
@@ -78,7 +78,7 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
             Arrays.asList("COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "UNLOCK");
 
     /** details of the vulnerability which we are attempting to find 45 = "Fingerprinting" */
-    private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_45");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_45");
 
     /** the logger object */
     private static final Logger LOGGER = LogManager.getLogger(InsecureHttpMethodScanRule.class);
@@ -113,10 +113,7 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -126,25 +123,12 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/OutOfBandXssScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/OutOfBandXssScanRule.java
@@ -32,13 +32,13 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.addon.oast.ExtensionOast;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 public class OutOfBandXssScanRule extends AbstractAppParamPlugin {
 
-    private static final Vulnerability VULN = Vulnerabilities.getVulnerability("wasc_8");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_8");
     private static final int PLUGIN_ID = 40031;
     private static final Logger LOGGER = LogManager.getLogger(OutOfBandXssScanRule.class);
 
@@ -68,10 +68,7 @@ public class OutOfBandXssScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (VULN != null) {
-            return VULN.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -81,25 +78,12 @@ public class OutOfBandXssScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (VULN != null) {
-            return VULN.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (VULN != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : VULN.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
@@ -35,8 +35,8 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /**
  * Goal: automate discovery of areas of a website where authentication via session cookies, or
@@ -61,7 +61,7 @@ public class SlackerCookieScanRule extends AbstractAppPlugin {
                     CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG,
                     CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG,
                     CommonAlertTag.WSTG_V42_SESS_02_COOKIE_ATTRS);
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_45");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_45");
     private static final Logger LOGGER = LogManager.getLogger(SlackerCookieScanRule.class);
 
     @Override
@@ -310,17 +310,7 @@ public class SlackerCookieScanRule extends AbstractAppPlugin {
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append("\n");
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Cookie Slack Detector: Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -34,9 +34,9 @@ import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.DiceMatcher;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.model.Tech;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * a scan rule that looks for application source code disclosure using path traversal techniques
@@ -106,7 +106,7 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
     };
 
     /** details of the vulnerability which we are attempting to find 33 = "Path Traversal" */
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_33");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_33");
 
     /** the logger object */
     private static final Logger LOGGER =
@@ -153,10 +153,7 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -166,25 +163,12 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
@@ -36,8 +36,8 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /**
  * a scan rule that looks for application source code disclosure using Git metadata/file disclosure
@@ -50,7 +50,7 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
      * details of the vulnerability which we are attempting to find 34 = "Predictable Resource
      * Location"
      */
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_34");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_34");
 
     /** the logger object */
     private static final Logger LOGGER =
@@ -103,17 +103,7 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     private String getEvidence(String filename, String gitURIs) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
@@ -42,8 +42,8 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 /**
  * a scan rule that looks for application source code disclosure using SVN metadata/file disclosure
@@ -69,7 +69,7 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
      * details of the vulnerability which we are attempting to find 34 = "Predictable Resource
      * Location"
      */
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_34");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_34");
 
     /** the logger object */
     private static final Logger LOGGER =
@@ -124,17 +124,7 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     public String getExtraInfo(String urlfilename, String attackFilename) {

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
 class SourceCodeDisclosureFileInclusionScanRuleUnitTest
         extends ActiveScannerTest<SourceCodeDisclosureFileInclusionScanRule> {
@@ -67,7 +67,7 @@ class SourceCodeDisclosureFileInclusionScanRuleUnitTest
     @Test
     void shouldReturnExpectedExampleAlert() {
         // Given
-        Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_33");
+        Vulnerability vuln = Vulnerabilities.getDefault().get("wasc_33");
         // When
         List<Alert> alerts = rule.getExampleAlerts();
         // Then

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Depend on newer version of Common Library add-on.
+- Use vulnerability data directly from Common Library add-on.
 
 ## [16] - 2023-07-11
 ### Changed

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -58,18 +58,18 @@ import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.addon.network.server.Server;
 import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 import org.zaproxy.zap.utils.Stats;
 
 public class DomXssScanRule extends AbstractAppParamPlugin {
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_8");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_8");
     private static final Logger LOGGER = LogManager.getLogger(DomXssScanRule.class);
     private static final int UNLIKELY_INT = 5397;
     private static final String UNLIKELY_STR = String.valueOf(UNLIKELY_INT);
@@ -151,10 +151,7 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     @Override
@@ -164,25 +161,12 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - The alerts of the Hash Disclosure scan rule no longer have the evidence duplicated in the Other Info field.
 - Depend on newer version of Common Library add-on.
+- Use vulnerability data directly from Common Library add-on.
 
 ## [50] - 2023-07-11
 ### Added

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -38,11 +38,11 @@ import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * The CsrfCountermeasuresScanRule identifies *potential* vulnerabilities with the lack of known
@@ -53,7 +53,7 @@ import org.zaproxy.zap.model.Vulnerability;
 public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
 
     /** contains the base vulnerability that this plugin refers to */
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_9");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_9");
 
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
@@ -255,31 +255,15 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
     }
 
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use HTTPS and resolve redirections in the alert references.
 - The alerts ASP.NET ViewState Disclosure and ASP.NET ViewState Integrity no longer have the evidence duplicated in the Other Info field.
 - Depend on newer version of Common Library add-on.
+- Use vulnerability data directly from Common Library add-on.
 
 ## [40] - 2023-07-20
 ### Added

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java
@@ -27,9 +27,9 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * An example passive scan rule, for more details see
@@ -40,7 +40,7 @@ import org.zaproxy.zap.model.Vulnerability;
 public class ExampleSimplePassiveScanRule extends PluginPassiveScanner {
 
     // wasc_10 is Denial of Service - well, its just an example ;)
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_10");
+    private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_10");
     private static final Logger LOGGER = LogManager.getLogger(ExampleSimplePassiveScanRule.class);
 
     private Random rnd = new Random();
@@ -98,37 +98,18 @@ public class ExampleSimplePassiveScanRule extends PluginPassiveScanner {
     @Override
     public String getName() {
         // Strip off the "Example Passive Scan Rule: " part if implementing a real one ;)
-        if (vuln != null) {
-            return "Example Passive Scan Rule: " + vuln.getAlert();
-        }
-        return "Example Passive Scan Rule: Denial of Service";
+        return "Example Passive Scan Rule: " + VULN.getName();
     }
 
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return VULN.getDescription();
     }
 
     public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
+        return VULN.getSolution();
     }
 
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append("\n");
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return VULN.getReferencesAsString();
     }
 }

--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 ### Changed
 - Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
+- Use vulnerability data directly from Common Library add-on.
 
 ## [0.6.0] - 2023-07-11
 ### Changed

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/EditAlertPanel.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/EditAlertPanel.java
@@ -23,9 +23,6 @@ import java.awt.CardLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComboBox;
@@ -42,8 +39,8 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.network.HttpRequestHeader;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
+import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.utils.ZapTextArea;
@@ -71,8 +68,6 @@ public class EditAlertPanel extends AbstractPanel {
     private JComboBox<String> alertEditRisk = null;
     private ZapTextArea alertOtherInfo = null;
     private DefaultComboBoxModel<String> nameListModel = null;
-
-    private List<Vulnerability> vulnerabilities = null;
 
     public EditAlertPanel() {
         super();
@@ -135,10 +130,10 @@ public class EditAlertPanel extends AbstractPanel {
             alertEditName = new JComboBox<>();
             alertEditName.setEditable(true);
             nameListModel = new DefaultComboBoxModel<>();
-            List<String> allVulns = getAllVulnerabilityNames();
-            for (String vuln : allVulns) {
-                nameListModel.addElement(vuln);
-            }
+            Vulnerabilities.getDefault().getAll().stream()
+                    .map(Vulnerability::getName)
+                    .sorted()
+                    .forEach(nameListModel::addElement);
             alertEditName.setModel(nameListModel);
 
             alertEditMethod = new JComboBox<>();
@@ -257,23 +252,6 @@ public class EditAlertPanel extends AbstractPanel {
         alertEditEvidence.discardAllEdits();
         setAlertOtherInfo(alertData.getOtherInfo());
         cardLayout.show(this, getAlertPane().getName());
-    }
-
-    private List<Vulnerability> getAllVulnerabilities() {
-        if (vulnerabilities == null) {
-            vulnerabilities = Vulnerabilities.getAllVulnerabilities();
-        }
-        return vulnerabilities;
-    }
-
-    private List<String> getAllVulnerabilityNames() {
-        List<Vulnerability> vulns = this.getAllVulnerabilities();
-        List<String> names = new ArrayList<>(vulns.size());
-        for (Vulnerability v : vulns) {
-            names.add(v.getAlert());
-        }
-        Collections.sort(names);
-        return names;
     }
 
     private void setAlertOtherInfo(String otherInfo) {


### PR DESCRIPTION
Stop using the (deprecated) core classes and use the ones provided by the `commonlib` add-on.