### PR TITLE
Client: Fixes ZAP Browser Extension Configuration issue

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/RedirectScript.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/RedirectScript.java
@@ -38,5 +38,8 @@ public class RedirectScript implements BrowserHook {
         JavascriptExecutor jsExecutor = (JavascriptExecutor) ssutils.getWebDriver();
         jsExecutor.executeScript("localStorage.setItem('localzapurl', '" + zapurl + "')");
         jsExecutor.executeScript("localStorage.setItem('localzapenable',false)");
+
+        // This statement make sure that the ZAP browser extension is configured properly
+        ssutils.getWebDriver().get(zapurl);
     }
 }


### PR DESCRIPTION
- Earlier ZAP browser extension was behaving abnormally when launched from ZAP. It sometimes had the variables set and sometimes didn't. This was because of the race condition between setting of the local variables and accessing them. So we make a extra reload to ensure that the browser extension has been configured properly. 