### PR TITLE
scripts: Use workPanels font in output panel

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The Scripts output panel will now use the work panel font defined in Display settings (Issue 8065).
 
 ## [40] - 2023-09-11
 ### Changed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -45,7 +45,6 @@ import org.parosproxy.paros.extension.AbstractPanel;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.utils.DisplayUtils;
-import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.ZapToggleButton;
 
@@ -216,7 +215,6 @@ public class ConsolePanel extends AbstractPanel {
             panelToolbar.setFloatable(false);
             panelToolbar.setRollover(true);
             panelToolbar.setPreferredSize(new java.awt.Dimension(800, 30));
-            panelToolbar.setFont(FontUtils.getFont("Dialog"));
             panelToolbar.setName("ParamsToolbar");
 
             panelToolbar.add(this.getRunButton(), LayoutHelper.getGBC(0, 0, 1, 0.0D));

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanel.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
+import org.zaproxy.zap.utils.FontUtils.FontType;
 import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.view.ZapToggleButton;
 
@@ -169,7 +170,7 @@ public class OutputPanel extends AbstractPanel {
             jScrollPane.setName("ConsoleScrollPane");
             jScrollPane.setHorizontalScrollBarPolicy(
                     javax.swing.JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-            jScrollPane.setFont(FontUtils.getFont("Dialog"));
+            jScrollPane.setFont(FontUtils.getFont(FontType.workPanels));
         }
         return jScrollPane;
     }
@@ -184,7 +185,7 @@ public class OutputPanel extends AbstractPanel {
             txtOutput = new ZapTextArea();
             txtOutput.setEditable(false);
             txtOutput.setLineWrap(true);
-            txtOutput.setFont(FontUtils.getFont("Dialog"));
+            txtOutput.setFont(FontUtils.getFont(FontType.workPanels));
             txtOutput.setName("");
             txtOutput.setComponentPopupMenu(ZapPopupMenu.INSTANCE);
         }


### PR DESCRIPTION
## Overview
- CHANGELOG > Add change note.
- ConsolePanel > Don't set font.
- OutputPanel > Use workPanels font.

## Related Issues
Related to zaproxy/zaproxy#8065

## Checklist
- [x] Update help - N/A
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests - N/A
- [x] Check code coverage - N/A
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
