### PR TITLE
zest: Render scripts in YAML

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Allow rendering Zest scripts in YAML. The format (JSON/YAML) may be changed via the Zest Options screen.
 
+### Changed
+- Depend on Common Library add-on.
 
 ## [40] - 2023-09-11
 ### Added 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -90,6 +90,7 @@ import org.zaproxy.zest.core.v1.ZestExpression;
 import org.zaproxy.zest.core.v1.ZestExpressionLength;
 import org.zaproxy.zest.core.v1.ZestExpressionStatusCode;
 import org.zaproxy.zest.core.v1.ZestFieldDefinition;
+import org.zaproxy.zest.core.v1.ZestJSON;
 import org.zaproxy.zest.core.v1.ZestLoop;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestResponse;
@@ -97,6 +98,7 @@ import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 import org.zaproxy.zest.core.v1.ZestStructuredExpression;
 import org.zaproxy.zest.core.v1.ZestVariables;
+import org.zaproxy.zest.core.v1.ZestYaml;
 import org.zaproxy.zest.impl.ZestScriptEngineFactory;
 
 public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, ScriptEventListener {
@@ -1571,6 +1573,18 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
         }
         this.clientUrlToWindowHandle.put(url, windowHandle);
         return windowHandle;
+    }
+
+    public ZestElement convertStringToElement(String string) {
+        return "YAML".equals(getParam().getScriptFormat())
+                ? ZestYaml.fromString(string)
+                : ZestJSON.fromString(string);
+    }
+
+    public String convertElementToString(ZestElement element) {
+        return "YAML".equals(getParam().getScriptFormat())
+                ? ZestYaml.toString(element)
+                : ZestJSON.toString(element);
     }
 
     public void startClientRecording(String uri) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/OptionsZestPanel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/OptionsZestPanel.java
@@ -24,6 +24,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
@@ -37,6 +38,7 @@ public class OptionsZestPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;
     private JTable tableIgnoreHeaders = null;
+    private JComboBox<String> scriptFormat;
     private JCheckBox incResps = null;
     private JScrollPane jScrollPane = null;
     private OptionsZestIgnoreHeadersTableModel ignoreHeadersModel = null;
@@ -52,16 +54,24 @@ public class OptionsZestPanel extends AbstractParamPanel {
         this.setLayout(new GridBagLayout());
         this.setSize(409, 268);
         this.setName(Constant.messages.getString("zest.options.title"));
-        this.add(this.getIncResps(), LayoutHelper.getGBC(0, 0, 1, 1.0, new Insets(0, 0, 5, 0)));
+        int row = 0;
+        this.add(
+                new JLabel(Constant.messages.getString("zest.options.label.scriptFormat")),
+                LayoutHelper.getGBC(0, row, 1, 1.0, new Insets(0, 0, 5, 0)));
+        this.add(getScriptFormat(), LayoutHelper.getGBC(1, row, 1, 1.0, new Insets(0, 0, 5, 0)));
+        row++;
+        this.add(this.getIncResps(), LayoutHelper.getGBC(0, row, 2, 1.0, new Insets(0, 0, 5, 0)));
+        row++;
         this.add(
                 new JLabel(Constant.messages.getString("zest.options.label.ignoreheaders")),
-                LayoutHelper.getGBC(0, 1, 1, 1.0, new Insets(0, 0, 5, 0)));
+                LayoutHelper.getGBC(0, row, 2, 1.0, new Insets(0, 0, 5, 0)));
+        row++;
         this.add(
                 getJScrollPane(),
                 LayoutHelper.getGBC(
                         0,
+                        row,
                         2,
-                        1,
                         1.0,
                         1.0,
                         GridBagConstraints.BOTH,
@@ -76,6 +86,7 @@ public class OptionsZestPanel extends AbstractParamPanel {
         getIncResps().setSelected(param.isIncludeResponses());
         getModel().setAllHeaders(param.getAllHeaders());
         getModel().setIgnoredHeaders(param.getIgnoredHeaders());
+        getScriptFormat().setSelectedItem(param.getScriptFormat());
     }
 
     @Override
@@ -87,6 +98,15 @@ public class OptionsZestPanel extends AbstractParamPanel {
         ZestParam param = optionsParam.getParamSet(ZestParam.class);
         param.setIncludeResponses(getIncResps().isSelected());
         param.setIgnoredHeaders(getModel().getIgnoredHeaders());
+        param.setScriptFormat((String) getScriptFormat().getSelectedItem());
+    }
+
+    private JComboBox<String> getScriptFormat() {
+        if (scriptFormat == null) {
+            scriptFormat = new JComboBox<>(new String[] {"JSON", "YAML"});
+            scriptFormat.setSelectedIndex(0);
+        }
+        return scriptFormat;
     }
 
     private JCheckBox getIncResps() {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
@@ -83,6 +83,7 @@ public class ZestParam extends AbstractParam {
 
     private static final String IGNORE_HEADERS_KEY = DEFAULT_ZEST_KEY + ".ignoreHeaders";
     private static final String INCLUDE_RESPONSES_KEY = DEFAULT_ZEST_KEY + ".incResponses";
+    private static final String ZEST_FORMAT_KEY = DEFAULT_ZEST_KEY + ".scriptFormat";
 
     /** The Constant log. */
     private static final Logger LOGGER = LogManager.getLogger(ZestParam.class);
@@ -95,12 +96,15 @@ public class ZestParam extends AbstractParam {
 
     private boolean includeResponses = true;
 
+    private String scriptFormat = "JSON";
+
     /** Instantiates a new Zest param. */
     public ZestParam() {}
 
     @Override
     protected void parse() {
         this.includeResponses = getBoolean(INCLUDE_RESPONSES_KEY, true);
+        this.scriptFormat = sanitizeScriptFormat(getString(ZEST_FORMAT_KEY, "JSON"));
         try {
 
             this.allHeaders.clear();
@@ -155,5 +159,21 @@ public class ZestParam extends AbstractParam {
     public void setIncludeResponses(boolean includeResponses) {
         this.includeResponses = includeResponses;
         getConfig().setProperty(INCLUDE_RESPONSES_KEY, this.includeResponses);
+    }
+
+    public String getScriptFormat() {
+        return scriptFormat;
+    }
+
+    public void setScriptFormat(String scriptFormat) {
+        this.scriptFormat = sanitizeScriptFormat(scriptFormat);
+        getConfig().setProperty(ZEST_FORMAT_KEY, this.scriptFormat);
+    }
+
+    private static String sanitizeScriptFormat(String format) {
+        if (format != null && "YAML".equalsIgnoreCase(format.strip())) {
+            return "YAML";
+        }
+        return "JSON";
     }
 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -28,7 +28,6 @@ import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
-import org.zaproxy.zest.core.v1.ZestJSON;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestScript.Type;
 
@@ -50,7 +49,7 @@ public class ZestScriptWrapper extends ScriptWrapper {
 
     public ZestScriptWrapper(ScriptWrapper script) {
         this.original = script;
-        zestScript = (ZestScript) ZestJSON.fromString(script.getContents());
+        zestScript = (ZestScript) getExtension().convertStringToElement(script.getContents());
         if (zestScript == null) {
             // new script
             zestScript = new ZestScript();
@@ -189,7 +188,7 @@ public class ZestScriptWrapper extends ScriptWrapper {
 
     @Override
     public String getContents() {
-        return ZestJSON.toString(this.zestScript);
+        return getExtension().convertElementToString(this.zestScript);
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -42,7 +42,6 @@ import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.view.StandardFieldsDialog;
-import org.zaproxy.zest.core.v1.ZestJSON;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.impl.ZestScriptEngineFactory;
 
@@ -235,7 +234,7 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
 
         scriptWrapper.setName(script.getTitle());
         scriptWrapper.setDescription(script.getDescription());
-        scriptWrapper.setContents(ZestJSON.toString(script));
+        scriptWrapper.setContents(extension.convertElementToString(script));
         scriptWrapper.setLoadOnStart(this.getBoolValue(FIELD_LOAD));
 
         if (this.isServerSide()) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
@@ -49,7 +49,6 @@ import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestAuthentication;
 import org.zaproxy.zest.core.v1.ZestHttpAuthentication;
-import org.zaproxy.zest.core.v1.ZestJSON;
 import org.zaproxy.zest.core.v1.ZestScript;
 
 @SuppressWarnings("serial")
@@ -361,7 +360,7 @@ public class ZestScriptsDialog extends StandardFieldsDialog {
 
         scriptWrapper.setName(script.getTitle());
         scriptWrapper.setDescription(script.getDescription());
-        scriptWrapper.setContents(ZestJSON.toString(script));
+        scriptWrapper.setContents(extension.convertElementToString(script));
         scriptWrapper.setLoadOnStart(this.getBoolValue(FIELD_LOAD));
         scriptWrapper.setDebug(this.getBoolValue(FIELD_DEBUG));
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestGenerateScriptFromAlertMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestGenerateScriptFromAlertMenu.java
@@ -40,7 +40,6 @@ import org.zaproxy.zest.core.v1.ZestActionFail;
 import org.zaproxy.zest.core.v1.ZestComment;
 import org.zaproxy.zest.core.v1.ZestConditional;
 import org.zaproxy.zest.core.v1.ZestExpressionRegex;
-import org.zaproxy.zest.core.v1.ZestJSON;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestVariables;
 
@@ -191,7 +190,7 @@ public class ZestGenerateScriptFromAlertMenu extends PopupMenuItemHttpMessageCon
         ScriptWrapper sw = new ScriptWrapper();
         sw.setName(sz.getTitle());
         sw.setDescription(sz.getDescription());
-        sw.setContents(ZestJSON.toString(sz));
+        sw.setContents(extension.convertElementToString(sz));
         sw.setType(extension.getExtScript().getScriptType(ExtensionScript.TYPE_STANDALONE));
         sw.setEngine(this.extension.getZestEngineWrapper());
 

--- a/addOns/zest/src/main/resources/org/zaproxy/zap/extension/zest/resources/Messages.properties
+++ b/addOns/zest/src/main/resources/org/zaproxy/zap/extension/zest/resources/Messages.properties
@@ -549,6 +549,7 @@ zest.options.label.header = Header
 zest.options.label.ignore = Ignore
 zest.options.label.ignoreheaders = Headers to ignore when recording Zest scripts
 zest.options.label.incresponses = Include responses
+zest.options.label.scriptFormat = Script Format
 zest.options.title = Zest
 
 zest.parameterize.popup = Zest: Parameterize Text...

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/VerifyScriptTemplates.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/VerifyScriptTemplates.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.zaproxy.zap.testutils.AbstractVerifyScriptTemplates;
-import org.zaproxy.zest.core.v1.ZestJSON;
+import org.zaproxy.zest.core.v1.ZestYaml;
 
 /** Verifies that the Zest script templates are parsed without errors. */
 public class VerifyScriptTemplates extends AbstractVerifyScriptTemplates {
@@ -35,6 +35,6 @@ public class VerifyScriptTemplates extends AbstractVerifyScriptTemplates {
 
     @Override
     protected void parseTemplate(Path template) throws Exception {
-        ZestJSON.fromString(new String(Files.readAllBytes(template), StandardCharsets.UTF_8));
+        ZestYaml.fromString(new String(Files.readAllBytes(template), StandardCharsets.UTF_8));
     }
 }

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -22,23 +22,29 @@ zapAddOn {
         url.set("https://www.zaproxy.org/docs/desktop/addons/zest/")
         dependencies {
             addOns {
+                register("commonlib") {
+                    version.set(">=1.16.0")
+                }
                 register("network") {
                     version.set(">=0.2.0")
                 }
+                register("scripts")
                 register("selenium") {
                     version.set(">= 15.13.0")
                 }
-                register("scripts")
             }
         }
     }
 }
 
 dependencies {
+    zapAddOn("commonlib")
     zapAddOn("network")
     zapAddOn("selenium")
 
-    implementation("org.zaproxy:zest:0.18.0") {
+    implementation("org.zaproxy:zest:0.19.0") {
+        // Provided by commonlib add-on.
+        exclude(group = "com.fasterxml.jackson")
         // Provided by Selenium add-on.
         exclude(group = "org.seleniumhq.selenium")
         // Provided by ZAP.


### PR DESCRIPTION
## Overview
Allow rendering Zest scripts in YAML. The format (JSON/YAML) may be changed via the Zest Options screen.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

