### PR TITLE
postman: Fix class loader issue

### DIFF
--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
@@ -21,6 +21,7 @@ package org.zaproxy.addon.postman;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -80,6 +81,9 @@ public class PostmanParser {
 
     public PostmanCollection parse(String collectionJson) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setTypeFactory(
+                TypeFactory.defaultInstance()
+                        .withClassLoader(PostmanParser.class.getClassLoader()));
         return objectMapper.readValue(collectionJson, PostmanCollection.class);
     }
 


### PR DESCRIPTION
## Overview
All add-ons have their own class loader and they are isolated from each other (unless they explicitly depend on others), with the move of Jackson libraries to `commonlib` add-on Jackson started to use the class loader of `commonlib` instead of `postman` which caused the deserialisation to fail to find the `postman` classes (as `commonlib` does not depend on `postman`). The change done in `PostmanParser` ensures Jackson uses the `postman` class loader and thus able to find the `postman` classes. The change in `ListDeserializer` is just to use the same configuration we set up initially (otherwise we would have to configure the `ObjectMapper` once again).

Thanks @thc202 for the fix and explanation :)

## Checklist
- [x] Update help (N/A)
- [x] Update changelog (N/A)
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests (N/A)
- [x] Check code coverage (N/A)
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

