### PR TITLE
reports: handle alert with empty desc

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
+### Fixed
+- Fix error when generating the High Level Report Sample with an alert that has an empty description (Issue 8071).
+
 ## [0.24.0] - 2023-08-17
 ### Changed
 - Maintenance changes.

--- a/addOns/reports/src/main/zapHomeFiles/reports/high-level-report/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/high-level-report/report.html
@@ -250,7 +250,7 @@
 										href="#">Alert Name</a>
 								</span></td>
 								<td><span
-									th:with="desc=${#strings.arraySplit(alert.userObject.description, '\n')[0]}">
+									th:with="desc=${#strings.isEmpty(alert.userObject.description) ? '' : #strings.arraySplit(alert.userObject.description, '\n')[0]}">
 										<div th:text="${desc}">Description</div>
 								</span></td>
 							</tr>

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -696,6 +696,13 @@ class ExtensionReportsUnitTest {
         AlertNode root = new AlertNode(0, "Test");
         reportData.setAlertTreeRootNode(root);
         root.add(getAlertNode("XSS", "XSS Description", Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+
+        Alert emptyAlert = new Alert(1, 1, 1, "");
+        emptyAlert.setMessage(new HttpMessage(new URI("http://example.com", true)));
+        AlertNode instanceEmptyAlert = new AlertNode(0, "");
+        instanceEmptyAlert.setUserObject(emptyAlert);
+        root.add(instanceEmptyAlert);
+
         addSites(reportData);
         return reportData;
     }
@@ -724,6 +731,7 @@ class ExtensionReportsUnitTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
+                "high-level-report",
                 "traditional-json",
                 "traditional-json-plus",
                 "traditional-md",
@@ -1170,6 +1178,7 @@ class ExtensionReportsUnitTest {
             Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
             Model.getSingleton().getOptionsParam().load(new ZapXmlConfiguration());
 
+            generateTestFile("high-level-report");
             generateTestFile("traditional-json");
             generateTestFile("traditional-md");
             generateTestFile("traditional-xml");

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-high-level-report.html
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-high-level-report.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Test Title</title>
+
+<script src="basic-high-level-report/Chart.min.js" type="text/javascript"></script>
+<script src="basic-high-level-report/main.js"
+	type="text/javascript"></script>
+<link rel="stylesheet" href="basic-high-level-report/Chart.min.css">
+<!-- CSS only -->
+
+<link rel="stylesheet" href="basic-high-level-report/main.css">
+<link rel="stylesheet" href="basic-high-level-report/bootstrap.min.css">
+<link rel="stylesheet" href="basic-high-level-report/normalize.css">
+
+</head>
+<body>
+	<!-- Header material for report template -->
+	<div class="container">
+		<div class="row"></div>
+		<div class="row">
+			<div class="mx-auto" style="width: 50%;">
+				
+					<h1>
+						<!-- The ZAP Logo -->
+						<img src="basic-high-level-report/zap32x32.png" alt="">
+						<th>Test Title</th>
+					</h1>
+				
+			</div>
+		</div>
+		<div class="row"></div>
+		<div class="row">
+			<em
+				class="text-right">!reports.report.generated!</em> <em
+				class="text-right">!reports.report.zapVersion!</em>
+		</div>
+	</div>
+	<p></p>
+
+	<!-- Description, and first row of charts-->
+	<div class="container ">
+		
+
+
+
+			<div class="row">
+				<div class="col-md-2 col-lg-2 col-sm-3 col-xs-12">
+					<div class="row">
+						<p></p>
+					</div>
+					<div class="row border-bottom">
+						<b>Most Severe Alert</b> <br> <span
+							class="risk-3">High</span>   <span
+							class="risk-0">Informational</span>
+					</div>
+
+				</div>
+
+
+				
+					<th>
+						<div class="col-md-5 col-lg-5 col-sm-9 col-xs-12 piChartWrapper">
+							<canvas class="styled_canvas" id="summaryChart" width="100%"
+								height="100%"></canvas>
+						</div>
+					</th>
+				
+
+				<script type="text/javascript">
+                    /*<![CDATA[*/
+                    var title = "Vulnerability Severity";
+                    var labels = [
+                    "!reports.report.risk.3!",
+                    "!reports.report.risk.2!",
+                    "!reports.report.risk.1!",
+                    "!reports.report.risk.0!"];
+                    var data = [
+                    1,
+                    null,
+                    null,
+                    1];
+                    /*]]>*/
+
+                    renderSummaryChart(title, labels, data);
+                </script>
+
+				
+
+
+					<div
+						class="col-md-5 col-lg-4 col-sm-9 col-xs-12 piChartWrapper styled_canvas">
+						<h3>Report Description</h3>
+						<ul>
+							
+								<li>Test Description</li>
+								
+							
+						</ul>
+
+					</div>
+
+				
+
+			</div>
+		
+
+	</div>
+	<p></p>
+	<div class="container left_right_borders">
+		<div class="row">
+
+			<div class="col-md-2 col-lg-3 col-sm-6 col-xs-12">
+				<div class="row">
+					<p></p>
+				</div>
+				<div class="row border-bottom">
+					<b>Most Common Bug</b><br>
+					<span id="common_bug"></span>
+				</div>
+				<div class="row"></div>
+			</div>
+
+			
+				<div
+					class="col-md-10 col-lg-9 col-sm-12 col-xs-12 horizontalBarChartWrapper">
+					<canvas class="styled_canvas" id="summaryChartBugs" width="100%"
+						height="50%"></canvas>
+				</div>
+			
+			<script type="text/javascript">
+                initializeSummaryBugsChartRender();
+            </script>
+			<script type="text/javascript">
+                    /*<![CDATA[*/
+                    bugs_count = 2;
+                    bugs_label = "XSS";
+                    risk = "!reports.report.risk.3!";
+                    bugs_color = ""
+                    if (risk === "High") {
+                        bugs_color = "red";
+                    } else if (risk === "Medium") {
+                        bugs_color = "orange";
+                    } else if (risk === "Low") {
+                        bugs_color = "yellow";
+                    } else {
+                        bugs_color = "blue";
+                    }
+                    if (bugs_count > highest_count) {
+                        highest_count = bugs_count;
+                        most_common_bug = bugs_label;
+                        most_common_bug_color = bugs_color;
+                        document.getElementById('common_bug').innerText = most_common_bug
+                                + ' (' + bugs_count + ')';
+                    }
+                    all_bugs_count.push(bugs_count)
+                    all_colors.push(bugs_color)
+                    all_labels.push(bugs_label)
+                    /*]]>*/
+                </script><script type="text/javascript">
+                    /*<![CDATA[*/
+                    bugs_count = 0;
+                    bugs_label = "";
+                    risk = "!reports.report.risk.0!";
+                    bugs_color = ""
+                    if (risk === "High") {
+                        bugs_color = "red";
+                    } else if (risk === "Medium") {
+                        bugs_color = "orange";
+                    } else if (risk === "Low") {
+                        bugs_color = "yellow";
+                    } else {
+                        bugs_color = "blue";
+                    }
+                    if (bugs_count > highest_count) {
+                        highest_count = bugs_count;
+                        most_common_bug = bugs_label;
+                        most_common_bug_color = bugs_color;
+                        document.getElementById('common_bug').innerText = most_common_bug
+                                + ' (' + bugs_count + ')';
+                    }
+                    all_bugs_count.push(bugs_count)
+                    all_colors.push(bugs_color)
+                    all_labels.push(bugs_label)
+                    /*]]>*/
+                </script>
+			<script type="text/javascript">
+                title = "Count of Vulnerability Occurrences";
+                class_of_most_common_bug = ''
+                if (most_common_bug_color === 'red')
+                    new_class = 'risk-3'
+                else if (most_common_bug_color === 'orange')
+                    new_class = 'risk-2'
+                else if (most_common_bug_color === 'yellow')
+                    new_class = 'risk-1'
+                else if (most_common_bug_color === 'blue')
+                    new_class = 'risk-0'
+                document.getElementById('common_bug').classList.add(new_class);
+                renderSummaryBugsChart(title, all_labels, all_bugs_count,
+                        all_colors);
+            </script>
+			<p></p>
+		</div>
+	</div>
+	<p></p>
+
+	<div class="container">
+
+		
+			<div class="row">
+
+				<h3>Vulnerability Impact</h3>
+				<table class="alerts table table-hover table-bordered table-striped">
+					<caption>
+						<div>Vulnerability Descriptions</div>
+					</caption>
+					<tr>
+						<th width="5%" align="center" scope="col">#</th>
+						<th width="20%" align="center" scope="col">Name</th>
+						<th width="75%" align="center" scope="col">Impact</th>
+					</tr>
+					
+						
+							<tr>
+
+								
+								
+								
+								
+
+								<td><span>XSS</span> <span>
+										<a title="Reference 1: Test Reference"
+										href="Test Reference">[1]</a>
+								</span></td>
+								<td><span>
+										<div>XSS Description</div>
+								</span></td>
+							</tr>
+						
+							<tr>
+
+								
+								
+								
+								
+
+								<td><span></span> </td>
+								<td><span>
+										<div></div>
+								</span></td>
+							</tr>
+						
+					
+				</table>
+				<div class="spacer-lg"></div>
+			</div>
+		
+	</div>
+
+	<!-- JavaScript Bundle with Popper -->
+	<script src="basic-high-level-report/bootstrap.bundle.min.js" type="text/javascript"></script>
+	<script src="basic-high-level-report/main.js"
+		type="text/javascript"></script>
+</body>
+</html>
+

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html-plus.html
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html-plus.html
@@ -58,7 +58,7 @@
             1,
             null,
             null,
-            null];
+            1];
             /*]]>*/
             new Chart(document.getElementById("summaryChart"),
                     {
@@ -127,7 +127,7 @@
 					<div>!reports.report.risk.0!</div>
 				</td>
 				<td align="center">
-					<div>0</div>
+					<div>1</div>
 				</td>
 			</tr>
 			<tr>
@@ -156,6 +156,11 @@
 				<td><a href="#plugin-1">XSS</a></td>
 				<td align="center" class="risk-3">!reports.report.risk.3!</td>
 				<td align="center">2</td>
+			</tr>
+			<tr>
+				<td><a href="#plugin-1"></a></td>
+				<td align="center" class="risk-0">!reports.report.risk.0!</td>
+				<td align="center">0</td>
 			</tr>
 		</table>
 		<div class="spacer-lg"></div>
@@ -495,6 +500,53 @@
 				<tr>
 					<td width="20%">!reports.report.alerts.detail.wascid!</td>
 					<td width="80%">456</td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.pluginid!</td>
+					<td width="80%"><a
+						href="https://www.zaproxy.org/docs/alerts/1/">1</a></td>
+				</tr>
+			</table>
+			<div class="spacer"></div>
+		
+			<table class="results">
+				<tr height="24">
+					<th width="20%" class="risk-0"><a
+						id="plugin-1"></a>
+						<div>!reports.report.risk.0!</div></th>
+					<th class="risk-0"></th>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.description!</td>
+					<td width="80%"></td>
+				</tr>
+				<TR vAlign="top">
+					<TD colspan="2"></TD>
+				</TR>
+				
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.instances!</td>
+					<td width="80%">0</td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.solution!</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.reference!</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.tags!</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.cweid!</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.wascid!</td>
+					<td width="80%"></td>
 				</tr>
 				<tr>
 					<td width="20%">!reports.report.alerts.detail.pluginid!</td>

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html.html
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html.html
@@ -174,7 +174,7 @@ td {
 					<div>!reports.report.risk.0!</div>
 				</td>
 				<td align="center">
-					<div>0</div>
+					<div>1</div>
 				</td>
 			</tr>
 			<tr>
@@ -203,6 +203,11 @@ td {
 				<td><a href="#1">XSS</a></td>
 				<td align="center" class="risk-3">!reports.report.risk.3!</td>
 				<td align="center">2</td>
+			</tr>
+			<tr>
+				<td><a href="#1"></a></td>
+				<td align="center" class="risk-0">!reports.report.risk.0!</td>
+				<td align="center">0</td>
 			</tr>
 		</table>
 		<div class="spacer-lg"></div>
@@ -317,6 +322,49 @@ td {
 				<tr>
 					<td width="20%">!reports.report.alerts.detail.wascid!</td>
 					<td width="80%">456</td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.pluginid!</td>
+					<td width="80%"><a
+						href="https://www.zaproxy.org/docs/alerts/1/">1</a></td>
+				</tr>
+			</table>
+			<div class="spacer"></div>
+		
+			<table class="results">
+				<tr height="24">
+					<th width="20%" class="risk-0"><a
+						id="1"></a>
+						<div>!reports.report.risk.0!</div></th>
+					<th class="risk-0"></th>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.description!</td>
+					<td width="80%"></td>
+				</tr>
+				<TR vAlign="top">
+					<TD colspan="2"></TD>
+				</TR>
+				
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.instances!</td>
+					<td width="80%">0</td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.solution!</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.reference!</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.cweid!</td>
+					<td width="80%"></td>
+				</tr>
+				<tr>
+					<td width="20%">!reports.report.alerts.detail.wascid!</td>
+					<td width="80%"></td>
 				</tr>
 				<tr>
 					<td width="20%">!reports.report.alerts.detail.pluginid!</td>

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-md.md
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-md.md
@@ -8,7 +8,7 @@
 | !reports.report.risk.3! | 1 |
 | !reports.report.risk.2! | 0 |
 | !reports.report.risk.1! | 0 |
-| !reports.report.risk.0! | 0 |
+| !reports.report.risk.0! | 1 |
 
 
 
@@ -18,6 +18,7 @@
 | !reports.report.alerts.list.name! | !reports.report.alerts.list.risklevel! | !reports.report.alerts.list.numinstances! |
 | --- | --- | --- |
 | XSS | !reports.report.risk.3! | 2 |
+|  | !reports.report.risk.0! | 0 |
 
 
 
@@ -65,6 +66,29 @@ Test Solution
 
 
 #### !reports.report.alerts.detail.wascid!: 456
+
+#### !reports.report.alerts.detail.sourceid!: 0
+
+### [  ](https://www.zaproxy.org/docs/alerts/1/)
+
+
+
+##### !reports.report.risk.0! (!reports.report.confidence.1!)
+
+### !reports.report.alerts.detail.description!
+
+
+
+!reports.report.alerts.detail.instances!: 0
+
+### !reports.report.alerts.detail.solution!
+
+
+
+### !reports.report.alerts.detail.reference!
+
+
+
 
 #### !reports.report.alerts.detail.sourceid!: 0
 


### PR DESCRIPTION
Change `high-level-report` to only try access the split description array when the description is not empty, when the description is empty the array is empty as well.
Add alert with empty fields to the tests and update resulting reports accordingly.

Fix zaproxy/zaproxy#8071.