### PR TITLE
reports: update JavaDoc links in help

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
+- Update JavaDoc links to always link to latest version of ZAP.
 
 ### Fixed
 - Fix error when generating the High Level Report Sample with an alert that has an empty description (Issue 8071).

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/create.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/create.html
@@ -90,13 +90,13 @@ themes:      # An optional list of themes - different colours and styles which a
 	the criteria selected.
 	<p>
 		Every node in the tree is an <a
-			href="https://javadoc.io/static/org.zaproxy/zap/2.10.0/org/zaproxy/zap/extension/alert/AlertNode.html">AlertNode</a>.
+			href="https://javadoc.io/doc/org.zaproxy/zap/latest/org/zaproxy/zap/extension/alert/AlertNode.html">AlertNode</a>.
 	</p>
 	<p>The top level node does not include any useful data.</p>
 	<p>
 		There is one second level node for each type of alert found. These
 		nodes have a 'userObject' of type <a
-			href="https://javadoc.io/static/org.zaproxy/zap/2.10.0/org/parosproxy/paros/core/scanner/Alert.html">Alert</a>
+			href="https://javadoc.io/doc/org.zaproxy/zap/latest/org/parosproxy/paros/core/scanner/Alert.html">Alert</a>
 		which gives you access to all of the alert data and the associated
 		request and response.
 	</p>


### PR DESCRIPTION
Link always to latest ZAP version.