### PR TITLE
postman: Prevent null values

### DIFF
--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
@@ -371,10 +371,20 @@ public class PostmanParser {
             contentType = HttpHeader.JSON_CONTENT_TYPE;
 
             GraphQl graphQlBody = body.getGraphQl();
-            String query = graphQlBody.getQuery().replaceAll("\r\n", "\\\\r\\\\n");
-            String variables = graphQlBody.getVariables().replaceAll("\\s", "");
 
-            bodyContent = String.format("{\"query\":\"%s\", \"variables\":%s}", query, variables);
+            String query = graphQlBody.getQuery();
+            String variables = graphQlBody.getVariables();
+
+            if (variables != null && !variables.isEmpty()) {
+                bodyContent =
+                        String.format(
+                                "{\"query\":\"%s\", \"variables\":%s}",
+                                query.replaceAll("\r\n", "\\\\r\\\\n"),
+                                variables.replaceAll("\\s", ""));
+            } else {
+                bodyContent =
+                        String.format("{\"query\":\"%s\"}", query.replaceAll("\r\n", "\\\\r\\\\n"));
+            }
         }
 
         if (!isContentTypeAlreadySet(request.getHeader())) {

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/Body.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/Body.java
@@ -21,6 +21,8 @@ package org.zaproxy.addon.postman.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import org.zaproxy.addon.postman.deserializers.ListDeserializer;
@@ -139,8 +141,9 @@ public class Body {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class File {
+        @JsonSetter(nulls = Nulls.SKIP)
         @JsonDeserialize(using = ObjectDeserializer.class)
-        private String src;
+        private String src = "";
 
         public String getSrc() {
             return src;
@@ -153,8 +156,9 @@ public class Body {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class FormData extends KeyValueData {
+        @JsonSetter(nulls = Nulls.SKIP)
         @JsonDeserialize(using = ObjectDeserializer.class)
-        private String src;
+        private String src = "";
 
         @JsonDeserialize(using = ObjectDeserializer.class)
         private String type;
@@ -185,8 +189,9 @@ public class Body {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class GraphQl {
+        @JsonSetter(nulls = Nulls.SKIP)
         @JsonDeserialize(using = ObjectDeserializer.class)
-        private String query;
+        private String query = "";
 
         @JsonDeserialize(using = ObjectDeserializer.class)
         private String variables;

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/KeyValueData.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/KeyValueData.java
@@ -20,8 +20,10 @@
 package org.zaproxy.addon.postman.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.zaproxy.addon.postman.deserializers.ObjectDeserializer;
 import org.zaproxy.addon.postman.models.Body.FormData;
@@ -37,11 +39,13 @@ public class KeyValueData extends AbstractListElement {
         this.value = value;
     }
 
+    @JsonSetter(nulls = Nulls.SKIP)
     @JsonDeserialize(using = ObjectDeserializer.class)
-    private String key;
+    private String key = "";
 
+    @JsonSetter(nulls = Nulls.SKIP)
     @JsonDeserialize(using = ObjectDeserializer.class)
-    private String value;
+    private String value = "";
 
     @JsonDeserialize(using = ObjectDeserializer.class)
     private boolean disabled;

--- a/addOns/postman/src/test/java/org/zaproxy/addon/postman/PostmanParserUnitTest.java
+++ b/addOns/postman/src/test/java/org/zaproxy/addon/postman/PostmanParserUnitTest.java
@@ -366,4 +366,44 @@ class PostmanParserUnitTest extends TestUtils {
         String outputCollection = PostmanParser.replaceVariables(inputCollection, variables);
         assertEquals(expectedOutputCollection, outputCollection);
     }
+
+    static Stream<String> nullFieldValuesTestData() {
+        String bodyBaseLeft = "{\"item\":{\"request\":{\"url\":\"https://example.com\"},\"body\":";
+        String bodyBaseRight = "}}";
+        return Stream.of(
+                "{\"item\":null}",
+                "{\"item\":{\"request\":null,\"name\":null}}",
+                "{\"item\":{\"request\":{\"url\":null,\"method\":null,\"header\":null,\"body\":null}}}",
+                "{\"item\":{\"request\":{\"url\":{\"raw\":null}}}}",
+                "{\"item\":{\"request\":{\"url\":{\"raw\":\"https://example.com\",\"header\":{\"key\":null,\"value\":null}}}}}",
+                bodyBaseLeft + "{\"mode\":null}" + bodyBaseRight,
+                bodyBaseLeft + "{\"mode\":\"raw\",\"raw\":null}" + bodyBaseRight,
+                bodyBaseLeft
+                        + "{\"mode\":\"raw\",\"raw\":\"some content\",\"options\":null}"
+                        + bodyBaseRight,
+                bodyBaseLeft
+                        + "{\"mode\":\"raw\",\"raw\":\"some content\",\"options\":{\"raw\":null}}"
+                        + bodyBaseRight,
+                bodyBaseLeft + "{\"mode\":\"urlencoded\",\"urlencoded\":null}" + bodyBaseRight,
+                bodyBaseLeft
+                        + "{\"mode\":\"urlencoded\",\"urlencoded\":{\"key\":null,\"value\":null}}"
+                        + bodyBaseRight,
+                bodyBaseLeft + "{\"mode\":\"formdata\",\"formdata\":null}" + bodyBaseRight,
+                bodyBaseLeft
+                        + "{\"mode\":\"formdata\",\"formdata\":{\"key\":null,\"value\":null,\"src\":null,\"type\":null}}"
+                        + bodyBaseRight,
+                bodyBaseLeft + "{\"mode\":\"file\",\"file\":null}" + bodyBaseRight,
+                bodyBaseLeft + "{\"mode\":\"file\",\"file\":{\"src\":null}}" + bodyBaseRight,
+                bodyBaseLeft + "{\"mode\":\"raw\",\"graphql\":null}" + bodyBaseRight,
+                bodyBaseLeft
+                        + "{\"mode\":\"raw\",\"graphql\":{\"query\":null,\"variables\":null}}"
+                        + bodyBaseRight);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullFieldValuesTestData")
+    void shouldNotFailForNullFieldValues(String collection) {
+        PostmanParser parser = new PostmanParser();
+        assertDoesNotThrow(() -> parser.importCollection(collection, "", false));
+    }
 }


### PR DESCRIPTION
## Overview
While working on error reporting, I observed that Postman's default values for attributes in body are set as empty strings. However, the users can potentially modify files, which could lead to exceptions in our addon.

## Checklist
- [x] Update help (N/A)
- [x] Update changelog (N/A)
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
