### PR TITLE
Disable client events only for Zest recording

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated the Firefox extension to v0.0.6.
 - Updated the Chrome extension to v0.0.5.
+- Disable client events automatically only for Zest recording.
 
 ## [0.0.1] - 2023-09-11
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/RedirectScript.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/RedirectScript.java
@@ -25,6 +25,8 @@ import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 
 public class RedirectScript implements BrowserHook {
 
+    static final int ZEST_CLIENT_RECORDER_INITIATOR = -73;
+
     private ClientIntegrationAPI api;
 
     public RedirectScript(ClientIntegrationAPI api) {
@@ -37,7 +39,9 @@ public class RedirectScript implements BrowserHook {
         ssutils.getWebDriver().get(zapurl);
         JavascriptExecutor jsExecutor = (JavascriptExecutor) ssutils.getWebDriver();
         jsExecutor.executeScript("localStorage.setItem('localzapurl', '" + zapurl + "')");
-        jsExecutor.executeScript("localStorage.setItem('localzapenable',false)");
+        if (ssutils.getRequester() == ZEST_CLIENT_RECORDER_INITIATOR) {
+            jsExecutor.executeScript("localStorage.setItem('localzapenable',false)");
+        }
 
         // This statement make sure that the ZAP browser extension is configured properly
         ssutils.getWebDriver().get(zapurl);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/RedirectScriptUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/RedirectScriptUnitTest.java
@@ -1,0 +1,80 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
+
+/** Unit test for {@link RedirectScript}. */
+class RedirectScriptUnitTest {
+
+    private static final String DISABLE_CLIENT_SCRIPT =
+            "localStorage.setItem('localzapenable',false)";
+
+    private TestWebDriver wd;
+    private SeleniumScriptUtils ssutils;
+    private ClientIntegrationAPI api;
+    private RedirectScript script;
+
+    @BeforeEach
+    void setUp() {
+        ssutils = mock(SeleniumScriptUtils.class);
+        wd = mock(TestWebDriver.class);
+        given(ssutils.getWebDriver()).willReturn(wd);
+        api = mock(ClientIntegrationAPI.class);
+        given(api.getCallbackUrl()).willReturn("callback-url");
+
+        script = new RedirectScript(api);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {HttpSender.PROXY_INITIATOR, HttpSender.AJAX_SPIDER_INITIATOR})
+    void shouldNotDisableClientForCommonInitiators(int initiator) {
+        // Given
+        given(ssutils.getRequester()).willReturn(initiator);
+        // When
+        script.browserLaunched(ssutils);
+        // Then
+        verify(wd, times(0)).executeScript(DISABLE_CLIENT_SCRIPT);
+    }
+
+    @Test
+    void shouldDisableClientForZestRecorder() {
+        // Given
+        given(ssutils.getRequester()).willReturn(RedirectScript.ZEST_CLIENT_RECORDER_INITIATOR);
+        // When
+        script.browserLaunched(ssutils);
+        // Then
+        verify(wd).executeScript(DISABLE_CLIENT_SCRIPT);
+    }
+
+    private interface TestWebDriver extends WebDriver, JavascriptExecutor {}
+}

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Depend on Common Library add-on.
+- Maintenance changes.
 
 ## [40] - 2023-09-11
 ### Added 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -48,6 +48,8 @@ import org.zaproxy.zest.impl.ZestScriptEngineFactory;
 @SuppressWarnings("serial")
 public class ZestRecordScriptDialog extends StandardFieldsDialog {
 
+    private static final int ZEST_CLIENT_RECORDER_INITIATOR = -73;
+
     private static final String FIELD_TITLE = "zest.dialog.script.label.title";
     private static final String FIELD_PREFIX = "zest.dialog.script.label.prefix";
     private static final String FIELD_DESC = "zest.dialog.script.label.desc";
@@ -198,7 +200,9 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
         ExtensionSelenium extSelenium =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
         try {
-            WebDriver wd = extSelenium.getProxiedBrowserByName(browserName);
+            WebDriver wd =
+                    extSelenium.getProxiedBrowserByName(
+                            ZEST_CLIENT_RECORDER_INITIATOR, browserName, null);
             wd.get(url);
         } catch (RuntimeException e) {
             String msg =


### PR DESCRIPTION
Change `RedirectScript` to only disable the client events if the caller has expected Zest recording initiator.
Change `ZestRecordScriptDialog` to use the custom initiator.