### PR TITLE
spider: exclude `DsStore` from JavaDoc

### DIFF
--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -73,3 +73,7 @@ spotless {
         listOf("src/**/DsStore.java"),
     )
 }
+
+tasks.named<Javadoc>("javadoc") {
+    exclude("**/DsStore.java")
+}


### PR DESCRIPTION
Do not prevent JavaDoc errors in the internal/third party class from generating the JavaDoc which is required to release to Maven Central.