### PR TITLE
Correct POM description configuration

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -295,7 +295,7 @@ subprojects {
                     pom {
                         name.set(project.zapAddOn.addOnName.map { "ZAP - $it Add-on" })
                         packaging = "jar"
-                        description.set(project.description)
+                        description.set(provider { project.description })
                         url.set("https://github.com/zaproxy/zap-extensions")
                         inceptionYear.set(project.property("zap.maven.pom.inceptionyear") as String)
 


### PR DESCRIPTION
Use a provider since the project description might not yet have been set when the POM is configured.