### PR TITLE
network: fix JavaDoc errors

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/BaseServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/BaseServer.java
@@ -52,7 +52,6 @@ import org.zaproxy.addon.network.server.Server;
  *   <li>{@link ChannelAttributes#REMOTE_ADDRESS};
  *   <li>{@link ChannelAttributes#TLS_UPGRADED} (always {@code false});
  *   <li>{@link ChannelAttributes#PROCESSING_MESSAGE} (always {@code false});
- *   <li>{@link ChannelAttributes#RECURSIVE_MESSAGE} (always {@code false}).
  * </ul>
  */
 public class BaseServer implements Server {

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/RecursiveRequestChecker.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/RecursiveRequestChecker.java
@@ -67,7 +67,7 @@ public class RecursiveRequestChecker {
     private static AwsCandidateHarvester awsCandidateHarvester;
 
     /**
-     * Tells whether or not the given {@code msg} served through the given {@given channel} is a
+     * Tells whether or not the given {@code msg} served through the given {@code channel} is a
      * recursive request.
      *
      * @param channel the channel where the message is being transmitted.


### PR DESCRIPTION
Remove reference to instance that no longer exists and correct tag.