### PR TITLE
postman: Adding variables support

### DIFF
--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/ImportDialog.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/ImportDialog.java
@@ -54,6 +54,7 @@ public class ImportDialog extends AbstractDialog {
 
     private JTextField fieldCollection;
     private JTextField fieldTarget;
+    private JTextField fieldVariables;
     private JButton buttonChooseFile;
     private JButton buttonCancel;
     private JButton buttonImport;
@@ -82,11 +83,23 @@ public class ImportDialog extends AbstractDialog {
                 getChooseFileButton(),
                 LayoutHelper.getGBC(2, fieldsRow, 1, 0.5, new Insets(0, 4, 4, 0)));
         fieldsRow++;
+
+        JLabel labelTaget =
+                new JLabel(Constant.messages.getString("postman.importDialog.labelTarget"));
         fieldsPanel.add(
-                new JLabel(Constant.messages.getString("postman.importDialog.labelTarget")),
-                LayoutHelper.getGBC(0, fieldsRow, 1, 0.5, new Insets(4, 0, 4, 4)));
+                labelTaget, LayoutHelper.getGBC(0, fieldsRow, 1, 0.5, new Insets(4, 0, 4, 4)));
+        labelTaget.setVisible(false);
         fieldsPanel.add(
                 getTargetField(),
+                LayoutHelper.getGBC(1, fieldsRow, 2, 0.5, new Insets(4, 4, 4, 0)));
+        getTargetField().setVisible(false);
+        fieldsRow++;
+
+        fieldsPanel.add(
+                new JLabel(Constant.messages.getString("postman.importDialog.labelVariables")),
+                LayoutHelper.getGBC(0, fieldsRow, 1, 0.5, new Insets(4, 0, 4, 4)));
+        fieldsPanel.add(
+                getVariablesField(),
                 LayoutHelper.getGBC(1, fieldsRow, 2, 0.5, new Insets(4, 4, 4, 0)));
 
         int row = 0;
@@ -124,6 +137,14 @@ public class ImportDialog extends AbstractDialog {
             setContextMenu(fieldTarget);
         }
         return fieldTarget;
+    }
+
+    private JTextField getVariablesField() {
+        if (fieldVariables == null) {
+            fieldVariables = new JTextField(25);
+            setContextMenu(fieldVariables);
+        }
+        return fieldVariables;
     }
 
     private static void setContextMenu(JTextField field) {
@@ -220,7 +241,9 @@ public class ImportDialog extends AbstractDialog {
         try {
             new URL(collectionLocation).toURI();
             new URI(collectionLocation, true);
-            importedWithoutErrors = parser.importFromUrl(getCollectionField().getText(), true);
+            importedWithoutErrors =
+                    parser.importFromUrl(
+                            getCollectionField().getText(), getVariablesField().getText(), true);
         } catch (URIException | MalformedURLException | URISyntaxException e1) {
             // Not a valid URI, try to import as a file
             var file = new File(collectionLocation);
@@ -233,7 +256,11 @@ public class ImportDialog extends AbstractDialog {
                 return false;
             }
             try {
-                importedWithoutErrors = parser.importFromFile(getCollectionField().getText(), true);
+                importedWithoutErrors =
+                        parser.importFromFile(
+                                getCollectionField().getText(),
+                                getVariablesField().getText(),
+                                true);
             } catch (IOException e2) {
                 handleParseException(e2);
                 return false;
@@ -277,6 +304,7 @@ public class ImportDialog extends AbstractDialog {
         getImportButton().setEnabled(!show);
         getCollectionField().setEnabled(!show);
         getTargetField().setEnabled(!show);
+        getVariablesField().setEditable(!show);
         getChooseFileButton().setEnabled(!show);
     }
 
@@ -323,5 +351,6 @@ public class ImportDialog extends AbstractDialog {
     void clearFields() {
         getCollectionField().setText("");
         getTargetField().setText("");
+        getVariablesField().setText("");
     }
 }

--- a/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/postman.html
+++ b/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/postman.html
@@ -7,13 +7,14 @@ Postman Support
 </HEAD>
 <BODY>
 <H1>Postman Support</H1>
-This add-on will allow you to spider and import Postman collections. It is currently under development.
+This add-on will allow you to import Postman collections through the UI, importing through the API and command line is under development.
 
 <H2>UI</H2>
 A menu item is added to the Import menu:
 <ul>
 <li>Import a Postman Collection</li>
 </ul>
+The dialog allows providing a comma-separated list of variables as key-value pairs in the format <code>key1=value1,key2=value2,...</code>
 
 <H2>API</H2>
 The following operations are added to the API:

--- a/addOns/postman/src/main/resources/org/zaproxy/addon/postman/resources/Messages.properties
+++ b/addOns/postman/src/main/resources/org/zaproxy/addon/postman/resources/Messages.properties
@@ -25,6 +25,7 @@ postman.importDialog.error.missingCollection = A Postman Collection file or URL 
 postman.importDialog.importButton = Import
 postman.importDialog.labelCollection = Collection File or URL
 postman.importDialog.labelTarget = Target URL
+postman.importDialog.labelVariables = Variables
 postman.importDialog.pasteAction = Paste
 postman.importDialog.requiredFields = indicates a required field
 postman.importDialog.title = Import Postman Collection


### PR DESCRIPTION
## Overview
The import dialog will now allow providing a comma-separated list of variables as key-value pairs in the format `key1=value1,key2=value2,...`

## Related Issues
https://github.com/zaproxy/zaproxy/issues/6960

## Checklist
- [x] Update help
- [x] Update changelog (N/A)
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
