### PR TITLE
scripts: update extender templates for Graal.js

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update extender template scripts to also work with Graal.js engine.
 
 ## [40] - 2023-09-11
 ### Changed

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add history record menu.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add history record menu.js
@@ -5,7 +5,7 @@
 // See the other templates for examples on how to do add different functionality. 
 
 // Script variable to use when uninstalling
-var popupmenuitemtype = Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer");
+var popupmenuitemtype = Java.extend(Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer"));
 var menuitem = new popupmenuitemtype("Example history reference menu") {
       performAction: function(href) {
         print("Example menu called with " + href.getHttpMessage().getRequestHeader().getURI().toString());

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add toolbar button.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add toolbar button.js
@@ -5,6 +5,7 @@
 // See the other templates for examples on how to do add different functionality. 
 
 // Script variable to use when uninstalling
+var SwingConstants = Java.type("javax.swing.SwingConstants");
 var jbutton = Java.type("javax.swing.JButton");
 var button = new jbutton();
 
@@ -58,7 +59,7 @@ function create_window() {
   var jmenubar = Java.type("javax.swing.JMenuBar");
   var jmenu = Java.type("javax.swing.JMenu");
   var jmenuitem = Java.type("javax.swing.JMenuItem");
-  var window = new absframe(){};
+  var window = new absframe();
   window.setAlwaysOnTop(false);
   window.setSize(500, 500);
   var menubar = new jmenubar();
@@ -70,8 +71,8 @@ function create_window() {
   menubar.add(menu);
   window.setJMenuBar(menubar);
   var lbl = new jlabel("A Label");
-  lbl.setHorizontalAlignment(jlabel.CENTER);
-  lbl.setVerticalAlignment(jlabel.CENTER);
+  lbl.setHorizontalAlignment(SwingConstants.CENTER);
+  lbl.setVerticalAlignment(SwingConstants.CENTER);
   window.setContentPane(lbl);
   window.setVisible(true);
 }

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
@@ -4,7 +4,7 @@
 // See the other templates for examples on how to do add different functionality. 
 
 // Script variable to use when uninstalling
-var popupmenuitemtype = Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer");
+var popupmenuitemtype = Java.extend(Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer"));
 var curlmenuitem = new popupmenuitemtype("Copy as curl Command") {
 	performAction: function(href) {
 		invokeWith(href.getHttpMessage());


### PR DESCRIPTION
Allow to run the extender templates with the JavaScript engines Nashorn and Graal.js without errors.