### PR TITLE
network: ensure servers stopped before starting

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Ensure servers are stopped when initialising after installation in `cmd` and `daemon` modes.
 
 ## [0.11.0] - 2023-09-26
 ### Added

--- a/addOns/network/gradle.properties
+++ b/addOns/network/gradle.properties
@@ -1,4 +1,4 @@
-version=0.12.0
+version=0.11.1
 release=false
 zap.maven.publish=true
 zap.maven.pom.inceptionyear=2021

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -854,6 +854,8 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
     }
 
     private void startLocalServers(String overrideAddress, int overridePort, boolean install) {
+        stopLocalServers();
+
         boolean commandLineMode = ZAP.getProcessType() == ZAP.ProcessType.cmdline;
         boolean daemonMode = ZAP.getProcessType() == ZAP.ProcessType.daemon;
 
@@ -1289,6 +1291,10 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
     @Override
     public void stop() {
+        stopLocalServers();
+    }
+
+    private void stopLocalServers() {
         localServers.values().removeIf(ExtensionNetwork::stopAdditionalLocalServer);
         stopLocalServer(mainProxyServer);
     }


### PR DESCRIPTION
Stop the servers before attempting to start them, the servers are started after the installation of the add-on but if done during startup core will execute the command line arguments of the extension which would start the servers again making the servers fail to bind (e.g. address already in use) and ZAP fail to start.