### PR TITLE
network: ensure custom port main proxy is stopped

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Ensure the main proxy with custom port (`-port`) is stopped when initialising after installation in `cmd` and `daemon` modes.
 
 ## [0.11.1] - 2023-09-27
 ### Fixed

--- a/addOns/network/gradle.properties
+++ b/addOns/network/gradle.properties
@@ -1,4 +1,4 @@
-version=0.12.0
+version=0.11.2
 release=false
 zap.maven.publish=true
 zap.maven.pom.inceptionyear=2021

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -884,6 +884,7 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
         if (overrides) {
             localServersOptions.setMainProxy(serverConfig);
+            stopLocalServer(mainProxyServer);
         }
 
         updateCoreProxy(serverConfig);


### PR DESCRIPTION
Stop the main proxy with custom port before attempting to start it.

Follow up #4939.