### PR TITLE
scripts: Persist default keep/replace behaviour

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Allow selecting a default behaviour when a script in the console changes on disk (Issues 5463, 7582). The allowed
+  options are "Ask Each Time", "Keep Script", and "Replace Script".
+
 ### Changed
 - Update extender template scripts to also work with Graal.js engine.
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -128,7 +128,7 @@ public class CommandPanel extends AbstractPanel {
     protected void setCommandScript(String str) {
         setCommandScriptContent(str);
         getTxtOutput().discardAllEdits();
-        getTxtOutput().requestFocus();
+        getTxtOutput().requestFocusInWindow();
     }
 
     protected void setCommandCursorPosition(int offset) {

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -45,6 +45,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.view.OptionsDialog;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.extension.api.API;
@@ -105,6 +106,9 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     private ExtensionScript extScript = null;
     private ScriptsTreeCellRenderer renderer = null;
 
+    private ScriptConsoleOptions scriptConsoleOptions;
+    private ScriptConsoleOptionsPanel scriptConsoleOptionsPanel;
+
     private ScriptWrapper currentLockedScript = null;
     private boolean lockOutputToDisplayedScript = false;
 
@@ -140,6 +144,9 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
+
+        extensionHook.addOptionsParamSet(getScriptConsoleOptions());
+
         this.getExtScript().addListener(this);
         extScriptType =
                 new ScriptType(
@@ -158,6 +165,12 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
         this.getExtScript().registerScriptEngineWrapper(nullEngineWrapper);
 
         if (hasView()) {
+            OptionsDialog optionsDialog = View.getSingleton().getOptionsDialog("");
+
+            String[] scriptNode = {Constant.messages.getString("options.script.title")};
+            scriptConsoleOptionsPanel = new ScriptConsoleOptionsPanel();
+            optionsDialog.addParamPanel(scriptNode, scriptConsoleOptionsPanel, true);
+
             extensionHook.getHookView().addSelectPanel(getScriptsPanel());
             extensionHook.addSessionListener(new ViewSessionChangedListener());
             extensionHook.getHookView().addWorkPanel(getConsolePanel());
@@ -252,6 +265,8 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
             if (scriptsPanel != null) {
                 scriptsPanel.unload();
             }
+            OptionsDialog optionsDialog = View.getSingleton().getOptionsDialog("");
+            optionsDialog.removeParamPanel(scriptConsoleOptionsPanel);
         }
 
         if (extScript != null) {
@@ -290,6 +305,13 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
             }
         }
         return extScript;
+    }
+
+    ScriptConsoleOptions getScriptConsoleOptions() {
+        if (scriptConsoleOptions == null) {
+            scriptConsoleOptions = new ScriptConsoleOptions();
+        }
+        return scriptConsoleOptions;
     }
 
     private ConsolePanel getConsolePanel() {

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptions.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptions.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts;
+
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.common.VersionedAbstractParam;
+
+public class ScriptConsoleOptions extends VersionedAbstractParam {
+
+    private static String BASE_KEY = "script.console";
+    private static String DEFAULT_SCRIPT_CHANGED_BEHAVIOUR =
+            BASE_KEY + ".defaultScriptChangedBehaviour";
+
+    /**
+     * The version of the configurations. Used to keep track of configurations changes between
+     * releases, if updates are needed.
+     */
+    private static final int CURRENT_CONFIG_VERSION = 1;
+
+    private DefaultScriptChangedBehaviour defaultScriptChangedBehaviour;
+
+    public DefaultScriptChangedBehaviour getDefaultScriptChangedBehaviour() {
+        return defaultScriptChangedBehaviour;
+    }
+
+    public void setDefaultScriptChangedBehaviour(DefaultScriptChangedBehaviour behaviour) {
+        this.defaultScriptChangedBehaviour = behaviour;
+        getConfig().setProperty(DEFAULT_SCRIPT_CHANGED_BEHAVIOUR, behaviour.name());
+    }
+
+    @Override
+    protected void parseImpl() {
+        defaultScriptChangedBehaviour =
+                getEnum(
+                        DEFAULT_SCRIPT_CHANGED_BEHAVIOUR,
+                        DefaultScriptChangedBehaviour.ASK_EACH_TIME);
+    }
+
+    @Override
+    protected String getConfigVersionKey() {
+        return BASE_KEY + VERSION_ATTRIBUTE;
+    }
+
+    @Override
+    protected int getCurrentVersion() {
+        return CURRENT_CONFIG_VERSION;
+    }
+
+    @Override
+    protected void updateConfigsImpl(int fileVersion) {}
+
+    public enum DefaultScriptChangedBehaviour {
+        KEEP,
+        REPLACE,
+        ASK_EACH_TIME;
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case KEEP:
+                    return Constant.messages.getString("scripts.changed.keep");
+                case REPLACE:
+                    return Constant.messages.getString("scripts.changed.replace");
+                case ASK_EACH_TIME:
+                default:
+                    return Constant.messages.getString("scripts.changed.askEachTime");
+            }
+        }
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptionsPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptionsPanel.java
@@ -1,0 +1,108 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.Box;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.view.AbstractParamPanel;
+import org.zaproxy.zap.extension.scripts.ScriptConsoleOptions.DefaultScriptChangedBehaviour;
+import org.zaproxy.zap.view.LayoutHelper;
+
+public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String NAME =
+            Constant.messages.getString("scripts.console.options.panelName");
+
+    private JComboBox<DefaultScriptChangedBehaviour> defaultScriptChangedBehaviour;
+
+    public ScriptConsoleOptionsPanel() {
+        super();
+        setName(NAME);
+        setLayout(new GridBagLayout());
+
+        int row = 0;
+        var defaultScriptChangedBehaviourLabel =
+                new JLabel(
+                        Constant.messages.getString(
+                                "scripts.console.options.defaultScriptChangedBehaviourLabel"));
+        add(
+                defaultScriptChangedBehaviourLabel,
+                LayoutHelper.getGBC(0, ++row, 1, 0.5, new Insets(2, 4, 4, 2)));
+        add(
+                getDefaultScriptChangedBehaviour(),
+                LayoutHelper.getGBC(1, row, 1, 0.5, new Insets(2, 2, 4, 4)));
+
+        add(
+                Box.createHorizontalGlue(),
+                LayoutHelper.getGBC(
+                        0,
+                        ++row,
+                        GridBagConstraints.REMAINDER,
+                        1.0,
+                        1.0,
+                        GridBagConstraints.BOTH,
+                        new Insets(0, 0, 0, 0)));
+    }
+
+    @Override
+    public void initParam(Object mainOptions) {
+        ScriptConsoleOptions options = getScriptConsoleOptions(mainOptions);
+        getDefaultScriptChangedBehaviour()
+                .setSelectedItem(options.getDefaultScriptChangedBehaviour());
+    }
+
+    @Override
+    public void saveParam(Object mainOptions) throws Exception {
+        ScriptConsoleOptions options = getScriptConsoleOptions(mainOptions);
+        options.setDefaultScriptChangedBehaviour(
+                (DefaultScriptChangedBehaviour)
+                        getDefaultScriptChangedBehaviour().getSelectedItem());
+    }
+
+    private static ScriptConsoleOptions getScriptConsoleOptions(Object mainOptions) {
+        return ((OptionsParam) mainOptions).getParamSet(ScriptConsoleOptions.class);
+    }
+
+    @Override
+    public String getHelpIndex() {
+        return "addon.scripts.options";
+    }
+
+    private JComboBox<DefaultScriptChangedBehaviour> getDefaultScriptChangedBehaviour() {
+        if (defaultScriptChangedBehaviour == null) {
+            defaultScriptChangedBehaviour =
+                    new JComboBox<>(
+                            new DefaultScriptChangedBehaviour[] {
+                                DefaultScriptChangedBehaviour.ASK_EACH_TIME,
+                                DefaultScriptChangedBehaviour.KEEP,
+                                DefaultScriptChangedBehaviour.REPLACE
+                            });
+        }
+        return defaultScriptChangedBehaviour;
+    }
+}

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/options.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/options.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Script Console Options</title>
+</head>
+<body>
+<h1>Script Console Options</h1>
+
+<h2>When the Script in the Console Changes on Disk</h2>
+<p>This setting allows you to configure the default behaviour when a script open in the Script Console changes on disk,
+    for example if it was updated in another code editor. There are three options to choose from:
+<ul>
+    <li><b>Ask Each Time</b>: This will prompt you each time the script is changed on disk, allowing you to choose whether
+        to keep the script in the console or replace it with the changed script.
+    <li><b>Keep Script</b>: This will always keep the script in the console, even if it is changed on disk.
+    <li><b>Replace Script</b>: This will always replace the script in the console with the changed script.
+</ul>
+
+Note that if there are unsaved changes to the script, you will always be prompted to choose which version to keep.
+
+</body>
+</html>

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/index.xml
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/index.xml
@@ -7,5 +7,6 @@
 	<indexitem text="scripts automation" target="addon.scripts.automation" />
 	<indexitem text="script console" target="addon.scripts.scripts" />
 	<indexitem text="script console tab" target="addon.scripts.console" />
+	<indexitem text="script console options" target="addon.scripts.options" />
 	<indexitem text="scripts tree tab" target="addon.scripts.tree" />
 </index>

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/map.jhm
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/map.jhm
@@ -9,5 +9,6 @@
 	<mapID target="addon.scripts.scripts" url="contents/scripts.html" />
 	<mapID target="addon.scripts.automation" url="contents/automation.html" />
 	<mapID target="addon.scripts.console" url="contents/console.html" />
+	<mapID target="addon.scripts.options" url="contents/options.html" />
 	<mapID target="addon.scripts.tree" url="contents/tree.html" />
 </map>

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/toc.xml
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/toc.xml
@@ -9,6 +9,7 @@
 			<tocitem text="Script Console" image="addon.scripts.icon" target="addon.scripts.scripts">
 				<tocitem text="Automation" target="addon.scripts.automation" />
 				<tocitem text="Console" target="addon.scripts.console" />
+				<tocitem text="Options" target="addon.scripts.options" />
 				<tocitem text="Tree" target="addon.scripts.tree" />
 			</tocitem>
 		</tocitem>

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -40,7 +40,8 @@ scripts.automation.info.startAction = Job: {0} Start action: {1}
 scripts.automation.name = Scripts Automation Framework Integration
 scripts.automation.warn.fileNotNeeded = Job: {0} File specified but not needed so will be ignored
 
-scripts.changed.keep = Keep script
+scripts.changed.askEachTime = Ask Each Time
+scripts.changed.keep = Keep Script
 scripts.changed.replace = Replace Script
 
 scripts.close.confirm = Changes to this script have not been saved.\nRemove the script and lose the changes?
@@ -48,6 +49,10 @@ scripts.close.popup = Remove Script
 
 scripts.console.changedOnDisk = The script has been changed by another program.\nKeep the version in the Script Console or replace\nit with the one changed by the other program?\nThis script has not been changed in the console.\n
 scripts.console.changedOnDiskAndConsole = The script has been changed by another program.\nKeep the version in the Script Console or replace\nit with the one changed by the other program?\nThis script has been changed in the console so if\nyou replace the script you will lose your changes.\n
+
+scripts.console.options.defaultScriptChangedBehaviourLabel = When the Script in the Console Changes on Disk:
+scripts.console.options.panelName = Script Console
+scripts.console.rememberChoice = Remember this choice
 
 scripts.desc = Scripting console, supports all JSR 223 scripting languages
 


### PR DESCRIPTION
## Overview
Allow the user to select the default behaviour when a script open in the Script Console changes on disk.

## Related Issues
- Closes zaproxy/zaproxy#5463
- Closes zaproxy/zaproxy#7582

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
