### PR TITLE
pscanrules: CSP - Set deprecation warning for prefetch-src

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - The CSRF Countermeasures scan rule now skips responses that are not HTML (Issue 7890).
+- A potential NullPointerException when a CSP declared via META tag was invalid.
+
+### Changed
+- CSP scan rule: Add deprecation warning for inclusion of prefetch-src (Issue 8077).
 
 ## [51] - 2023-09-08
 ### Added


### PR DESCRIPTION
- CHANGELOG > Add change note.
- ContentSecurityPolicyScanRule > Set deprecation warning for prefetch-src if included.
- ContentSecurityPolicyScanRuleUnitTest > Add/update tests to assert the new behavior.

## Overview
ContentSecurityPolicyScanRule - Only alert on wildcard prefetch-src if included in CSP

## Related Issues
Fixes zaproxy/zaproxy#8077

## Checklist
- [X] Update help - N/A
- [X] Update changelog
- [X] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

Note: I'll probably work on some other deprecations upstream in salvation as well.