### PR TITLE
network: allow to disable host normalization

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Allow to completely disable host header normalization.
 
 ## [0.11.2] - 2023-09-27
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -774,13 +774,16 @@ public class HttpSenderApache
             return request;
         }
 
-        String host = null;
-        Object hostValue = properties.get("host");
-        if (hostValue != null) {
-            host = hostValue.toString();
-        }
+        boolean hostNormalisation = !Boolean.FALSE.equals(properties.get("host.normalization"));
+        if (hostNormalisation) {
+            String host = null;
+            Object hostValue = properties.get("host");
+            if (hostValue != null) {
+                host = hostValue.toString();
+            }
 
-        addHostHeader(msg, host);
+            addHostHeader(msg, host);
+        }
 
         BasicClassicHttpRequest copy =
                 new BasicClassicHttpRequest(
@@ -796,7 +799,7 @@ public class HttpSenderApache
         copy.setVersion(toHttpVersion(msg.getRequestHeader().getVersion()));
         boolean skipHostHeader = false;
         for (HttpHeaderField header : msg.getRequestHeader().getHeaders()) {
-            if (HttpRequestHeader.HOST.equals(header.getName())) {
+            if (hostNormalisation && HttpRequestHeader.HOST.equals(header.getName())) {
                 if (skipHostHeader) {
                     continue;
                 }


### PR DESCRIPTION
Allow to completely disable the host header normalization when sending the HTTP messages to allow the user to send any number of host headers with any values.