### PR TITLE
QuickStart ZAPit: carry on if non success code returned

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- ZAPit: carry on even if non success code returned.
 
 ## [41] - 2023-09-28
 ### Added

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -81,7 +81,7 @@ public class AttackThread extends Thread {
         try {
             Stats.incCounter("stats.quickstart.attack");
             extension.notifyProgress(Progress.started);
-            SiteNode startNode = this.extension.accessNode(this.url, REQ_CONFIG);
+            SiteNode startNode = this.extension.accessNode(this.url, REQ_CONFIG, true);
 
             if (startNode == null) {
                 LOGGER.debug("Failed to access URL {}", url);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -320,7 +320,7 @@ public class ExtensionQuickStart extends ExtensionAdaptor
         attackThread.start();
     }
 
-    protected SiteNode accessNode(URL url, HttpRequestConfig config) {
+    protected SiteNode accessNode(URL url, HttpRequestConfig config, boolean successOnly) {
         SiteNode startNode = null;
         // Request the URL
         try {
@@ -328,7 +328,7 @@ public class ExtensionQuickStart extends ExtensionAdaptor
             getHttpSender().sendAndReceive(msg, config);
             getHttpSender().setUseGlobalState(false);
 
-            if (!HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode())) {
+            if (successOnly && !HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode())) {
                 notifyProgress(
                         Progress.failed,
                         Constant.messages.getString(

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ZapItScan.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ZapItScan.java
@@ -92,7 +92,8 @@ public class ZapItScan {
                         HttpRequestConfig.builder()
                                 .setFollowRedirects(true)
                                 .setRedirectionValidator(zirv)
-                                .build());
+                                .build(),
+                        false);
 
         List<MessageSummary> msgs = zirv.getMessages();
         if (msgs.isEmpty()) {


### PR DESCRIPTION
## Overview
As per title :)

Example output:
```
ZAPit scan of https://www.whatsapp.com
Requests:
	https://www.whatsapp.com
		Request took 209 msec
		Response code 400 (Bad Request)
		Response body size 6,244 bytes
		No request cookies
		No response cookies
Technology:
	HSTS
	HTTP/3
Number of alerts: 4
	Medium: Content Security Policy (CSP) Header Not Set : ""
	Low: Permissions Policy Header Not Set : ""
	Informational: Modern Web Application : "<noscript>2020</noscript>"
	Informational: Non-Storable Content : "400"
Root page stats:
	Content type: text/html; charset="utf-8"
	Number of HTML tags: 45
	Number of HTML links: 3
	Number of HTML forms: 0
	Number of HTML input fields: 0
```

## Related Issues

## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
