### PR TITLE
spider: enable japicmp check

### DIFF
--- a/addOns/spider/gradle.properties
+++ b/addOns/spider/gradle.properties
@@ -2,3 +2,5 @@ version=0.7.0
 release=false
 zap.maven.publish=true
 zap.maven.pom.inceptionyear=2022
+zap.japicmp=true
+zap.japicmp.baseversion=0.6.0


### PR DESCRIPTION
Check that the add-on keeps being binary compatible with the version released to Maven Central.