### PR TITLE
network: prevent UI during install with no view

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update default user-agents.
 
+### Fixed
+- Do not initialize the view when failed to start the main proxy in `cmd` and `daemon` modes.
+
 ## [0.11.2] - 2023-09-27
 ### Fixed
 - Ensure the main proxy with custom port (`-port`) is stopped when initialising after installation in `cmd` and `daemon` modes.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -902,7 +902,7 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
             }
         } catch (Exception e) {
 
-            if (!install && (daemonMode || commandLineMode)) {
+            if (!install && !hasView()) {
                 String message =
                         "Failed to start the main proxy: "
                                 + e.getClass().getName()
@@ -927,7 +927,7 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                             Constant.messages.getString(
                                     "network.cmdline.proxy.error.host.assign", address);
                 } else if (containsMessage(e, "denied") || containsMessage(e, "in use")) {
-                    if (promptUserMainProxyPort()) {
+                    if (hasView() && promptUserMainProxyPort()) {
                         return;
                     }
 
@@ -944,6 +944,12 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                         Constant.messages.getString(
                                 "network.cmdline.proxy.error.generic", e.getMessage());
                 LOGGER.warn("Failed to start the main proxy: {}", e.getMessage());
+                if (!hasView()) {
+                    return;
+                }
+            } else if (!hasView()) {
+                LOGGER.warn("Failed to start the main proxy: {}", detailedError);
+                return;
             }
 
             JOptionPane.showMessageDialog(


### PR DESCRIPTION
Ensure the UI is not initialized if there's no view during install when failed to start the main proxy (e.g. the port is already in use).

---
From ZAP Developer Group: https://groups.google.com/g/zaproxy-develop/c/Ypb5EW8y0iY/m/nFY4W7iXBAAJ