### PR TITLE
Replace `hub` with `gh` in workflows

### DIFF
--- a/.github/workflows/create_eval_villian_update.yml
+++ b/.github/workflows/create_eval_villian_update.yml
@@ -39,5 +39,5 @@ jobs:
           git commit -m "Eval Villain Update $SHORT_DATE" -m "Updates based on https://addons.mozilla.org/firefox/addon/eval-villain/" --signoff
           git push --set-upstream origin $BRANCH --force
           # Open the PR
-          hub pull-request --no-edit
+          gh pr create -f
         fi

--- a/.github/workflows/create_retirejs_update.yml
+++ b/.github/workflows/create_retirejs_update.yml
@@ -43,5 +43,5 @@ jobs:
           git commit -m "retire.js Update $SHORT_DATE" -m "Updates based on $SRC_BASE" --signoff
           git push --set-upstream origin $BRANCH --force
           # Open the PR
-          hub pull-request --no-edit
+          gh pr create -f
         fi

--- a/.github/workflows/create_wappalyzer_update.yml
+++ b/.github/workflows/create_wappalyzer_update.yml
@@ -48,5 +48,5 @@ jobs:
           git commit -m "Wappalyzer Update $SHORT_DATE" -m "Updates based on $SRC_BASE" --signoff
           git push --set-upstream origin $BRANCH --force
           # Open the PR
-          hub pull-request --no-edit
+          gh pr create -f
         fi

--- a/.github/workflows/create_webdriver_update.yml
+++ b/.github/workflows/create_webdriver_update.yml
@@ -97,5 +97,5 @@ jobs:
         if [ $IS_UPDT -eq 1 ]; then
           git push --set-upstream origin $BRANCH --force
           # Open the PR
-          hub pull-request --no-edit
+          gh pr create -f
         fi


### PR DESCRIPTION
The `hub` command is no longer included by default and `gh` is the recommended replacement.