### PR TITLE
Correct release process

### DIFF
--- a/.github/workflows/release-add-on.yml
+++ b/.github/workflows/release-add-on.yml
@@ -23,8 +23,6 @@ jobs:
         java-version: 11
     - name: Generate Release State
       run: ./gradlew :addOns:generateReleaseStateLastCommit
-    - name: Generate JARs for BOM data
-      run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g jar
     - name: Build and Release Add-On
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}

--- a/addOns/webdrivers/webdriverlinux/gradle.properties
+++ b/addOns/webdrivers/webdriverlinux/gradle.properties
@@ -1,2 +1,2 @@
 version=63
-release=true
+release=false

--- a/addOns/webdrivers/webdrivermacos/gradle.properties
+++ b/addOns/webdrivers/webdrivermacos/gradle.properties
@@ -1,2 +1,2 @@
 version=63
-release=true
+release=false

--- a/addOns/webdrivers/webdriverwindows/gradle.properties
+++ b/addOns/webdrivers/webdriverwindows/gradle.properties
@@ -1,2 +1,2 @@
 version=63
-release=true
+release=false


### PR DESCRIPTION
Ensure the output of the BOM tasks don't overlap.
Only run the JAR tasks for the BOMs when needed.
Reset the release state of pending add-ons.