### PR TITLE
selenium: update Selenium library

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update Selenium to version 4.13.0.
+- Update Selenium to version 4.14.0.
 
 ## [15.14.0] - 2023-09-26
 ### Added

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -2,6 +2,9 @@ import org.zaproxy.gradle.addon.AddOnStatus
 
 description = "WebDriver provider and includes HtmlUnit browser"
 
+val selenium by configurations.creating
+configurations.api { extendsFrom(selenium) }
+
 zapAddOn {
     addOnName.set("Selenium")
     addOnStatus.set(AddOnStatus.RELEASE)
@@ -17,6 +20,10 @@ zapAddOn {
                 }
             }
         }
+
+        bundledLibs {
+            libs.from(selenium)
+        }
     }
 
     apiClientGen {
@@ -27,14 +34,9 @@ zapAddOn {
 }
 
 dependencies {
-    var seleniumVersion = "4.13.0"
-    api("org.seleniumhq.selenium:selenium-java:$seleniumVersion") {
-        exclude(group = "io.netty")
-    }
-    implementation("org.seleniumhq.selenium:selenium-http-jdk-client:$seleniumVersion")
-    api("org.seleniumhq.selenium:htmlunit-driver:4.12.0") {
-        exclude(group = "io.netty")
-    }
+    var seleniumVersion = "4.14.0"
+    selenium("org.seleniumhq.selenium:selenium-java:$seleniumVersion")
+    selenium("org.seleniumhq.selenium:htmlunit-driver:4.13.0")
     implementation(libs.log4j.slf4j) {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -89,10 +89,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
 
     private static final Logger LOGGER = LogManager.getLogger(ExtensionSelenium.class);
 
-    static {
-        System.setProperty("webdriver.http.factory", "jdk-http-client");
-    }
-
     private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
             Collections.unmodifiableList(Arrays.asList(ExtensionNetwork.class));
 


### PR DESCRIPTION
Update Selenium library to version 4.14.0.
Update the htmlunit-driver to latest version 4.13.0.
Remove Netty exclusions and JDK HTTP client dependency, the latter is now the default.
Bundle the Selenium libraries for proper inclusion of metadata files which contain the declaration of the supported CDP versions.