### PR TITLE
Update codebase to ZAP 2.14

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [9] - 2023-09-08
 ### Added

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -156,7 +156,7 @@ subprojects {
         }
     }
 
-    val zapGav = "org.zaproxy:zap:2.13.0"
+    val zapGav = "org.zaproxy:zap:2.14.0-SNAPSHOT"
     dependencies {
         "zap"(zapGav)
     }
@@ -167,7 +167,7 @@ subprojects {
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })
 
         manifest {
-            zapVersion.set("2.13.0")
+            zapVersion.set("2.14.0")
 
             changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
             repo.set("https://github.com/zaproxy/zap-extensions/")

--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 - Depend on newer version of Automation Framework add-on for the automation job (Related to Issue 7961).
 

--- a/addOns/allinonenotes/CHANGELOG.md
+++ b/addOns/allinonenotes/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [57] - 2023-09-08
 ### Changed

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [44] - 2023-09-08
 ### Changed

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [48] - 2023-09-08
 ### Added

--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [0.9.0] - 2023-07-11

--- a/addOns/authstats/CHANGELOG.md
+++ b/addOns/authstats/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [2] - 2021-10-07

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.32.0] - 2023-10-04
 ### Fixed

--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Dependency updates.
 
 ## [7] - 2021-10-07

--- a/addOns/browserView/CHANGELOG.md
+++ b/addOns/browserView/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [6] - 2023-03-13
 ### Added

--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [14] - 2023-07-11

--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [4] - 2022-09-23

--- a/addOns/callgraph/CHANGELOG.md
+++ b/addOns/callgraph/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [5] - 2021-10-07
 ### Added

--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 - Add client stats to telemetry.
 

--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ### Added
 - AJAX spider enhancement.

--- a/addOns/codedx/CHANGELOG.md
+++ b/addOns/codedx/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Dependency updates.
 - Maintenance changes.
 

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Add solution to 'Brute Forcing Log-in Credentials', 'Brute Forcing Session Identifiers' and 'Brute Forcing Directories and Files' vulnerabilities (Issue 8056).
 - Update vulnerabilities' CWE references to use HTTPS scheme.
 

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/internal/vulns/LegacyVulnerabilitiesLoader.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/internal/vulns/LegacyVulnerabilitiesLoader.java
@@ -36,6 +36,7 @@ import org.zaproxy.zap.utils.LocaleUtils;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Helper class that loads {@code Vulnerability} from a XML file for a given {@code Locale}. */
+@SuppressWarnings("removal")
 public final class LegacyVulnerabilitiesLoader {
 
     private static final Logger LOGGER = LogManager.getLogger(LegacyVulnerabilitiesLoader.class);

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/internal/vulns/LegacyVulnerabilitiesLoaderUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/internal/vulns/LegacyVulnerabilitiesLoaderUnitTest.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.model.Vulnerability;
 import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link LegacyVulnerabilitiesLoader}. */
+@SuppressWarnings("removal")
 class LegacyVulnerabilitiesLoaderUnitTest extends TestUtils {
 
     private static final String DEFAULT_FILE_NAME = "vulnerabilities";

--- a/addOns/coreLang/CHANGELOG.md
+++ b/addOns/coreLang/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [15] - 2022-02-14
 ### Changed

--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 - Promoted to Beta.
 

--- a/addOns/database/CHANGELOG.md
+++ b/addOns/database/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.2.0] - 2023-07-11
 ### Changed

--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.14.0.
+
 ### Added
 - Add ZAP API endpoint to get the OpenAPI definition of the ZAP API.
 

--- a/addOns/diff/CHANGELOG.md
+++ b/addOns/diff/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [13] - 2023-07-11

--- a/addOns/directorylistv1/CHANGELOG.md
+++ b/addOns/directorylistv1/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [6] - 2023-07-11
 ### Changed

--- a/addOns/directorylistv2_3/CHANGELOG.md
+++ b/addOns/directorylistv2_3/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/directorylistv2_3_lc/CHANGELOG.md
+++ b/addOns/directorylistv2_3_lc/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [17] - 2023-09-08
 ### Changed

--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [1.3.0] - 2023-09-08
 ### Changed

--- a/addOns/evalvillain/CHANGELOG.md
+++ b/addOns/evalvillain/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.3.0] - 2023-09-26
 ### Changed

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Depend on newer versions of Automation Framework and Common Library add-ons (Related to Issue 7961).
 
 ## [0.6.0] - 2023-07-11

--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 - Tweak help for proper rendering in the website.
 

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [13.11.0] - 2023-10-04
 ### Changed

--- a/addOns/fuzzdb/CHANGELOG.md
+++ b/addOns/fuzzdb/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [9] - 2022-09-23
 ### Changed

--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Update Graal JavaScript engine.
 
 ## [0.4.0] - 2023-07-11

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Fingerprinting check for the Absinthe GraphQL engine.
 
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Dependency updates.
 
 ## [0.19.0] - 2023-09-07

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 - Dependency updates.
 

--- a/addOns/highlighter/CHANGELOG.md
+++ b/addOns/highlighter/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [8] - 2021-10-07
 ### Added

--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [4] - 2022-09-23

--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [13] - 2023-07-11

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ### Fixed
 - Update the content-length header field after setting the request body in the authentication template.

--- a/addOns/jsonview/CHANGELOG.md
+++ b/addOns/jsonview/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [3] - 2023-09-07
 ### Changed

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [13] - 2023-09-07
 ### Changed

--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [1.1.0] - 2021-10-07
 ### Changed

--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to completely disable host header normalization.
 
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Update default user-agents.
 - Update dependencies.
 

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [0.16.0] - 2023-07-11

--- a/addOns/onlineMenu/CHANGELOG.md
+++ b/addOns/onlineMenu/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [11] - 2023-07-11
 ### Changed

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [36] - 2023-09-07
 ### Changed

--- a/addOns/packpentester/CHANGELOG.md
+++ b/addOns/packpentester/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.1.0] - 2022-05-12
 

--- a/addOns/packscanrules/CHANGELOG.md
+++ b/addOns/packscanrules/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.0.1] - 2022-05-13
 

--- a/addOns/paramdigger/CHANGELOG.md
+++ b/addOns/paramdigger/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.2.0] - 2023-06-06
 ### Fixed

--- a/addOns/plugnhack/CHANGELOG.md
+++ b/addOns/plugnhack/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent exception if no display (Issue 3978).
 
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [13] - 2022-10-27

--- a/addOns/portscan/CHANGELOG.md
+++ b/addOns/portscan/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 - Default number of threads to 2 * processor count.
 

--- a/addOns/postman/CHANGELOG.md
+++ b/addOns/postman/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.1.0] - 2023-10-04
 ### Added

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A potential NullPointerException when a CSP declared via META tag was invalid.
 
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - CSP scan rule: Add deprecation warning for inclusion of prefetch-src (Issue 8077).
 
 ## [51] - 2023-09-08

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [41] - 2023-09-08
 ### Changed

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [35] - 2023-09-08
 ### Changed

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [42] - 2023-10-04
 ### Changed

--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [14] - 2023-09-07
 ### Added

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.25.0] - 2023-10-04
 ### Changed

--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option to manipulate Host header.
 
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [7.3.0] - 2023-07-11

--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [0.7.0] - 2023-09-08
 ### Changed

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -5,9 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Updated with upstream retire.js pattern changes.
-
-
 
 ## [0.25.0] - 2023-08-14
 ### Changed

--- a/addOns/reveal/CHANGELOG.md
+++ b/addOns/reveal/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [6] - 2023-07-11
 ### Changed

--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/saml/CHANGELOG.md
+++ b/addOns/saml/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [10] - 2022-10-28

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [41] - 2023-10-04
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -412,6 +412,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
         displayScript(script, true);
     }
 
+    @Override
     public void displayScript(ScriptWrapper script, boolean allowFocus) {
         if (!View.isInitialised()) {
             return;
@@ -809,6 +810,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
         selectNode(node, expand, true);
     }
 
+    @Override
     public void selectNode(ScriptNode node, boolean expand, boolean allowFocus) {
         if (View.isInitialised()) {
             this.getScriptsPanel().showInTree(node, expand, allowFocus);

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update Selenium to version 4.14.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [15.14.0] - 2023-09-26
 ### Added

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ### Fixed
 - Prevent exception if no display (Issue 3978).

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [19] - 2023-09-07
 ### Changed

--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [0.6.0] - 2023-09-07

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.14.0.
+
 ### Fixed
 - Add URL to start event.
 

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [15] - 2021-10-20

--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [12] - 2022-10-28

--- a/addOns/svndigger/CHANGELOG.md
+++ b/addOns/svndigger/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/tips/CHANGELOG.md
+++ b/addOns/tips/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [11] - 2023-07-11

--- a/addOns/tokengen/CHANGELOG.md
+++ b/addOns/tokengen/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [15] - 2021-10-07
 ### Changed

--- a/addOns/treetools/CHANGELOG.md
+++ b/addOns/treetools/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [8] - 2021-10-07
 ### Added

--- a/addOns/viewstate/CHANGELOG.md
+++ b/addOns/viewstate/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.13.0.
+- Update minimum ZAP version to 2.14.0.
 
 ## [3] - 2021-10-07
 ### Changed

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [21.24.0] - 2023-09-07
 ### Changed

--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update ChromeDriver to 118.0.5993.70.
-
-
+- Update minimum ZAP version to 2.14.0.
 
 ## [63] - 2023-10-09
 ### Changed

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update ChromeDriver to 118.0.5993.70.
-
-
+- Update minimum ZAP version to 2.14.0.
 
 ## [63] - 2023-10-09
 ### Changed

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update ChromeDriver to 118.0.5993.70.
-
-
+- Update minimum ZAP version to 2.14.0.
 
 ## [63] - 2023-10-09
 ### Changed

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
 ## [29] - 2023-07-11

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.14.0.
 
 ## [41] - 2023-09-26
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,9 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 
     spotless {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -14,7 +14,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.13.0")
+    compileOnly("org.zaproxy:zap:2.14.0-SNAPSHOT")
     implementation(project(":addOns:network"))
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 


### PR DESCRIPTION
Change all add-ons and `testutils` to use 2.14 (SNAPSHOT).
Update code accordingly (e.g. address deprecations).