### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Update Zest library to 0.20.0:
+  - Update Selenium to version 4.14.0.
 
 ## [41] - 2023-09-26
 ### Added

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     zapAddOn("network")
     zapAddOn("selenium")
 
-    implementation("org.zaproxy:zest:0.19.0") {
+    implementation("org.zaproxy:zest:0.20.0") {
         // Provided by commonlib add-on.
         exclude(group = "com.fasterxml.jackson")
         // Provided by Selenium add-on.


### PR DESCRIPTION
Update Zest library to 0.20.0:
 - Update Selenium to version 4.14.0.