### PR TITLE
Remove usage of ZAP snapshot

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -156,7 +156,7 @@ subprojects {
         }
     }
 
-    val zapGav = "org.zaproxy:zap:2.14.0-SNAPSHOT"
+    val zapGav = "org.zaproxy:zap:2.14.0"
     dependencies {
         "zap"(zapGav)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,9 +16,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
     }
 
     spotless {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -14,7 +14,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.14.0-SNAPSHOT")
+    compileOnly("org.zaproxy:zap:2.14.0")
     implementation(project(":addOns:network"))
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 


### PR DESCRIPTION
Use the main release which is already available.