### PR TITLE
Include `testutils`'s JAR for BOMs

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -75,7 +75,9 @@ val createPullRequestNextDevIter by tasks.registering(CreatePullRequest::class) 
 }
 
 val releaseAddOn by tasks.registering
-val allJarsForBom by tasks.registering
+val allJarsForBom by tasks.registering {
+    dependsOn(project(":testutils").tasks.named(JavaPlugin.JAR_TASK_NAME))
+}
 
 val crowdinExcludedProjects = setOf(
     childProjects.get("dev"),


### PR DESCRIPTION
The `testutils` can also be a dependency of add-ons.