### PR TITLE
frontendscanner: correct API parameter name

### DIFF
--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
@@ -137,7 +137,7 @@ public class FrontEndScannerProxyListener implements ProxyListener {
                         .append("<script src='")
                         .append(frontEndApiUrl)
                         .append("?action=getFile")
-                        .append("&filename=front-end-scanner.js")
+                        .append("&fileName=front-end-scanner.js")
                         .append("&historyReferenceId=")
                         .append(historyReferenceId)
                         .append("'></script>");

--- a/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
+++ b/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
@@ -98,7 +98,7 @@ class FrontEndScannerProxyListenerUnitTest extends TestUtils {
         String expectedHtmlFormat =
                 "<!doctype html><html lang='en'><head><script src='https:\\/\\/"
                         + HOSTNAME
-                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><script><\\/script><\\/head><body><\\/body></html>";
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&fileName=front-end-scanner.js&historyReferenceId=42'><\\/script><script><\\/script><\\/head><body><\\/body></html>";
         String result = msg.getResponseBody().toString();
 
         assertTrue(result.matches(expectedHtmlFormat));
@@ -118,7 +118,7 @@ class FrontEndScannerProxyListenerUnitTest extends TestUtils {
         String expectedHtmlFormat =
                 "<!doctype html><html lang='en'><head><meta><script src='https:\\/\\/"
                         + HOSTNAME
-                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&fileName=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
         String result = msg.getResponseBody().toString();
 
         assertTrue(result.matches(expectedHtmlFormat));
@@ -139,7 +139,7 @@ class FrontEndScannerProxyListenerUnitTest extends TestUtils {
         String expectedHtmlFormat =
                 "<!doctype html><html lang='en'><head><meta><meta><script src='https:\\/\\/"
                         + HOSTNAME
-                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&fileName=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
         String result = msg.getResponseBody().toString();
 
         assertTrue(result.matches(expectedHtmlFormat));
@@ -159,7 +159,7 @@ class FrontEndScannerProxyListenerUnitTest extends TestUtils {
         String expectedHtmlFormat =
                 "<!doctype html><html lang='en'><head><script src='https:\\/\\/"
                         + HOSTNAME
-                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></head></html>";
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&fileName=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></head></html>";
         String result = msg.getResponseBody().toString();
 
         assertTrue(result.matches(expectedHtmlFormat));
@@ -179,7 +179,7 @@ class FrontEndScannerProxyListenerUnitTest extends TestUtils {
         String expectedHtmlFormat =
                 "<!doctype html><html lang='en'><head><script src='https:\\/\\/"
                         + HOSTNAME
-                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&fileName=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
         String result = msg.getResponseBody().toString();
 
         assertTrue(result.matches(expectedHtmlFormat));
@@ -199,7 +199,7 @@ class FrontEndScannerProxyListenerUnitTest extends TestUtils {
         String expectedHtmlFormat =
                 "<head><script src='https:\\/\\/"
                         + HOSTNAME
-                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body>";
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&fileName=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body>";
         String result = msg.getResponseBody().toString();
 
         assertTrue(result.matches(expectedHtmlFormat));
@@ -219,7 +219,7 @@ class FrontEndScannerProxyListenerUnitTest extends TestUtils {
         String expectedHtmlFormat =
                 "<head><script src='https:\\/\\/"
                         + HOSTNAME
-                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body>";
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&fileName=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body>";
         String result = msg.getResponseBody().toString();
 
         assertTrue(result.matches(expectedHtmlFormat));


### PR DESCRIPTION
ZAP issues `&filename=front-end-scanner.js` which cause 400 for `front-end-scanner.js`, change `filename` to `fileName` correct this error.

Tested in firefox

## Overview
Briefly describe the purpose, goals, and changes or improvements made in this pull request.

## Related Issues
Specify any related issues or pull requests by linking to them.

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
