### PR TITLE
graphql, openapi: Update dependencies

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [0.20.0] - 2023-10-12
 ### Added

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("spider")
 
-    implementation("com.graphql-java:graphql-java:21.1")
+    implementation("com.graphql-java:graphql-java:21.2")
 
     testImplementation(project(":testutils"))
     testImplementation(libs.log4j.core)

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [37] - 2023-10-12
 ### Changed

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -54,7 +54,6 @@ configurations {
     "implementation" {
         // Not needed:
         exclude(group = "com.google.code.findbugs", module = "jsr305")
-        exclude(group = "org.slf4j", module = "slf4j-ext")
     }
 }
 
@@ -63,13 +62,13 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("spider")
 
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.16")
-    implementation("io.swagger:swagger-compat-spec-parser:1.0.67") {
+    implementation("io.swagger.parser.v3:swagger-parser:2.1.18")
+    implementation("io.swagger:swagger-compat-spec-parser:1.0.68") {
         // Not needed:
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
-    implementation(libs.log4j.slf4j) {
+    implementation(libs.log4j.slf4j2) {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")
     }


### PR DESCRIPTION
- graphql-java: `21.1` -> `21.2`.
- swagger-compat-spec-parser: `1.0.67` -> `1.0.68`.
