### PR TITLE
network: handle content encodings

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- On weekly releases and versions after 2.14, handle content encodings (Issue 2198).
 
 ## [0.12.0] - 2023-10-12
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ContentEncodingsHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ContentEncodingsHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal;
+
+import java.util.List;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.zaproxy.zap.network.HttpEncoding;
+import org.zaproxy.zap.network.HttpEncodingDeflate;
+import org.zaproxy.zap.network.HttpEncodingGzip;
+
+public class ContentEncodingsHandler /* TODO implements HttpEncodingsHandler */ {
+
+    public void handle(HttpHeader header, HttpBody body) {
+        String encoding = header.getHeader(HttpHeader.CONTENT_ENCODING);
+        if (encoding == null || encoding.isEmpty()) {
+            body.setContentEncodings(List.of());
+            return;
+        }
+
+        List<HttpEncoding> encodings = List.of();
+        if (encoding.contains(HttpHeader.DEFLATE)) {
+            encodings = List.of(HttpEncodingDeflate.getSingleton());
+        } else if (encoding.contains(HttpHeader.GZIP)) {
+            encodings = List.of(HttpEncodingGzip.getSingleton());
+        }
+
+        body.setContentEncodings(encodings);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/ContentEncodingsHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/ContentEncodingsHandlerUnitTest.java
@@ -1,0 +1,98 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal;
+
+import static java.util.Arrays.asList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.zaproxy.zap.network.HttpEncodingDeflate;
+import org.zaproxy.zap.network.HttpEncodingGzip;
+
+/** Unit test for {@link ContentEncodingsHandler}. */
+class ContentEncodingsHandlerUnitTest {
+
+    private ContentEncodingsHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new ContentEncodingsHandler();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {HttpHeader.GZIP, "x-gzip"})
+    void shouldSetGzipEncodingToBody(String contentEncodingHeader) {
+        // Given
+        HttpHeader header = mock(HttpHeader.class);
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncodingHeader);
+        HttpBody body = mock(HttpBody.class);
+        // When
+        handler.handle(header, body);
+        // Then
+        verify(body).setContentEncodings(asList(HttpEncodingGzip.getSingleton()));
+    }
+
+    @Test
+    void shouldSetDeflateEncodingToBody() {
+        // Given
+        HttpHeader header = mock(HttpHeader.class);
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(HttpHeader.DEFLATE);
+        HttpBody body = mock(HttpBody.class);
+        // When
+        handler.handle(header, body);
+        // Then
+        verify(body).setContentEncodings(asList(HttpEncodingDeflate.getSingleton()));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldNotSetContentEncodingToBodyIfContentEncodingIsNotPresentOrIsEmpty(
+            String contentEncoding) {
+        // Given
+        HttpHeader header = mock(HttpHeader.class);
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        HttpBody body = mock(HttpBody.class);
+        // When
+        handler.handle(header, body);
+        // Then
+        verify(body).setContentEncodings(List.of());
+    }
+
+    @Test
+    void shouldNotSetContentEncodingToBodyIfContentEncodingNotSupported() {
+        // Given
+        HttpHeader header = mock(HttpHeader.class);
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn("Encoding Not Supported");
+        HttpBody body = mock(HttpBody.class);
+        // When
+        handler.handle(header, body);
+        // Then
+        verify(body).setContentEncodings(List.of());
+    }
+}


### PR DESCRIPTION
Set a custom handler into core to handle the content encodings from the add-on (e.g. to support more encodings).

Part of zaproxy/zaproxy#2198.

---
Needs zaproxy/zaproxy#8130.