### PR TITLE
wappalyzer: Tweak help titles

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated with last AliasIO/Wappalyzer icon and pattern changes.
 - Updated with first set of icon and pattern changes from enthec/webappanalyzer.
+- Help entries are now identified as 'Technology Detection - Wappalyzer' to simplify searching/filtering.
 
 ## [21.25.0] - 2023-10-13
 ### Changed

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -2,7 +2,7 @@
 <HTML>
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
-<TITLE>Technology Detection</TITLE>
+<TITLE>Technology Detection - Wappalyzer</TITLE>
 </HEAD>
 <BODY>
 <H1>Technology Detection Using Wappalyzer</H1>


### PR DESCRIPTION
## Overview
 Help entries are now identified as 'Technology Detection - Wappalyzer' to simplify searching/filtering.
