### PR TITLE
revisit: check `HistoryReference` exists

### DIFF
--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Update minimum ZAP version to 2.14.0.
 
+### Fixed
+- Prevent exception when processing history after deleting messages.
+
 ## [4] - 2021-10-07
 ### Added
 - Add info and repo URLs.

--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
@@ -210,7 +210,8 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
 
                     for (int i = 1; i <= node.getHistoryReference().getHistoryId(); i++) {
                         HistoryReference hr = extHist.getHistoryReference(i);
-                        if (hr.getHistoryType() == HistoryReference.TYPE_PROXIED
+                        if (hr != null
+                                && hr.getHistoryType() == HistoryReference.TYPE_PROXIED
                                 && isSimilarRequest(url, hr.getURI().toString())) {
                             if (!url.equals(hr.getURI().toString())) {
                                 // We dont perform an exact match above so that we can


### PR DESCRIPTION
Check that the `hr` is not null, which might be if it was deleted.

---
Fix from #5007, which got accidentally closed while addressing the review comments.