### PR TITLE
openapi: Headers Generator fix

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Dependency updates.
 
+### Fixed
+- An issue in the headers generator which might lead to content-type header being incorrectly set.
+
 ## [37] - 2023-10-12
 ### Changed
 - Update minimum ZAP version to 2.14.0.

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/HeadersGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/HeadersGenerator.java
@@ -42,6 +42,9 @@ public class HeadersGenerator {
     private static final char COOKIE_NAME_VALUE_SEPARATOR = '=';
     private static final String COOKIE_SEPARATOR = "; ";
 
+    private static final List<String> HEADERS_TO_SKIP_CUSTOM =
+            List.of(ACCEPT, HttpHeader.CONTENT_TYPE);
+
     private DataGenerator dataGenerator;
 
     public HeadersGenerator(DataGenerator dataGenerator) {
@@ -65,6 +68,9 @@ public class HeadersGenerator {
                 }
                 if (HEADER.equals(parameter.getIn())) {
                     String name = parameter.getName();
+                    if (HEADERS_TO_SKIP_CUSTOM.stream().anyMatch(x -> x.equalsIgnoreCase(name))) {
+                        continue;
+                    }
                     String value = dataGenerator.generate(name, parameter);
                     HttpHeaderField header = new HttpHeaderField(name, value);
                     headers.add(header);


### PR DESCRIPTION
## Overview
Fixed an issue in the headers generator which might lead to content-type header being incorrectly overridden.

## Checklist
- [NA] Update help
- [X] Update changelog
- [X] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [X] Check code coverage
- [X] Sign-off commits
- [X] Squash commits
- [X] Use a descriptive title
