### PR TITLE
alertFilters: tidy up code

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [18] - 2023-10-12
 ### Changed

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFilterTableModel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFilterTableModel.java
@@ -78,7 +78,7 @@ public class AlertFilterTableModel extends AbstractMultipleOptionsTableModel<Ale
             case 0:
                 return af.isEnabled();
             case 1:
-                return ExtensionAlertFilters.getRuleNameForId(af.getRuleId());
+                return ExtensionAlertFilters.getScanRulesInfo().getNameById(af.getRuleId());
             case 2:
                 return af.getUrl();
             case 3:

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -32,7 +32,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordAlert;
 import org.parosproxy.paros.db.TableAlert;
@@ -55,9 +54,6 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.alert.PopupMenuItemAlert;
 import org.zaproxy.zap.extension.alertFilters.internal.ScanRulesInfo;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
-import org.zaproxy.zap.extension.ascan.PolicyManager;
-import org.zaproxy.zap.extension.ascan.ScanPolicy;
-import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.model.SessionStructure;
@@ -101,9 +97,6 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
     private int lastAlert = -1;
 
     private static ScanRulesInfo scanRulesInfo;
-    private static Map<String, Integer> nameToId = new HashMap<>();
-    private static Map<Integer, String> idToName = new HashMap<>();
-    private static List<String> allRuleNames;
     private static ExtensionActiveScan extAscan;
 
     private GlobalAlertFilterParam globalAlertFilterParam;
@@ -151,50 +144,6 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
                             ExtensionFactory.getAddOnLoader().getPassiveScanRules());
         }
         return scanRulesInfo;
-    }
-
-    public static List<String> getAllRuleNames() {
-        if (allRuleNames == null) {
-            allRuleNames = new ArrayList<>();
-            PolicyManager pm = getExtAscan().getPolicyManager();
-            ScanPolicy sp = pm.getDefaultScanPolicy();
-            for (Plugin plugin : sp.getPluginFactory().getAllPlugin()) {
-                allRuleNames.add(plugin.getName());
-                nameToId.put(plugin.getName(), Integer.valueOf(plugin.getId()));
-                idToName.put(Integer.valueOf(plugin.getId()), plugin.getName());
-            }
-            List<PluginPassiveScanner> listTest =
-                    new ArrayList<>(CoreFunctionality.getBuiltInPassiveScanRules());
-            listTest.addAll(ExtensionFactory.getAddOnLoader().getPassiveScanRules());
-            for (PluginPassiveScanner scanner : listTest) {
-                if (scanner.getName() != null) {
-                    allRuleNames.add(scanner.getName());
-                    nameToId.put(scanner.getName(), Integer.valueOf(scanner.getPluginId()));
-                    idToName.put(Integer.valueOf(scanner.getPluginId()), scanner.getName());
-                }
-            }
-            Collections.sort(allRuleNames);
-        }
-        return allRuleNames;
-    }
-
-    public static int getIdForRuleName(String name) {
-        if (allRuleNames == null) {
-            // init
-            getAllRuleNames();
-        }
-        if (nameToId.containsKey(name)) {
-            return nameToId.get(name);
-        }
-        return -1;
-    }
-
-    public static String getRuleNameForId(int ruleId) {
-        if (allRuleNames == null) {
-            // init
-            getAllRuleNames();
-        }
-        return idToName.get(Integer.valueOf(ruleId));
     }
 
     @Override

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
@@ -69,6 +69,14 @@ public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
         return entriesById.get(id);
     }
 
+    public String getNameById(int id) {
+        Entry entry = entriesById.get(id);
+        if (entry != null) {
+            return entry.getName();
+        }
+        return String.valueOf(id);
+    }
+
     @Override
     public Entry get(int index) {
         return entries.get(index);

--- a/addOns/alertFilters/src/test/java/org/zaproxy/zap/extension/alertFilters/AlertFilterUnitTest.java
+++ b/addOns/alertFilters/src/test/java/org/zaproxy/zap/extension/alertFilters/AlertFilterUnitTest.java
@@ -37,7 +37,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
 /** Unit test for {@link AlertFilter}. */
-class AlertFilterTest {
+class AlertFilterUnitTest {
 
     private static final String ALERT_METHOD = "PATCH";
     private Alert alert;


### PR DESCRIPTION
Remove mappings from the extension by using the `ScanRulesInfo`.
Rename a test class to have common suffix.