### PR TITLE
alertFilters: allow to filter by alert ref

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Allow to filter by alert reference (Issue 7438).
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFilter.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFilter.java
@@ -42,7 +42,7 @@ public class AlertFilter extends Enableable {
 
     // Use -1 for global alert filters
     private int contextId;
-    private int ruleId;
+    private String ruleId;
     // Use -1 as false positive
     private int newRisk;
     private String parameter;
@@ -63,7 +63,7 @@ public class AlertFilter extends Enableable {
 
     public AlertFilter(
             int contextId,
-            int ruleId,
+            String ruleId,
             int newRisk,
             String url,
             boolean isUrlRegex,
@@ -86,7 +86,7 @@ public class AlertFilter extends Enableable {
 
     public AlertFilter(
             int contextId,
-            int ruleId,
+            String ruleId,
             int newRisk,
             String url,
             boolean isUrlRegex,
@@ -115,7 +115,7 @@ public class AlertFilter extends Enableable {
 
     public AlertFilter(
             int contextId,
-            int ruleId,
+            String ruleId,
             int newRisk,
             String url,
             boolean isUrlRegex,
@@ -146,7 +146,7 @@ public class AlertFilter extends Enableable {
     public AlertFilter(int contextId, Alert alert) {
         super();
         this.contextId = contextId;
-        this.ruleId = alert.getPluginId();
+        this.ruleId = alert.getAlertRef();
         this.parameter = alert.getParam();
         this.url = alert.getUri();
         this.attack = alert.getAttack();
@@ -163,11 +163,11 @@ public class AlertFilter extends Enableable {
         this.contextId = contextId;
     }
 
-    public int getRuleId() {
+    public String getRuleId() {
         return ruleId;
     }
 
-    public void setRuleId(int ruleId) {
+    public void setRuleId(String ruleId) {
         this.ruleId = ruleId;
     }
 
@@ -341,7 +341,7 @@ public class AlertFilter extends Enableable {
             alertFilter = new AlertFilter();
             alertFilter.setContextId(contextId);
             alertFilter.setEnabled(Boolean.parseBoolean(pieces[0]));
-            alertFilter.setRuleId(Integer.parseInt(pieces[1]));
+            alertFilter.setRuleId(pieces[1]);
             alertFilter.setNewRisk(Integer.parseInt(pieces[2]));
             alertFilter.setUrl(new String(Base64.decodeBase64(pieces[3])));
             alertFilter.setUrlRegex(Boolean.parseBoolean(pieces[4]));
@@ -384,10 +384,14 @@ public class AlertFilter extends Enableable {
             LOGGER.debug("Filter disabled");
             return false;
         }
-        if (getRuleId() != alert.getPluginId()) {
-            // rule ids dont match
+        if (!getRuleId().equals(String.valueOf(alert.getPluginId()))
+                && !getRuleId().equals(alert.getAlertRef())) {
             LOGGER.debug(
-                    "Filter didn't match plugin id: {} != {}", getRuleId(), alert.getPluginId());
+                    "Filter didn't match scan rule ID and alert ref: {} != {} && {} != {}",
+                    getRuleId(),
+                    alert.getPluginId(),
+                    getRuleId(),
+                    alert.getAlertRef());
             return false;
         }
         if (!ignoreContext && this.contextId != -1) {
@@ -450,7 +454,7 @@ public class AlertFilter extends Enableable {
         result = prime * result + (isUrlRegex ? 1231 : 1237);
         result = prime * result + newRisk;
         result = prime * result + ((parameter == null) ? 0 : parameter.hashCode());
-        result = prime * result + ruleId;
+        result = prime * result + (ruleId == null ? 0 : ruleId.hashCode());
         result = prime * result + ((url == null) ? 0 : url.hashCode());
         result = prime * result + methods.hashCode();
         return result;
@@ -477,7 +481,9 @@ public class AlertFilter extends Enableable {
         if (parameter == null) {
             if (other.parameter != null) return false;
         } else if (!parameter.equals(other.parameter)) return false;
-        if (ruleId != other.ruleId) return false;
+        if (!Objects.equals(ruleId, other.ruleId)) {
+            return false;
+        }
         if (url == null) {
             if (other.url != null) return false;
         } else if (!url.equals(other.url)) return false;

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
@@ -250,7 +250,7 @@ public class AlertFilterAPI extends ApiImplementor {
                 af =
                         new AlertFilter(
                                 context.getId(),
-                                ApiUtils.getIntParam(params, PARAM_RULE_ID),
+                                params.getString(PARAM_RULE_ID),
                                 ApiUtils.getIntParam(params, PARAM_NEW_LEVEL),
                                 ApiUtils.getOptionalStringParam(params, PARAM_URL),
                                 getParam(params, PARAM_URL_IS_REGEX, false),
@@ -271,7 +271,7 @@ public class AlertFilterAPI extends ApiImplementor {
                 af =
                         new AlertFilter(
                                 context.getId(),
-                                ApiUtils.getIntParam(params, PARAM_RULE_ID),
+                                params.getString(PARAM_RULE_ID),
                                 ApiUtils.getIntParam(params, PARAM_NEW_LEVEL),
                                 ApiUtils.getOptionalStringParam(params, PARAM_URL),
                                 getParam(params, PARAM_URL_IS_REGEX, false),
@@ -293,7 +293,7 @@ public class AlertFilterAPI extends ApiImplementor {
                 af =
                         new AlertFilter(
                                 -1,
-                                ApiUtils.getIntParam(params, PARAM_RULE_ID),
+                                params.getString(PARAM_RULE_ID),
                                 ApiUtils.getIntParam(params, PARAM_NEW_LEVEL),
                                 ApiUtils.getOptionalStringParam(params, PARAM_URL),
                                 getParam(params, PARAM_URL_IS_REGEX, false),
@@ -321,7 +321,7 @@ public class AlertFilterAPI extends ApiImplementor {
                 af =
                         new AlertFilter(
                                 -1,
-                                ApiUtils.getIntParam(params, PARAM_RULE_ID),
+                                params.getString(PARAM_RULE_ID),
                                 ApiUtils.getIntParam(params, PARAM_NEW_LEVEL),
                                 ApiUtils.getOptionalStringParam(params, PARAM_URL),
                                 getParam(params, PARAM_URL_IS_REGEX, false),
@@ -413,7 +413,7 @@ public class AlertFilterAPI extends ApiImplementor {
         if (includeContext) {
             fields.put(PARAM_CONTEXT_ID, Integer.toString(af.getContextId()));
         }
-        fields.put(PARAM_RULE_ID, Integer.toString(af.getRuleId()));
+        fields.put(PARAM_RULE_ID, af.getRuleId());
         fields.put(PARAM_NEW_LEVEL, Integer.toString(af.getNewRisk()));
         fields.put(PARAM_URL, af.getUrl());
         fields.put(PARAM_URL_IS_REGEX, Boolean.toString(af.isUrlRegex()));

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/GlobalAlertFilterParam.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/GlobalAlertFilterParam.java
@@ -164,7 +164,7 @@ public class GlobalAlertFilterParam extends VersionedAbstractParam {
                 alertFilters.add(
                         new AlertFilter(
                                 -1,
-                                sub.getInt(FILTER_RULE_ID_KEY),
+                                sub.getString(FILTER_RULE_ID_KEY),
                                 sub.getInt(FILTER_NEW_RISK_KEY),
                                 sub.getString(FILTER_URL_KEY, null),
                                 sub.getBoolean(FILTER_URL_IS_REGEX_KEY, false),

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterJob.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterJob.java
@@ -179,7 +179,7 @@ public class AlertFilterJob extends AutomationJob {
 
     private boolean isValid(AlertFilterData afd, AutomationProgress progress) {
         boolean result = true;
-        if (afd.getRuleId() < 0) {
+        if (StringUtils.isBlank(afd.getRuleId()) || isNegativeInteger(afd.getRuleId())) {
             progress.error(
                     Constant.messages.getString(
                             "alertFilters.automation.error.invalidruleid",
@@ -244,6 +244,15 @@ public class AlertFilterJob extends AutomationJob {
             }
         }
         return result;
+    }
+
+    private static boolean isNegativeInteger(String ruleId) {
+        try {
+            return Integer.parseInt(ruleId) < 0;
+        } catch (NumberFormatException ignore) {
+            // Not an integer.
+        }
+        return false;
     }
 
     @Override
@@ -444,7 +453,7 @@ public class AlertFilterJob extends AutomationJob {
     }
 
     public static class AlertFilterData extends AutomationData {
-        private int ruleId;
+        private String ruleId;
         private String ruleName;
         private String context;
         private String newRisk;
@@ -462,11 +471,11 @@ public class AlertFilterJob extends AutomationJob {
             methods = List.of();
         }
 
-        public int getRuleId() {
+        public String getRuleId() {
             return ruleId;
         }
 
-        public void setRuleId(int ruleId) {
+        public void setRuleId(String ruleId) {
             this.ruleId = ruleId;
         }
 

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.alertFilters.internal;
 
+import java.lang.reflect.Constructor;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,15 +27,24 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
+import org.zaproxy.zap.extension.pscan.PassiveScanData;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
 
+    private static final Logger LOGGER = LogManager.getLogger(ScanRulesInfo.class);
+
     private List<Entry> entries;
-    private Map<Integer, Entry> entriesById;
+    private Map<String, Entry> entriesById;
 
     public ScanRulesInfo(
             ExtensionActiveScan extensionActiveScan,
@@ -44,37 +54,83 @@ public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
         entriesById = new HashMap<>();
         ScanPolicy sp = extensionActiveScan.getPolicyManager().getDefaultScanPolicy();
         for (Plugin scanRule : sp.getPluginFactory().getAllPlugin()) {
-            addEntry(scanRule.getId(), scanRule.getName());
+            addEntry(scanRule, scanRule.getId(), scanRule.getName());
         }
         for (PluginPassiveScanner scanRule : builtInPassiveScanRules) {
-            addEntry(scanRule.getPluginId(), scanRule.getName());
+            addEntry(scanRule, scanRule.getPluginId(), scanRule.getName());
         }
         for (PluginPassiveScanner scanRule : passiveScanRules) {
-            addEntry(scanRule.getPluginId(), scanRule.getName());
+            addEntry(scanRule, scanRule.getPluginId(), scanRule.getName());
         }
         Collections.sort(entries);
     }
 
-    private void addEntry(int id, String name) {
+    private void addEntry(Object scanRule, int id, String name) {
         if (id == -1) {
             return;
         }
 
+        String idStr = String.valueOf(id);
+        addEntry(idStr, name);
+
+        addAlertRefs(idStr, scanRule);
+    }
+
+    private void addAlertRefs(String id, Object scanRule) {
+        if (!(scanRule instanceof ExampleAlertProvider)) {
+            return;
+        }
+
+        ExampleAlertProvider exampleAlertProvider = (ExampleAlertProvider) scanRule;
+        if (scanRule instanceof PluginPassiveScanner) {
+            try {
+                PluginPassiveScanner pps = ((PluginPassiveScanner) exampleAlertProvider).copy();
+                Constructor<PassiveScanData> constructor =
+                        PassiveScanData.class.getDeclaredConstructor(HttpMessage.class);
+                constructor.setAccessible(true);
+                PassiveScanData psd =
+                        constructor.newInstance(
+                                new HttpMessage(new HttpRequestHeader("GET / HTTP/1.1")));
+                pps.setHelper(psd);
+                exampleAlertProvider = pps;
+            } catch (Exception e) {
+                LOGGER.warn("Failed to initialize the passive scan rule:", e);
+                return;
+            }
+        }
+
+        List<Alert> exampleAlerts;
+        try {
+            exampleAlerts = exampleAlertProvider.getExampleAlerts();
+        } catch (Exception e) {
+            LOGGER.warn("Failed to get the example alerts:", e);
+            return;
+        }
+
+        if (exampleAlerts == null || exampleAlerts.isEmpty()) {
+            return;
+        }
+        exampleAlerts.stream()
+                .filter(e -> !e.getAlertRef().equals(id))
+                .forEach(e -> addEntry(e.getAlertRef(), e.getName()));
+    }
+
+    private void addEntry(String id, String name) {
         Entry entry = new Entry(id, name);
         entriesById.put(id, entry);
         entries.add(entry);
     }
 
-    public Entry getById(int id) {
+    public Entry getById(String id) {
         return entriesById.get(id);
     }
 
-    public String getNameById(int id) {
+    public String getNameById(String id) {
         Entry entry = entriesById.get(id);
         if (entry != null) {
             return entry.getName();
         }
-        return String.valueOf(id);
+        return id;
     }
 
     @Override
@@ -99,16 +155,15 @@ public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
 
     public static class Entry implements Comparable<Entry> {
 
-        private final int id;
+        private final String id;
         private final String name;
 
-        Entry(int id, String name) {
+        Entry(String id, String name) {
             this.id = id;
-            this.name =
-                    name == null || name.isEmpty() ? String.valueOf(id) : name + " (" + id + ")";
+            this.name = name == null || name.isEmpty() ? id : name + " (" + id + ")";
         }
 
-        public int getId() {
+        public String getId() {
             return id;
         }
 
@@ -125,7 +180,7 @@ public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
             if (result != 0) {
                 return result;
             }
-            return Integer.compare(id, o.id);
+            return id.compareTo(o.id);
         }
 
         @Override
@@ -142,7 +197,7 @@ public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
                 return false;
             }
             Entry other = (Entry) obj;
-            return id == other.id;
+            return Objects.equals(id, other.id);
         }
 
         @Override

--- a/addOns/alertFilters/src/main/javahelp/org/zaproxy/zap/extension/alertFilters/resources/help/contents/alertFilterDialog.html
+++ b/addOns/alertFilters/src/main/javahelp/org/zaproxy/zap/extension/alertFilters/resources/help/contents/alertFilterDialog.html
@@ -19,7 +19,7 @@ This can either be 'Global' for a Global Alert Filter or the name of an existing
 It is only editable when you create an Alert Filter from an existing Alert.
 
 <H3>Alert Type</H3>
-A pull down containing all of the active and passive alert rules currently installed.
+A pull down containing all of the active and passive alert rules currently installed. Contains also the (known) alert references of the scan rules.
 
 <H3>New Risk Level</H3>
 The new risk level to be assigned to any alerts raised that match the criteria defined by the rule.

--- a/addOns/alertFilters/src/main/javahelp/org/zaproxy/zap/extension/alertFilters/resources/help/contents/automation.html
+++ b/addOns/alertFilters/src/main/javahelp/org/zaproxy/zap/extension/alertFilters/resources/help/contents/automation.html
@@ -17,7 +17,7 @@ The alertFilter job allows you to define global and context specific alert filte
     parameters:
       deleteGlobalAlerts: true         # Boolean, if true then will delete all existing global alerts, default false
     alertFilters:                      # A list of alertFilters to be applied
-      - ruleId:                        # Int: Mandatory alert rule id
+      - ruleId:                        # Int: Mandatory, the scan rule ID or the alert reference
         newRisk:                       # String: Mandatory new risk level, one of 'False Positive', 'Info', 'Low', 'Medium', 'High'
         context:                       # String: Optional context name, if empty then a global alert filter will be created
         url:                           # String: Optional string to match against the alert, supports environment vars

--- a/addOns/alertFilters/src/main/resources/org/zaproxy/zap/extension/alertFilters/resources/alertFilter-max.yaml
+++ b/addOns/alertFilters/src/main/resources/org/zaproxy/zap/extension/alertFilters/resources/alertFilter-max.yaml
@@ -2,7 +2,7 @@
     parameters:
       deleteGlobalAlerts: true         # Boolean, if true then will delete all existing global alerts, default false
     alertFilters:                      # A list of alertFilters to be applied
-      - ruleId:                        # Int: Mandatory alert rule id
+      - ruleId:                        # Int: Mandatory, the scan rule ID or the alert reference
         newRisk:                       # String: Mandatory new risk level, one of 'False Positive', 'Info', 'Low', 'Medium', 'High'
         context:                       # String: Optional context name, if empty then a global alert filter will be created
         url:                           # String: Optional string to match against the alert, supports environment vars

--- a/addOns/alertFilters/src/test/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFiltersUnitTest.java
+++ b/addOns/alertFilters/src/test/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFiltersUnitTest.java
@@ -78,8 +78,8 @@ class ExtensionAlertFiltersUnitTest {
         assertThat(
                 m.getAlertFilters(),
                 contains(
-                        new AlertFilter(ctxId, 42, 1, "", false, "", true),
-                        new AlertFilter(ctxId, 43, 1, "", false, "", false)));
+                        new AlertFilter(ctxId, "42", 1, "", false, "", true),
+                        new AlertFilter(ctxId, "43", 1, "", false, "", false)));
         verify(session).getContextDataStrings(ctxId, 500);
     }
 
@@ -94,7 +94,8 @@ class ExtensionAlertFiltersUnitTest {
         // Then
         ContextAlertFilterManager m = extension.getContextAlertFilterManager(ctxId);
         assertThat(
-                m.getAlertFilters(), contains(new AlertFilter(ctxId, 43, 1, "", false, "", false)));
+                m.getAlertFilters(),
+                contains(new AlertFilter(ctxId, "43", 1, "", false, "", false)));
         verify(session).getContextDataStrings(ctxId, 500);
     }
 
@@ -124,8 +125,8 @@ class ExtensionAlertFiltersUnitTest {
         assertThat(
                 m.getAlertFilters(),
                 contains(
-                        new AlertFilter(ctxId, 42, 1, "", false, "", true),
-                        new AlertFilter(ctxId, 43, 1, "", false, "", false)));
+                        new AlertFilter(ctxId, "42", 1, "", false, "", true),
+                        new AlertFilter(ctxId, "43", 1, "", false, "", false)));
     }
 
     @Test
@@ -139,7 +140,8 @@ class ExtensionAlertFiltersUnitTest {
         // Then
         ContextAlertFilterManager m = extension.getContextAlertFilterManager(ctxId);
         assertThat(
-                m.getAlertFilters(), contains(new AlertFilter(ctxId, 43, 1, "", false, "", false)));
+                m.getAlertFilters(),
+                contains(new AlertFilter(ctxId, "43", 1, "", false, "", false)));
     }
 
     private static Session sessionWithAlertFilters(String... filters) {

--- a/addOns/alertFilters/src/test/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterJobUnitTest.java
+++ b/addOns/alertFilters/src/test/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterJobUnitTest.java
@@ -146,6 +146,26 @@ class AlertFilterJobUnitTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"0-1", "2-3"})
+    void shouldAcceptAlertRefInRuleId(String alertRef) {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        AlertFilterJob job = new AlertFilterJob();
+        String contextStr = "parameters: \nalertFilters:\n- ruleId: " + alertRef;
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> jobData = yaml.load(contextStr);
+
+        // When
+        job.setJobData(jobData);
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(
+                progress.getErrors(),
+                not(hasItem("!alertFilters.automation.error.invalidruleid!")));
+    }
+
+    @ParameterizedTest
     @ValueSource(ints = {-2, -1})
     void shouldErrorOnInvalidRuleId(long scanRuleId) {
         // Given


### PR DESCRIPTION
Allow to specify the alert reference where the scan rule ID is being specified and update code accordingly (e.g. change `int` to `String`).
Change `ScanRulesInfo` to get the alert references from the scan rules that provide example alerts.

Fix zaproxy/zaproxy#7438.