### PR TITLE
spiderAjax: add menu item to Contexts tree

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Add context menu item to Contexts tree to show the AJAX Spider dialogue with the selected Context.
 
+### Changed
+- Add icon to the Tools menu item.
+- Scale icons.
 
 ## [23.17.0] - 2023-10-12
 ### Changed

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
@@ -19,9 +19,7 @@
  */
 package org.zaproxy.zap.extension.spiderAjax;
 
-import javax.swing.ImageIcon;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
@@ -32,27 +30,10 @@ public class PopupMenuAjaxSite extends PopupMenuItemSiteNodeContainer {
     private static final long serialVersionUID = 1L;
     private ExtensionAjax extension = null;
 
-    /**
-     * @param label
-     */
     public PopupMenuAjaxSite(String label, ExtensionAjax extension) {
         super(label);
-        this.setIcon(new ImageIcon(getClass().getResource("/resource/icon/16/spiderAjax.png")));
+        this.setIcon(extension.getIcon());
         this.extension = extension;
-    }
-
-    /**
-     * @return
-     */
-    private ExtensionAjax getExtensionSpider() {
-        if (extension == null) {
-            extension =
-                    (ExtensionAjax)
-                            Control.getSingleton()
-                                    .getExtensionLoader()
-                                    .getExtension(ExtensionAjax.NAME);
-        }
-        return extension;
     }
 
     /** */
@@ -93,9 +74,6 @@ public class PopupMenuAjaxSite extends PopupMenuItemSiteNodeContainer {
     /** */
     @Override
     public boolean isEnableForInvoker(Invoker invoker, HttpMessageContainer httpMessageContainer) {
-        if (getExtensionSpider() == null) {
-            return false;
-        }
         switch (invoker) {
             case ALERTS_PANEL:
             case ACTIVE_SCANNER_PANEL:

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -40,6 +40,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.ScanStatus;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
@@ -87,8 +88,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
         this.add(getAJAXSpiderPanel(), java.awt.BorderLayout.CENTER);
         scanStatus =
                 new ScanStatus(
-                        new ImageIcon(
-                                SpiderPanel.class.getResource("/resource/icon/16/spiderAjax.png")),
+                        extension.getIcon(),
                         this.extension.getMessages().getString("spiderajax.panel.title"));
 
         this.setDefaultAccelerator(
@@ -207,11 +207,9 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
             startScanButton = new JButton();
             startScanButton.setText(
                     this.extension.getMessages().getString("spiderajax.toolbar.button.start"));
-            startScanButton.setIcon(
-                    new ImageIcon(
-                            SpiderPanel.class.getResource("/resource/icon/16/spiderAjax.png")));
+            startScanButton.setIcon(extension.getIcon());
             startScanButton.setEnabled(!Mode.safe.equals(Control.getSingleton().getMode()));
-            startScanButton.addActionListener(e -> extension.showScanDialog(null));
+            startScanButton.addActionListener(e -> extension.showScanDialog((Target) null));
         }
         return startScanButton;
     }

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/internal/PopupMenuItemSpiderDialogWithContext.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/internal/PopupMenuItemSpiderDialogWithContext.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.spiderAjax.internal;
+
+import org.zaproxy.zap.extension.spiderAjax.ExtensionAjax;
+import org.zaproxy.zap.extension.stdmenus.PopupContextTreeMenu;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.Target;
+
+/**
+ * A {@code PopupContextTreeMenu} that allows to show the AJAX Spider dialogue for a selected {@link
+ * Context}.
+ */
+public class PopupMenuItemSpiderDialogWithContext extends PopupContextTreeMenu {
+
+    private static final long serialVersionUID = 1L;
+
+    public PopupMenuItemSpiderDialogWithContext(ExtensionAjax extension) {
+        super(false);
+
+        setText(extension.getMessages().getString("spiderajax.site.popup"));
+        setIcon(extension.getIcon());
+
+        addActionListener(
+                e -> {
+                    Context context = extension.getModel().getSession().getContext(getContextId());
+                    extension.showScanDialog(new Target(context));
+                });
+    }
+}


### PR DESCRIPTION
Add a context menu item to the Contexts tree that allows to show the AJAX Spider dialogue with the selected Context.
Add icon to the tools menu item.
Update all UI components to use the same (scaled) icon.
Tidy up `PopupMenuAjaxSite`, remove unnecessary getter and null check.