### PR TITLE
replacer: allow to replace the Host header

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Allow to replace (change or remove) the Host header (Issue 5475).
 
 ## [15] - 2023-10-12
 ### Changed

--- a/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
+++ b/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
@@ -36,6 +36,9 @@ If the header is not present and the replacement text is not empty then the head
 In this case the 'Match String' will be treated as a string or regex expression.
 If it is present in the request header then it will be replaced by the replacement text.
 
+<h5>Host Header</h5>
+Both the Request Header and Request Header String match types can change/remove the Host header, while sending the message to the original request-target.
+
 <h4>Request Body String</h4>
 In this case the 'Match String' will be treated as a string or regex expression.
 If it is present in the request body then it will be replaced by the replacement text.


### PR DESCRIPTION
Disable Host header normalization when the rules affect the Host header.

Fix zaproxy/zaproxy#5475.