### PR TITLE
Remove usages of Commons Lang v2

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.10.0] - 2023-10-12
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollector.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollector.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URIException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.network.HttpBody;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
@@ -34,7 +34,7 @@ import javax.swing.JPanel;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.httpclient.URI;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDetectionScanRule.java
@@ -30,7 +30,7 @@ import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ExtensionAuthhelper.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ExtensionAuthhelper.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.swing.ImageIcon;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import net.htmlparser.jericho.Source;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;

--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Maintenance changes.
 
 ### Added
 - Add ZAP API endpoint to get the OpenAPI definition of the ZAP API.

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestAuthDirectory.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestAuthDirectory.java
@@ -22,7 +22,7 @@ package org.zaproxy.addon.dev;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 /** A test directory which uses authentication. */
 public abstract class TestAuthDirectory extends TestDirectory {

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/jsonMultipleCookies/JsonMultipleCookiesDir.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/jsonMultipleCookies/JsonMultipleCookiesDir.java
@@ -21,7 +21,7 @@ package org.zaproxy.addon.dev.auth.jsonMultipleCookies;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.zaproxy.addon.dev.TestAuthDirectory;
 import org.zaproxy.addon.dev.TestProxyServer;
 

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/gen/openapi/ZapApiDefinition.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/gen/openapi/ZapApiDefinition.java
@@ -27,7 +27,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.api.API.Format;
 import org.zaproxy.zap.extension.api.API.RequestType;

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [43] - 2023-10-12
 ### Changed

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ZapItScan.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ZapItScan.java
@@ -32,7 +32,7 @@ import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import net.ltgt.gradle.errorprone.errorprone
+import org.zaproxy.gradle.spotless.ValidateImports
 
 plugins {
     id("com.diffplug.spotless")
@@ -8,6 +9,13 @@ plugins {
 }
 
 apply(from = "$rootDir/gradle/ci.gradle.kts")
+
+val validateImports = ValidateImports(
+    mapOf(
+        "import org.apache.commons.lang." to
+            "Import/use classes from Commons Lang 3, instead of Lang 2.",
+    ),
+)
 
 allprojects {
     apply(plugin = "com.diffplug.spotless")
@@ -27,6 +35,9 @@ allprojects {
             java {
                 licenseHeaderFile("$rootDir/gradle/spotless/license.java")
                 googleJavaFormatAosp()
+
+                bumpThisNumberIfACustomStepChanges(1)
+                custom("validateImports", validateImports)
             }
         }
     }

--- a/buildSrc/src/main/java/org/zaproxy/gradle/spotless/ValidateImports.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/spotless/ValidateImports.java
@@ -1,0 +1,57 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.spotless;
+
+import com.diffplug.spotless.FormatterFunc;
+import java.util.Map;
+import java.util.Objects;
+
+public class ValidateImports implements FormatterFunc {
+
+    private final Map<String, String> invalidImports;
+
+    public ValidateImports(Map<String, String> invalidImports) {
+        this.invalidImports = Objects.requireNonNull(invalidImports);
+    }
+
+    @Override
+    public String apply(String input) throws Exception {
+        for (var entry : invalidImports.entrySet()) {
+            if (input.contains(entry.getKey())) {
+                throw new InvalidImportException(entry.getValue());
+            }
+        }
+        return input;
+    }
+
+    private static final class InvalidImportException extends AssertionError {
+
+        private static final long serialVersionUID = 1L;
+
+        InvalidImportException(String message) {
+            super(message);
+        }
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Replace v2 classes with v3.
Add Spotless step to disallow use of v2 classes.

Follow up #4295.