### PR TITLE
Client: Firefox profile init fixes

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Cases where the Firefox profile was not added successfully via Selenium.
 
 ## [0.3.0] - 2023-10-23
 ### Changed

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
@@ -191,11 +191,14 @@ public class ClientIntegrationAPI extends ApiImplementor {
             String body = msg.getRequestBody().toString();
 
             if (body.startsWith(PARAM_OBJECT_JSON + "=")) {
-                handleReportObject(decodeParam(body, PARAM_OBJECT_JSON));
+                JSONObject json = decodeParam(body, PARAM_OBJECT_JSON);
+                LOGGER.debug("Got object: {}", json);
+                handleReportObject(json);
 
             } else if (body.startsWith(PARAM_EVENT_JSON)) {
-                this.extension.addReportedObject(
-                        new ReportedEvent(decodeParam(body, PARAM_EVENT_JSON)));
+                JSONObject json = decodeParam(body, PARAM_EVENT_JSON);
+                LOGGER.debug("Got event: {}", json);
+                this.extension.addReportedObject(new ReportedEvent(json));
             } else if (body.startsWith(PARAM_STATEMENT_JSON)) {
                 try {
                     this.extension.addZestStatement(decodeParamString(body, PARAM_STATEMENT_JSON));


### PR DESCRIPTION
## Overview
Hit a case where Selenium was not updating the Firefox profiles.ini
This meant that the extension had to be manually approved every time Firefox was started.
This fixes that by manually adding it in, if possible.

## Related Issues
Specify any related issues or pull requests by linking to them.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
