### PR TITLE
graphql: Updates and fixes

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## Unreleased
 ### Changed
 - Dependency updates.
+- Maintenance changes.
+
+### Fixed
+- The query generator was not using lists and non-null fields to generate queries when the lenient maximum query depth
+  criteria was met.
 
 ## [0.20.0] - 2023-10-12
 ### Added

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -62,7 +62,11 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("spider")
 
-    implementation("com.graphql-java:graphql-java:21.2")
+    implementation("com.graphql-java:graphql-java:21.3")
+    implementation(libs.log4j.slf4j2) {
+        // Provided by ZAP.
+        exclude(group = "org.apache.logging.log4j")
+    }
 
     testImplementation(project(":testutils"))
     testImplementation(libs.log4j.core)

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlGenerator.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlGenerator.java
@@ -358,8 +358,7 @@ public class GraphQlGenerator {
      * @param variableName StringBuilder used for variable names.
      * @return the generated query
      */
-    private String getFirstLeafQuery(
-            GraphQLType type, JSONObject variables, StringBuilder variableName) {
+    String getFirstLeafQuery(GraphQLType type, JSONObject variables, StringBuilder variableName) {
 
         class Node {
             final GraphQLType graphQLType;
@@ -479,10 +478,11 @@ public class GraphQlGenerator {
     }
 
     private GraphQLFieldDefinition getFirstLeafField(GraphQLType type) {
+        type = GraphQLTypeUtil.unwrapAll(type);
         if (type instanceof GraphQLObjectType) {
             GraphQLObjectType object = (GraphQLObjectType) type;
             return object.getFieldDefinitions().stream()
-                    .filter(f -> GraphQLTypeUtil.isLeaf(f.getType()))
+                    .filter(f -> GraphQLTypeUtil.isLeaf(GraphQLTypeUtil.unwrapAll(f.getType())))
                     .findFirst()
                     .orElse(null);
         }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -54,7 +54,8 @@ public class GraphQlParser {
                     IntrospectionQueryBuilder.Options.defaultOptions()
                             .descriptions(false)
                             .directiveIsRepeatable(false)
-                            .inputValueDeprecation(false));
+                            .inputValueDeprecation(false)
+                            .isOneOf(false));
     private static AtomicInteger threadId = new AtomicInteger();
     private static final String INTROSPECTION_ALERT_REF = ExtensionGraphQl.TOOL_ALERT_ID + "-1";
     private static final Map<String, String> INTROSPECTION_ALERT_TAGS =

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
@@ -22,6 +22,9 @@ package org.zaproxy.addon.graphql;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.UnExecutableSchemaGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.model.ValueGenerator;
@@ -377,6 +380,17 @@ class GraphQlGeneratorUnitTest extends TestUtils {
         generator = createGraphQlGenerator(getHtml("deepNestedLeaf.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query ";
+        assertEquals(expectedQuery, query);
+    }
+
+    @Test
+    void getFirstLeafQueryShouldWorkForWrappedTypes() {
+        String sdl = getHtml("listsAndNonNull.graphql");
+        GraphQLSchema schema =
+                UnExecutableSchemaGenerator.makeUnExecutableSchema(new SchemaParser().parse(sdl));
+        generator = createGraphQlGenerator(sdl);
+        String query = generator.getFirstLeafQuery(schema.getQueryType(), null, null);
+        String expectedQuery = "{ jellyBean { count } } ";
         assertEquals(expectedQuery, query);
     }
 }


### PR DESCRIPTION
- Update graphql-java to `21.3`.
- Remove the experimental `oneOf` directive from the introspection query that was added in graphql-java `21.2`. The RFC it was proposed in hasn't been formally approved yet, and many server implementations don't support it, which results in the failure of introspection. I tested the add-on against DVGA to verify this behaviour.
- Fix an issue with the generator where it was not making use of wrapped types (lists, non-null) to generate queries when the lenient max query depth criteria was met.
- Include the SLF4J2 -> Log4j bridge with the add-on.