### PR TITLE
exim: Keep Export menu items sorted

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- A generic UI component for keeping menu items sorted.
 
 ## [1.18.0] - 2023-10-12
 ### Changed

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ZapSortedMenu.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ZapSortedMenu.java
@@ -1,0 +1,91 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.ui;
+
+import java.awt.Component;
+import java.text.Collator;
+import java.util.Comparator;
+import javax.swing.Action;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+
+/**
+ * @since 1.19.0
+ */
+@SuppressWarnings("serial")
+public class ZapSortedMenu extends JMenu {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Comparator<JMenuItem> comparator;
+
+    public ZapSortedMenu() {
+        this((item1, item2) -> Collator.getInstance().compare(item1.getText(), item2.getText()));
+    }
+
+    public ZapSortedMenu(Comparator<JMenuItem> comparator) {
+        this.comparator = comparator;
+    }
+
+    @Override
+    public JMenuItem add(JMenuItem menuItem) {
+        super.add(menuItem, getSortedIndex(menuItem));
+        return menuItem;
+    }
+
+    @Override
+    public Component add(Component c) {
+        return super.add(c, getSortedIndex(c));
+    }
+
+    @Override
+    public Component add(Component c, int index) {
+        return add(c);
+    }
+
+    @Override
+    public void insert(String s, int pos) {
+        add(s);
+    }
+
+    @Override
+    public JMenuItem insert(JMenuItem mi, int pos) {
+        return add(mi);
+    }
+
+    @Override
+    public JMenuItem insert(Action a, int pos) {
+        return add(a);
+    }
+
+    private int getSortedIndex(Component comp) {
+        if (!(comp instanceof JMenuItem)) {
+            return -1;
+        }
+        int pos = 0;
+        for (int i = 0; i < getItemCount(); ++i) {
+            if (comparator.compare((JMenuItem) comp, getItem(i)) < 0) {
+                break;
+            }
+            pos = i + 1;
+        }
+        return pos;
+    }
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/ui/ZapSortedMenuUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/ui/ZapSortedMenuUnitTest.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class ZapSortedMenuUnitTest {
+
+    @Test
+    void shouldKeepMenuItemsSortedAlphabetically() {
+        // Given
+        var menu = new ZapSortedMenu();
+        // When
+        menu.add("Z");
+        menu.add("A");
+        // Then
+        assertThat(menu.getItemCount(), is(equalTo(2)));
+        assertThat(menu.getItem(0).getText(), is(equalTo("A")));
+        assertThat(menu.getItem(1).getText(), is(equalTo("Z")));
+    }
+}

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Keep the Export menu items sorted alphabetically.
 
 ## [0.7.0] - 2023-10-12
 ### Changed

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -31,7 +31,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.17.0 & < 2.0.0")
+                    version.set(">= 1.19.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.view.MainMenuBar;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.commonlib.ExtensionCommonlib;
 import org.zaproxy.addon.commonlib.ui.ProgressPanel;
+import org.zaproxy.addon.commonlib.ui.ZapSortedMenu;
 import org.zaproxy.addon.exim.har.MenuImportHar;
 import org.zaproxy.addon.exim.har.PopupMenuItemSaveHarMessage;
 import org.zaproxy.addon.exim.log.MenuItemImportLogs;
@@ -139,7 +140,7 @@ public class ExtensionExim extends ExtensionAdaptor {
 
     private JMenu getMenuExport() {
         if (menuExport == null) {
-            menuExport = new JMenu();
+            menuExport = new ZapSortedMenu();
             menuExport.setText(Constant.messages.getString("exim.menu.export"));
             menuExport.setMnemonic(Constant.messages.getChar("exim.menu.export.mnemonic"));
         }


### PR DESCRIPTION
## Overview
- Duplicate the ZapSortedMenu class from the core to commonlib, as discussed in IRC.
- Update exim to use ZapSortedMenu for the Export menu.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title