### PR TITLE
scripts: Allow configuring indentation settings

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Allow setting the tab size and whether to use tabs or spaces for indentation in the console.
+  The old defaults were to use the tab character with a tab size of 5.
+  The new defaults are to use spaces with a tab size of 4.
 
 ## [42] - 2023-10-12
 ### Changed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -29,12 +29,14 @@ import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
+import org.parosproxy.paros.extension.OptionsChangedListener;
+import org.parosproxy.paros.model.OptionsParam;
 import org.zaproxy.zap.extension.scripts.autocomplete.ScriptAutoCompleteKeyListener;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapLabel;
 
 @SuppressWarnings("serial")
-public class CommandPanel extends AbstractPanel {
+public class CommandPanel extends AbstractPanel implements OptionsChangedListener {
 
     private static final long serialVersionUID = -947074835463140074L;
 
@@ -183,5 +185,15 @@ public class CommandPanel extends AbstractPanel {
             this.remove(largeScriptPanel);
             this.add(getJScrollPane(), getJScrollPane().getName());
         }
+    }
+
+    @Override
+    public void optionsChanged(OptionsParam mainOptions) {
+        optionsChanged(mainOptions.getParamSet(ScriptConsoleOptions.class));
+    }
+
+    void optionsChanged(ScriptConsoleOptions options) {
+        getTxtOutput().setTabSize(options.getTabSize());
+        getTxtOutput().setTabsEmulated(!options.isUseTabCharacter());
     }
 }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -437,7 +437,7 @@ public class ConsolePanel extends AbstractPanel {
         return listener;
     }
 
-    private CommandPanel getCommandPanel() {
+    CommandPanel getCommandPanel() {
         if (commandPanel == null) {
             commandPanel = new CommandPanel(getKeyListener());
             commandPanel.setEditable(false);

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -174,6 +174,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
             extensionHook.getHookView().addSelectPanel(getScriptsPanel());
             extensionHook.addSessionListener(new ViewSessionChangedListener());
             extensionHook.getHookView().addWorkPanel(getConsolePanel());
+            extensionHook.addOptionsChangedListener(getConsolePanel().getCommandPanel());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupInvokeScriptWithHttpMessageMenu());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupEnableDisableScript());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupRemoveScript());
@@ -189,6 +190,13 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuItemSaveScript());
             ExtensionHelp.enableHelpKey(getConsolePanel(), "addon.scripts.console");
             ExtensionHelp.enableHelpKey(getScriptsPanel(), "addon.scripts.tree");
+        }
+    }
+
+    @Override
+    public void optionsLoaded() {
+        if (hasView()) {
+            getConsolePanel().getCommandPanel().optionsChanged(getScriptConsoleOptions());
         }
     }
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptions.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptions.java
@@ -27,6 +27,8 @@ public class ScriptConsoleOptions extends VersionedAbstractParam {
     private static String BASE_KEY = "script.console";
     private static String DEFAULT_SCRIPT_CHANGED_BEHAVIOUR =
             BASE_KEY + ".defaultScriptChangedBehaviour";
+    private static String TAB_SIZE = BASE_KEY + ".codeStyle.tabSize";
+    private static String USE_TAB_CHARACTER = BASE_KEY + ".codeStyle.useTabCharacter";
 
     /**
      * The version of the configurations. Used to keep track of configurations changes between
@@ -35,6 +37,8 @@ public class ScriptConsoleOptions extends VersionedAbstractParam {
     private static final int CURRENT_CONFIG_VERSION = 1;
 
     private DefaultScriptChangedBehaviour defaultScriptChangedBehaviour;
+    private int tabSize;
+    private boolean useTabCharacter;
 
     public DefaultScriptChangedBehaviour getDefaultScriptChangedBehaviour() {
         return defaultScriptChangedBehaviour;
@@ -45,12 +49,32 @@ public class ScriptConsoleOptions extends VersionedAbstractParam {
         getConfig().setProperty(DEFAULT_SCRIPT_CHANGED_BEHAVIOUR, behaviour.name());
     }
 
+    public int getTabSize() {
+        return tabSize;
+    }
+
+    public void setTabSize(int tabSize) {
+        this.tabSize = tabSize;
+        getConfig().setProperty(TAB_SIZE, tabSize);
+    }
+
+    public boolean isUseTabCharacter() {
+        return useTabCharacter;
+    }
+
+    public void setUseTabCharacter(boolean useTabCharacter) {
+        this.useTabCharacter = useTabCharacter;
+        getConfig().setProperty(USE_TAB_CHARACTER, useTabCharacter);
+    }
+
     @Override
     protected void parseImpl() {
         defaultScriptChangedBehaviour =
                 getEnum(
                         DEFAULT_SCRIPT_CHANGED_BEHAVIOUR,
                         DefaultScriptChangedBehaviour.ASK_EACH_TIME);
+        tabSize = getInt(TAB_SIZE, 4);
+        useTabCharacter = getBoolean(USE_TAB_CHARACTER, false);
     }
 
     @Override

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptionsPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptionsPanel.java
@@ -23,12 +23,16 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import javax.swing.Box;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.TitledBorder;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.extension.scripts.ScriptConsoleOptions.DefaultScriptChangedBehaviour;
+import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.view.LayoutHelper;
 
 public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
@@ -39,6 +43,9 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
             Constant.messages.getString("scripts.console.options.panelName");
 
     private JComboBox<DefaultScriptChangedBehaviour> defaultScriptChangedBehaviour;
+    private JPanel codeStylePanel;
+    private ZapNumberSpinner tabSizeSpinner;
+    private JCheckBox useTabCharacterCheckBox;
 
     public ScriptConsoleOptionsPanel() {
         super();
@@ -56,6 +63,7 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
         add(
                 getDefaultScriptChangedBehaviour(),
                 LayoutHelper.getGBC(1, row, 1, 0.5, new Insets(2, 2, 4, 4)));
+        add(getCodeStylePanel(), LayoutHelper.getGBC(0, ++row, 2, 1.0, new Insets(0, 4, 4, 4)));
 
         add(
                 Box.createHorizontalGlue(),
@@ -74,6 +82,8 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
         ScriptConsoleOptions options = getScriptConsoleOptions(mainOptions);
         getDefaultScriptChangedBehaviour()
                 .setSelectedItem(options.getDefaultScriptChangedBehaviour());
+        getTabSizeSpinner().setValue(options.getTabSize());
+        getUseTabCharacterCheckBox().setSelected(options.isUseTabCharacter());
     }
 
     @Override
@@ -82,6 +92,8 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
         options.setDefaultScriptChangedBehaviour(
                 (DefaultScriptChangedBehaviour)
                         getDefaultScriptChangedBehaviour().getSelectedItem());
+        options.setTabSize(getTabSizeSpinner().getValue());
+        options.setUseTabCharacter(getUseTabCharacterCheckBox().isSelected());
     }
 
     private static ScriptConsoleOptions getScriptConsoleOptions(Object mainOptions) {
@@ -104,5 +116,42 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
                             });
         }
         return defaultScriptChangedBehaviour;
+    }
+
+    private JPanel getCodeStylePanel() {
+        if (codeStylePanel == null) {
+            codeStylePanel = new JPanel(new GridBagLayout());
+            codeStylePanel.setBorder(
+                    new TitledBorder(
+                            Constant.messages.getString("scripts.options.codeStyle.title")));
+            int row = 0;
+            var tabSizeLabel =
+                    new JLabel(Constant.messages.getString("scripts.options.codeStyle.tabSize"));
+            codeStylePanel.add(
+                    tabSizeLabel, LayoutHelper.getGBC(0, ++row, 1, 0.5, new Insets(2, 4, 2, 2)));
+            codeStylePanel.add(
+                    getTabSizeSpinner(),
+                    LayoutHelper.getGBC(1, row, 1, 0.5, new Insets(2, 2, 2, 4)));
+            codeStylePanel.add(
+                    getUseTabCharacterCheckBox(),
+                    LayoutHelper.getGBC(0, ++row, 2, 1.0, new Insets(2, 4, 4, 4)));
+        }
+        return codeStylePanel;
+    }
+
+    private ZapNumberSpinner getTabSizeSpinner() {
+        if (tabSizeSpinner == null) {
+            tabSizeSpinner = new ZapNumberSpinner(1, 4, 16);
+        }
+        return tabSizeSpinner;
+    }
+
+    private JCheckBox getUseTabCharacterCheckBox() {
+        if (useTabCharacterCheckBox == null) {
+            useTabCharacterCheckBox = new JCheckBox();
+            useTabCharacterCheckBox.setText(
+                    Constant.messages.getString("scripts.options.codeStyle.useTabCharacter"));
+        }
+        return useTabCharacterCheckBox;
     }
 }

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/options.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/options.html
@@ -19,5 +19,17 @@
 
 Note that if there are unsaved changes to the script, you will always be prompted to choose which version to keep.
 
+<h2>Code Style</h2>
+
+<h3>Tab Size</h3>
+<p>Set the width by which the code should be indented when you press Tab.
+    The unit is the width of one space character.
+    The default tab size is 4.
+
+<h3>Use Tab Character</h3>
+<p>Use tab characters (<code>\t</code>) instead of spaces for indentation.
+    The size of one tab character is determined by the <strong>Tab Size</strong> setting.
+    The default is to use spaces.
+
 </body>
 </html>

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -96,6 +96,9 @@ scripts.list.toolbar.button.stop = Stop Script
 
 scripts.menu.tools.enable = Enable / Disable Scripts
 
+scripts.options.codeStyle.tabSize = Tab Size:
+scripts.options.codeStyle.title = Code Style
+scripts.options.codeStyle.useTabCharacter = Use Tab Character
 scripts.options.title = Scripts
 
 scripts.output.clear.button.toolTip = Clear script output panel


### PR DESCRIPTION
## Overview
Allow setting the tab size and whether to use tabs or spaces for indentation in the console.

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title