### PR TITLE
callhome: upload API stats

### DIFF
--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Add API stats to telemetry.
 
 ## [0.8.0] - 2023-10-12
 ### Changed

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
@@ -286,6 +286,7 @@ public class ExtensionCallHome extends ExtensionAdaptor
                     || key.startsWith("soap.")
                     || key.startsWith("spiderAjax.")
                     || key.startsWith("stats.alertFilter")
+                    || key.startsWith("stats.api.")
                     || key.startsWith("stats.ascan.")
                     || key.startsWith("stats.auth.")
                     || key.startsWith("stats.auto.")


### PR DESCRIPTION
Allow to know how the API is used.