### PR TITLE
Use varied high and low delays in time-based attack tests

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Use high and low delays for linear regression time-based tests to fix false positives from delays that were smaller than normal variance in application response times.
 
 ## [58] - 2023-10-12
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
@@ -211,11 +211,8 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
     /** The default number of seconds used in time-based attacks (i.e. sleep commands). */
     private static final int DEFAULT_TIME_SLEEP_SEC = 5;
 
-    // time-based attack detection will not send more than the following number of requests
-    private static final int BLIND_REQUEST_LIMIT = 5;
-    // time-based attack detection will try to take less than the following number of seconds
-    // note: detection of this length will generally only happen in the positive (detecting) case.
-    private static final double BLIND_SECONDS_LIMIT = 20.0;
+    // limit the maximum number of requests sent for time-based attack detection
+    private static final int BLIND_REQUESTS_LIMIT = 4;
 
     // error range allowable for statistical time-based blind attacks (0-1.0)
     private static final double TIME_CORRELATION_ERROR_RANGE = 0.15;
@@ -623,8 +620,8 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
                     // use TimingUtils to detect a response to sleep payloads
                     isInjectable =
                             TimingUtils.checkTimingDependence(
-                                    BLIND_REQUEST_LIMIT,
-                                    BLIND_SECONDS_LIMIT,
+                                    BLIND_REQUESTS_LIMIT,
+                                    timeSleepSeconds,
                                     requestSender,
                                     TIME_CORRELATION_ERROR_RANGE,
                                     TIME_SLOPE_ERROR_RANGE);


### PR DESCRIPTION
## Overview
Per discussion in https://github.com/zaproxy/zaproxy/issues/8112 TimingUtils is currently using step function of delays starting at 1 second and incrementing by 1 second. However, real world applications and networks often have normal response time variations > 1 second so this is prone to false positives. This change switches to using alternating high and low delays (15 seconds, 1 second) to minimize false positives.

## Related Issues
https://github.com/zaproxy/zaproxy/issues/8112
https://github.com/zaproxy/zap-extensions/pull/4679
https://github.com/zaproxy/zap-extensions/pull/4997
https://groups.google.com/g/zaproxy-develop/c/KGSkNHlLtqk

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
