### PR TITLE
network: notify `ProxyListener`s concurrently

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Notify proxy listeners concurrently, might break listeners that do not correctly handle concurrency.
 
 ## [0.13.0] - 2023-11-17
 ### Added


### PR DESCRIPTION
This PR is 1st step to address https://github.com/zaproxy/zaproxy/issues/8146
Assumptions made are described in comment.

2nd step will be in PR to zaproxy repository. https://github.com/zaproxy/zaproxy/pull/8158

I tried proposed changes - they seem to be working fine. Requests are being processed in parallel, breakpoints wait for user interaction, not blocking other requests.
Probably there are some scenarios requiring further code changes? Please take a look.