### PR TITLE
network: do not set content-length to SSE

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Handle cookies like browsers, mostly send what is received (Issues 1232 and 7874).
+- Do not set content-length to SSE responses, which would end up being closed prematurely.
 
 ## [0.12.0] - 2023-10-12
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -520,7 +520,7 @@ public class HttpSenderApache
 
         updateRequestHeaders(message.getRequestHeader(), requestCtx.getRequest());
 
-        if (isSet(requestCtx, RemoveTransferEncoding.ATTR_NAME)) {
+        if (isSet(requestCtx, RemoveTransferEncoding.ATTR_NAME) && !message.isEventStream()) {
             message.getResponseHeader().setContentLength(message.getResponseBody().length());
         }
 


### PR DESCRIPTION
Only set the content-length if not a SSE response when the transfer-encoding header is removed.

---
WIP as I want to add some tests to ensure this does not regress.
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/SguXEsVzHYE/m/7uiRfwIuAAAJ

Introduced in #3944.