### PR TITLE
callhome: upload error stats

### DIFF
--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Add error stats to telemetry.
 
 ## [0.9.0] - 2023-10-31
 ### Changed

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
@@ -294,6 +294,7 @@ public class ExtensionCallHome extends ExtensionAdaptor
                     || key.startsWith("stats.client.")
                     || key.startsWith("stats.code.")
                     || key.startsWith("stats.config.")
+                    || key.startsWith("stats.error.")
                     || key.startsWith("stats.exim.")
                     || key.startsWith("stats.fuzz.")
                     || key.startsWith("stats.graphql.")


### PR DESCRIPTION
Allow to know how many errors are happening.