### PR TITLE
scripts: Add save shortcut and fix race condition

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -11,9 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A gear button to the console toolbar to open the Script Console options screen.
 - An enable / disable script button to the console toolbar to toggle enabling the open script.
 - Options to allow editing the font name and size used in the console (Issue 8065).
+- The shortcut `ctrl+S` (`cmd+S` on macOS) to save the script in the console.
 
 ### Changed
 - The "Save Script" button was moved to the console toolbar.
+
+### Fixed
+- Saving the script was causing the "Keep or Replace" dialog to show, even when no external changes were made to the script.
 
 ## [42] - 2023-10-12
 ### Changed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -322,7 +322,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
         return scriptConsoleOptions;
     }
 
-    private ConsolePanel getConsolePanel() {
+    ConsolePanel getConsolePanel() {
         if (consolePanel == null) {
             consolePanel = new ConsolePanel(this);
             consolePanel.setName(Constant.messages.getString("scripts.panel.title"));

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -308,10 +308,11 @@ public class ScriptsListPanel extends AbstractPanel {
     protected void saveScript(ScriptWrapper script) {
         if (script.getFile() != null) {
             try {
-                extension.getExtScript().saveScript(script);
+                synchronized (extension.getConsolePanel().getScriptLock()) {
+                    extension.getExtScript().saveScript(script);
+                }
                 ((ScriptTreeModel) this.getTree().getModel())
                         .nodeChanged(this.getSelectedScriptNode());
-
             } catch (IOException e1) {
                 View.getSingleton()
                         .showWarningDialog(
@@ -351,10 +352,11 @@ public class ScriptsListPanel extends AbstractPanel {
                 script.setFile(file);
 
                 try {
-                    extension.getExtScript().saveScript(script);
+                    synchronized (extension.getConsolePanel().getScriptLock()) {
+                        extension.getExtScript().saveScript(script);
+                    }
                     ((ScriptTreeModel) this.getTree().getModel())
                             .nodeChanged(this.getSelectedScriptNode());
-
                 } catch (IOException e1) {
                     View.getSingleton()
                             .showWarningDialog(

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/console.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/console.html
@@ -29,6 +29,7 @@ Templates can be viewed in the console but cannot be edited.<br/>
 
 <h3>Save Script</h3>
 This button allows you to save the script currently displayed in the console to a file.<br/>
+The shortcut `ctrl+S` (or `cmd+S` on macOS) may also be used for this purpose.<br/>
 
 <h3>Enable / Disable Script</h3>
 This button may be used to enable or disable the script currently displayed in the console.<br/>


### PR DESCRIPTION
## Overview
- Add the shortcut `ctrl+S` (`cmd+S` on macOS) to save the script in the console.
- Fix a race condition between saving a script and checking if it was changed on disk by synchronizing those statements.
The issue is that `ScriptWrapper#hasChangedOnDisk()` is being called from the polling thread even before `ScriptWrapper#lastModified` is updated in `ScriptWrapper#saveScript()`. I think the proper fix would be to make these methods synchronized in the core.

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title