### PR TITLE
selenium: update API client gen conf

### DIFF
--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -28,7 +28,6 @@ zapAddOn {
 
     apiClientGen {
         api.set("org.zaproxy.zap.extension.selenium.SeleniumAPI")
-        options.set("org.zaproxy.zap.extension.selenium.SeleniumOptions")
         messages.set(file("src/main/resources/org/zaproxy/zap/extension/selenium/resources/Messages.properties"))
     }
 }


### PR DESCRIPTION
No longer set the options through the client generator configuration, as it is now set in the code.