### PR TITLE
reports: Address warnings in Risk and Confidence HTML template

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Addressed warnings caused by Risk and Confidence HTML template.
 
 ## [0.26.0] - 2023-10-12
 ### Changed

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     }
 
     testImplementation(project(":testutils"))
+    testImplementation(libs.log4j.core)
 }
 
 spotless {

--- a/addOns/reports/src/main/zapHomeFiles/reports/risk-confidence-html/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/risk-confidence-html/report.html
@@ -470,7 +470,7 @@
 														method and URL</span>
 												</summary>
 												<th-block
-													data-th-replace="::alertsTable(alert=${filteredAlert})">
+													data-th-replace="~{::alertsTable(alert=${filteredAlert})}">
 												</th-block>
 											</details></li>
 									</ol>
@@ -605,14 +605,14 @@
 		<th scope="row"
 			data-th-text="#{report.template.alertsTable.description}">Description</th>
 		<td><th-block
-				data-th-replace="::nl2p(text=${userObject.description})">Description</th-block></td>
+				data-th-replace="~{::nl2p(text=${userObject.description})}">Description</th-block></td>
 	</tr>
 	<tr data-th-unless="${userObject.otherInfo.isEmpty()}">
 		<th scope="row"
 			data-th-text="#{report.template.alertsTable.otherInfo}">Other
 			info</th>
 		<td><th-block
-				data-th-replace="::nl2p(text=${userObject.otherInfo})">Other
+				data-th-replace="~{::nl2p(text=${userObject.otherInfo})}">Other
 			info</th-block></td>
 	</tr>
 	<tr>
@@ -691,7 +691,7 @@
 	<tr data-th-unless="${userObject.solution.isEmpty()}">
 		<th scope="row" data-th-text="#{report.template.alertsTable.solution}">Solution</th>
 		<td><th-block
-				data-th-replace="::nl2p(text=${userObject.solution})">Solution</th-block></td>
+				data-th-replace="~{::nl2p(text=${userObject.solution})}">Solution</th-block></td>
 	</tr>
 </table>
 </th-block> </th-block>


### PR DESCRIPTION
# OVERVIEW
- CHANGELOG > Added fix note.
- report.html > Wrapped previous un-wrapped fragments.
- ExtensionReportsUnitTest > Add unit test asserting that reports generate without warnings. Update other tests as appropriate.
- reports.gradle.kts > Add Log4j as a test dependency.

Addresses warnings such as:
```
1368064 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::alertsTable(alert=${filteredAlert})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 473, col 14. Please use the complete syntax of fragment expressions instead ("~{::alertsTable(alert=${filteredAlert})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368087 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.description})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 608, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.description})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368107 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.solution})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 694, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.solution})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368109 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::alertsTable(alert=${filteredAlert})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 473, col 14. Please use the complete syntax of fragment expressions instead ("~{::alertsTable(alert=${filteredAlert})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368110 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.description})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 608, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.description})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368114 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.solution})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 694, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.solution})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368115 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::alertsTable(alert=${filteredAlert})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 473, col 14. Please use the complete syntax of fragment expressions instead ("~{::alertsTable(alert=${filteredAlert})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368116 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.description})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 608, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.description})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368121 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.solution})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 694, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.solution})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368124 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::alertsTable(alert=${filteredAlert})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 473, col 14. Please use the complete syntax of fragment expressions instead ("~{::alertsTable(alert=${filteredAlert})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368124 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.description})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 608, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.description})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368125 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.otherInfo})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 615, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.otherInfo})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368138 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.solution})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 694, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.solution})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368142 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::alertsTable(alert=${filteredAlert})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 473, col 14. Please use the complete syntax of fragment expressions instead ("~{::alertsTable(alert=${filteredAlert})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368142 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.description})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 608, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.description})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368146 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.solution})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 694, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.solution})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368148 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::alertsTable(alert=${filteredAlert})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 473, col 14. Please use the complete syntax of fragment expressions instead ("~{::alertsTable(alert=${filteredAlert})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368149 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.description})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 608, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.description})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368153 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.solution})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 694, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.solution})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368156 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::alertsTable(alert=${filteredAlert})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 473, col 14. Please use the complete syntax of fragment expressions instead ("~{::alertsTable(alert=${filteredAlert})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368158 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.description})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 608, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.description})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368159 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.otherInfo})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 615, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.otherInfo})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
1368163 [AWT-EventQueue-0] WARN  org.thymeleaf.standard.processor.AbstractStandardFragmentInsertionTagProcessor - [THYMELEAF][AWT-EventQueue-0][C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html] Deprecated unwrapped fragment expression "::nl2p(text=${userObject.solution})" found in template C:\Users\thorin\ZAP_D\reports\risk-confidence-html\report.html, line 694, col 5. Please use the complete syntax of fragment expressions instead ("~{::nl2p(text=${userObject.solution})}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
```

Ref: https://stackoverflow.com/a/75947428/7718222

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
