### PR TITLE
scripts: Allow modifying console font

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   The new defaults are to use spaces with a tab size of 4.
 - A gear button to the console toolbar to open the Script Console options screen.
 - An enable / disable script button to the console toolbar to toggle enabling the open script.
+- Options to allow editing the font name and size used in the console (Issue 8065).
 
 ### Changed
 - The "Save Script" button was moved to the console toolbar.

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -22,9 +22,11 @@ package org.zaproxy.zap.extension.scripts;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Component;
+import java.awt.Font;
 import java.awt.event.KeyListener;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.text.StyleContext;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.parosproxy.paros.Constant;
@@ -193,6 +195,10 @@ public class CommandPanel extends AbstractPanel implements OptionsChangedListene
     }
 
     void optionsChanged(ScriptConsoleOptions options) {
+        var font =
+                StyleContext.getDefaultStyleContext()
+                        .getFont(options.getFontName(), Font.PLAIN, options.getFontSize());
+        getTxtOutput().setFont(font);
         getTxtOutput().setTabSize(options.getTabSize());
         getTxtOutput().setTabsEmulated(!options.isUseTabCharacter());
     }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptions.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptions.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.scripts;
 
+import java.awt.Font;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 
@@ -27,6 +28,8 @@ public class ScriptConsoleOptions extends VersionedAbstractParam {
     private static String BASE_KEY = "script.console";
     private static String DEFAULT_SCRIPT_CHANGED_BEHAVIOUR =
             BASE_KEY + ".defaultScriptChangedBehaviour";
+    private static String FONT_NAME = BASE_KEY + ".font.name";
+    private static String FONT_SIZE = BASE_KEY + ".font.size";
     private static String TAB_SIZE = BASE_KEY + ".codeStyle.tabSize";
     private static String USE_TAB_CHARACTER = BASE_KEY + ".codeStyle.useTabCharacter";
 
@@ -37,6 +40,8 @@ public class ScriptConsoleOptions extends VersionedAbstractParam {
     private static final int CURRENT_CONFIG_VERSION = 1;
 
     private DefaultScriptChangedBehaviour defaultScriptChangedBehaviour;
+    private String fontName;
+    private int fontSize;
     private int tabSize;
     private boolean useTabCharacter;
 
@@ -47,6 +52,24 @@ public class ScriptConsoleOptions extends VersionedAbstractParam {
     public void setDefaultScriptChangedBehaviour(DefaultScriptChangedBehaviour behaviour) {
         this.defaultScriptChangedBehaviour = behaviour;
         getConfig().setProperty(DEFAULT_SCRIPT_CHANGED_BEHAVIOUR, behaviour.name());
+    }
+
+    public String getFontName() {
+        return fontName;
+    }
+
+    public void setFontName(String fontName) {
+        this.fontName = fontName;
+        getConfig().setProperty(FONT_NAME, fontName);
+    }
+
+    public int getFontSize() {
+        return fontSize;
+    }
+
+    public void setFontSize(int fontSize) {
+        this.fontSize = fontSize;
+        getConfig().setProperty(FONT_SIZE, fontSize);
     }
 
     public int getTabSize() {
@@ -73,6 +96,10 @@ public class ScriptConsoleOptions extends VersionedAbstractParam {
                 getEnum(
                         DEFAULT_SCRIPT_CHANGED_BEHAVIOUR,
                         DefaultScriptChangedBehaviour.ASK_EACH_TIME);
+        fontName = getString(FONT_NAME, Font.MONOSPACED);
+        if ((fontSize = getInt(FONT_SIZE, 12)) < 1) {
+            fontSize = 12;
+        }
         tabSize = getInt(TAB_SIZE, 4);
         useTabCharacter = getBoolean(USE_TAB_CHARACTER, false);
     }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptionsPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptionsPanel.java
@@ -19,19 +19,27 @@
  */
 package org.zaproxy.zap.extension.scripts;
 
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import javax.swing.Box;
+import javax.swing.DefaultListCellRenderer;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.border.TitledBorder;
+import javax.swing.plaf.basic.BasicComboBoxRenderer;
+import javax.swing.text.StyleContext;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.extension.scripts.ScriptConsoleOptions.DefaultScriptChangedBehaviour;
+import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.view.LayoutHelper;
 
@@ -43,6 +51,9 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
             Constant.messages.getString("scripts.console.options.panelName");
 
     private JComboBox<DefaultScriptChangedBehaviour> defaultScriptChangedBehaviour;
+    private JPanel fontPanel;
+    private JComboBox<String> fontNameComboBox;
+    private ZapNumberSpinner fontSizeSpinner;
     private JPanel codeStylePanel;
     private ZapNumberSpinner tabSizeSpinner;
     private JCheckBox useTabCharacterCheckBox;
@@ -52,7 +63,7 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
         setName(NAME);
         setLayout(new GridBagLayout());
 
-        int row = 0;
+        int row = -1;
         var defaultScriptChangedBehaviourLabel =
                 new JLabel(
                         Constant.messages.getString(
@@ -63,6 +74,7 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
         add(
                 getDefaultScriptChangedBehaviour(),
                 LayoutHelper.getGBC(1, row, 1, 0.5, new Insets(2, 2, 4, 4)));
+        add(getFontPanel(), LayoutHelper.getGBC(0, ++row, 2, 1.0, new Insets(0, 4, 4, 4)));
         add(getCodeStylePanel(), LayoutHelper.getGBC(0, ++row, 2, 1.0, new Insets(0, 4, 4, 4)));
 
         add(
@@ -82,6 +94,8 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
         ScriptConsoleOptions options = getScriptConsoleOptions(mainOptions);
         getDefaultScriptChangedBehaviour()
                 .setSelectedItem(options.getDefaultScriptChangedBehaviour());
+        getFontNameComboBox().setSelectedItem(options.getFontName());
+        getFontSizeSpinner().setValue(options.getFontSize());
         getTabSizeSpinner().setValue(options.getTabSize());
         getUseTabCharacterCheckBox().setSelected(options.isUseTabCharacter());
     }
@@ -92,6 +106,8 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
         options.setDefaultScriptChangedBehaviour(
                 (DefaultScriptChangedBehaviour)
                         getDefaultScriptChangedBehaviour().getSelectedItem());
+        options.setFontName((String) getFontNameComboBox().getSelectedItem());
+        options.setFontSize(getFontSizeSpinner().getValue());
         options.setTabSize(getTabSizeSpinner().getValue());
         options.setUseTabCharacter(getUseTabCharacterCheckBox().isSelected());
     }
@@ -118,13 +134,37 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
         return defaultScriptChangedBehaviour;
     }
 
+    private JPanel getFontPanel() {
+        if (fontPanel == null) {
+            fontPanel = new JPanel(new GridBagLayout());
+            fontPanel.setBorder(
+                    new TitledBorder(Constant.messages.getString("scripts.options.font.title")));
+            int row = -1;
+            var fontNameLabel =
+                    new JLabel(Constant.messages.getString("scripts.options.font.fontName"));
+            fontPanel.add(
+                    fontNameLabel, LayoutHelper.getGBC(0, ++row, 1, 0.5, new Insets(2, 4, 2, 2)));
+            fontPanel.add(
+                    getFontNameComboBox(),
+                    LayoutHelper.getGBC(1, row, 1, 0.5, new Insets(2, 2, 2, 4)));
+            var fontSizeLabel =
+                    new JLabel(Constant.messages.getString("scripts.options.font.fontSize"));
+            fontPanel.add(
+                    fontSizeLabel, LayoutHelper.getGBC(0, ++row, 1, 0.5, new Insets(2, 4, 2, 2)));
+            fontPanel.add(
+                    getFontSizeSpinner(),
+                    LayoutHelper.getGBC(1, row, 1, 0.5, new Insets(2, 2, 2, 4)));
+        }
+        return fontPanel;
+    }
+
     private JPanel getCodeStylePanel() {
         if (codeStylePanel == null) {
             codeStylePanel = new JPanel(new GridBagLayout());
             codeStylePanel.setBorder(
                     new TitledBorder(
                             Constant.messages.getString("scripts.options.codeStyle.title")));
-            int row = 0;
+            int row = -1;
             var tabSizeLabel =
                     new JLabel(Constant.messages.getString("scripts.options.codeStyle.tabSize"));
             codeStylePanel.add(
@@ -137,6 +177,23 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
                     LayoutHelper.getGBC(0, ++row, 2, 1.0, new Insets(2, 4, 4, 4)));
         }
         return codeStylePanel;
+    }
+
+    private JComboBox<String> getFontNameComboBox() {
+        if (fontNameComboBox == null) {
+            String[] availableFonts =
+                    GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
+            fontNameComboBox = new JComboBox<>(availableFonts);
+            fontNameComboBox.setRenderer(new JComboBoxFontRenderer());
+        }
+        return fontNameComboBox;
+    }
+
+    private ZapNumberSpinner getFontSizeSpinner() {
+        if (fontSizeSpinner == null) {
+            fontSizeSpinner = new ZapNumberSpinner(1, 12, 100);
+        }
+        return fontSizeSpinner;
     }
 
     private ZapNumberSpinner getTabSizeSpinner() {
@@ -153,5 +210,27 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
                     Constant.messages.getString("scripts.options.codeStyle.useTabCharacter"));
         }
         return useTabCharacterCheckBox;
+    }
+
+    @SuppressWarnings("serial")
+    private static class JComboBoxFontRenderer extends BasicComboBoxRenderer {
+        protected DefaultListCellRenderer defaultRenderer = new DefaultListCellRenderer();
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Component getListCellRendererComponent(
+                JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            var renderer =
+                    (JLabel)
+                            defaultRenderer.getListCellRendererComponent(
+                                    list, value, index, isSelected, cellHasFocus);
+            renderer.setFont(
+                    StyleContext.getDefaultStyleContext()
+                            .getFont(
+                                    (String) value,
+                                    Font.PLAIN,
+                                    FontUtils.getFont(Font.PLAIN).getSize()));
+            return renderer;
+        }
     }
 }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.scripts;
 
 import java.awt.Component;
-import java.awt.Font;
 import java.io.IOException;
 import java.util.List;
 import java.util.Vector;
@@ -36,7 +35,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DisplayUtils;
-import org.zaproxy.zap.utils.FontUtils;
 
 public class SyntaxHighlightTextArea extends RSyntaxTextArea {
 
@@ -122,15 +120,6 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
         setCloseCurlyBraces(false);
         setCloseMarkupTags(false);
         setClearWhitespaceLinesEnabled(false);
-
-        Font font;
-        if (!FontUtils.isDefaultFontSet()) {
-            // Use default RSyntaxTextArea font instead but with correct font size.
-            font = FontUtils.getFont(this.getFont().getFontName());
-        } else {
-            font = FontUtils.getFont(Font.PLAIN);
-        }
-        this.setFont(font);
 
         if (DisplayUtils.isDarkLookAndFeel()) {
             darkLaF = true;

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/options.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/options.html
@@ -19,6 +19,16 @@
 
 Note that if there are unsaved changes to the script, you will always be prompted to choose which version to keep.
 
+<h2>Font</h2>
+
+<h3>Font Name</h3>
+<p>Set the name of the font used in the script console.
+    A monospaced font is used by default.
+
+<h3>Font Size</h3>
+<p>Set the size of the font used in the script console.
+    The default font size is 12.
+
 <h2>Code Style</h2>
 
 <h3>Tab Size</h3>

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -95,10 +95,13 @@ scripts.list.toolbar.button.save = Save Script ...
 scripts.list.toolbar.button.stop = Stop Script
 
 scripts.menu.tools.enable = Enable / Disable Scripts
-
 scripts.options.codeStyle.tabSize = Tab Size:
 scripts.options.codeStyle.title = Code Style
 scripts.options.codeStyle.useTabCharacter = Use Tab Character
+
+scripts.options.font.fontName = Font Name:
+scripts.options.font.fontSize = Font Size:
+scripts.options.font.title = Font
 scripts.options.title = Scripts
 
 scripts.output.clear.button.toolTip = Clear script output panel


### PR DESCRIPTION
## Overview
Provide options to allow editing the font name and size used in the Script Console code editor.

## Related Issues
- Closes zaproxy/zaproxy#8065.

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title