### PR TITLE
client: tweaks for better look and feel

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Do not use white background in Client Details and show Client Map icons properly when using Mac OS X look and feel (Issue 8175).
+
 ## [0.4.0] - 2023-10-31
 ### Added
 - Note about custom containers in the help.

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientMapPanel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientMapPanel.java
@@ -30,6 +30,8 @@ import javax.swing.ImageIcon;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
+import javax.swing.LookAndFeel;
+import javax.swing.UIManager;
 import javax.swing.tree.TreePath;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
@@ -75,6 +77,14 @@ public class ClientMapPanel extends AbstractPanel {
         clientTree.setToggleClickCount(1);
         clientTree.setCellRenderer(new ClientMapTreeCellRenderer());
         clientTree.setComponentPopupMenu(new ClientCustomPopupMenu());
+
+        // Let the cell renderer define the height to properly show the icons.
+        LookAndFeel laf = UIManager.getLookAndFeel();
+        if (laf != null
+                && Constant.isMacOsX()
+                && UIManager.getSystemLookAndFeelClassName().equals(laf.getClass().getName())) {
+            clientTree.setRowHeight(0);
+        }
 
         clientTree.addTreeSelectionListener(
                 e -> {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientNodeDetailsPanel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientNodeDetailsPanel.java
@@ -19,11 +19,8 @@
  */
 package org.zaproxy.addon.client;
 
-import java.awt.Color;
+import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -36,7 +33,6 @@ import javax.swing.SortOrder;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.ZapTable;
 
 public class ClientNodeDetailsPanel extends AbstractPanel {
@@ -53,7 +49,7 @@ public class ClientNodeDetailsPanel extends AbstractPanel {
     public ClientNodeDetailsPanel() {
         super();
 
-        this.setLayout(new GridBagLayout());
+        this.setLayout(new BorderLayout());
         setName(Constant.messages.getString(ExtensionClientIntegration.PREFIX + ".details.title"));
         setIcon(
                 new ImageIcon(
@@ -61,12 +57,7 @@ public class ClientNodeDetailsPanel extends AbstractPanel {
                                 ExtensionClientIntegration.RESOURCES
                                         + "/application-browser.png")));
 
-        this.setBackground(Color.WHITE);
-
-        add(
-                urlLabel,
-                LayoutHelper.getGBC(
-                        0, 0, 1, 1.0, 0.0, GridBagConstraints.BOTH, new Insets(2, 2, 2, 2)));
+        add(urlLabel, BorderLayout.NORTH);
 
         table = new ZapTable();
         table.setModel(getComponentTableModel());
@@ -83,16 +74,7 @@ public class ClientNodeDetailsPanel extends AbstractPanel {
                     }
                 });
 
-        add(
-                new JScrollPane(table),
-                LayoutHelper.getGBC(
-                        0, 1, 1, 1.0, 1.0, GridBagConstraints.BOTH, new Insets(2, 2, 2, 2)));
-
-        // Padding
-        add(
-                new JLabel(),
-                LayoutHelper.getGBC(
-                        0, 2, 1, 1.0, 1.0, GridBagConstraints.BOTH, new Insets(2, 2, 2, 2)));
+        add(new JScrollPane(table));
     }
 
     public void setClientNode(ClientNode node) {


### PR DESCRIPTION
Do not set background colour in Client Details and remove bottom padding, which does not seem to be needed.
Show icons properly in Client Map when using Mac OS X look and feel.

Part of zaproxy/zaproxy#8175.