### PR TITLE
Client: History and Details menus

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Client History and Details context menu items.
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientDetailsPanel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientDetailsPanel.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.client;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.util.List;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -77,5 +78,9 @@ public class ClientDetailsPanel extends AbstractPanel {
 
     public void clear() {
         this.nodeDetailsPanel.clear();
+    }
+
+    public List<ClientSideComponent> getSelectedRows() {
+        return nodeDetailsPanel.getSelectedRows();
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientHistoryTableModel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientHistoryTableModel.java
@@ -102,7 +102,7 @@ public class ClientHistoryTableModel extends AbstractTableModel {
                 case 5:
                     return node.getNodeName();
                 case 6:
-                    return node.getNodeId();
+                    return node.getId();
                 case 7:
                     return node.getText();
                 default:
@@ -133,6 +133,10 @@ public class ClientHistoryTableModel extends AbstractTableModel {
             }
         }
         return null;
+    }
+
+    public ReportedObject getReportedObject(int rowIndex) {
+        return this.history.get(rowIndex);
     }
 
     public synchronized void addReportedObject(ReportedObject obj) {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientNodeDetailsPanel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientNodeDetailsPanel.java
@@ -20,24 +20,33 @@
 package org.zaproxy.addon.client;
 
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.SortOrder;
-import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.LayoutHelper;
+import org.zaproxy.zap.view.ZapTable;
 
 public class ClientNodeDetailsPanel extends AbstractPanel {
+
+    public static final String CLIENT_DETAILS_NAME = "tableClientDetails";
 
     private static final long serialVersionUID = 1L;
 
     private ComponentTableModel componentTableModel;
+    private ZapTable table;
 
     private JLabel urlLabel = new JLabel();
 
@@ -59,10 +68,20 @@ public class ClientNodeDetailsPanel extends AbstractPanel {
                 LayoutHelper.getGBC(
                         0, 0, 1, 1.0, 0.0, GridBagConstraints.BOTH, new Insets(2, 2, 2, 2)));
 
-        JXTable table = new JXTable();
+        table = new ZapTable();
         table.setModel(getComponentTableModel());
+        table.setName(CLIENT_DETAILS_NAME);
         table.setSortOrder(0, SortOrder.ASCENDING);
         table.setColumnControlVisible(true);
+        table.setComponentPopupMenu(
+                new JPopupMenu() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public void show(Component invoker, int x, int y) {
+                        View.getSingleton().getPopupMenu().show(invoker, x, y);
+                    }
+                });
 
         add(
                 new JScrollPane(table),
@@ -91,10 +110,17 @@ public class ClientNodeDetailsPanel extends AbstractPanel {
         this.getComponentTableModel().setComponents(new ArrayList<>());
     }
 
-    private ComponentTableModel getComponentTableModel() {
+    protected ComponentTableModel getComponentTableModel() {
         if (componentTableModel == null) {
             componentTableModel = new ComponentTableModel();
         }
         return componentTableModel;
+    }
+
+    public List<ClientSideComponent> getSelectedRows() {
+        return Arrays.stream(table.getSelectedRows())
+                .map(table::convertRowIndexToModel)
+                .mapToObj(getComponentTableModel()::getComponent)
+                .collect(Collectors.toList());
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientUtils.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientUtils.java
@@ -19,6 +19,9 @@
  */
 package org.zaproxy.addon.client;
 
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -106,5 +109,10 @@ public class ClientUtils {
         }
         sb.append(')');
         return sb.toString();
+    }
+
+    public static void setClipboardContents(String str) {
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(new StringSelection(str), null);
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ComponentTableModel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ComponentTableModel.java
@@ -82,6 +82,10 @@ public class ComponentTableModel extends AbstractTableModel {
         return false;
     }
 
+    public ClientSideComponent getComponent(int rowIndex) {
+        return components.get(rowIndex);
+    }
+
     @Override
     public Object getValueAt(int rowIndex, int columnIndex) {
         ClientSideComponent component = components.get(rowIndex);

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -108,6 +108,8 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
             extensionHook.getHookView().addSelectPanel(getClientMapPanel());
             extensionHook.getHookView().addWorkPanel(getClientDetailsPanel());
             extensionHook.getHookView().addStatusPanel(getClientHistoryPanel());
+
+            // Client Map menu items
             extensionHook
                     .getHookMenu()
                     .addPopupMenuItem(new PopupMenuClientAttack(this.getClientMapPanel()));
@@ -123,6 +125,68 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
             extensionHook
                     .getHookMenu()
                     .addPopupMenuItem(new PopupMenuClientShowInSites(this.getClientMapPanel()));
+
+            // Client History menu items
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(
+                            new PopupMenuClientHistoryCopy(
+                                    this.getClientHistoryPanel(),
+                                    Constant.messages.getString(
+                                            "client.history.popup.copy.nodeids"),
+                                    ReportedObject::getId));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(
+                            new PopupMenuClientHistoryCopy(
+                                    this.getClientHistoryPanel(),
+                                    Constant.messages.getString(
+                                            "client.history.popup.copy.nodenames"),
+                                    ReportedObject::getNodeName));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(
+                            new PopupMenuClientHistoryCopy(
+                                    this.getClientHistoryPanel(),
+                                    Constant.messages.getString("client.history.popup.copy.urls"),
+                                    ReportedObject::getUrl));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(
+                            new PopupMenuClientHistoryCopy(
+                                    this.getClientHistoryPanel(),
+                                    Constant.messages.getString("client.history.popup.copy.texts"),
+                                    ReportedObject::getText));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(
+                            new PopupMenuClientHistoryCopy(
+                                    this.getClientHistoryPanel(),
+                                    Constant.messages.getString("client.history.popup.copy.types"),
+                                    ReportedObject::getI18nType));
+
+            // Client Details menu items
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(
+                            new PopupMenuClientDetailsCopy(
+                                    this.getClientDetailsPanel(),
+                                    Constant.messages.getString("client.details.popup.copy.hrefs"),
+                                    ClientSideComponent::getHref));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(
+                            new PopupMenuClientDetailsCopy(
+                                    this.getClientDetailsPanel(),
+                                    Constant.messages.getString("client.details.popup.copy.ids"),
+                                    ClientSideComponent::getId));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(
+                            new PopupMenuClientDetailsCopy(
+                                    this.getClientDetailsPanel(),
+                                    Constant.messages.getString("client.details.popup.copy.texts"),
+                                    ClientSideComponent::getText));
         }
     }
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/PopupMenuClientDetailsCopy.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/PopupMenuClientDetailsCopy.java
@@ -20,26 +20,32 @@
 package org.zaproxy.addon.client;
 
 import java.awt.event.ActionEvent;
-import org.parosproxy.paros.Constant;
+import java.util.function.Function;
 
-public class PopupMenuClientCopyUrls extends PopupMenuItemClient {
+@SuppressWarnings("serial")
+public class PopupMenuClientDetailsCopy extends PopupMenuItemClientDetails {
 
     private static final long serialVersionUID = 1L;
 
-    public PopupMenuClientCopyUrls(ClientMapPanel clientMapPanel) {
-        super(Constant.messages.getString("client.tree.popup.copyurls"), clientMapPanel);
+    private Function<ClientSideComponent, String> function;
+
+    public PopupMenuClientDetailsCopy(
+            ClientDetailsPanel clientDetailsPanel,
+            String text,
+            Function<ClientSideComponent, String> function) {
+        super(text, clientDetailsPanel);
+        this.function = function;
     }
 
     @Override
     public void performAction(ActionEvent e) {
         StringBuilder sb = new StringBuilder();
-        for (ClientNode node : getClientMapPanel().getSelectedNodes()) {
-            if (!node.isRoot()
-                    && node.getUserObject() != null
-                    && !node.getUserObject().isStorage()) {
-                sb.append(node.getUserObject().getUrl());
-                sb.append('\n');
+        for (ClientSideComponent obj : getClientDetailsPanel().getSelectedRows()) {
+            String val = this.function.apply(obj);
+            if (val != null) {
+                sb.append(val);
             }
+            sb.append('\n');
         }
         ClientUtils.setClipboardContents(sb.toString());
     }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/PopupMenuClientHistoryCopy.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/PopupMenuClientHistoryCopy.java
@@ -20,26 +20,32 @@
 package org.zaproxy.addon.client;
 
 import java.awt.event.ActionEvent;
-import org.parosproxy.paros.Constant;
+import java.util.function.Function;
 
-public class PopupMenuClientCopyUrls extends PopupMenuItemClient {
+@SuppressWarnings("serial")
+public class PopupMenuClientHistoryCopy extends PopupMenuItemClientHistory {
 
     private static final long serialVersionUID = 1L;
 
-    public PopupMenuClientCopyUrls(ClientMapPanel clientMapPanel) {
-        super(Constant.messages.getString("client.tree.popup.copyurls"), clientMapPanel);
+    private Function<ReportedObject, String> function;
+
+    public PopupMenuClientHistoryCopy(
+            ClientHistoryPanel clientHistoryPanel,
+            String text,
+            Function<ReportedObject, String> function) {
+        super(text, clientHistoryPanel);
+        this.function = function;
     }
 
     @Override
     public void performAction(ActionEvent e) {
         StringBuilder sb = new StringBuilder();
-        for (ClientNode node : getClientMapPanel().getSelectedNodes()) {
-            if (!node.isRoot()
-                    && node.getUserObject() != null
-                    && !node.getUserObject().isStorage()) {
-                sb.append(node.getUserObject().getUrl());
-                sb.append('\n');
+        for (ReportedObject obj : getClientHistoryPanel().getSelectedRows()) {
+            String val = this.function.apply(obj);
+            if (val != null) {
+                sb.append(val);
             }
+            sb.append('\n');
         }
         ClientUtils.setClipboardContents(sb.toString());
     }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/PopupMenuItemClientDetails.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/PopupMenuItemClientDetails.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.zaproxy.zap.view.ZapTable;
+
+public abstract class PopupMenuItemClientDetails extends ExtensionPopupMenuItem {
+
+    private static final long serialVersionUID = 1L;
+    private ClientDetailsPanel clientDetailsPanel;
+
+    public PopupMenuItemClientDetails(String text, ClientDetailsPanel clientDetailsPanel) {
+        super(text);
+        this.clientDetailsPanel = clientDetailsPanel;
+        this.addActionListener(l -> performAction(l));
+    }
+
+    @Override
+    public boolean isEnableForComponent(Component invoker) {
+        boolean enabled =
+                invoker instanceof ZapTable
+                        && ClientNodeDetailsPanel.CLIENT_DETAILS_NAME.equals(invoker.getName());
+        this.setEnabled(!clientDetailsPanel.getSelectedRows().isEmpty());
+        return enabled;
+    }
+
+    public ClientDetailsPanel getClientDetailsPanel() {
+        return clientDetailsPanel;
+    }
+
+    abstract void performAction(ActionEvent e);
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/PopupMenuItemClientHistory.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/PopupMenuItemClientHistory.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.zaproxy.zap.view.ZapTable;
+
+public abstract class PopupMenuItemClientHistory extends ExtensionPopupMenuItem {
+
+    private static final long serialVersionUID = 1L;
+    private ClientHistoryPanel clientHistoryPanel;
+
+    public PopupMenuItemClientHistory(String text, ClientHistoryPanel clientHistoryPanel) {
+        super(text);
+        this.clientHistoryPanel = clientHistoryPanel;
+        this.addActionListener(l -> performAction(l));
+    }
+
+    @Override
+    public boolean isEnableForComponent(Component invoker) {
+        boolean enabled =
+                invoker instanceof ZapTable
+                        && ClientHistoryPanel.CLIENT_HISTORY_NAME.equals(invoker.getName());
+        this.setEnabled(!clientHistoryPanel.getSelectedRows().isEmpty());
+        return enabled;
+    }
+
+    public ClientHistoryPanel getClientHistoryPanel() {
+        return clientHistoryPanel;
+    }
+
+    abstract void performAction(ActionEvent e);
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ReportedEvent.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ReportedEvent.java
@@ -19,30 +19,15 @@
  */
 package org.zaproxy.addon.client;
 
-import java.util.Date;
 import net.sf.json.JSONObject;
 
 public class ReportedEvent extends ReportedObject {
 
-    private String tagName;
-    private String url;
     private int count;
 
     public ReportedEvent(JSONObject json) {
-        super(new Date(json.getLong("timestamp")), json.getString("eventName"));
-        if (json.containsKey("tagName")) {
-            this.tagName = json.getString("tagName");
-        }
-        this.url = json.getString("url");
+        super(json, json.getString("eventName"));
         this.count = json.getInt("count");
-    }
-
-    public String getTagName() {
-        return tagName;
-    }
-
-    public String getUrl() {
-        return url;
     }
 
     public int getCount() {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ReportedNode.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ReportedNode.java
@@ -19,55 +19,11 @@
  */
 package org.zaproxy.addon.client;
 
-import java.util.Date;
 import net.sf.json.JSONObject;
 
 public class ReportedNode extends ReportedObject {
 
-    private String tagName;
-    private String nodeId;
-    private String nodeName;
-    private String url;
-    private String href;
-    private String text;
-
     public ReportedNode(JSONObject json) {
-        super(new Date(json.getLong("timestamp")), json.getString("type")); // Not for storage
-        if (json.containsKey("tagName")) {
-            this.tagName = json.getString("tagName");
-        }
-        this.nodeId = json.getString("id");
-        this.nodeName = json.getString("nodeName");
-        this.url = json.getString("url");
-        if (json.containsKey("href")) {
-            this.href = json.getString("href");
-        }
-        if (json.containsKey("text")) {
-            this.text = json.getString("text").trim();
-        }
-    }
-
-    public String getTagName() {
-        return tagName;
-    }
-
-    public String getNodeId() {
-        return nodeId;
-    }
-
-    public String getNodeName() {
-        return nodeName;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public String getHref() {
-        return href;
-    }
-
-    public String getText() {
-        return text;
+        super(json);
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ReportedObject.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ReportedObject.java
@@ -20,19 +20,44 @@
 package org.zaproxy.addon.client;
 
 import java.util.Date;
+import net.sf.json.JSONObject;
 import org.parosproxy.paros.Constant;
 
 public abstract class ReportedObject {
 
     private Date timestamp;
     private String type;
+    private String tagName;
+    private String id;
+    private String nodeName;
+    private String url;
+    private String xpath;
+    private String href;
+    private String text;
 
     private static final String I18N_PREFIX = "client.type.";
 
-    protected ReportedObject(Date timestamp, String type) {
-        super();
-        this.timestamp = timestamp;
+    protected ReportedObject(JSONObject json) {
+        this(json, json.getString("type"));
+    }
+
+    protected ReportedObject(JSONObject json, String type) {
+        this.timestamp = new Date(json.getLong("timestamp"));
         this.type = type;
+        this.tagName = getParam(json, "tagName");
+        this.id = getParam(json, "id");
+        this.nodeName = getParam(json, "nodeName");
+        this.url = getParam(json, "url");
+        this.xpath = getParam(json, "xpath");
+        this.href = getParam(json, "href");
+        this.text = getParam(json, "text");
+    }
+
+    protected static String getParam(JSONObject json, String param) {
+        if (json.containsKey(param)) {
+            return json.getString(param);
+        }
+        return null;
     }
 
     public Date getTimestamp() {
@@ -48,5 +73,33 @@ public abstract class ReportedObject {
             return Constant.messages.getString(I18N_PREFIX + type);
         }
         return type;
+    }
+
+    public String getTagName() {
+        return tagName;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getNodeName() {
+        return nodeName;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getXpath() {
+        return xpath;
+    }
+
+    public String getHref() {
+        return href;
+    }
+
+    public String getText() {
+        return text;
     }
 }

--- a/addOns/client/src/main/javahelp/org/zaproxy/addon/client/resources/help/contents/client.html
+++ b/addOns/client/src/main/javahelp/org/zaproxy/addon/client/resources/help/contents/client.html
@@ -74,6 +74,20 @@ The types of data displayed include:
 <li>Link: Links detected in the DOM 
 </ul>
 
+The following context menu items are supported:
+
+<h4>Copy HREFs to Clipboard</h4>
+
+Copies the HREFs of the selected entries into the clipboard, separated by newlines.
+
+<h4>Copy IDs to Clipboard</h4>
+
+Copies the IDs of the selected entries into the clipboard, separated by newlines.
+
+<h4>Copy Texts to Clipboard</h4>
+
+Copies the Texts of the selected entries into the clipboard, separated by newlines.
+
 <h3>Client History</h3>
 
 The Client History tab shows all of the client side events sent from the browser extension to ZAP.
@@ -86,6 +100,28 @@ In addition to the data displayed in the Client Details tab it also includes:
 <li>Page Load: Browser <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event">load</a> event 
 <li>Page Unload: Browser <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event">unload</a> event 
 </ul>
+
+The following context menu items are supported:
+
+<h4>Copy Node IDs to Clipboard</h4>
+
+Copies the Node IDs of the selected entries into the clipboard, separated by newlines.
+
+<h4>Copy Node Names to Clipboard</h4>
+
+Copies the Node Names of the selected entries into the clipboard, separated by newlines.
+
+<h4>Copy Source URLs to Clipboard</h4>
+
+Copies the Source URLs of the selected entries into the clipboard, separated by newlines.
+
+<h4>Copy Texts to Clipboard</h4>
+
+Copies the Texts of the selected entries into the clipboard, separated by newlines.
+
+<h4>Copy Types to Clipboard</h4>
+
+Copies the Types of the selected entries into the clipboard, separated by newlines.
 
 <h2>AJAX Spider Enhancement</h2>
 

--- a/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
+++ b/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
@@ -8,8 +8,16 @@ client.components.type.input = Input
 client.components.type.link = Link
 
 client.desc = Client Side Integration
+client.details.popup.copy.hrefs = Copy HREFs to Clipboard
+client.details.popup.copy.ids = Copy IDs to Clipboard
+client.details.popup.copy.texts = Copy Texts to Clipboard
 client.details.title = Client Details
 client.error.nofile = File not found : {0}
+client.history.popup.copy.nodeids = Copy Node IDs to Clipboard
+client.history.popup.copy.nodenames = Copy Node Names to Clipboard
+client.history.popup.copy.texts = Copy Texts to Clipboard
+client.history.popup.copy.types = Copy Types to Clipboard
+client.history.popup.copy.urls = Copy Source URLs to Clipboard
 client.history.table.header.count = #
 client.history.table.header.id = ID
 client.history.table.header.nodeid = Node ID


### PR DESCRIPTION
## Overview
Add context menus for copying table cell values from the Client Details and History tabs.

## Related Issues
Fixes https://github.com/zaproxy/zaproxy/issues/8173

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
