### PR TITLE
Address concurrency issues in tests

### DIFF
--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -54,6 +54,8 @@ class AuthUtilsUnitTest extends TestUtils {
 
     @BeforeEach
     void setUp() throws Exception {
+        setUpZap();
+
         mockMessages(new ExtensionAuthhelper());
         AuthUtils.clean();
     }

--- a/addOns/bruteforce/src/test/java/org/zaproxy/zap/extension/bruteforce/BruteForceParamUnitTest.java
+++ b/addOns/bruteforce/src/test/java/org/zaproxy/zap/extension/bruteforce/BruteForceParamUnitTest.java
@@ -49,7 +49,7 @@ class BruteForceParamUnitTest {
     @BeforeAll
     static void beforeAll() {
         Constant.messages = mock(I18N.class);
-        Control.initSingletonForTesting(Model.getSingleton(), mock(ExtensionLoader.class));
+        Control.initSingletonForTesting(mock(Model.class), mock(ExtensionLoader.class));
     }
 
     @AfterAll

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/MissingUrlsThreadUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/MissingUrlsThreadUnitTest.java
@@ -37,8 +37,9 @@ import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.eventBus.EventPublisher;
 import org.zaproxy.zap.model.StandardParameterParser;
 import org.zaproxy.zap.model.Target;
+import org.zaproxy.zap.testutils.TestUtils;
 
-class MissingUrlsThreadUnitTest {
+class MissingUrlsThreadUnitTest extends TestUtils {
 
     private static final String AAA_URL = "https://aaa.example.com";
     private static final String CCC_URL = "https://ccc.example.com";
@@ -49,12 +50,12 @@ class MissingUrlsThreadUnitTest {
     private ClientNode root;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
+        setUpZap();
+
         model = mock(Model.class);
         session = mock(Session.class);
-        given(model.getSession()).willReturn(session);
         siteMap = mock(SiteMap.class);
-        given(session.getSiteTree()).willReturn(siteMap);
         StandardParameterParser ssp = new StandardParameterParser();
         given(session.getUrlParamParser(any(String.class))).willReturn(ssp);
         root = new ClientNode(new ClientSideDetails("Root", ""), session);
@@ -63,6 +64,9 @@ class MissingUrlsThreadUnitTest {
     @Test
     void shouldAddUrlInUnderStartNode() throws IOException {
         // Given
+        given(model.getSession()).willReturn(session);
+        given(session.getSiteTree()).willReturn(siteMap);
+
         ClientMap map = new ClientMap(root);
         map.getOrAddNode(AAA_URL, false, false);
 

--- a/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/FuzzOptionsUnitTest.java
+++ b/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/FuzzOptionsUnitTest.java
@@ -49,7 +49,7 @@ class FuzzOptionsUnitTest {
     @BeforeAll
     static void beforeAll() {
         Constant.messages = mock(I18N.class);
-        Control.initSingletonForTesting(Model.getSingleton(), mock(ExtensionLoader.class));
+        Control.initSingletonForTesting(mock(Model.class), mock(ExtensionLoader.class));
     }
 
     @AfterAll

--- a/addOns/portscan/src/test/java/org/zaproxy/zap/extension/portscan/PortScanParamUnitTest.java
+++ b/addOns/portscan/src/test/java/org/zaproxy/zap/extension/portscan/PortScanParamUnitTest.java
@@ -49,7 +49,7 @@ class PortScanParamUnitTest {
     @BeforeAll
     static void beforeAll() {
         Constant.messages = mock(I18N.class);
-        Control.initSingletonForTesting(Model.getSingleton(), mock(ExtensionLoader.class));
+        Control.initSingletonForTesting(mock(Model.class), mock(ExtensionLoader.class));
     }
 
     @AfterAll

--- a/addOns/retest/src/test/java/org/zaproxy/addon/retest/RetestPlanGeneratorUnitTest.java
+++ b/addOns/retest/src/test/java/org/zaproxy/addon/retest/RetestPlanGeneratorUnitTest.java
@@ -42,8 +42,9 @@ import org.zaproxy.addon.automation.jobs.RequestorJob;
 import org.zaproxy.addon.automation.tests.AbstractAutomationTest;
 import org.zaproxy.addon.automation.tests.AutomationAlertTest;
 import org.zaproxy.zap.network.HttpRequestBody;
+import org.zaproxy.zap.testutils.TestUtils;
 
-class RetestPlanGeneratorUnitTest {
+class RetestPlanGeneratorUnitTest extends TestUtils {
 
     private static AutomationPlan retestPlan;
 

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/SpiderParamUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/SpiderParamUnitTest.java
@@ -49,7 +49,7 @@ class SpiderParamUnitTest {
     @BeforeAll
     static void beforeAll() {
         Constant.messages = mock(I18N.class);
-        Control.initSingletonForTesting(Model.getSingleton(), mock(ExtensionLoader.class));
+        Control.initSingletonForTesting(mock(Model.class), mock(ExtensionLoader.class));
     }
 
     @AfterAll


### PR DESCRIPTION
Either mock or set up ZAP properly to avoid reusing the same ZAP home by multiple tests at the same time, which would lead to the test process being exited.