### PR TITLE
selenium: add scroll bar to options panel

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update Selenium to version 4.14.1.
 
+### Fixed
+- Add vertical scroll bar to the options panel to prevent the options from being hidden when resizing the Options dialogue (Issue 8178).
+
 ## [15.15.0] - 2023-10-12
 ### Changed
 - Update Selenium to version 4.14.0.

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.selenium;
 
+import java.awt.BorderLayout;
 import java.awt.Dialog;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -40,7 +41,9 @@ import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.JTextField;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.border.TitledBorder;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
@@ -326,8 +329,9 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         browserExtLayout.setVerticalGroup(
                 browserExtLayout.createSequentialGroup().addComponent(browserExtOptionsPanel));
 
-        GroupLayout layout = new GroupLayout(this);
-        setLayout(layout);
+        JPanel innerPanel = new JPanel();
+        GroupLayout layout = new GroupLayout(innerPanel);
+        innerPanel.setLayout(layout);
 
         layout.setAutoCreateGaps(true);
         layout.setAutoCreateContainerGaps(true);
@@ -342,6 +346,13 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                         .addComponent(driversPanel)
                         .addComponent(binariesPanel)
                         .addComponent(browserExtPanel));
+
+        setLayout(new BorderLayout());
+        add(
+                new JScrollPane(
+                        innerPanel,
+                        ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+                        ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER));
     }
 
     private static JPanel createBinaryPanel(
@@ -664,6 +675,8 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                 ResourceBundle resourceBundle) {
             super(model, false);
             this.resourceBundle = resourceBundle;
+
+            getTable().setVisibleRowCount(5);
         }
 
         @Override


### PR DESCRIPTION
Prevent the options from being hidden when resizing the panel. Reduce the number of rows that need to be shown in the extensions table, as they are not usually many and keeps the panel smaller.

Fix zaproxy/zaproxy#8178.