### PR TITLE
jython, zest: Move options under "Scripts" node

### DIFF
--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Move "Jython" under "Scripts > Engine" in the Options panel list.
 
 ## [13] - 2023-09-07
 ### Changed

--- a/addOns/jython/jython.gradle.kts
+++ b/addOns/jython/jython.gradle.kts
@@ -9,6 +9,13 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/python-scripting/")
+        dependencies {
+            addOns {
+                register("scripts") {
+                    version.set(">=44")
+                }
+            }
+        }
     }
 }
 

--- a/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/ExtensionJython.java
+++ b/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/ExtensionJython.java
@@ -54,6 +54,7 @@ public class ExtensionJython extends ExtensionAdaptor {
 
     private ExtensionScript extScript = null;
     private JythonOptionsParam jythonOptionsParam;
+    private JythonOptionsPanel jythonOptionsPanel;
 
     public ExtensionJython() {
         super(NAME);
@@ -71,14 +72,25 @@ public class ExtensionJython extends ExtensionAdaptor {
                         new JythonEngineWrapper(jythonOptionsParam, new PyScriptEngineFactory()));
 
         extensionHook.addOptionsParamSet(this.jythonOptionsParam);
-        if (null != super.getView()) {
-            extensionHook.getHookView().addOptionPanel(new JythonOptionsPanel());
+        if (hasView()) {
+            String[] scriptEngineNode = {
+                Constant.messages.getString("options.script.title"),
+                Constant.messages.getString("scripts.options.engine.title")
+            };
+            getView().getOptionsDialog().addParamPanel(scriptEngineNode, getOptionsPanel(), true);
         }
     }
 
     @Override
     public boolean canUnload() {
-        return false;
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        if (hasView()) {
+            getView().getOptionsDialog().removeParamPanel(getOptionsPanel());
+        }
     }
 
     private ExtensionScript getExtScript() {
@@ -90,6 +102,13 @@ public class ExtensionJython extends ExtensionAdaptor {
                                     .getExtension(ExtensionScript.NAME);
         }
         return extScript;
+    }
+
+    private JythonOptionsPanel getOptionsPanel() {
+        if (jythonOptionsPanel == null) {
+            jythonOptionsPanel = new JythonOptionsPanel();
+        }
+        return jythonOptionsPanel;
     }
 
     @Override

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Rename "Script Console" in the Options panel list to "Console".
 
 ## [43] - 2023-11-13
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -451,7 +451,7 @@ public class ConsolePanel extends AbstractPanel {
                                     .getMenuToolsControl()
                                     .options(
                                             Constant.messages.getString(
-                                                    "scripts.console.options.panelName")));
+                                                    "scripts.options.console.title")));
         }
         return optionsButton;
     }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptionsPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptConsoleOptionsPanel.java
@@ -47,8 +47,7 @@ public class ScriptConsoleOptionsPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String NAME =
-            Constant.messages.getString("scripts.console.options.panelName");
+    private static final String NAME = Constant.messages.getString("scripts.options.console.title");
 
     private JComboBox<DefaultScriptChangedBehaviour> defaultScriptChangedBehaviour;
     private JPanel fontPanel;

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -51,7 +51,6 @@ scripts.console.changedOnDisk = The script has been changed by another program.\
 scripts.console.changedOnDiskAndConsole = The script has been changed by another program.\nKeep the version in the Script Console or replace\nit with the one changed by the other program?\nThis script has been changed in the console so if\nyou replace the script you will lose your changes.\n
 
 scripts.console.options.defaultScriptChangedBehaviourLabel = When the Script in the Console Changes on Disk:
-scripts.console.options.panelName = Script Console
 scripts.console.rememberChoice = Remember this choice
 
 scripts.desc = Scripting console, supports all JSR 223 scripting languages
@@ -98,6 +97,9 @@ scripts.menu.tools.enable = Enable / Disable Scripts
 scripts.options.codeStyle.tabSize = Tab Size:
 scripts.options.codeStyle.title = Code Style
 scripts.options.codeStyle.useTabCharacter = Use Tab Character
+
+scripts.options.console.title = Console
+scripts.options.engine.title = Engine
 
 scripts.options.font.fontName = Font Name:
 scripts.options.font.fontSize = Font Size:

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Move "Zest" under "Scripts > Engine" in the Options panel list.
 
 ## [42] - 2023-10-12
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -181,7 +181,12 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             extensionHook.addSessionListener(new ViewSessionChangedListener());
 
             extensionHook.getHookView().addStatusPanel(this.getZestResultsPanel());
-            extensionHook.getHookView().addOptionPanel(getOptionsPanel());
+
+            String[] scriptEngineNode = {
+                Constant.messages.getString("options.script.title"),
+                Constant.messages.getString("scripts.options.engine.title")
+            };
+            getView().getOptionsDialog().addParamPanel(scriptEngineNode, getOptionsPanel(), true);
 
             this.dialogManager = new ZestDialogManager(this, this.getExtScript().getScriptUI());
             new ZestMenuManager(this, extensionHook);
@@ -333,6 +338,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             View view = View.getSingleton();
             view.removeMainToolbarButton(getRecordButton());
             view.removeMainToolbarSeparator(getToolbarSeparator());
+            view.getOptionsDialog().removeParamPanel(getOptionsPanel());
             dialogManager.unload();
         }
 

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -28,7 +28,9 @@ zapAddOn {
                 register("network") {
                     version.set(">=0.2.0")
                 }
-                register("scripts")
+                register("scripts") {
+                    version.set(">=44")
+                }
                 register("selenium") {
                     version.set(">= 15.13.0")
                 }


### PR DESCRIPTION
## Overview
* Move "Jython" and "Zest" under "Scripts > Engine" in the Options panel list.
* Rename "Script Console" to "Console" in the Options panel list.

<img src="https://github.com/zaproxy/zap-extensions/assets/16446369/8918e224-9bf9-46ec-876f-eeedf599a05e" width=500>

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
