### PR TITLE
alertFilters: allow to specify custom rule ID

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Allow to filter by alert reference (Issue 7438).
+- Allow to specify custom IDs through the GUI.
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AddAlertFilterDialog.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AddAlertFilterDialog.java
@@ -31,11 +31,9 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.automation.jobs.JobUtils;
-import org.zaproxy.zap.extension.alertFilters.ExtensionAlertFilters;
 import org.zaproxy.zap.extension.alertFilters.automation.AlertFilterJob.Risk;
-import org.zaproxy.zap.extension.alertFilters.internal.ScanRulesInfo;
+import org.zaproxy.zap.extension.alertFilters.internal.ui.AlertSelectionPanel;
 import org.zaproxy.zap.extension.alertFilters.internal.ui.MethodSelectionPanel;
-import org.zaproxy.zap.extension.alertFilters.internal.ui.ScanRulesInfoComboBoxModel;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
@@ -68,7 +66,7 @@ public class AddAlertFilterDialog extends StandardFieldsDialog {
     private int tableIndex;
     private AlertFilterJob job;
     private AlertFilterTableModel model;
-    private ScanRulesInfoComboBoxModel scanRulesInfoComboBoxModel;
+    private AlertSelectionPanel alertSelectionPanel;
     private MethodSelectionPanel methodSelectionPanel;
 
     public AddAlertFilterDialog(AlertFilterJob job, AlertFilterTableModel model) {
@@ -80,7 +78,7 @@ public class AddAlertFilterDialog extends StandardFieldsDialog {
             AlertFilterTableModel model,
             AlertFilterJob.AlertFilterData rule,
             int tableIndex) {
-        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(550, 450));
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(650, 450));
         if (rule == null) {
             rule = new AlertFilterJob.AlertFilterData();
             this.addFilter = true;
@@ -90,10 +88,9 @@ public class AddAlertFilterDialog extends StandardFieldsDialog {
         this.model = model;
         this.tableIndex = tableIndex;
 
-        ScanRulesInfo scanRulesInfo = ExtensionAlertFilters.getScanRulesInfo();
-        scanRulesInfoComboBoxModel = new ScanRulesInfoComboBoxModel(scanRulesInfo);
-        scanRulesInfoComboBoxModel.setSelectedItem(scanRulesInfo.getById(rule.getRuleId()));
-        this.addComboField(RULE_PARAM, scanRulesInfoComboBoxModel);
+        alertSelectionPanel = new AlertSelectionPanel();
+        alertSelectionPanel.setSelectedId(rule.getRuleId());
+        addCustomComponent(RULE_PARAM, alertSelectionPanel.getPanel());
 
         List<String> contextNames = this.job.getEnv().getContextNames();
         // Add blank option
@@ -136,9 +133,8 @@ public class AddAlertFilterDialog extends StandardFieldsDialog {
 
     @Override
     public void save() {
-        ScanRulesInfo.Entry scanRule = scanRulesInfoComboBoxModel.getSelectedItem();
-        rule.setRuleId(scanRule.getId());
-        rule.setRuleName(scanRule.getName());
+        rule.setRuleId(alertSelectionPanel.getSelectedId());
+        rule.setRuleName(alertSelectionPanel.getSelectedName());
         rule.setContext(this.getStringValue(CONTEXT_PARAM));
         rule.setNewRisk(Risk.getRiskFromI18n(this.getStringValue(NEW_RISK_PARAM)).toString());
         rule.setParameter(this.getStringValue(PARAM_PARAM));

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -119,6 +120,10 @@ public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
         Entry entry = new Entry(id, name);
         entriesById.put(id, entry);
         entries.add(entry);
+    }
+
+    public Set<String> getIds() {
+        return entriesById.keySet();
     }
 
     public Entry getById(String id) {

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ui/AlertSelectionPanel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ui/AlertSelectionPanel.java
@@ -1,0 +1,99 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.alertFilters.internal.ui;
+
+import java.awt.event.ItemEvent;
+import javax.swing.GroupLayout;
+import javax.swing.JComboBox;
+import javax.swing.JPanel;
+import org.zaproxy.zap.extension.alertFilters.ExtensionAlertFilters;
+import org.zaproxy.zap.extension.alertFilters.internal.ScanRulesInfo;
+
+public class AlertSelectionPanel {
+
+    private final JPanel panel;
+    private final JComboBox<ScanRulesInfo.Entry> names;
+    private final JComboBox<String> ids;
+
+    public AlertSelectionPanel() {
+        names =
+                new JComboBox<>(
+                        new ScanRulesInfoComboBoxModel(ExtensionAlertFilters.getScanRulesInfo()));
+        ids = new JComboBox<>();
+        ids.setEditable(true);
+
+        panel = new JPanel();
+        GroupLayout layout = new GroupLayout(panel);
+        panel.setLayout(layout);
+        layout.setAutoCreateGaps(true);
+
+        layout.setHorizontalGroup(
+                layout.createSequentialGroup().addComponent(names).addComponent(ids));
+
+        layout.setVerticalGroup(layout.createParallelGroup().addComponent(names).addComponent(ids));
+
+        names.addItemListener(
+                e -> {
+                    if (e.getStateChange() == ItemEvent.DESELECTED) {
+                        return;
+                    }
+
+                    ids.setSelectedItem(((ScanRulesInfo.Entry) e.getItem()).getId());
+                });
+        ids.addItemListener(
+                e -> {
+                    if (e.getStateChange() == ItemEvent.DESELECTED) {
+                        return;
+                    }
+
+                    if (e.getItem() == null) {
+                        return;
+                    }
+
+                    names.setSelectedItem(
+                            ExtensionAlertFilters.getScanRulesInfo()
+                                    .getById(e.getItem().toString()));
+                });
+
+        reset();
+    }
+
+    public JPanel getPanel() {
+        return panel;
+    }
+
+    public void reset() {
+        ids.removeAllItems();
+        ExtensionAlertFilters.getScanRulesInfo().getIds().stream().sorted().forEach(ids::addItem);
+    }
+
+    public String getSelectedId() {
+        String selected = (String) ids.getSelectedItem();
+        return selected == null || selected.isBlank() ? null : selected;
+    }
+
+    public void setSelectedId(String id) {
+        ids.setSelectedItem(id);
+    }
+
+    public String getSelectedName() {
+        return ExtensionAlertFilters.getScanRulesInfo().getNameById(getSelectedId());
+    }
+}

--- a/addOns/alertFilters/src/main/javahelp/org/zaproxy/zap/extension/alertFilters/resources/help/contents/alertFilterDialog.html
+++ b/addOns/alertFilters/src/main/javahelp/org/zaproxy/zap/extension/alertFilters/resources/help/contents/alertFilterDialog.html
@@ -19,7 +19,8 @@ This can either be 'Global' for a Global Alert Filter or the name of an existing
 It is only editable when you create an Alert Filter from an existing Alert.
 
 <H3>Alert Type</H3>
-A pull down containing all of the active and passive alert rules currently installed. Contains also the (known) alert references of the scan rules.
+The first pull down lists all of the active and passive alert rules currently installed along with their (known) alert references.
+The second pull down lists all known IDs (scan rules and alert references). It also allows to manually specify one, if not listed (e.g. custom rule or not yet installed).
 
 <H3>New Risk Level</H3>
 The new risk level to be assigned to any alerts raised that match the criteria defined by the rule.


### PR DESCRIPTION
Rework the UI to allow to specify a custom ID (scan rule or alert reference) as it might not be known to ZAP (e.g. not yet installed or using a custom script rule).