### PR TITLE
pscanrulesAlpha: Link website alert pages <-> help

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
-
-## [41] - 2023-11-15
 ### Added
 - Website alert links (Issue 8189).
 

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.14.0.
 
+## [41] - 2023-11-15
+### Added
+- Website alert links (Issue 8189).
+
 ## [41] - 2023-09-08
 ### Changed
 - Maintenance changes.

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -401,7 +401,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
-    public String getHelpLink(){
+    public String getHelpLink() {
         return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-alpha/#base64-disclosure";
     }
 }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -400,4 +400,8 @@ public class Base64Disclosure extends PluginPassiveScanner {
     private static String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
+
+    public String getHelpLink(){
+        return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-alpha/#base64-disclosure";
+    }
 }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java
@@ -165,6 +165,10 @@ public class FetchMetadataRequestHeadersScanRule extends PluginPassiveScanner {
         }
     }
 
+    public String getHelpLink(){
+        return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-alpha/#fetch-metadata-request-headers-scan-rule";
+    }
+
     static class SecFetchSite extends FetchMetaDataRequestHeaders {
         public static final String HEADER = "Sec-Fetch-Site";
         private static final String SFS_PREFIX_MESSAGE =

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java
@@ -165,7 +165,7 @@ public class FetchMetadataRequestHeadersScanRule extends PluginPassiveScanner {
         }
     }
 
-    public String getHelpLink(){
+    public String getHelpLink() {
         return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-alpha/#fetch-metadata-request-headers-scan-rule";
     }
 

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -25,6 +25,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <strong>Note:</strong> At Low Threshold all occurrences within each response will be included.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java">Base64Disclosure.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10094">10094</a>.
 
 <H2>Example Passive Scan Rule: Denial of Service</H2>
 This implements a very simple example passive scan rule.<br>
@@ -77,6 +78,7 @@ Sec-Fetch-User is only sent for requests initiated by user activation.
 </ul>
 <p>
  Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java">FetchMetadataRequestHeadersScanRule.java</a>
+ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90005/">90005</a>.
 
 </BODY>
 </HTML>

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -25,7 +25,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <strong>Note:</strong> At Low Threshold all occurrences within each response will be included.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java">Base64Disclosure.java</a><br>
-Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10094">10094</a>.
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10094/">10094</a>.
 
 <H2>Example Passive Scan Rule: Denial of Service</H2>
 This implements a very simple example passive scan rule.<br>

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -24,7 +24,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 </ul>
 <strong>Note:</strong> At Low Threshold all occurrences within each response will be included.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java">Base64Disclosure.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java">Base64Disclosure.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10094">10094</a>.
 
 <H2>Example Passive Scan Rule: Denial of Service</H2>
@@ -77,7 +77,7 @@ Sec-Fetch-User is only sent for requests initiated by user activation.
  <li><b>Sec-Fetch-User Header Has an Invalid Value</b></li>
 </ul>
 <p>
- Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java">FetchMetadataRequestHeadersScanRule.java</a>
+ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java">FetchMetadataRequestHeadersScanRule.java</a><br>
  Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90005/">90005</a>.
 
 </BODY>


### PR DESCRIPTION
## Overview
added getHelpLink method in Base64Disclosure.java and FetchMetadataRequestHeadersScanRule.java
added anchor tag for respective method in pscanalpha.html 

## Related Issues
This PR is part of issues [#8189](https://github.com/zaproxy/zaproxy/issues/8189)
@psiinon can you please review it

### Added
- Website alert links (Issue 8189).

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
