### PR TITLE
pscanrulesAlpha: Full Path disclosure vulnerability scanning

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.14.0.
 ### Added
 - Website alert links (Issue 8189).
+- Full Path Disclosure vulnerability passive scanner (Issue 413).
 
 ## [41] - 2023-09-08
 ### Changed

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -19,5 +19,6 @@ zapAddOn {
 dependencies {
     zapAddOn("commonlib")
 
+    implementation("com.google.re2j:re2j:1.7")
     testImplementation(project(":testutils"))
 }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRule.java
@@ -1,0 +1,115 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+import java.util.List;
+import java.util.Map;
+import net.htmlparser.jericho.Source;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class FullPathDisclosureScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
+    private static final int PLUGIN_ID = 110009;
+    private static final String MESSAGE_PREFIX = "pscanalpha.fullpathdisclosurealert.";
+    private static final Logger LOGGER = LogManager.getLogger(FullPathDisclosureScanRule.class);
+
+    // matches the following paths:
+    // example for windows : C:\folder\folder
+    // example for unix : /dir/dir/
+    // default paths : /usr or /home etc..
+    private static final Pattern PATH_PATTERN =
+            Pattern.compile(
+                    ("(?:/bin/|/usr/|/mnt/|/proc/|/sbin/|/dev/|/lib/|/tmp/|/opt/|/home/|/var/|/root/|/etc/|"
+                            + "/Applications/|/Volumes/|/System/|/Users/|/Developer/|/Library/|"
+                            + "[a-z]\\:(\\\\Program Files\\\\|\\\\Users\\\\|\\\\Windows\\\\|\\\\ProgramData\\\\|\\\\Progra~1\\\\).*)"),
+                    Pattern.CASE_INSENSITIVE);
+    private static final Map<String, String> ALERT_TAGS =
+            CommonAlertTag.toMap(
+                    CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG,
+                    CommonAlertTag.WSTG_V42_ERRH_01_ERR);
+
+    @Override
+    public int getPluginId() {
+        return PLUGIN_ID;
+    }
+
+    @Override
+    public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (getHelper().isSuccess(msg)) {
+            return;
+        }
+        String responseBody = msg.getResponseBody().toString();
+        Matcher pathMatcher = PATH_PATTERN.matcher(responseBody);
+        if (pathMatcher.find()) {
+            String evidence = pathMatcher.group();
+            LOGGER.debug("Found full path in response: {}", evidence);
+            buildAlert(evidence).raise();
+        }
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return ALERT_TAGS;
+    }
+
+    private String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    private String getSolution() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+    }
+
+    private String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    private AlertBuilder buildAlert(String evidence) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_LOW)
+                .setRisk(Alert.RISK_LOW)
+                .setEvidence(evidence)
+                .setDescription(getDescription())
+                .setSolution(getSolution())
+                .setReference(getReference())
+                .setSolution(getSolution())
+                .setWascId(13) // WASC-13 Information Leakage
+                .setCweId(209); // CWE-209: Generation of Error Message Containing Sensitive
+        // Information
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(buildAlert("/home/servers/ProdServer/").build());
+    }
+}

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -80,5 +80,17 @@ Sec-Fetch-User is only sent for requests initiated by user activation.
  Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java">FetchMetadataRequestHeadersScanRule.java</a><br>
  Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90005/">90005</a>.
 
+<H2 id="id-110009">Full Path Disclosure Scan Rule</H2>
+<p>A Full Path Disclosure vulnerability is where the path to the root of the application providing valuable information for attackers.
+Examples of Full Path Disclosure Vulnerabilities are : /home/omg/htdocs/file/ or C:\Users\username\server\
+</p>
+<p>The attacker could use this path to steal credentials or other private information. For more information visit : <a href="https://owasp.org/www-community/attacks/Full_Path_Disclosure">OWASP article.</a></p>
+
+<p>Latest code:
+ <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRule.java">FullPathDisclosureScanRule.java</a>
+ <br>
+ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/110009/">110009</a>.
+</p>
+
 </BODY>
 </HTML>

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -19,6 +19,11 @@ pscanalpha.examplefile.other = This is for information that doesn't fit in any o
 pscanalpha.examplefile.refs = https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/
 pscanalpha.examplefile.soln = A general description of how to solve the problem.
 
+pscanalpha.fullpathdisclosurealert.desc = The full path of files which might be sensitive has been exposed to the client.
+pscanalpha.fullpathdisclosurealert.name = Full Path Disclosure
+pscanalpha.fullpathdisclosurealert.refs = https://owasp.org/www-community/attacks/Full_Path_Disclosure
+pscanalpha.fullpathdisclosurealert.soln = Disable directory browsing in your web server. Refer to the web server documentation.
+
 pscanalpha.metadata-request-headers.name = Fetch Metadata Request Headers
 pscanalpha.metadata-request-headers.sfd.invalid-values.desc = Specifies how and where the data would be used. For instance, if the value is audio, then the requested resource must be audio data and not any other type of resource.
 

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRuleUnitTest.java
@@ -1,0 +1,169 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+
+class FullPathDisclosureScanRuleUnitTest extends PassiveScannerTest<FullPathDisclosureScanRule> {
+
+    @Test
+    void shouldNotRaiseAnyAlertsWhenResponseIsSuccess() throws URIException {
+        // Given
+        HttpMessage msg = createMessage("/home/servers/", HttpStatusCode.OK);
+        given(passiveScanData.isSuccess(msg)).willReturn(true);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    void shouldNotRaiseAlertsWhenHtmlTagsLookLikeUnixPath() throws URIException {
+        // Given
+        String testBody =
+                "\n"
+                        + "<!DOCTYPE html>\n"
+                        + "<html lang=\"en\">\n"
+                        + "<head>\n"
+                        + "<meta charset=\"utf-8\">\n"
+                        + "<title>Error</title>\n"
+                        + "</head>\n"
+                        + "<body>\n"
+                        + "<pre>Cannot GET /</pre>\n"
+                        + "</body>\n"
+                        + "</html>\n";
+        HttpMessage message = createMessage(testBody, HttpStatusCode.NOT_FOUND);
+        given(passiveScanData.isSuccess(message)).willReturn(false);
+        // When
+        scanHttpResponseReceive(message);
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    void shouldRaiseLowRiskAlertWhenWindowsFullPathIsDisclosed() throws URIException {
+        // Given
+        String testBody =
+                "<pre>Error: Failed to lookup view &quot;no&quot; in views directory &quot;D:\\Progra~1\\testingServer/public&quot;<br>";
+        HttpMessage msg = createMessage(testBody, HttpStatusCode.NOT_FOUND);
+        given(passiveScanData.isSuccess(msg)).willReturn(false);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(Alert.RISK_LOW, alertsRaised.get(0).getRisk());
+    }
+
+    @Test
+    void shouldRaiseLowRiskAlertWhenUnixBasedFullPathIsDisclosed() throws URIException {
+        // Given
+        String testBody =
+                "<pre>Error: Failed to lookup view &quot;no&quot; in views directory &quot;/home/Software/testingServer/&quot;<br>";
+        HttpMessage msg = createMessage(testBody, HttpStatusCode.NOT_FOUND);
+        given(passiveScanData.isSuccess(msg)).willReturn(false);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(Alert.RISK_LOW, alertsRaised.get(0).getRisk());
+    }
+
+    @Test
+    void shouldNotAlertOnPlainPathUrl() throws URIException {
+        // Given
+        String testBody =
+                "<html><body><a href='/student/dashboard/en-us.'>Dashboard</a></body></html>";
+        HttpMessage msg = createMessage(testBody, HttpStatusCode.NOT_FOUND);
+        given(passiveScanData.isSuccess(msg)).willReturn(false);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                "c:\\Program Files\\",
+                "f:\\Users\\",
+                "c:\\Windows\\",
+                "c:\\ProgramData\\",
+                "c:\\Progra~1\\",
+                "/bin/",
+                "/usr/",
+                "/mnt/",
+                "/proc/",
+                "/sbin/",
+                "/dev/",
+                "/lib/",
+                "/tmp/",
+                "/opt/",
+                "/home/",
+                "/var/",
+                "/root/",
+                "/etc/",
+                "/Applications/",
+                "/Volumes/",
+                "/System/",
+                "/Developer/",
+                "/Library/",
+                "/Users/"
+            })
+    void shouldRaiseAlertWhenDefaultPathIsExposed(String defaultPath) throws URIException {
+        // Given
+        HttpMessage msg =
+                createMessage("Error : Cant find" + defaultPath, HttpStatusCode.NOT_FOUND);
+        given(passiveScanData.isSuccess(msg)).willReturn(false);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(defaultPath, alertsRaised.get(0).getEvidence());
+    }
+
+    @Override
+    protected FullPathDisclosureScanRule createScanner() {
+        return new FullPathDisclosureScanRule();
+    }
+
+    private HttpMessage createMessage(String body, Integer status) throws URIException {
+        HttpRequestHeader requestHeader = new HttpRequestHeader();
+        requestHeader.setURI(new URI("http://example.com", false));
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(requestHeader);
+        msg.getResponseHeader().setStatusCode(status);
+        msg.setResponseBody(body);
+        return msg;
+    }
+}


### PR DESCRIPTION
## Overview
A passive scanner to scan for full path disclosure vulnerability on windows and UNIX systems.

## Related Issues
[Issue link](https://github.com/zaproxy/zaproxy/issues/413)

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
