### PR TITLE
network: add support for br content encoding

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- On weekly releases and versions after 2.14, handle content encodings (Issue 2198).
+- On weekly releases and versions after 2.14, handle content encodings and add `br` content encoding on supported OSes (Issue 2198).
 
 ### Fixed
 - Handle cookies like browsers, mostly send what is received (Issues 1232 and 7874).

--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -5,8 +5,12 @@ description = "Provides core networking capabilities."
 val bouncyCastle by configurations.creating
 configurations.api { extendsFrom(bouncyCastle) }
 
+val brotli by configurations.creating
 val hc by configurations.creating
-configurations.implementation { extendsFrom(hc) }
+configurations.implementation {
+    extendsFrom(brotli)
+    extendsFrom(hc)
+}
 
 zapAddOn {
     addOnName.set("Network")
@@ -23,6 +27,7 @@ zapAddOn {
 
         bundledLibs {
             libs.from(bouncyCastle)
+            libs.from(brotli)
             libs.from(hc)
         }
     }
@@ -71,6 +76,13 @@ dependencies {
     bouncyCastle("org.bouncycastle:bcmail-$bcJava:$bcVersion")
     bouncyCastle("org.bouncycastle:bcprov-$bcJava:$bcVersion")
     bouncyCastle("org.bouncycastle:bcpkix-$bcJava:$bcVersion")
+
+    val brotliVersion = "1.13.0"
+    brotli("com.aayushatharva.brotli4j:brotli4j:$brotliVersion")
+    brotli("com.aayushatharva.brotli4j:native-windows-x86_64:$brotliVersion")
+    brotli("com.aayushatharva.brotli4j:native-linux-x86_64:$brotliVersion")
+    brotli("com.aayushatharva.brotli4j:native-osx-x86_64:$brotliVersion")
+    brotli("com.aayushatharva.brotli4j:native-osx-aarch64:$brotliVersion")
 
     implementation("org.jitsi:ice4j:3.0-24-g34c2ce5") {
         // Don't need its dependencies, for now.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ContentEncodingsHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ContentEncodingsHandler.java
@@ -40,6 +40,8 @@ public class ContentEncodingsHandler /* TODO implements HttpEncodingsHandler */ 
             encodings = List.of(HttpEncodingDeflate.getSingleton());
         } else if (encoding.contains(HttpHeader.GZIP)) {
             encodings = List.of(HttpEncodingGzip.getSingleton());
+        } else if (HttpEncodingBrotli.isAvailable() && encoding.contains("br")) {
+            encodings = List.of(HttpEncodingBrotli.getSingleton());
         }
 
         body.setContentEncodings(encodings);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/HttpEncodingBrotli.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/HttpEncodingBrotli.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal;
+
+import com.aayushatharva.brotli4j.Brotli4jLoader;
+import com.aayushatharva.brotli4j.decoder.Decoder;
+import com.aayushatharva.brotli4j.decoder.DecoderJNI;
+import com.aayushatharva.brotli4j.decoder.DirectDecompress;
+import com.aayushatharva.brotli4j.encoder.Encoder;
+import java.io.IOException;
+import org.zaproxy.zap.network.HttpEncoding;
+
+/** The {@link HttpEncoding} for the {@code br} coding. */
+class HttpEncodingBrotli implements HttpEncoding {
+
+    private static final HttpEncodingBrotli SINGLETON = new HttpEncodingBrotli();
+
+    private static final boolean AVAILABLE;
+
+    static {
+        boolean available = false;
+        try {
+            Brotli4jLoader.ensureAvailability();
+            available = true;
+        } catch (UnsatisfiedLinkError e) {
+            // Nothing to do.
+        }
+        AVAILABLE = available;
+    }
+
+    /**
+     * Gets the singleton.
+     *
+     * @return the br content encoding.
+     */
+    public static HttpEncodingBrotli getSingleton() {
+        return SINGLETON;
+    }
+
+    public static boolean isAvailable() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public byte[] encode(byte[] content) throws IOException {
+        return Encoder.compress(content);
+    }
+
+    @Override
+    public byte[] decode(byte[] content) throws IOException {
+        DirectDecompress directDecompress = Decoder.decompress(content);
+        DecoderJNI.Status status = directDecompress.getResultStatus();
+        if (status == DecoderJNI.Status.DONE) {
+            return directDecompress.getDecompressedData();
+        }
+        throw new IOException("Failed to decode: " + status);
+    }
+}

--- a/addOns/network/src/main/javahelp/help/contents/options/localservers.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/localservers.html
@@ -61,7 +61,13 @@
 	<H4>Remove Accept-Encoding Request Header</H4>
 	Allows the proxy to remove the "Accept-Encoding" request-header field, so no (unsupported) encoding transformations are done to the response.<br/>
 	This option should be always enabled unless when testing the encoding transformations.<br/>
-	The messages encoded with unsupported encodings will not be correctly scanned (either by passive and active scanners).
+	The messages encoded with unsupported encodings will not be correctly scanned (either by passive or active scanners).<br/>
+	Supported content encodings:
+	<ul>
+		<li><code>br</code>, on Linux x64, macOS (Intel and Apple Silicon), and Windows x64</li>
+		<li><code>deflate</code></li>
+		<li><code>gzip</code></li>
+	</ul>
 
 	<H4>Decode Response</H4>
 	Allows the proxy to automatically decode (i.e. gzip, deflate) the response. This option is needed for applications that ignore

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/ContentEncodingsHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/ContentEncodingsHandlerUnitTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -68,6 +69,21 @@ class ContentEncodingsHandlerUnitTest {
         handler.handle(header, body);
         // Then
         verify(body).setContentEncodings(asList(HttpEncodingDeflate.getSingleton()));
+    }
+
+    @Test
+    @EnabledIf(
+            value = "org.zaproxy.addon.network.internal.HttpEncodingBrotli#isAvailable",
+            disabledReason = "OS not supported")
+    void shouldSetBrotliEncodingToBody() {
+        // Given
+        HttpHeader header = mock(HttpHeader.class);
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn("br");
+        HttpBody body = mock(HttpBody.class);
+        // When
+        handler.handle(header, body);
+        // Then
+        verify(body).setContentEncodings(asList(HttpEncodingBrotli.getSingleton()));
     }
 
     @ParameterizedTest

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/HttpEncodingBrotliUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/HttpEncodingBrotliUnitTest.java
@@ -1,0 +1,66 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+/** Unit test for {@link HttpEncodingBrotli}. */
+@EnabledIf(
+        value = "org.zaproxy.addon.network.internal.HttpEncodingBrotli#isAvailable",
+        disabledReason = "OS not supported")
+class HttpEncodingBrotliUnitTest {
+
+    private static final byte[] CONTENT = "42".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] CONTENT_ENCODED = {-117, 0, -128, 52, 50, 3};
+
+    private HttpEncodingBrotli encoding = HttpEncodingBrotli.getSingleton();
+
+    @Test
+    void shouldEncodeContent() throws IOException {
+        // Given / When
+        byte[] encodedContent = encoding.encode(CONTENT);
+        // Then
+        assertThat(encodedContent, is(equalTo(CONTENT_ENCODED)));
+    }
+
+    @Test
+    void shouldDecodeContent() throws IOException {
+        // Given / When
+        byte[] decodedContent = encoding.decode(CONTENT_ENCODED);
+        // Then
+        assertThat(decodedContent, is(equalTo(CONTENT)));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDecodingIfNotProperlyEncoded() {
+        // Given
+        byte[] invalidContent = new byte[] {'I', 'n', 'v', 'a', 'l', 'i', 'd'};
+        // When / Then
+        assertThrows(IOException.class, () -> encoding.decode(invalidContent));
+    }
+}


### PR DESCRIPTION
Support encoding/decoding on Linux x64, macOS, and Windows x64.

Part of zaproxy/zaproxy#2198.