### PR TITLE
pscanrulesBeta: Source Code Disclosure skip binary'ish responses

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- The Source Code Disclosure rule no longer considers responses that contain ISO control characters (those which are likely to be binary file types) (Issue 8191).
 
 ## [35] - 2023-09-08
 ### Changed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
@@ -654,7 +654,8 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
         if (ResourceIdentificationUtils.isCss(msg)
                 || ResourceIdentificationUtils.isJavaScript(msg)
                 || ResourceIdentificationUtils.isImage(msg)
-                || ResourceIdentificationUtils.isFont(msg)) {
+                || ResourceIdentificationUtils.isFont(msg)
+                || ResourceIdentificationUtils.responseContainsControlChars(msg)) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -118,7 +118,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 
 <H2>Source Code Disclosure</H2>
 Application Source Code was disclosed by the web server.<br>
-NOTE: Ignores CSS, JavaScript, images, and font files.
+NOTE: Ignores CSS, JavaScript, images, font files, and responses that contain ISO control characters (those which are likely binary files).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a>
 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRuleUnitTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 
@@ -195,6 +196,17 @@ class SourceCodeDisclosureScanRuleUnitTest
         // Given
         msg.setResponseBody(wrapWithHTML(CODE_PHP2));
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, type);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(0, alertsRaised.size());
+    }
+
+    @Test
+    void shouldNotRaiseAlertOnValidPhpWhenControlCharactersInResponse()
+            throws HttpMalformedHeaderException, IOException {
+        // Given
+        msg.setResponseBody("<?=#:æ´Dü?>");
         // When
         scanHttpResponseReceive(msg);
         // Then


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- pscanbea.html > Updated help entry.
- ScourceCodeDisclosureScanRule > Add control characters check in skip conditional.
- ScourceCodeDisclosureScanRuleUnitTest > Add test to assert the new behavior.

## Related Issues
Fixes zaproxy/zaproxy#8191

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
