### PR TITLE
ascanrules: Should parse correct quotes and attributes

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Use high and low delays for linear regression time-based tests to fix false positives from delays that were smaller than normal variance in application response times.
+- Catch correct context while analysing attributes instead of the last attribute where eyecatcher was reflected.
 
 ## [58] - 2023-10-12
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
@@ -324,9 +324,15 @@ public class HtmlContextAnalyser {
                 Iterator<Attribute> iter = element.getAttributes().iterator();
                 while (iter.hasNext()) {
                     Attribute att = iter.next();
+
                     if (att.getValue() != null
-                            && att.getValue().toLowerCase().indexOf(target.toLowerCase()) >= 0) {
+                            && att.getValue().toLowerCase().indexOf(target.toLowerCase()) >= 0
+                            && context.getStart() >= att.getValueSegment().getBegin()
+                            && context.getEnd() <= att.getValueSegment().getEnd()) {
                         // Found the injected value
+                        if (!context.getSurroundingQuote().equals("" + att.getQuoteChar())) {
+                            context.setSurroundingQuote("" + att.getQuoteChar());
+                        }
                         context.setTagAttribute(att.getName());
                         context.setTagAttributeValue(att.getValue());
                         context.setInUrlAttribute(this.isUrlAttribute(att.getName()));

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyserUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyserUnitTest.java
@@ -192,4 +192,47 @@ public class HtmlContextAnalyserUnitTest extends TestUtils {
         assertThat(tagMap.get("span").size(), is(equalTo(0)));
         assertThat(tagMap.get("a").size(), is(equalTo(0)));
     }
+
+    @Test
+    void shouldParseTheCorrectSurroundingQuotesForTagAttributes() throws Exception {
+        String catcher = "hg4378as";
+        msg = new HttpMessage();
+        msg.setRequestHeader("GET /index.html HTTP/1.1");
+        msg.setResponseBody(
+                "<html> <body> <span id='{\"entity\": \""
+                        + catcher
+                        + "\"}'>hello</span> <a></a> </body> </html>");
+        HtmlContextAnalyser analyser = new HtmlContextAnalyser(msg);
+        List<HtmlContext> contexts = analyser.getHtmlContexts(catcher, null, 0);
+        assertThat(contexts.size(), is(equalTo(1)));
+        HtmlContext ctx = contexts.get(0);
+        assertThat(ctx.getParentTag(), is(equalTo("span")));
+        assertThat(ctx.getSurroundingQuote(), is(equalTo("\'")));
+    }
+
+    @Test
+    void shouldParseTheCorrectAttribute() throws Exception {
+        String catcher = "hg4378as";
+        msg = new HttpMessage();
+        msg.setRequestHeader("GET /index.html HTTP/1.1");
+        msg.setResponseBody(
+                "<html> <body> <span id='{\"entity\": \""
+                        + catcher
+                        + "\"}' name=\""
+                        + catcher
+                        + "\">hello</span> <a></a> </body> </html>");
+        HtmlContextAnalyser analyser = new HtmlContextAnalyser(msg);
+        List<HtmlContext> contexts = analyser.getHtmlContexts(catcher, null, 0);
+        assertThat(contexts.size(), is(equalTo(2)));
+
+        HtmlContext ctx1 = contexts.get(0);
+        assertThat(ctx1.getParentTag(), is(equalTo("span")));
+        assertThat(ctx1.getTagAttribute(), is(equalTo("id")));
+        assertThat(ctx1.getSurroundingQuote(), is(equalTo("'")));
+
+        HtmlContext ctx2 = contexts.get(1);
+        assertThat(ctx2.getParentTag(), is(equalTo("span")));
+        assertThat(ctx2.getTagAttribute(), is(equalTo("name")));
+        assertThat(ctx2.getSurroundingQuote(), is(equalTo("\"")));
+    }
 }


### PR DESCRIPTION
## Overview
Fixes HtmlContextAnalyser not parsing surrounding quotes properly for tag attributes and also not catching the correct context when there were multiple attributes in which eyecatcher was being reflected.

## Related Issues
Fixes: https://github.com/zaproxy/zaproxy/issues/8177

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
