### PR TITLE
pscanrules: Application Error Disclosure skip binary'ish responses

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The Application Error Disclosure rule no longer considers responses that contain ISO control characters (those which are likely to be binary file types).
 
 ## [52] - 2023-10-12
 ### Fixed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -157,6 +157,9 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
      */
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (ResourceIdentificationUtils.responseContainsControlChars(msg)) {
+            return;
+        }
 
         // First check if it's an INTERNAL SERVER ERROR
         if (getHelper().isPage500(msg)) {

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -43,6 +43,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <H2>Application Errors</H2>
 Check server responses for HTTP 500 - Internal Server Error type responses or those that contain a known error string. <br>
 <strong>Note:</strong> Matches made within script blocks or files are against the entire content not only comments.<br>
+Skips responses that contain ISO control characters (those which are likely binary files).<br>
 At HIGH Threshold don’t alert on HTTP 500 (but do for other error patterns). Also, such known error strings are much less likely to be relevant in static pages like JS / CSS so these files are only scanned at LOW threshold.<br>
 For Internal Server Error (HTTP 500) the Alert is set to Low risk and in other case it is set to Medium risk.
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
@@ -334,6 +334,22 @@ class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<ApplicationErr
     }
 
     @Test
+    void shouldNotRaiseAlertOnBinaryResponse() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(REQUEST_HEADER);
+        msg.setResponseHeader(createResponseHeader(OK));
+        String expectedEvidence = "Microsoft OLE DB Provider for ODBC Drivers";
+        msg.setResponseBody(":æ´Dü" + expectedEvidence);
+        given(passiveScanData.isPage500(any())).willReturn(false);
+        given(passiveScanData.isPage404(any())).willReturn(false);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(equalTo(0)));
+    }
+
+    @Test
     void shouldNotRaiseAlertForResponseCodeOkAndContentTypeWebAssemblyWhenFilePayloadPresent()
             throws HttpMalformedHeaderException {
         // Given


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- pscanrules.html > Updated help entry.
- ApplicationErrorScanRule > Add control characters check in skip conditional.
- ApplicationErrorScanRuleUnitTest > Add test to assert the new behavior.

## Related Issues
Encountered:
> 84173 [ZAP-PassiveScan-3] WARN org.zaproxy.zap.extension.pscan.PassiveScanTask - Passive Scan rule Application Error Disclosure took 6 seconds to scan https://zapmp4issuedemo.dotnest.net/TheComingSoonTheme/assets/mp4/bg.mp4 video/mp4 13292671

while working on zaproxy/zaproxy#8191 / zaproxy/zap-extensions#5101

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
