### PR TITLE
openapi: Add test to ensure plus is maintained in Intl Phone Numbers

### DIFF
--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -98,6 +98,28 @@ class BodyGeneratorUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldGenerateIntlPhoneWithLeadingPlusChar() throws IOException {
+        // Ensure https://github.com/zaproxy/zaproxy/issues/6644 doesn't reoccur
+        // Given
+        OpenAPI openAPI = parseResource("petstore_reduced_intl_phone.yaml");
+        // When
+        String json =
+                generators
+                        .getBodyGenerator()
+                        .generate(
+                                openAPI.getPaths()
+                                        .get("/pets")
+                                        .getPost()
+                                        .getRequestBody()
+                                        .getContent()
+                                        .get("application/json"));
+        // Then
+        assertEquals(
+                "{\"name\":\"John Doe\",\"tag\":\"John Doe\",\"phoneNumber\":\"+15555555555\"}",
+                json);
+    }
+
+    @Test
     void shouldGenerateJsonObject() throws IOException {
         OpenAPI openAPI = parseResource("PetStore_defn.yaml");
 

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/petstore_reduced_intl_phone.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/petstore_reduced_intl_phone.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+servers:
+  - url: http://localhost:@@@PORT@@@/
+paths:
+  /pets:
+    post:
+      description: For https://github.com/zaproxy/zaproxy/issues/6644
+      operationId: addPet
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              properties:
+                name:
+                  type: string
+                tag:
+                  type: string
+                phoneNumber:
+                  type: string
+                  description: Cell Phone Number
+                  example: '+15555555555'
+      responses:
+        default:
+          content:
+            text/plain: {}


### PR DESCRIPTION
## Overview
Add test to ensure plus is maintained in Intl Phone Numbers

## Related Issues
zaproxy/zaproxy#6644 

## Checklist
- [NA] Update help
- [NA] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
