### PR TITLE
soap: correct use of and generated values

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Use empty values as defined by the Value Generator configuration (Issue 8202).
+- Correct generation of values for `date` and `dateTime`, it would fail with warnings in previous versions.
 
 ## [20] - 2023-10-12
 ### Changed


### PR DESCRIPTION
Use the generated values always and use as default the appropriate ones generated by the class itself.
Correct date formats which were failing to compile.

Fix zaproxy/zaproxy#8202.