### PR TITLE
Client: Add back hash nodes

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Dropped "to Clipboard" from ZAP copy menu items (Issue 8179).
+- Changed to add back '#' nodes.
 
 ## [0.5.0] - 2023-11-07
 ### Added

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientMap.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientMap.java
@@ -84,7 +84,7 @@ public class ClientMap extends SortedTreeModel {
                         nodeUrl = nodeName + "/";
                     } else {
                         boolean lastBeforeFragment =
-                                (i == nodeNames.size() - 2)
+                                (i <= nodeNames.size() - 2)
                                         && (nodeNames.get(i + 1).startsWith("#")
                                                 || nodeNames.get(i + 1).startsWith("/#"));
 
@@ -92,12 +92,16 @@ public class ClientMap extends SortedTreeModel {
                             // Special case - we will not have the param values at this point
                             nodeUrl = url.substring(0, url.indexOf("#"));
                         } else {
-
                             String pUrl = parent.getUserObject().getUrl();
-                            if (!pUrl.endsWith("/") && !nodeName.startsWith("/")) {
-                                pUrl += "/";
+
+                            if (nodeName.equals("#") || nodeName.equals("/#")) {
+                                nodeUrl = pUrl + "#";
+                            } else {
+                                if (!pUrl.endsWith("/") && !nodeName.startsWith("/")) {
+                                    pUrl += "/";
+                                }
+                                nodeUrl = pUrl + nodeName + "/";
                             }
-                            nodeUrl = pUrl + nodeName + "/";
                         }
                     }
                     child =

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientUtils.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientUtils.java
@@ -86,7 +86,13 @@ public class ClientUtils {
             }
         }
         if (fragment != null) {
-            nodes.add(prefix + fragment);
+            if (fragment.length() == 1) {
+                // Just the #, nothing else
+                nodes.add(prefix + fragment);
+            } else {
+                nodes.add(prefix + '#');
+                nodes.add(fragment.substring(1));
+            }
             prefix = "";
         }
         if (StringUtils.isNotBlank(prefix)) {

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientMapUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientMapUnitTest.java
@@ -68,6 +68,35 @@ class ClientMapUnitTest {
     }
 
     @Test
+    void shouldHandleBaseSiteSlashFragmentSlash() {
+        // Given
+        ClientMap map = new ClientMap(root);
+
+        // When
+        map.getOrAddNode(AAA_URL + "/#/", false, false);
+
+        // Then
+        assertThat(root.getChildCount(), is(1));
+        assertThat(root.getUserObject().getName(), is("Root"));
+        assertThat(root.getUserObject().getUrl(), is(""));
+
+        assertThat(root.getChildAt(0).getUserObject().getName(), is(AAA_URL));
+        assertThat(root.getChildAt(0).getUserObject().getUrl(), is(AAA_URL + "/"));
+        assertThat(root.getChildAt(0).getChildCount(), is(1));
+
+        assertThat(root.getChildAt(0).getChildAt(0).getUserObject().getName(), is("/#"));
+        assertThat(root.getChildAt(0).getChildAt(0).getUserObject().getUrl(), is(AAA_URL + "/#"));
+        assertThat(root.getChildAt(0).getChildAt(0).getChildCount(), is(1));
+
+        assertThat(
+                root.getChildAt(0).getChildAt(0).getChildAt(0).getUserObject().getName(), is("/"));
+        assertThat(
+                root.getChildAt(0).getChildAt(0).getChildAt(0).getUserObject().getUrl(),
+                is(AAA_URL + "/#/"));
+        assertThat(root.getChildAt(0).getChildAt(0).getChildAt(0).getChildCount(), is(0));
+    }
+
+    @Test
     void shouldAddOrderedNodes() {
         // Given
         ClientMap map = new ClientMap(root);
@@ -254,28 +283,58 @@ class ClientMapUnitTest {
         assertThat(root.getChildCount(), is(1));
         assertThat(root.getChildAt(0).getUserObject().getName(), is("https://www.example.com"));
         assertThat(root.getChildAt(0).getChildCount(), is(3));
-        assertThat(root.getChildAt(0).getChildAt(0).getUserObject().getName(), is("#second"));
+
+        assertThat(root.getChildAt(0).getChildAt(0).getUserObject().getName(), is("#"));
         assertThat(
-                root.getChildAt(0).getChildAt(0).getUserObject().getUrl(),
+                root.getChildAt(0).getChildAt(0).getChildAt(0).getUserObject().getName(),
+                is("second"));
+        assertThat(
+                root.getChildAt(0).getChildAt(0).getChildAt(0).getUserObject().getUrl(),
                 is("https://www.example.com#second"));
-        assertThat(root.getChildAt(0).getChildAt(0).getChildCount(), is(0));
-        assertThat(root.getChildAt(0).getChildAt(1).getUserObject().getName(), is("/#first"));
+
+        assertThat(root.getChildAt(0).getChildAt(1).getChildCount(), is(1));
+        assertThat(root.getChildAt(0).getChildAt(1).getUserObject().getName(), is("/#"));
+        assertThat(root.getChildAt(0).getChildAt(1).getChildAt(0).getChildCount(), is(0));
         assertThat(
-                root.getChildAt(0).getChildAt(1).getUserObject().getUrl(),
+                root.getChildAt(0).getChildAt(1).getChildAt(0).getUserObject().getName(),
+                is("first"));
+        assertThat(
+                root.getChildAt(0).getChildAt(1).getChildAt(0).getUserObject().getUrl(),
                 is("https://www.example.com/#first"));
-        assertThat(root.getChildAt(0).getChildAt(1).getChildCount(), is(0));
+        assertThat(root.getChildAt(0).getChildAt(1).getChildAt(0).getChildCount(), is(0));
+
         assertThat(root.getChildAt(0).getChildAt(2).getUserObject().getName(), is("/(p1,p2)"));
         assertThat(
                 root.getChildAt(0).getChildAt(2).getUserObject().getUrl(),
                 is("https://www.example.com/?p2=v3&p1=v4"));
         assertThat(root.getChildAt(0).getChildAt(2).getChildCount(), is(1));
         assertThat(
-                root.getChildAt(0).getChildAt(2).getChildAt(0).getUserObject().getName(),
-                is("#third"));
+                root.getChildAt(0).getChildAt(2).getChildAt(0).getUserObject().getName(), is("#"));
+        System.out.println(root.getChildAt(0).getChildAt(2).getChildAt(0).getUserObject().getUrl());
+        System.out.println("https://www.example.com/?p2=v3&p1=v4#/");
         assertThat(
                 root.getChildAt(0).getChildAt(2).getChildAt(0).getUserObject().getUrl(),
+                is("https://www.example.com/?p2=v3&p1=v4#"));
+        assertThat(root.getChildAt(0).getChildAt(2).getChildAt(0).getChildCount(), is(1));
+        assertThat(
+                root.getChildAt(0)
+                        .getChildAt(2)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getUserObject()
+                        .getName(),
+                is("third"));
+        assertThat(
+                root.getChildAt(0)
+                        .getChildAt(2)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getUserObject()
+                        .getUrl(),
                 is("https://www.example.com/?p2=v3&p1=v4#third"));
-        assertThat(root.getChildAt(0).getChildAt(2).getChildAt(0).getChildCount(), is(0));
+        assertThat(
+                root.getChildAt(0).getChildAt(2).getChildAt(0).getChildAt(0).getChildCount(),
+                is(0));
     }
 
     @Test

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientNodeUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientNodeUnitTest.java
@@ -147,6 +147,22 @@ class ClientNodeUnitTest {
                 is(EXAMPLE_COM + "/"));
         assertThat(
                 site.getChildAt(0).getChildAt(0).getChildAt(0).getChildAt(0).getChildCount(),
+                is(1));
+        assertThat(
+                site.getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getSite(),
+                is(EXAMPLE_COM + "/"));
+        assertThat(
+                site.getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildCount(),
                 is(0));
     }
 
@@ -172,6 +188,21 @@ class ClientNodeUnitTest {
         assertNotNull(site.getChildAt(0).getChildAt(0).getChildAt(0).getChildAt(0).getSession());
         assertThat(
                 site.getChildAt(0).getChildAt(0).getChildAt(0).getChildAt(0).getChildCount(),
+                is(1));
+        assertNotNull(
+                site.getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getSession());
+        assertThat(
+                site.getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildAt(0)
+                        .getChildCount(),
                 is(0));
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientUtilsUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientUtilsUnitTest.java
@@ -108,30 +108,54 @@ class ClientUtilsUnitTest {
             assertThat(nodes.get(1), is("/(a)"));
         }
 
+        @Test
+        void shouldHandleSiteNoSlashWithFragment() {
+            // Given / When
+            List<String> nodes = ClientUtils.urlToNodes(EXAMPLE_COM + "#", spp);
+
+            // Then
+            assertThat(nodes.size(), is(2));
+            assertThat(nodes.get(0), is(EXAMPLE_COM));
+            assertThat(nodes.get(1), is("#"));
+        }
+
         @ParameterizedTest
-        @ValueSource(strings = {"", "f", "a=b", "a&b=c/d=f#f"})
+        @ValueSource(strings = {"f", "a=b", "a&b=c/d=f#f"})
         void shouldHandleBaseSiteNoSlashWithFragment(String fragment) {
             // Given / When
             List<String> nodes = ClientUtils.urlToNodes(EXAMPLE_COM + "#" + fragment, spp);
 
             // Then
+            assertThat(nodes.size(), is(3));
+            assertThat(nodes.get(0), is(EXAMPLE_COM));
+            assertThat(nodes.get(1), is("#"));
+            assertThat(nodes.get(2), is(fragment));
+        }
+
+        @Test
+        void shouldHandleSiteWithSlashWithFragment() {
+            // Given / When
+            List<String> nodes = ClientUtils.urlToNodes(EXAMPLE_COM + "/#", spp);
+
+            // Then
             assertThat(nodes.size(), is(2));
             assertThat(nodes.get(0), is(EXAMPLE_COM));
-            assertThat(nodes.get(1), is("#" + fragment));
+            assertThat(nodes.get(1), is("/#"));
         }
 
         @ParameterizedTest
         // Check fragments can contain any characters that are also significant in the
         // rest of the URL
-        @ValueSource(strings = {"", "f", "a=b", "a&b=c/d=f#f"})
+        @ValueSource(strings = {"f", "a=b", "a&b=c/d=f#f"})
         void shouldHandleBaseSiteWithSlashWithFragment(String fragment) {
             // Given / When
             List<String> nodes = ClientUtils.urlToNodes(EXAMPLE_COM + "/#" + fragment, spp);
 
             // Then
-            assertThat(nodes.size(), is(2));
+            assertThat(nodes.size(), is(3));
             assertThat(nodes.get(0), is(EXAMPLE_COM));
-            assertThat(nodes.get(1), is("/#" + fragment));
+            assertThat(nodes.get(1), is("/#"));
+            assertThat(nodes.get(2), is(fragment));
         }
 
         @Test
@@ -140,10 +164,11 @@ class ClientUtilsUnitTest {
             List<String> nodes = ClientUtils.urlToNodes(EXAMPLE_COM + "/p?a=b#f", spp);
 
             // Then
-            assertThat(nodes.size(), is(3));
+            assertThat(nodes.size(), is(4));
             assertThat(nodes.get(0), is(EXAMPLE_COM));
             assertThat(nodes.get(1), is("p(a)"));
-            assertThat(nodes.get(2), is("#f"));
+            assertThat(nodes.get(2), is("#"));
+            assertThat(nodes.get(3), is("f"));
         }
 
         @Test
@@ -152,12 +177,13 @@ class ClientUtilsUnitTest {
             List<String> nodes = ClientUtils.urlToNodes(EXAMPLE_COM + "/p/q/r?a=b#f", spp);
 
             // Then
-            assertThat(nodes.size(), is(5));
+            assertThat(nodes.size(), is(6));
             assertThat(nodes.get(0), is(EXAMPLE_COM));
             assertThat(nodes.get(1), is("p"));
             assertThat(nodes.get(2), is("q"));
             assertThat(nodes.get(3), is("r(a)"));
-            assertThat(nodes.get(4), is("#f"));
+            assertThat(nodes.get(4), is("#"));
+            assertThat(nodes.get(5), is("f"));
         }
 
         @Test
@@ -166,13 +192,14 @@ class ClientUtilsUnitTest {
             List<String> nodes = ClientUtils.urlToNodes(EXAMPLE_COM + "/p/q/r/?a=b#f", spp);
 
             // Then
-            assertThat(nodes.size(), is(6));
+            assertThat(nodes.size(), is(7));
             assertThat(nodes.get(0), is(EXAMPLE_COM));
             assertThat(nodes.get(1), is("p"));
             assertThat(nodes.get(2), is("q"));
             assertThat(nodes.get(3), is("r"));
             assertThat(nodes.get(4), is("/(a)"));
-            assertThat(nodes.get(5), is("#f"));
+            assertThat(nodes.get(5), is("#"));
+            assertThat(nodes.get(6), is("f"));
         }
 
         @Test
@@ -181,13 +208,14 @@ class ClientUtilsUnitTest {
             List<String> nodes = ClientUtils.urlToNodes(EXAMPLE_COM + "/p/q/r/?e=f&a=b&c#f", spp);
 
             // Then
-            assertThat(nodes.size(), is(6));
+            assertThat(nodes.size(), is(7));
             assertThat(nodes.get(0), is(EXAMPLE_COM));
             assertThat(nodes.get(1), is("p"));
             assertThat(nodes.get(2), is("q"));
             assertThat(nodes.get(3), is("r"));
             assertThat(nodes.get(4), is("/(a,c,e)"));
-            assertThat(nodes.get(5), is("#f"));
+            assertThat(nodes.get(5), is("#"));
+            assertThat(nodes.get(6), is("f"));
         }
     }
 


### PR DESCRIPTION
## Overview
PR #5040 was a big improvement, but I accidently changed it so that `#` and `/#` were no longer separate nodes.
This changes that back as I think it makes more sense.
Its not a bug as such - this is just the GUI structure, so its up to us what it looks like.

## Related Issues

#5040 

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
