### PR TITLE
automation: correct requestor job output

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Show method and URL when outputting the status code mismatch of `requestor` job.
 
 ## [0.34.0] - 2023-11-16
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/RequestorJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/RequestorJob.java
@@ -231,7 +231,9 @@ public class RequestorJob extends AutomationJob {
                     progress.warn(
                             Constant.messages.getString(
                                     "automation.error.requestor.codemismatch",
-                                    msg,
+                                    msg.getRequestHeader().getMethod()
+                                            + " "
+                                            + msg.getRequestHeader().getURI(),
                                     req.getResponseCode(),
                                     receivedCode));
                 }


### PR DESCRIPTION
Show method and URL instead of relying on `HttpMessage`'s `toString()` method (which is not implemented), when showing the output message for the status code mismatch.