### PR TITLE
ascanrules: Add XSS mutations

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Support for mutations in reflected XSS rule.
+
 ### Changed
 - Depend on newer version of Common Library add-on.
 

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -75,6 +75,8 @@ If the alert threshold is set to LOW, XSS injection located in a JSON response r
 For other response content-types a LOW confidence alert is raised.<br>
 If the alert threshold is set to either MEDIUM or HIGH, XSS injection located in non-HTML responses do not generate alerts.<br>
 <p>
+If specific characters are stripped out of a reflected payload then the attacks will be repeated with alternative characters that might have the same effect.
+<p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java">CrossSiteScriptingScanRule.java</a>
 
 <H2>Cross Site Scripting (persistent)</H2>


### PR DESCRIPTION
## Overview
Add support for XSS mutations, where we can swap a filtered character out with an alternative.
The first this we do is to check if the response does reflect the payload but with specific characters filtered out.
If it does not we carry on - this means there will be no extra requests in nearly all cases and so this rule should not take any longer.
If however specific characters are filtered out then we try again with mutations know to work.
Suggestions for other mutations gratefully received 😉 

This allow ZAP to find 2 more of the vulnerabilities on https://xssy.uk/allLabs

## Related Issues

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
