### PR TITLE
spider: Address todo items and handle multiple Link response headers

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Handle multiple "Link" HTTP Response headers.
+- Maintenance changes.
 
 ## [0.7.0] - 2023-10-12
 ### Changed


### PR DESCRIPTION
## Overview
- CHANGELOG > Add notes.
- SpiderHttpHeaderParser > Use core constants, and handle multiple Link response headers.
- SpiderHttpHeaderParserUnitTest > Add new test asserting the new behavior.

## Checklist
- [NA] Update help
- [X] Update changelog
- [X] Run `./gradlew spotlessApply` for code formatting
- [X] Write tests
- [X] Check code coverage
- [X] Sign-off commits
- [X] Squash commits
- [X] Use a descriptive title
