### PR TITLE
ascanrules: Hidden File Finder-Fix threshold handling to align w/ help

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Threshold handling in the Hidden File Finder scan rule.
 
 ## [59] - 2023-12-07
 ### Added

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
@@ -124,20 +124,18 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
             int statusCode = testMsg.getResponseHeader().getStatusCode();
             if (isPage200(testMsg)) {
                 String responseBody = testMsg.getResponseBody().toString();
-                // If all the content checks matched then confidence is high
                 boolean matches =
                         doesNotMatch(responseBody, file.getNotContent())
                                 && doesMatch(responseBody, file.getContent())
                                 && doesBinaryMatch(responseBody, file.getBinary());
                 if (matches && !file.isCustom()) {
                     raiseAlert(testMsg, Alert.CONFIDENCE_HIGH, getRisk(), file);
-                } else if (this.getAlertThreshold().equals(AlertThreshold.HIGH)
-                        || file.isCustom()) {
+                } else if (this.getAlertThreshold().equals(AlertThreshold.LOW) || file.isCustom()) {
                     raiseAlert(testMsg, Alert.CONFIDENCE_LOW, getRisk(), file);
                 }
             } else if ((statusCode == HttpStatusCode.UNAUTHORIZED
                             || statusCode == HttpStatusCode.FORBIDDEN)
-                    && this.getAlertThreshold().equals(AlertThreshold.HIGH)) {
+                    && this.getAlertThreshold().equals(AlertThreshold.LOW)) {
                 raiseAlert(testMsg, Alert.CONFIDENCE_LOW, Alert.RISK_INFO, file);
             }
         }

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -147,7 +147,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 This scan rule checks for various web accessible files which may leak administrative, configuration, or credential information.
 The original included set of payloads were based on <a href="https://github.com/hannob/snallygaster">Snallygaster</a> by Hanno Böck.
 Such payloads are verified by checking response code, and content. If the response code is 200 (Ok) then additional content checks are performed to increase alert confidence.
-If the response code is 401 (Unauthorized) or 403 (Forbidden) or the content checks are un-successful then an alert is raised with lower confidence (at HIGH Threshold).
+If the response code is 401 (Unauthorized) or 403 (Forbidden) or the content checks are un-successful then an alert is raised with lower confidence (at LOW Threshold).
 <strong>Note:</strong> If the Custom Payloads addon is installed you can add your own hidden file paths (payloads) in the Custom Payloads options panel. 
 For custom payloads only the response status code is checked. If there is a requirement to include a content check then it is also possible to add payloads to 
 the <code>json/hidden_files.json</code> file in ZAP's user directory (in which case they will be treated as included payloads).

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
@@ -239,8 +239,8 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
     }
 
     @ParameterizedTest
-    @EnumSource(names = {"LOW", "MEDIUM"})
-    void shouldNotRaiseAlertIfTestedUrlRespondsForbiddenWhenThresholdNotHigh(
+    @EnumSource(names = {"MEDIUM", "HIGH"})
+    void shouldNotRaiseAlertIfTestedUrlRespondsForbiddenWhenThresholdNotLow(
             AlertThreshold threshold) throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldNotAlert";
@@ -268,7 +268,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
     }
 
     @Test
-    void shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsForbiddenAtHighThreshold()
+    void shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsForbiddenAtLowThreshold()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -286,7 +286,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         HttpMessage msg = this.getHttpMessage(servePath);
 
         rule.init(msg, this.parent);
-        rule.setAlertThreshold(AlertThreshold.HIGH);
+        rule.setAlertThreshold(AlertThreshold.LOW);
         HiddenFilesScanRule.addTestPayload(hiddenFile);
 
         // When
@@ -328,7 +328,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
     }
 
     @Test
-    void shouldAlertWithLowConfidenceIfContentStringsDontAllMatchAtHighThreshold()
+    void shouldAlertWithLowConfidenceIfContentStringsDontAllMatchAtLowThreshold()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -346,7 +346,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         HttpMessage msg = this.getHttpMessage(servePath);
 
         rule.init(msg, this.parent);
-        rule.setAlertThreshold(AlertThreshold.HIGH);
+        rule.setAlertThreshold(AlertThreshold.LOW);
         HiddenFilesScanRule.addTestPayload(hiddenFile);
 
         // When
@@ -362,8 +362,8 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
     }
 
     @ParameterizedTest
-    @EnumSource(names = {"LOW", "MEDIUM"})
-    void shouldNotAlertIfContentStringsDontAllMatchWhenNotHighThreshold(AlertThreshold threshold)
+    @EnumSource(names = {"MEDIUM", "HIGH"})
+    void shouldNotAlertIfContentStringsDontAllMatchWhenNotLowThreshold(AlertThreshold threshold)
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -519,7 +519,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
 
     @Test
     void
-            shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkWithRelevantContentButDoesContainNotContentAtHighThreshold()
+            shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkWithRelevantContentButDoesContainNotContentAtLowThreshold()
                     throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -540,7 +540,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         HttpMessage msg = this.getHttpMessage(servePath);
 
         rule.init(msg, this.parent);
-        rule.setAlertThreshold(AlertThreshold.HIGH);
+        rule.setAlertThreshold(AlertThreshold.LOW);
         HiddenFilesScanRule.addTestPayload(hiddenFile);
 
         // When
@@ -555,9 +555,9 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
     }
 
     @ParameterizedTest
-    @EnumSource(names = {"LOW", "MEDIUM"})
+    @EnumSource(names = {"MEDIUM", "HIGH"})
     void
-            shouldNotRaiseAlertIfTestedUrlRespondsOkWithRelevantContentButDoesContainNotContentWhenNotHighThreshold(
+            shouldNotRaiseAlertIfTestedUrlRespondsOkWithRelevantContentButDoesContainNotContentWhenNotLowThreshold(
                     AlertThreshold threshold) throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -627,7 +627,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
 
     @Test
     void
-            shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkWithoutRelevantBinContentAtHighThreshold()
+            shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkWithoutRelevantBinContentAtLowThreshold()
                     throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -653,7 +653,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         HttpMessage msg = this.getHttpMessage(servePath);
 
         rule.init(msg, this.parent);
-        rule.setAlertThreshold(AlertThreshold.HIGH);
+        rule.setAlertThreshold(AlertThreshold.LOW);
         HiddenFilesScanRule.addTestPayload(hiddenFile);
 
         // When
@@ -668,8 +668,8 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
     }
 
     @ParameterizedTest
-    @EnumSource(names = {"LOW", "MEDIUM"})
-    void shouldNotRaiseAlertIfTestedUrlRespondsOkWithoutRelevantBinContentWhenNotHighThreshold(
+    @EnumSource(names = {"MEDIUM", "HIGH"})
+    void shouldNotRaiseAlertIfTestedUrlRespondsOkWithoutRelevantBinContentWhenNotLowThreshold(
             AlertThreshold threshold) throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";


### PR DESCRIPTION
## Overview
Per:
https://www.zaproxy.org/docs/desktop/ui/dialogs/scanpolicy/#threshold Low should mean potentially more alerts.

- ascanrules.html > Update help.
- CHANGELOG > Add fix note.
- HiddenFilesScanRule > Adjust Threshold handling.
- HiddenFilesScanRuleUnitTest > Adjust to properly test the fixed behavior.

## Related Issues
- zaproxy/zaproxy#8234
- zaproxy/zap-extensions#2514 :cry: Seems to be where I implemented this backward to start with.

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
