### PR TITLE
pscanrules: Big Redirect rule - Also alert on multiple HREFs in body

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The Big Redirect scan rule will now also alert on responses that have multiple HREFs (idea from xnl-h4ck3r).
+    - It also now includes example alert and alert reference functionality for documentation generation purposes (Issues 6119, 7100, and 8189).
 
 ## [53] - 2023-11-30
 ### Changed

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -54,11 +54,14 @@ amount of time needed to passively scan.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java">ApplicationErrorScanRule.java</a>
 
-<H2>Big Redirect Detected (Potential Sensitive Information Leak)</H2>
+<H2 id="id-10044">Big Redirect Detected (Potential Sensitive Information Leak)</H2>
 This check predicts the size of various redirect type responses and generates an alert if the response is greater than the predicted size. 
 A large redirect response may indicate that although a redirect has taken place the page actually contained content (which may reveal sensitive information, PII, etc.).
+It will also raise an alert if the body of the redirect response contains multiple HREFs.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java">BigRedirectsScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10044/">10044</a>.
 
 <H2>Cache Control</H2>
 Checks "Cache-Control" response headers against general industry best practice settings for protection of sensitive content.<br>

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -30,8 +30,10 @@ pscanrules.authenticationcredentialscaptured.soln = Use HTTPS, and use a secure 
 
 pscanrules.bigredirects.desc = The server has responded with a redirect that seems to provide a large response. This may indicate that although the server sent a redirect it also responded with body content (which may include sensitive details, PII, etc.).
 pscanrules.bigredirects.extrainfo = Location header URI length: {0} [{1}].\nPredicted response size: {2}.\nResponse Body Length: {3}.
+pscanrules.bigredirects.multi.desc = The server has responded with a redirect that seems to contain multiple links. This may indicate that although the server sent a redirect it also responded with body content links (which may include sensitive details, PII, lead to admin panels, etc.).
+pscanrules.bigredirects.multi.extrainfo = The response contained {0} occurrences of "HREF".
+pscanrules.bigredirects.multi.name = Multiple HREFs Redirect Detected (Potential Sensitive Information Leak)
 pscanrules.bigredirects.name = Big Redirect Detected (Potential Sensitive Information Leak)
-pscanrules.bigredirects.refs = 
 pscanrules.bigredirects.soln = Ensure that no sensitive information is leaked via redirect responses. Redirect responses should have almost no content.
 
 pscanrules.cachecontrol.desc = The cache-control header has not been set properly or is missing, allowing the browser and proxies to cache content. For static assets like css, js, or image files this might be intended, however, the resources should be reviewed to ensure that no sensitive content will be cached.


### PR DESCRIPTION
## Overview
- BigRedirectScanRule > Add further functionality to check if the response contains multiple HREFs, example alerts, and Alert Refs.
- BigRedirectScanRuleUnitTest > Add tests for new behavior, example alerts, and alert refs.
- CHANGELOG > Add change notes.
- Messages.properties > Add supporting resources.
- pscanrules.html > Update help entry.

Hat tip to @xnl-h4ck3r for the idea: https://twitter.com/xnl_h4ck3r/status/1724808036706091496

## Related Issues
- zaproxy/zaproxy#6119
- zaproxy/zaproxy#7100
- zaproxy/zaproxy#8189

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
