### PR TITLE
ascanrules: use timing utils in MsSQL scan rule

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Threshold handling in the Hidden File Finder scan rule.
+- Improved SQL Injection - MsSQL scan rule by using time-based linear regression tests.
 
 ## [59] - 2023-12-07
 ### Added

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlScanRuleUnitTest.java
@@ -27,6 +27,8 @@ import static org.hamcrest.Matchers.is;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -66,22 +68,27 @@ class SqlInjectionMsSqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMs
     @Test
     void shouldAlertIfSleepTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
+        Pattern sleepPattern = Pattern.compile("WAITFOR DELAY '0:0:(\\d+)'");
 
         this.nano.addHandler(
                 new NanoServerHandler(test) {
-                    private int time = 100;
 
                     @Override
                     protected Response serve(IHTTPSession session) {
                         String name = getFirstParamValue(session, "name");
                         String response = "<html><body></body></html>";
-                        if (name != null && name.contains(" WAITFOR DELAY ")) {
-                            try {
-                                Thread.sleep(time);
-                            } catch (InterruptedException e) {
-                                // Ignore
-                            }
-                            time += 1000;
+                        if (name == null) {
+                            return newFixedLengthResponse(response);
+                        }
+                        Matcher match = sleepPattern.matcher(name);
+                        if (!match.find()) {
+                            return newFixedLengthResponse(name);
+                        }
+                        try {
+                            int sleepInput = Integer.parseInt(match.group(1));
+                            Thread.sleep(sleepInput * 1000L);
+                        } catch (InterruptedException e) {
+                            // Ignore
                         }
                         return newFixedLengthResponse(response);
                     }
@@ -90,13 +97,13 @@ class SqlInjectionMsSqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMs
         HttpMessage msg = this.getHttpMessage(test + "?name=test");
 
         this.rule.init(msg, this.parent);
-        this.rule.setSleepInSeconds(1);
+        this.rule.setSleepInSeconds(2);
 
         this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("name"));
-        assertThat(alertsRaised.get(0).getAttack(), equalTo("test' WAITFOR DELAY '0:0:1' -- "));
+        assertThat(alertsRaised.get(0).getAttack(), equalTo("test WAITFOR DELAY '0:0:2' -- "));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_HIGH));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
     }
@@ -117,7 +124,7 @@ class SqlInjectionMsSqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMs
                         } catch (InterruptedException e) {
                             // Ignore
                         }
-                        time += 1000;
+                        time += 100;
                         return newFixedLengthResponse(response);
                     }
                 });
@@ -125,7 +132,7 @@ class SqlInjectionMsSqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMs
         HttpMessage msg = this.getHttpMessage(test + "?name=test");
 
         this.rule.init(msg, this.parent);
-        this.rule.setSleepInSeconds(1);
+        this.rule.setSleepInSeconds(2);
 
         this.rule.scan();
 


### PR DESCRIPTION
Adapt `SqlInjectionMsSqlScanRule` to do the time-based tests with the timing utils.