### PR TITLE
pscanrulesAlpha: use IDs for alert links

### DIFF
--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -45,7 +45,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class Base64Disclosure extends PluginPassiveScanner {
+public class Base64Disclosure extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     /**
      * a set of patterns used to identify Base64 encoded data. Set a minimum length to reduce false
@@ -399,9 +399,5 @@ public class Base64Disclosure extends PluginPassiveScanner {
 
     private static String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    public String getHelpLink() {
-        return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-alpha/#base64-disclosure";
     }
 }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CommonPassiveScanRuleInfo.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CommonPassiveScanRuleInfo.java
@@ -1,0 +1,30 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+public interface CommonPassiveScanRuleInfo {
+
+    public int getPluginId();
+
+    public default String getHelpLink() {
+        return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-alpha/#id-"
+                + getPluginId();
+    }
+}

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRule.java
@@ -32,7 +32,8 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class FetchMetadataRequestHeadersScanRule extends PluginPassiveScanner {
+public class FetchMetadataRequestHeadersScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
     private static final String FETCH_METADATA_REQUEST_MESSAGE_PREFIX =
             "pscanalpha.metadata-request-headers.";
 
@@ -163,10 +164,6 @@ public class FetchMetadataRequestHeadersScanRule extends PluginPassiveScanner {
                     .setWascId(9)
                     .setEvidence(evidence);
         }
-    }
-
-    public String getHelpLink() {
-        return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-alpha/#fetch-metadata-request-headers-scan-rule";
     }
 
     static class SecFetchSite extends FetchMetaDataRequestHeaders {

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -16,7 +16,7 @@ For more details see: <a href="https://www.zaproxy.org/blog/2014-04-03-hacking-z
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanRule.java">ExampleFilePassiveScanRule.java</a>
 
-<H2>Base64 Disclosure</H2>
+<H2 id="id-10094">Base64 Disclosure</H2>
 <ul>
  <li><b>ASP.NET ViewState Disclosure:</b> An ASP.NET ViewState was disclosed by the application/web server</li>
  <li><b>ASP.NET ViewState Integrity:</b> The application does not use a Message Authentication Code (MAC) to protect the integrity of the ASP.NET ViewState, which can be tampered with by a malicious client</li>
@@ -33,7 +33,7 @@ For more details see: <a href="https://www.zaproxy.org/blog/2014-04-03-hacking-z
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java">ExampleSimplePassiveScanRule.java</a>
 
-<H2>Fetch Metadata Request Headers Scan Rule</H2>
+<H2 id="id-90005">Fetch Metadata Request Headers Scan Rule</H2>
 Fetch Metadata Request headers are HTTP request headers that provide additional information about a request's origin.
 This additional information helps the server to implement resource isolation policy, allowing external sites to request only
 those resources that are intended for sharing, and that are used appropriately. This approach can help mitigate common


### PR DESCRIPTION
Use the IDs of the scan rules for the links.
Also, add an interface to define the URL in a single place which avoids the need to change the scan rule when promoting/demoting.

Related to zaproxy/zaproxy#8189.