### PR TITLE
ascanrules: correct evidence in MsSQL and Hyper

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicScanRule.java
@@ -276,10 +276,10 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
                 paramName,
                 paramValue);
 
-        AtomicReference<HttpMessage> message = new AtomicReference<>();
-        AtomicReference<String> attack = new AtomicReference<>();
         Iterator<String> it = SQL_HYPERSONIC_TIME_REPLACEMENTS.iterator();
         for (int i = 0; !isStop() && it.hasNext() && i < blindTargetCount; i++) {
+            AtomicReference<HttpMessage> message = new AtomicReference<>();
+            AtomicReference<String> attack = new AtomicReference<>();
             String sleepPayload = it.next();
             TimingUtils.RequestSender requestSender =
                     x -> {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlScanRule.java
@@ -216,10 +216,10 @@ public class SqlInjectionMsSqlScanRule extends AbstractAppParamPlugin {
                 paramName,
                 paramValue);
 
-        AtomicReference<HttpMessage> message = new AtomicReference<>();
-        AtomicReference<String> attack = new AtomicReference<>();
         Iterator<String> it = SQL_MSSQL_TIME_REPLACEMENTS.iterator();
         for (int i = 0; !isStop() && it.hasNext() && i < blindTargetCount; i++) {
+            AtomicReference<HttpMessage> message = new AtomicReference<>();
+            AtomicReference<String> attack = new AtomicReference<>();
             String sleepPayload = it.next();
             TimingUtils.RequestSender requestSender =
                     x -> {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicScanRuleUnitTest.java
@@ -69,7 +69,9 @@ class SqlInjectionHypersonicScanRuleUnitTest
     @Test
     void shouldAlertIfSleepTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
-        Pattern sleepPattern = Pattern.compile("Thread.sleep\"\\((\\d+)\\)");
+        // Match one of the middle payloads, for proper evidence check.
+        Pattern sleepPattern =
+                Pattern.compile("\\); select \"java.lang.Thread.sleep\"\\((\\d+)\\)");
 
         this.nano.addHandler(
                 new NanoServerHandler(test) {
@@ -107,7 +109,7 @@ class SqlInjectionHypersonicScanRuleUnitTest
         assertThat(
                 alertsRaised.get(0).getAttack(),
                 equalTo(
-                        "; select \"java.lang.Thread.sleep\"(2000) from INFORMATION_SCHEMA.SYSTEM_COLUMNS where TABLE_NAME = 'SYSTEM_COLUMNS' and COLUMN_NAME = 'TABLE_NAME' -- "));
+                        "); select \"java.lang.Thread.sleep\"(2000) from INFORMATION_SCHEMA.SYSTEM_COLUMNS where TABLE_NAME = 'SYSTEM_COLUMNS' and COLUMN_NAME = 'TABLE_NAME' -- "));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_HIGH));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
     }

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlScanRuleUnitTest.java
@@ -68,7 +68,8 @@ class SqlInjectionMsSqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMs
     @Test
     void shouldAlertIfSleepTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
-        Pattern sleepPattern = Pattern.compile("WAITFOR DELAY '0:0:(\\d+)'");
+        // Match one of the middle payloads, for proper evidence check.
+        Pattern sleepPattern = Pattern.compile("\\) ' WAITFOR DELAY '0:0:(\\d+)'");
 
         this.nano.addHandler(
                 new NanoServerHandler(test) {
@@ -103,7 +104,7 @@ class SqlInjectionMsSqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMs
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getParam(), equalTo("name"));
-        assertThat(alertsRaised.get(0).getAttack(), equalTo("test WAITFOR DELAY '0:0:2' -- "));
+        assertThat(alertsRaised.get(0).getAttack(), equalTo("test) ' WAITFOR DELAY '0:0:2' -- "));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_HIGH));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
     }


### PR DESCRIPTION
Move the declaration of the variables, to ensure the expected message and evidence is included in the alert.