### PR TITLE
scripts: prevent GUI init in daemon mode

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Rename "Script Console" in the Options panel list to "Console".
 
+### Fixed
+- Prevent GUI initialization in daemon mode when installing the add-on.
+
 ## [43] - 2023-11-13
 ### Added
 - Allow setting the tab size and whether to use tabs or spaces for indentation in the console.


### PR DESCRIPTION
Don't enable the built in script that requires the GUI when it's not available (e.g. running daemon mode).

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/oaR0MvG1BPQ/m/HSSFj9NQAwAJ