### PR TITLE
scripts: Migrate scan rule functionality from core

### DIFF
--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- This add-on now depends on the Scripts add-on for providing scanning related functionality.
+- The active and passive scan rule templates were updated to import classes from the scripts add-on.
 
 ### Fixed
 - Update the content-length header field after setting the request body in the authentication template.

--- a/addOns/jruby/jruby.gradle.kts
+++ b/addOns/jruby/jruby.gradle.kts
@@ -9,6 +9,13 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/ruby-scripting/")
+        dependencies {
+            addOns {
+                register("scripts") {
+                    version.set(">=45.0.0")
+                }
+            }
+        }
     }
 }
 

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/active/Active default template.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/active/Active default template.rb
@@ -5,13 +5,13 @@
       
 require 'java'
 java_package 'org.zaproxy.zap.extension.ascan'
-java_import 'org.zaproxy.zap.extension.ascan.ActiveScript'
-java_import 'org.zaproxy.zap.extension.ascan.ScriptsActiveScanner'
+java_import 'org.zaproxy.zap.extension.scripts.scanrules.ActiveScript'
+java_import 'org.zaproxy.zap.extension.scripts.scanrules.ScriptsActiveScanner'
 java_import 'org.parosproxy.paros.network.HttpMessage'
 java_import 'org.parosproxy.paros.view.View'
 
 class JRubyActiveScript 
-  include Java::org.zaproxy.zap.extension.ascan.ActiveScript
+  include Java::org.zaproxy.zap.extension.scripts.scanrules.ActiveScript
 
   java_signature 'scan(ScriptsActiveScanner, HttpMessage, String, String)'
   def scan(sas, msg, param, value)

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.rb
@@ -5,15 +5,15 @@
 
 require 'java'
 java_package 'org.zaproxy.zap.extension.pscan'
-java_import 'org.zaproxy.zap.extension.pscan.PassiveScript'
+java_import 'org.zaproxy.zap.extension.scripts.scanrules.PassiveScript'
 java_import 'org.zaproxy.zap.extension.pscan.PluginPassiveScanner'
-java_import 'org.zaproxy.zap.extension.pscan.scanner.ScriptsPassiveScanner'
+java_import 'org.zaproxy.zap.extension.scripts.scanrules.ScriptsPassiveScanner'
 java_import 'org.parosproxy.paros.network.HttpMessage'
 java_import 'net.htmlparser.jericho.Source'
 java_import 'org.parosproxy.paros.view.View'
 
 class JRubyPassiveScript 
-  include Java::org.zaproxy.zap.extension.pscan.PassiveScript
+  include Java::org.zaproxy.zap.extension.scripts.scanrules.PassiveScript
 
   java_signature 'scan(ScriptsPassiveScanner, HttpMessage, Source)'
   def scan(ps, msg, src)

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- The scan rule functionality of scripts was moved from the ZAP core to this add-on (Related to Issue 7105).
 
 ## [44] - 2023-12-19
 ### Changed

--- a/addOns/scripts/gradle.properties
+++ b/addOns/scripts/gradle.properties
@@ -1,2 +1,2 @@
-version=45
+version=45.0.0
 release=false

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScript.java
@@ -1,0 +1,29 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import javax.script.ScriptException;
+import org.parosproxy.paros.network.HttpMessage;
+
+public interface ActiveScript {
+
+    void scan(ScriptsActiveScanner sas, HttpMessage msg, String param, String value)
+            throws ScriptException;
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScript2.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScript2.java
@@ -1,0 +1,28 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import javax.script.ScriptException;
+import org.parosproxy.paros.network.HttpMessage;
+
+public interface ActiveScript2 {
+
+    void scanNode(ScriptsActiveScanner sas, HttpMessage msg) throws ScriptException;
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScript.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import javax.script.ScriptException;
+import net.htmlparser.jericho.Source;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public interface PassiveScript {
+
+    void scan(ScriptsPassiveScanner scriptsPassiveScanner, HttpMessage msg, Source source)
+            throws ScriptException;
+
+    /**
+     * Tells whether the scanner applies to the given history type.
+     *
+     * <p>By default it scans the {@link PluginPassiveScanner#getDefaultHistoryTypes() default
+     * history types}.
+     *
+     * @param historyType the history type of the message to be scanned.
+     * @return {@code true} if the scanner applies to the given history type, {@code false}
+     *     otherwise.
+     */
+    default boolean appliesToHistoryType(int historyType) {
+        return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScanner.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScanner.java
@@ -1,0 +1,367 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.script.ScriptsCache;
+import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceProvider;
+
+public class ScriptsActiveScanner extends AbstractAppParamPlugin {
+
+    private ExtensionScript extension = null;
+    private ScriptsCache<ActiveScript> cachedScripts;
+
+    private static final Logger LOGGER = LogManager.getLogger(ScriptsActiveScanner.class);
+
+    /**
+     * A {@code Set} containing the scripts that do not implement {@code ActiveScript2}, to show an
+     * error if those scripts do not implement {@code ActiveScript} (thus not implementing any of
+     * the required interfaces).
+     *
+     * @see #scan()
+     * @see #scan(HttpMessage, String, String)
+     */
+    private Set<ScriptWrapper> scriptsNoInterface = new HashSet<>();
+
+    @Override
+    public int getId() {
+        return 50000;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString("scripts.scanRules.ascan.name");
+    }
+
+    @Override
+    public String[] getDependency() {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return "";
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.MISC;
+    }
+
+    @Override
+    public String getSolution() {
+        return "";
+    }
+
+    @Override
+    public String getReference() {
+        return "";
+    }
+
+    @Override
+    public void init() {
+        if (shouldSkipScan()) {
+            getParent()
+                    .pluginSkipped(
+                            this,
+                            Constant.messages.getString("scripts.scanRules.ascan.skipReason"));
+        }
+    }
+
+    /**
+     * Tells whether the scanner should be skipped. The scanner should be skipped when the {@code
+     * ExtensionScript} is not enabled, when there are no scripts, or if there are none is enabled.
+     *
+     * @return {@code true} if the scanner should be skipped, {@code false} otherwise
+     */
+    private boolean shouldSkipScan() {
+        if (this.getExtension() == null) {
+            return true;
+        }
+
+        List<ScriptWrapper> scripts = getActiveScripts();
+        if (scripts.isEmpty()) {
+            return true;
+        }
+
+        for (ScriptWrapper script : scripts) {
+            if (script.isEnabled()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the scripts of active script type.
+     *
+     * <p><strong>Note:</strong> this method should be called only when {@code getExtension()}
+     * returns non-{@code null}.
+     *
+     * @return a {@code List} containing the scripts with active script type, never {@code null}
+     * @see #getExtension()
+     * @see ExtensionActiveScan#SCRIPT_TYPE_ACTIVE
+     */
+    private List<ScriptWrapper> getActiveScripts() {
+        return this.getExtension().getScripts(ExtensionActiveScan.SCRIPT_TYPE_ACTIVE);
+    }
+
+    private ExtensionScript getExtension() {
+        if (extension == null) {
+            extension =
+                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        }
+        return extension;
+    }
+
+    @Override
+    public void scan() {
+        List<ScriptWrapper> scripts = this.getActiveScripts();
+
+        for (Iterator<ScriptWrapper> it = scripts.iterator(); it.hasNext() && !isStop(); ) {
+            ScriptWrapper script = it.next();
+            try {
+                if (script.isEnabled()) {
+                    ActiveScript2 s = extension.getInterface(script, ActiveScript2.class);
+
+                    if (s != null) {
+                        HttpMessage msg = this.getNewMsg();
+                        LOGGER.debug(
+                                "Calling script {} scanNode for {}",
+                                script.getName(),
+                                msg.getRequestHeader().getURI());
+                        s.scanNode(this, msg);
+                    } else {
+                        scriptsNoInterface.add(script);
+                    }
+                }
+
+            } catch (Exception e) {
+                extension.handleScriptException(script, e);
+            }
+        }
+
+        if (!isStop()) {
+            InterfaceProvider<ActiveScript> interfaceProvider =
+                    (scriptWrapper, targetInterface) -> {
+                        ActiveScript s = extension.getInterface(scriptWrapper, targetInterface);
+                        if (s != null) {
+                            return s;
+                        }
+                        if (scriptsNoInterface.contains(scriptWrapper)) {
+                            extension.handleFailedScriptInterface(
+                                    scriptWrapper,
+                                    Constant.messages.getString(
+                                            "scripts.scanRules.ascan.interfaceError",
+                                            scriptWrapper.getName()));
+                        }
+                        return null;
+                    };
+            cachedScripts =
+                    getExtension()
+                            .createScriptsCache(
+                                    Configuration.<ActiveScript>builder()
+                                            .setScriptType(ExtensionActiveScan.SCRIPT_TYPE_ACTIVE)
+                                            .setTargetInterface(ActiveScript.class)
+                                            .setInterfaceProvider(interfaceProvider)
+                                            .build());
+            super.scan();
+        }
+        scriptsNoInterface.clear();
+    }
+
+    @Override
+    public void scan(HttpMessage msg, String param, String value) {
+        cachedScripts.refresh();
+
+        for (CachedScript<ActiveScript> cachedScript : cachedScripts.getCachedScripts()) {
+            if (isStop()) {
+                return;
+            }
+
+            ScriptWrapper script = cachedScript.getScriptWrapper();
+            try {
+                LOGGER.debug(
+                        "Calling script {} scan for {} param={} value={}",
+                        script.getName(),
+                        msg.getRequestHeader().getURI(),
+                        param,
+                        value);
+                cachedScript.getScript().scan(this, msg, param, value);
+
+            } catch (Exception e) {
+                extension.handleScriptException(script, e);
+            }
+        }
+    }
+
+    @Override
+    public boolean isStop() {
+        return super.isStop();
+    }
+
+    public String setParam(HttpMessage msg, String param, String value) {
+        return super.setParameter(msg, param, value);
+    }
+
+    @Override
+    public void sendAndReceive(HttpMessage msg) throws IOException {
+        super.sendAndReceive(msg);
+    }
+
+    @Override
+    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect) throws IOException {
+        super.sendAndReceive(msg, isFollowRedirect);
+    }
+
+    @Override
+    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect, boolean handleAntiCSRF)
+            throws IOException {
+        super.sendAndReceive(msg, isFollowRedirect, handleAntiCSRF);
+    }
+
+    @Override
+    public AlertBuilder newAlert() {
+        return super.newAlert();
+    }
+
+    /**
+     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
+    public void raiseAlert(
+            int risk,
+            int confidence,
+            String name,
+            String description,
+            String uri,
+            String param,
+            String attack,
+            String otherInfo,
+            String solution,
+            String evidence,
+            int cweId,
+            int wascId,
+            HttpMessage msg) {
+        super.bingo(
+                risk,
+                confidence,
+                name,
+                description,
+                uri,
+                param,
+                attack,
+                otherInfo,
+                solution,
+                evidence,
+                cweId,
+                wascId,
+                msg);
+    }
+
+    /**
+     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
+    public void raiseAlert(
+            int risk,
+            int confidence,
+            String name,
+            String description,
+            String uri,
+            String param,
+            String attack,
+            String otherInfo,
+            String solution,
+            String evidence,
+            String reference,
+            int cweId,
+            int wascId,
+            HttpMessage msg) {
+        super.bingo(
+                risk,
+                confidence,
+                name,
+                description,
+                uri,
+                param,
+                attack,
+                otherInfo,
+                solution,
+                evidence,
+                reference,
+                cweId,
+                wascId,
+                msg);
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_INFO;
+    }
+
+    @Override
+    public int getCweId() {
+        return 0;
+    }
+
+    @Override
+    public int getWascId() {
+        return 0;
+    }
+
+    @Override
+    public boolean isPage200(HttpMessage msg) {
+        return super.isPage200(msg);
+    }
+
+    @Override
+    public boolean isPage404(HttpMessage msg) {
+        return super.isPage404(msg);
+    }
+
+    @Override
+    public boolean isPage500(HttpMessage msg) {
+        return super.isPage500(msg);
+    }
+
+    @Override
+    public boolean isPageOther(HttpMessage msg) {
+        return super.isPageOther(msg);
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsPassiveScanner.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsPassiveScanner.java
@@ -1,0 +1,213 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import net.htmlparser.jericho.Source;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.script.ScriptsCache;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+
+public class ScriptsPassiveScanner extends PluginPassiveScanner {
+
+    private static final Logger LOGGER = LogManager.getLogger(ScriptsPassiveScanner.class);
+
+    private final ScriptsCache<PassiveScript> scripts;
+
+    private int currentHistoryType;
+
+    public ScriptsPassiveScanner() {
+        ExtensionScript extension =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        scripts =
+                extension != null
+                        ? extension.createScriptsCache(
+                                Configuration.<PassiveScript>builder()
+                                        .setScriptType(ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE)
+                                        .setTargetInterface(PassiveScript.class)
+                                        .setInterfaceErrorMessageProvider(
+                                                sw ->
+                                                        Constant.messages.getString(
+                                                                "scripts.scanRules.pscan.interfaceError",
+                                                                sw.getName()))
+                                        .build())
+                        : null;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString("scripts.scanRules.pscan.name");
+    }
+
+    @Override
+    public int getPluginId() {
+        return 50001;
+    }
+
+    @Override
+    public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (scripts == null) {
+            return;
+        }
+
+        scripts.refreshAndExecute(
+                (sw, script) -> {
+                    if (appliesToCurrentHistoryType(sw, script)) {
+                        script.scan(this, msg, source);
+                    }
+                });
+    }
+
+    @Override
+    public ScriptsPassiveScanner copy() {
+        ScriptsPassiveScanner copy = new ScriptsPassiveScanner();
+        copy.currentHistoryType = currentHistoryType;
+        return copy;
+    }
+
+    private boolean appliesToCurrentHistoryType(ScriptWrapper wrapper, PassiveScript ps) {
+        try {
+            return ps.appliesToHistoryType(currentHistoryType);
+        } catch (UndeclaredThrowableException e) {
+            // Python script implementation throws an exception if this optional/default method is
+            // not
+            // actually implemented by the script (other script implementations, Zest/ECMAScript,
+            // just
+            // use the default method).
+            if (e.getCause() instanceof NoSuchMethodException
+                    && "appliesToHistoryType".equals(e.getCause().getMessage())) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
+                            "Script [Name={}, Engine={}]  does not implement the optional method appliesToHistoryType: ",
+                            wrapper.getName(),
+                            wrapper.getEngineName(),
+                            e);
+                }
+                return super.appliesToHistoryType(currentHistoryType);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public AlertBuilder newAlert() {
+        return super.newAlert();
+    }
+
+    /**
+     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
+    public void raiseAlert(
+            int risk,
+            int confidence,
+            String name,
+            String description,
+            String uri,
+            String param,
+            String attack,
+            String otherInfo,
+            String solution,
+            String evidence,
+            int cweId,
+            int wascId,
+            HttpMessage msg) {
+
+        raiseAlert(
+                risk,
+                confidence,
+                name,
+                description,
+                uri,
+                param,
+                attack,
+                otherInfo,
+                solution,
+                evidence,
+                null,
+                cweId,
+                wascId,
+                msg);
+    }
+
+    /**
+     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
+    public void raiseAlert(
+            int risk,
+            int confidence,
+            String name,
+            String description,
+            String uri,
+            String param,
+            String attack,
+            String otherInfo,
+            String solution,
+            String evidence,
+            String reference,
+            int cweId,
+            int wascId,
+            HttpMessage msg) {
+
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(name)
+                .setDescription(description)
+                .setParam(param)
+                .setOtherInfo(otherInfo)
+                .setSolution(solution)
+                .setReference(reference)
+                .setEvidence(evidence)
+                .setCweId(cweId)
+                .setWascId(wascId)
+                .setMessage(msg)
+                .raise();
+    }
+
+    /**
+     * @deprecated Replaced by {@link #addHistoryTag(String)}
+     */
+    @Override
+    @Deprecated
+    public void addTag(String tag) {
+        super.addHistoryTag(tag);
+    }
+
+    @Override
+    public void addHistoryTag(String tag) {
+        super.addHistoryTag(tag);
+    }
+
+    @Override
+    public boolean appliesToHistoryType(int historyType) {
+        this.currentHistoryType = historyType;
+        return true;
+    }
+}

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -122,6 +122,12 @@ scripts.popup.useForContextAs = Use for Context as...
 
 scripts.runscript.popup = Invoke with Script...
 
+scripts.scanRules.ascan.interfaceError = The provided Active Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
+scripts.scanRules.ascan.name = Script Active Scan Rules
+scripts.scanRules.ascan.skipReason = no scripts enabled
+scripts.scanRules.pscan.interfaceError = The provided Passive Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
+scripts.scanRules.pscan.name = Script Passive Scan Rules
+
 scripts.script.load.charset.confirmbutton = Load Script
 scripts.script.load.charset.label = Character Encoding:
 scripts.script.load.charset.message = Unable to read the script with default character encoding(s):\n{0}\nIt contains invalid character sequence(s).\nYou can select other character encoding.

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/active/Active default template.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/active/Active default template.js
@@ -1,0 +1,90 @@
+// Note that new active scripts will initially be disabled
+// Right click the script in the Scripts tree and select "enable"  
+
+/**
+ * Scans a "node", i.e. an individual entry in the Sites Tree.
+ * The scanNode function will typically be called once for every page. 
+ * 
+ * @param as - the ActiveScan parent object that will do all the core interface tasks 
+ *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
+ *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
+ */
+function scanNode(as, msg) {
+	// Debugging can be done using println like this
+	print('scan called for url=' + msg.getRequestHeader().getURI().toString());
+
+	// Copy requests before reusing them
+	msg = msg.cloneRequest();
+	
+	// sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
+	as.sendAndReceive(msg, false, false);
+
+	// Test the responses and raise alerts as below
+
+	// Check if the scan was stopped before performing lengthy tasks
+	if (as.isStop()) {
+		return
+	}
+	// Do lengthy task...
+	
+	// Raise less reliable alert (that is, prone to false positives) when in LOW alert threshold
+	// Expected values: "LOW", "MEDIUM", "HIGH"
+	if (as.getAlertThreshold() == "LOW") {
+		// ...
+	}
+	
+	// Do more tests in HIGH attack strength
+	// Expected values: "LOW", "MEDIUM", "HIGH", "INSANE"
+	if (as.getAttackStrength() == "HIGH") {
+		// ...
+	}
+}
+
+/**
+ * Scans a specific parameter in an HTTP message.
+ * The scan function will typically be called for every parameter in every URL and Form for every page.
+ * 
+ * @param as - the ActiveScan parent object that will do all the core interface tasks 
+ *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
+ *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
+ * @param {string} param - the name of the parameter being manipulated for this test/scan.
+ * @param {string} value - the original parameter value.
+ */
+function scan(as, msg, param, value) {
+	// Debugging can be done using println like this
+	print('scan called for url=' + msg.getRequestHeader().getURI().toString() + 
+		' param=' + param + ' value=' + value);
+	
+	// Copy requests before reusing them
+	msg = msg.cloneRequest();
+	
+	// setParam (message, parameterName, newValue)
+	as.setParam(msg, param, 'Your attack');
+	
+	// sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
+	as.sendAndReceive(msg, false, false);
+	
+	// Test the response here, and make other requests as required
+	if (true) {	// Change to a test which detects the vulnerability
+		// risk: 0: info, 1: low, 2: medium, 3: high
+		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
+		as.newAlert()
+			.setRisk(1)
+			.setConfidence(1)
+			.setName('Active Vulnerability title')
+			.setDescription('Full description')
+			.setParam(param)
+			.setAttack('Your attack')
+			.setEvidence('Evidence')
+			.setOtherInfo('Any other info')
+			.setSolution('The solution')
+			.setReference('References')
+			.setCweId(0)
+			.setWascId(0)
+			.setMessage(msg)
+			.raise();
+	}
+}
+

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.js
@@ -1,0 +1,61 @@
+// Passive scan rules should not make any requests 
+
+// Note that new passive scripts will initially be disabled
+// Right click the script in the Scripts tree and select "enable"  
+
+var PluginPassiveScanner = Java.type("org.zaproxy.zap.extension.pscan.PluginPassiveScanner");
+
+/**
+ * Passively scans an HTTP message. The scan function will be called for 
+ * request/response made via ZAP, actual messages depend on the function
+ * "appliesToHistoryType", defined below.
+ * 
+ * @param ps - the PassiveScan parent object that will do all the core interface tasks 
+ *     (i.e.: providing access to Threshold settings, raising alerts, etc.). 
+ *     This is an ScriptsPassiveScanner object.
+ * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
+ * @param src - the Jericho Source representation of the message being scanned.
+ */
+function scan(ps, msg, src) {
+	// Test the request and/or response here
+	if (true) {	// Change to a test which detects the vulnerability
+		// risk: 0: info, 1: low, 2: medium, 3: high
+		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
+		ps.newAlert()
+			.setRisk(1)
+			.setConfidence(1)
+			.setName('Passive Vulnerability title')
+			.setDescription('Full description')
+			.setParam('The param')
+			.setEvidence('Evidence')
+			.setOtherInfo('Any other info')
+			.setSolution('The solution')
+			.setReference('References')
+			.setCweId(0)
+			.setWascId(0)
+			.raise();
+		
+		//addTag(String tag)
+		ps.addTag('tag')			
+	}
+	
+	// Raise less reliable alert (that is, prone to false positives) when in LOW alert threshold
+	// Expected values: "LOW", "MEDIUM", "HIGH"
+	if (ps.getAlertThreshold() == "LOW") {
+		// ...
+	}
+}
+
+/**
+ * Tells whether or not the scanner applies to the given history type.
+ *
+ * @param {Number} historyType - The ID of the history type of the message to be scanned.
+ * @return {boolean} Whether or not the message with the given type should be scanned by this scanner.
+ */
+function appliesToHistoryType(historyType) {
+	// For example, to just scan spider messages:
+	// return historyType == org.parosproxy.paros.model.HistoryReference.TYPE_SPIDER;
+
+	// Default behaviour scans default types.
+	return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
+}

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScannerUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScannerUnitTest.java
@@ -1,0 +1,469 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import javax.script.ScriptException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.HostProcess;
+import org.parosproxy.paros.core.scanner.NameValuePair;
+import org.parosproxy.paros.core.scanner.ScannerParam;
+import org.parosproxy.paros.core.scanner.Variant;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+import org.zaproxy.zap.extension.ascan.VariantFactory;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.script.ScriptsCache;
+import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+import org.zaproxy.zap.extension.scripts.ExtensionScriptsUI;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link ScriptsActiveScanner}. */
+class ScriptsActiveScannerUnitTest extends TestUtils {
+
+    private static final String SCRIPT_TYPE = ExtensionActiveScan.SCRIPT_TYPE_ACTIVE;
+    private static final Class<ActiveScript> TARGET_INTERFACE_CACHE = ActiveScript.class;
+
+    private ExtensionScript extensionScript;
+    private HostProcess parent;
+    private HttpMessage message;
+    private ExtensionLoader extensionLoader;
+    private Model model;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        setUpZap();
+        extensionScript = mock(ExtensionScript.class);
+        parent = mock(HostProcess.class);
+        message = new HttpMessage(new HttpRequestHeader("GET / HTTP/1.1"));
+        extensionLoader = mock(ExtensionLoader.class);
+        model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        Control.initSingletonForTesting(model, extensionLoader);
+    }
+
+    @Override
+    protected void setUpMessages() {
+        mockMessages(new ExtensionScriptsUI());
+    }
+
+    @Test
+    void shouldSkipIfExtensionScriptIsNull() {
+        // Given
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(null);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        scriptsActiveScanner.init(message, parent);
+        // Then
+        verify(parent).pluginSkipped(scriptsActiveScanner, "no scripts enabled");
+    }
+
+    @Test
+    void shouldSkipIfNoActiveScripts() {
+        // Given
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE)).willReturn(asList());
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        scriptsActiveScanner.init(message, parent);
+        // Then
+        verify(parent).pluginSkipped(scriptsActiveScanner, "no scripts enabled");
+    }
+
+    @Test
+    void shouldSkipIfNoEnabledActiveScripts() {
+        // Given
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(mock(ScriptWrapper.class)));
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        scriptsActiveScanner.init(message, parent);
+        // Then
+        verify(parent).pluginSkipped(scriptsActiveScanner, "no scripts enabled");
+    }
+
+    @Test
+    void shouldHaveAName() {
+        // Given
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        String name = scriptsActiveScanner.getName();
+        // Then
+        assertThat(name, is(equalTo("Script Active Scan Rules")));
+    }
+
+    @Test
+    void shouldHaveSpecificPluginId() {
+        // Given
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        int pluginId = scriptsActiveScanner.getId();
+        // Then
+        assertThat(pluginId, is(equalTo(50000)));
+    }
+
+    @Test
+    void shouldHaveSpecificCategory() {
+        // Given
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        int category = scriptsActiveScanner.getCategory();
+        // Then
+        assertThat(category, is(equalTo(Category.MISC)));
+    }
+
+    @Test
+    void shouldHaveNoDependencies() {
+        // Given
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        String[] dependencies = scriptsActiveScanner.getDependency();
+        // Then
+        assertThat(dependencies, is(nullValue()));
+    }
+
+    @Test
+    void shouldScanNodesWithActiveScript2() throws Exception {
+        // Given
+        ActiveScript2 script1 = mock(ActiveScript2.class);
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript2.class);
+        ActiveScript2 script2 = mock(ActiveScript2.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript2.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(script1, times(1)).scanNode(scriptsActiveScanner, message);
+        verify(script2, times(1)).scanNode(scriptsActiveScanner, message);
+    }
+
+    @Test
+    void shouldNotCallScanNodeOnDisabledActiveScript2() throws Exception {
+        // Given
+        ScriptWrapper scriptWrapper1 = mock(ScriptWrapper.class);
+        given(scriptWrapper1.isEnabled()).willReturn(false);
+        ActiveScript2 script2 = mock(ActiveScript2.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript2.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(extensionScript, times(0)).getInterface(scriptWrapper1, ActiveScript2.class);
+        verify(script2, times(1)).scanNode(scriptsActiveScanner, message);
+    }
+
+    @Test
+    void shouldHandleExceptionsThrownByActiveScript2() throws Exception {
+        // Given
+        ActiveScript2 script1 = mock(ActiveScript2.class);
+        ScriptException exception = mock(ScriptException.class);
+        doThrow(exception).when(script1).scanNode(any(), any());
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript2.class);
+        ActiveScript2 script2 = mock(ActiveScript2.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript2.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(script1, times(1)).scanNode(scriptsActiveScanner, message);
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper1, exception);
+        verify(script2, times(1)).scanNode(scriptsActiveScanner, message);
+    }
+
+    @Test
+    void shouldStopScanningNodesWithActiveScript2WhenScanStopped() throws Exception {
+        // Given
+        ActiveScript2 script1 = mock(ActiveScript2.class);
+        doAnswer(stopScan()).when(script1).scanNode(any(), any());
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript2.class);
+        ScriptWrapper scriptWrapper2 = mock(ScriptWrapper.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(script1, times(1)).scanNode(scriptsActiveScanner, message);
+        verify(extensionScript, times(0)).getInterface(scriptWrapper2, ActiveScript2.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCreateScriptsCacheWithExpectedConfiguration() throws Exception {
+        // Given
+        ActiveScript script = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper = createScriptWrapper(script, ActiveScript.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE)).willReturn(asList(scriptWrapper));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        ArgumentCaptor<Configuration<ActiveScript>> argumentCaptor =
+                ArgumentCaptor.forClass(Configuration.class);
+        verify(extensionScript).createScriptsCache(argumentCaptor.capture());
+        Configuration<ActiveScript> configuration = argumentCaptor.getValue();
+        assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
+        assertThat(configuration.getTargetInterface(), is(equalTo(TARGET_INTERFACE_CACHE)));
+        assertThat(configuration.getInterfaceProvider(), is(not(nullValue())));
+        assertThat(configuration.getInterfaceErrorMessageProvider(), is(nullValue()));
+    }
+
+    @Test
+    void shouldFailScriptsThatDoNotImplementNeitherActiveScript2NorActiveScript() {
+        // Given
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.isEnabled()).willReturn(true);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE)).willReturn(asList(scriptWrapper));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        given(extensionScript.<ActiveScript>createScriptsCache(any()))
+                .willAnswer(
+                        e -> {
+                            Configuration<ActiveScript> configuration = e.getArgument(0);
+                            configuration
+                                    .getInterfaceProvider()
+                                    .getInterface(scriptWrapper, ActiveScript.class);
+                            return null;
+                        });
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(extensionScript).handleFailedScriptInterface(eq(scriptWrapper), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldScanParamsWithActiveScript() throws Exception {
+        // Given
+        ActiveScript script1 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript.class);
+        ActiveScript script2 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        ScriptsCache<ActiveScript> scriptsCache =
+                createScriptsCache(
+                        createCachedScript(script1, scriptWrapper1),
+                        createCachedScript(script2, scriptWrapper2));
+        given(extensionScript.<ActiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        given(parent.getScannerParam()).willReturn(mock(ScannerParam.class));
+        String name1 = "Name1";
+        String value1 = "Value1";
+        NameValuePair param1 = param(name1, value1);
+        String name2 = "Name2";
+        String value2 = "Value2";
+        NameValuePair param2 = param(name2, value2);
+        Variant variant = mock(Variant.class);
+        given(variant.getParamList()).willReturn(asList(param1, param2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(variant));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(scriptsCache, times(2)).refresh();
+        verify(scriptsCache, times(2)).getCachedScripts();
+        verify(script1, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(script1, times(1)).scan(scriptsActiveScanner, message, name2, value2);
+        verify(script2, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(script2, times(1)).scan(scriptsActiveScanner, message, name2, value2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldStopScanningParamsWithActiveScriptWhenScanStopped() throws Exception {
+        // Given
+        ActiveScript script1 = mock(ActiveScript.class);
+        doAnswer(stopScan()).when(script1).scan(any(), any(), any(), any());
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript.class);
+        ActiveScript script2 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        ScriptsCache<ActiveScript> scriptsCache =
+                createScriptsCache(
+                        createCachedScript(script1, scriptWrapper1),
+                        createCachedScript(script2, scriptWrapper2));
+        given(extensionScript.<ActiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        given(parent.getScannerParam()).willReturn(mock(ScannerParam.class));
+        String name1 = "Name1";
+        String value1 = "Value1";
+        NameValuePair param1 = param(name1, value1);
+        String name2 = "Name2";
+        String value2 = "Value2";
+        NameValuePair param2 = param(name2, value2);
+        Variant variant = mock(Variant.class);
+        given(variant.getParamList()).willReturn(asList(param1, param2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(variant));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(scriptsCache, times(1)).refresh();
+        verify(scriptsCache, times(1)).getCachedScripts();
+        verify(script1, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(script1, times(0)).scan(scriptsActiveScanner, message, name2, value2);
+        verify(script2, times(0)).scan(any(), any(), any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldHandleExceptionsThrownByActiveScript() throws Exception {
+        // Given
+        ActiveScript script1 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript.class);
+        ActiveScript script2 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        ScriptsCache<ActiveScript> scriptsCache =
+                createScriptsCache(
+                        createCachedScript(script1, scriptWrapper1),
+                        createCachedScript(script2, scriptWrapper2));
+        given(extensionScript.<ActiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        given(parent.getScannerParam()).willReturn(mock(ScannerParam.class));
+        String name1 = "Name1";
+        String value1 = "Value1";
+        NameValuePair param1 = param(name1, value1);
+        ScriptException exception = mock(ScriptException.class);
+        doThrow(exception).when(script1).scan(any(), any(), eq(name1), eq(value1));
+        String name2 = "Name2";
+        String value2 = "Value2";
+        NameValuePair param2 = param(name2, value2);
+        Variant variant = mock(Variant.class);
+        given(variant.getParamList()).willReturn(asList(param1, param2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(variant));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(scriptsCache, times(2)).refresh();
+        verify(scriptsCache, times(2)).getCachedScripts();
+        verify(script1, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper1, exception);
+        verify(script2, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(script2, times(1)).scan(scriptsActiveScanner, message, name2, value2);
+    }
+
+    private <T> ScriptWrapper createScriptWrapper(T script, Class<T> scriptClass) throws Exception {
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.isEnabled()).willReturn(true);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getInterface(scriptWrapper, scriptClass)).willReturn(script);
+        return scriptWrapper;
+    }
+
+    private Answer<Void> stopScan() {
+        return e -> {
+            given(parent.isStop()).willReturn(true);
+            return null;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> CachedScript<T> createCachedScript(T script, ScriptWrapper scriptWrapper) {
+        CachedScript<T> cachedScript = mock(CachedScript.class);
+        given(cachedScript.getScript()).willReturn(script);
+        given(cachedScript.getScriptWrapper()).willReturn(scriptWrapper);
+        return cachedScript;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ScriptsCache<T> createScriptsCache(CachedScript<T>... cachedScripts) {
+        ScriptsCache<T> scriptsCache = mock(ScriptsCache.class);
+        given(scriptsCache.getCachedScripts()).willReturn(asList(cachedScripts));
+        return scriptsCache;
+    }
+
+    private static NameValuePair param(String name, String value) {
+        NameValuePair nvp = mock(NameValuePair.class);
+        given(nvp.getName()).willReturn(name);
+        given(nvp.getValue()).willReturn(value);
+        return nvp;
+    }
+}

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsPassiveScannerUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsPassiveScannerUnitTest.java
@@ -1,0 +1,330 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import net.htmlparser.jericho.Source;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.pscan.PassiveScanData;
+import org.zaproxy.zap.extension.pscan.PassiveScanTaskHelper;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.script.ScriptsCache;
+import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceErrorMessageProvider;
+import org.zaproxy.zap.extension.script.ScriptsCache.ScriptWrapperAction;
+import org.zaproxy.zap.extension.scripts.ExtensionScriptsUI;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link ScriptsPassiveScanner}. */
+class ScriptsPassiveScannerUnitTest extends TestUtils {
+
+    private static final String SCRIPT_TYPE = ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE;
+    private static final Class<PassiveScript> TARGET_INTERFACE = PassiveScript.class;
+
+    private ExtensionLoader extensionLoader;
+    private ExtensionScript extensionScript;
+    private HttpMessage message;
+    private int id;
+    private Source source;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        setUpZap();
+        extensionScript = mock(ExtensionScript.class);
+        extensionLoader = mock(ExtensionLoader.class);
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        message = mock(HttpMessage.class);
+        id = 1;
+        source = new Source("");
+
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+    }
+
+    @Override
+    protected void setUpMessages() {
+        mockMessages(new ExtensionScriptsUI());
+    }
+
+    @Test
+    void shouldNotThrowIfExtensionScriptIsNull() {
+        // Given
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(null);
+        // When / Then
+        ScriptsPassiveScanner scriptsPassiveScanner =
+                assertDoesNotThrow(ScriptsPassiveScanner::new);
+        assertDoesNotThrow(() -> scriptsPassiveScanner.scanHttpRequestSend(message, id));
+        assertDoesNotThrow(
+                () -> scriptsPassiveScanner.scanHttpResponseReceive(message, id, source));
+    }
+
+    @Test
+    void shouldHaveAName() {
+        // Given
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        // When
+        String name = scriptsPassiveScanner.getName();
+        // Then
+        assertThat(name, is(equalTo("Script Passive Scan Rules")));
+    }
+
+    @Test
+    void shouldHaveSpecificPluginId() {
+        // Given
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        // When
+        int pluginId = scriptsPassiveScanner.getPluginId();
+        // Then
+        assertThat(pluginId, is(equalTo(50001)));
+    }
+
+    @Test
+    void shouldAddTagsWithTaskHelper() {
+        // Given
+        String tag = "Tag";
+        PassiveScanTaskHelper taskHelper = mock(PassiveScanTaskHelper.class);
+        HistoryReference href = mock(HistoryReference.class);
+        when(message.getHistoryRef()).thenReturn(href);
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        PassiveScanData passiveScanData = mock(PassiveScanData.class);
+        when(passiveScanData.getMessage()).thenReturn(message);
+        scriptsPassiveScanner.setHelper(passiveScanData);
+        scriptsPassiveScanner.setTaskHelper(taskHelper);
+        // When
+        scriptsPassiveScanner.addHistoryTag(tag);
+        // Then
+        verify(taskHelper).addHistoryTag(href, tag);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAddingTagWithoutParent() {
+        // Given
+        String tag = "Tag";
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        // When / Then
+        assertThrows(NullPointerException.class, () -> scriptsPassiveScanner.addHistoryTag(tag));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 1, 2, 3, 10, 100})
+    void shouldApplyToAllHistoryTypes(int historyType) {
+        // Given
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        // When
+        boolean applies = scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // Then
+        assertThat(applies, is(equalTo(true)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCreateScriptsCacheWithExpectedConfiguration() {
+        // Given / When
+        new ScriptsPassiveScanner();
+        // Then
+        ArgumentCaptor<Configuration<PassiveScript>> argumentCaptor =
+                ArgumentCaptor.forClass(Configuration.class);
+        verify(extensionScript).createScriptsCache(argumentCaptor.capture());
+        Configuration<PassiveScript> configuration = argumentCaptor.getValue();
+        assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
+        assertThat(configuration.getTargetInterface(), is(equalTo(TARGET_INTERFACE)));
+        InterfaceErrorMessageProvider errorMessageProvider =
+                configuration.getInterfaceErrorMessageProvider();
+        assertThat(errorMessageProvider, is(not(nullValue())));
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.getName()).willReturn("Name");
+        assertThat(errorMessageProvider.getErrorMessage(scriptWrapper), is(not(nullValue())));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRefreshScriptsAndCallScan() throws Exception {
+        // Given
+        PassiveScript script = Mockito.mock(TARGET_INTERFACE);
+        given(script.appliesToHistoryType(anyInt())).willReturn(true);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        int historyType = 5;
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(scriptsCache, times(1)).refreshAndExecute(any(ScriptWrapperAction.class));
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        ArgumentCaptor<ScriptsPassiveScanner> argumentCaptor =
+                ArgumentCaptor.forClass(ScriptsPassiveScanner.class);
+        verify(script, times(1)).scan(argumentCaptor.capture(), eq(message), eq(source));
+        assertThat(argumentCaptor.getValue(), is(sameInstance(scriptsPassiveScanner)));
+    }
+
+    @Test
+    void shouldScanWithCopy() throws Exception {
+        // Given
+        PassiveScript script = Mockito.mock(TARGET_INTERFACE);
+        given(script.appliesToHistoryType(anyInt())).willReturn(true);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        int historyType = 5;
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        ScriptsPassiveScanner copy = scriptsPassiveScanner.copy();
+        copy.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(1)).scan(any(), any(), any());
+    }
+
+    @Test
+    void shouldNotCallScanIfScriptDoesNotApplyToHistoryType() throws Exception {
+        // Given
+        PassiveScript script = Mockito.mock(TARGET_INTERFACE);
+        given(script.appliesToHistoryType(anyInt())).willReturn(false);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        int historyType = 5;
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(0)).scan(any(), any(), any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 15})
+    void shouldHandleScriptsThatDoNotImplementAppliesToHistoryType(int historyType)
+            throws Exception {
+        // Given
+        PassiveScript script = Mockito.mock(TARGET_INTERFACE);
+        NoSuchMethodException cause = mock(NoSuchMethodException.class);
+        given(cause.getMessage()).willReturn("appliesToHistoryType");
+        UndeclaredThrowableException exception = mock(UndeclaredThrowableException.class);
+        given(exception.getCause()).willReturn(cause);
+        given(script.appliesToHistoryType(anyInt())).willThrow(exception);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(1)).scan(any(), any(), any());
+    }
+
+    @Test
+    void shouldPropagateExceptionThrownByAppliesToHistoryTypeIfNotCausedByMissingMethod()
+            throws Exception {
+        // Given
+        PassiveScript script = Mockito.mock(TARGET_INTERFACE);
+        NoSuchMethodException cause = mock(NoSuchMethodException.class);
+        given(cause.getMessage()).willReturn("other method");
+        UndeclaredThrowableException exception = mock(UndeclaredThrowableException.class);
+        given(exception.getCause()).willReturn(cause);
+        given(script.appliesToHistoryType(anyInt())).willThrow(exception);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        int historyType = 5;
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(0)).scan(any(), any(), any());
+    }
+
+    @Test
+    void shouldPropagateExceptionThrownByAppliesToHistoryTypeIfNotNoSuchMethodException()
+            throws Exception {
+        // Given
+        PassiveScript script = Mockito.mock(TARGET_INTERFACE);
+        UndeclaredThrowableException exception = mock(UndeclaredThrowableException.class);
+        given(script.appliesToHistoryType(anyInt())).willThrow(exception);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        int historyType = 5;
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(0)).scan(any(), any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> CachedScript<T> createCachedScript(T script) {
+        CachedScript<T> cachedScript = mock(CachedScript.class);
+        given(cachedScript.getScript()).willReturn(script);
+        return cachedScript;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> ScriptsCache<T> createScriptsCache(CachedScript<T> cachedScript) {
+        ScriptsCache<T> scriptsCache = mock(ScriptsCache.class);
+        Answer<Void> answer =
+                invocation -> {
+                    ScriptWrapperAction<T> action =
+                            (ScriptWrapperAction<T>) invocation.getArguments()[0];
+                    try {
+                        action.apply(cachedScript.getScriptWrapper(), cachedScript.getScript());
+                    } catch (Throwable ignore) {
+                    }
+                    return null;
+                };
+        doAnswer(answer).when(scriptsCache).refreshAndExecute(any(ScriptWrapperAction.class));
+        return scriptsCache;
+    }
+}

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum Scripts add-on version to 45.
 
 ## [43] - 2023-12-19
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
@@ -26,8 +26,8 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.network.ExtensionNetwork;
-import org.zaproxy.zap.extension.ascan.ActiveScript;
-import org.zaproxy.zap.extension.ascan.ScriptsActiveScanner;
+import org.zaproxy.zap.extension.scripts.scanrules.ActiveScript;
+import org.zaproxy.zap.extension.scripts.scanrules.ScriptsActiveScanner;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestResponse;
 

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -29,7 +29,7 @@ zapAddOn {
                     version.set(">=0.2.0")
                 }
                 register("scripts") {
-                    version.set(">=44")
+                    version.set(">=45.0.0")
                 }
                 register("selenium") {
                     version.set(">= 15.13.0")
@@ -42,6 +42,7 @@ zapAddOn {
 dependencies {
     zapAddOn("commonlib")
     zapAddOn("network")
+    zapAddOn("scripts")
     zapAddOn("selenium")
 
     implementation("org.zaproxy:zest:0.20.0") {


### PR DESCRIPTION
## Overview
Migrate scripts scanning infrastructure from core to add-ons.

## Related Issues
- First step towards https://github.com/zaproxy/zaproxy/issues/7105.
- See also https://github.com/zaproxy/zaproxy/pull/8265.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title