### PR TITLE
pscanrules: Update reference links (http -> https)

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - The Big Redirect scan rule will now also alert on responses that have multiple HREFs (idea from xnl-h4ck3r).
     - It also now includes example alert and alert reference functionality for documentation generation purposes (Issues 6119, 7100, and 8189).
-- Update Vulnerabilities' references to use https links for X-Content-Type-Options Header Missing and Content-Type Header Missing (Issue 8262).
+- Update reference for X-Content-Type-Options Header Missing and Content-Type Header Missing (Issue 8262).
 
 ## [53] - 2023-11-30
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed 
+- Update Vulnerabilities' references to use https links (Issue 8262).
+
 ### Changed
 - The Big Redirect scan rule will now also alert on responses that have multiple HREFs (idea from xnl-h4ck3r).
     - It also now includes example alert and alert reference functionality for documentation generation purposes (Issues 6119, 7100, and 8189).

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,12 +4,10 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-### Changed 
-- Update Vulnerabilities' references to use https links (Issue 8262).
-
 ### Changed
 - The Big Redirect scan rule will now also alert on responses that have multiple HREFs (idea from xnl-h4ck3r).
     - It also now includes example alert and alert reference functionality for documentation generation purposes (Issues 6119, 7100, and 8189).
+- Update Vulnerabilities' references to use https links for X-Content-Type-Options Header Missing and Content-Type Header Missing (Issue 8262).
 
 ## [53] - 2023-11-30
 ### Changed

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -68,7 +68,7 @@ pscanrules.contentsecuritypolicymissing.soln = Ensure that your web server, appl
 pscanrules.contenttypemissing.desc = The Content-Type header was either missing or empty.
 pscanrules.contenttypemissing.name = Content-Type Header Missing
 pscanrules.contenttypemissing.name.empty = Content-Type Header Empty
-pscanrules.contenttypemissing.refs = https://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
+pscanrules.contenttypemissing.refs = https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)?redirectedfrom=MSDN
 pscanrules.contenttypemissing.soln = Ensure each page is setting the specific and appropriate content-type value for the content being delivered.
 
 pscanrules.cookiehttponly.desc = A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
@@ -405,7 +405,7 @@ pscanrules.xchromeloggerdata.soln = Disable this functionality in Production whe
 pscanrules.xcontenttypeoptions.desc = The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.
 pscanrules.xcontenttypeoptions.name = X-Content-Type-Options Header Missing
 pscanrules.xcontenttypeoptions.otherinfo = This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.\nAt "High" threshold this scan rule will not alert on client or server error responses.
-pscanrules.xcontenttypeoptions.refs = https://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx\nhttps://owasp.org/www-community/Security_Headers
+pscanrules.xcontenttypeoptions.refs = https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)?redirectedfrom=MSDN\nhttps://owasp.org/www-community/Security_Headers
 pscanrules.xcontenttypeoptions.soln = Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.\nIf possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.
 
 pscanrules.xdebugtoken.desc = The response contained an X-Debug-Token or X-Debug-Token-Link header. This indicates that Symfony's Profiler may be in use and exposing sensitive data.

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -68,7 +68,7 @@ pscanrules.contentsecuritypolicymissing.soln = Ensure that your web server, appl
 pscanrules.contenttypemissing.desc = The Content-Type header was either missing or empty.
 pscanrules.contenttypemissing.name = Content-Type Header Missing
 pscanrules.contenttypemissing.name.empty = Content-Type Header Empty
-pscanrules.contenttypemissing.refs = https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)?redirectedfrom=MSDN
+pscanrules.contenttypemissing.refs = https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)
 pscanrules.contenttypemissing.soln = Ensure each page is setting the specific and appropriate content-type value for the content being delivered.
 
 pscanrules.cookiehttponly.desc = A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
@@ -405,7 +405,7 @@ pscanrules.xchromeloggerdata.soln = Disable this functionality in Production whe
 pscanrules.xcontenttypeoptions.desc = The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.
 pscanrules.xcontenttypeoptions.name = X-Content-Type-Options Header Missing
 pscanrules.xcontenttypeoptions.otherinfo = This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.\nAt "High" threshold this scan rule will not alert on client or server error responses.
-pscanrules.xcontenttypeoptions.refs = https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)?redirectedfrom=MSDN\nhttps://owasp.org/www-community/Security_Headers
+pscanrules.xcontenttypeoptions.refs = https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)\nhttps://owasp.org/www-community/Security_Headers
 pscanrules.xcontenttypeoptions.soln = Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.\nIf possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.
 
 pscanrules.xdebugtoken.desc = The response contained an X-Debug-Token or X-Debug-Token-Link header. This indicates that Symfony's Profiler may be in use and exposing sensitive data.

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -68,7 +68,7 @@ pscanrules.contentsecuritypolicymissing.soln = Ensure that your web server, appl
 pscanrules.contenttypemissing.desc = The Content-Type header was either missing or empty.
 pscanrules.contenttypemissing.name = Content-Type Header Missing
 pscanrules.contenttypemissing.name.empty = Content-Type Header Empty
-pscanrules.contenttypemissing.refs = http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
+pscanrules.contenttypemissing.refs = https://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
 pscanrules.contenttypemissing.soln = Ensure each page is setting the specific and appropriate content-type value for the content being delivered.
 
 pscanrules.cookiehttponly.desc = A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
@@ -405,7 +405,7 @@ pscanrules.xchromeloggerdata.soln = Disable this functionality in Production whe
 pscanrules.xcontenttypeoptions.desc = The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.
 pscanrules.xcontenttypeoptions.name = X-Content-Type-Options Header Missing
 pscanrules.xcontenttypeoptions.otherinfo = This issue still applies to error type pages (401, 403, 500, etc.) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.\nAt "High" threshold this scan rule will not alert on client or server error responses.
-pscanrules.xcontenttypeoptions.refs = http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx\nhttps://owasp.org/www-community/Security_Headers
+pscanrules.xcontenttypeoptions.refs = https://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx\nhttps://owasp.org/www-community/Security_Headers
 pscanrules.xcontenttypeoptions.soln = Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for all web pages.\nIf possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.
 
 pscanrules.xdebugtoken.desc = The response contained an X-Debug-Token or X-Debug-Token-Link header. This indicates that Symfony's Profiler may be in use and exposing sensitive data.


### PR DESCRIPTION
## Overview
Update Vulnerabilities' references and descriptions to use https links for Content type header missing and X-Content-Type-Options Header Missing(Issue 8262).

## Related Issues
Related to: zaproxy/zaproxy/issues/8262

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
