### PR TITLE
network: correct handling of group by in the API

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Notify proxy listeners concurrently, might break listeners that do not correctly handle concurrency.
 
+### Fixed
+- Accept rate limit rule's group by in lower case, when handling the API requests.
+
 ## [0.13.0] - 2023-11-17
 ### Added
 - On weekly releases and versions after 2.14, handle content encodings and add `br` content encoding on supported OSes (Issue 2198).

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -610,18 +611,12 @@ public class NetworkApi extends ApiImplementor {
                         throw new ApiException(
                                 ApiException.Type.ILLEGAL_PARAMETER, PARAM_REQUESTS_PER_SECOND);
                     }
-                    RateLimitRule.GroupBy groupBy;
-                    try {
-                        if (params.containsKey(PARAM_GROUP_BY)) {
-                            groupBy =
-                                    RateLimitRule.GroupBy.valueOf(params.getString(PARAM_GROUP_BY));
-                        } else {
-                            groupBy = RateLimitRule.GroupBy.RULE;
-                        }
-                    } catch (JSONException e) {
-                        throw new ApiException(
-                                ApiException.Type.ILLEGAL_PARAMETER, PARAM_GROUP_BY, e);
-                    }
+
+                    RateLimitRule.GroupBy groupBy =
+                            getGroupBy(
+                                    params.optString(
+                                            PARAM_GROUP_BY, RateLimitRule.GroupBy.RULE.name()));
+
                     boolean enabled = getParam(params, PARAM_ENABLED, true);
 
                     this.extensionNetwork
@@ -650,6 +645,18 @@ public class NetworkApi extends ApiImplementor {
 
             default:
                 throw new ApiException(ApiException.Type.BAD_ACTION);
+        }
+    }
+
+    private static RateLimitRule.GroupBy getGroupBy(String groupByName) throws ApiException {
+        if (groupByName.isEmpty()) {
+            return RateLimitRule.GroupBy.RULE;
+        }
+
+        try {
+            return RateLimitRule.GroupBy.valueOf(groupByName.toUpperCase(Locale.ROOT));
+        } catch (Exception e) {
+            throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_GROUP_BY, e);
         }
     }
 


### PR DESCRIPTION
Accept the group by in any case form, to not require the user to upper case it (docs also suggest using lower case).

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/gsOWsrciXjs/m/yuOoFTWZAgAJ