### PR TITLE
pscanrules: Add example alerts, alert refs, and ref verification

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - The Big Redirect scan rule will now also alert on responses that have multiple HREFs (idea from xnl-h4ck3r).
-    - It also now includes example alert and alert reference functionality for documentation generation purposes (Issues 6119, 7100, and 8189).
+    - It also now includes example alert and alert reference functionality for documentation generation and cross linking purposes (Issues 6119, 7100, and 8189).
 - Update reference for X-Content-Type-Options Header Missing and Content-Type Header Missing (Issue 8262).
+    - They now also include example alerts for documentation generation and cross linking purposes (Issues 6119, 7100, and 8189).
 - Update reference for Loosely Scoped Cookie (Issue 8262).
-
 
 ## [53] - 2023-11-30
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
@@ -49,33 +49,34 @@ public class ContentTypeMissingScanRule extends PluginPassiveScanner {
             if (!contentType.isEmpty()) {
                 for (String contentTypeDirective : contentType) {
                     if (contentTypeDirective.isEmpty()) {
-                        this.raiseAlert(msg, id, contentTypeDirective, false);
+                        buildAlert(false).raise();
                     }
                 }
             } else {
-                this.raiseAlert(msg, id, "", true);
+                buildAlert(true).raise();
             }
         }
     }
 
-    private void raiseAlert(
-            HttpMessage msg, int id, String contentType, boolean isContentTypeMissing) {
+    private AlertBuilder buildAlert(boolean isContentTypeMissing) {
         String issue = Constant.messages.getString(MESSAGE_PREFIX + "name.empty");
+        String alertRef = PLUGIN_ID + "-2";
         if (isContentTypeMissing) {
             issue = getName();
+            alertRef = PLUGIN_ID + "-1";
         }
 
-        newAlert()
+        return newAlert()
                 .setName(issue)
                 .setRisk(getRisk())
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription())
-                .setParam(contentType)
+                .setParam(HttpHeader.CONTENT_TYPE)
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setCweId(getCweId())
                 .setWascId(getWascId())
-                .raise();
+                .setAlertRef(alertRef);
     }
 
     @Override
@@ -115,5 +116,10 @@ public class ContentTypeMissingScanRule extends PluginPassiveScanner {
     @Override
     public int getPluginId() {
         return PLUGIN_ID;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(buildAlert(true).build(), buildAlert(false).build());
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
@@ -67,22 +67,22 @@ public class XContentTypeOptionsScanRule extends PluginPassiveScanner {
             List<String> xContentTypeOptions =
                     msg.getResponseHeader().getHeaderValues(HttpHeader.X_CONTENT_TYPE_OPTIONS);
             if (xContentTypeOptions.isEmpty()) {
-                this.raiseAlert(msg, id, "");
+                buildAlert("").raise();
             } else {
                 for (String xContentTypeOptionsDirective : xContentTypeOptions) {
                     // 'nosniff' is currently the only defined value for this header, so this logic
                     // is ok
                     if (xContentTypeOptionsDirective.toLowerCase(Locale.ROOT).indexOf("nosniff")
                             < 0) {
-                        this.raiseAlert(msg, id, xContentTypeOptionsDirective);
+                        buildAlert(xContentTypeOptionsDirective).raise();
                     }
                 }
             }
         }
     }
 
-    private void raiseAlert(HttpMessage msg, int id, String xContentTypeOption) {
-        newAlert()
+    private AlertBuilder buildAlert(String xContentTypeOption) {
+        return newAlert()
                 .setRisk(getRisk())
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription())
@@ -92,8 +92,7 @@ public class XContentTypeOptionsScanRule extends PluginPassiveScanner {
                 .setReference(getReference())
                 .setEvidence(xContentTypeOption)
                 .setCweId(getCweId())
-                .setWascId(getWascId())
-                .raise();
+                .setWascId(getWascId());
     }
 
     @Override
@@ -137,5 +136,10 @@ public class XContentTypeOptionsScanRule extends PluginPassiveScanner {
 
     public int getWascId() {
         return 15; // WASC-15: Application Misconfiguration
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(buildAlert("").build());
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRuleUnitTest.java
@@ -23,9 +23,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
@@ -80,6 +82,20 @@ class ContentTypeMissingScanRuleUnitTest extends PassiveScannerTest<ContentTypeM
     }
 
     @Test
+    void shouldHaveExpectedExampleAlerts() {
+        // Given / WHen
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(2)));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
+    }
+
+    @Test
     void shouldNotAlertIfResponseBodyIsEmpty() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -115,6 +131,7 @@ class ContentTypeMissingScanRuleUnitTest extends PassiveScannerTest<ContentTypeM
         assertThat(
                 alertsRaised.get(0).getName(),
                 equalTo(Constant.messages.getString("pscanrules.contenttypemissing.name.empty")));
+        assertThat(alertsRaised.get(0).getAlertRef(), is(equalTo("10019-2")));
     }
 
     @Test
@@ -128,5 +145,6 @@ class ContentTypeMissingScanRuleUnitTest extends PassiveScannerTest<ContentTypeM
         assertThat(
                 alertsRaised.get(0).getName(),
                 equalTo(Constant.messages.getString("pscanrules.contenttypemissing.name")));
+        assertThat(alertsRaised.get(0).getAlertRef(), is(equalTo("10019-1")));
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionScanRuleUnitTest.java
@@ -22,12 +22,16 @@ package org.zaproxy.zap.extension.pscanrules;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -63,6 +67,25 @@ class XContentTypeOptionScanRuleUnitTest extends PassiveScannerTest<XContentType
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getValue())));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertTrue(StringUtils.isNotBlank(alert.getDescription()));
+        assertTrue(StringUtils.isNotBlank(alert.getSolution()));
+        assertTrue(StringUtils.isNotBlank(alert.getOtherInfo()));
+        assertTrue(StringUtils.isNotBlank(alert.getReference()));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 
     @Test


### PR DESCRIPTION
## Overview
- ContentTypeMissingScanRule & XContentTypeOptionsScanRule > Added example alerts, alert refs (where application), and ref verification.
- UnitTests > Updated to assert expected example alerts, details, and refs.
- CHANGELOG > Note added and updated existing.

## Related Issues
Follow-up to: 
- zaproxy/zap-extensions#5184

Related to:
- zaproxy/zaproxy#6119
- zaproxy/zaproxy#7100
- zaproxy/zaproxy#8189

## Checklist
- [NA] Update help
- [X] Update changelog
- [X] Run `./gradlew spotlessApply` for code formatting
- [X] Write tests
- [X] Check code coverage
- [X] Sign-off commits
- [X] Squash commits
- [X] Use a descriptive title
