### PR TITLE
pscanrules: Update reference links (http -> https) Alert: 90033

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+Update Vulnerabilities' references to use https links for Loosely Scoped Cookie (Issue 8262).
+
 ### Changed
 - The Big Redirect scan rule will now also alert on responses that have multiple HREFs (idea from xnl-h4ck3r).
     - It also now includes example alert and alert reference functionality for documentation generation purposes (Issues 6119, 7100, and 8189).

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,12 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-Update Vulnerabilities' references to use https links for Loosely Scoped Cookie (Issue 8262).
-
 ### Changed
 - The Big Redirect scan rule will now also alert on responses that have multiple HREFs (idea from xnl-h4ck3r).
     - It also now includes example alert and alert reference functionality for documentation generation purposes (Issues 6119, 7100, and 8189).
 - Update reference for X-Content-Type-Options Header Missing and Content-Type Header Missing (Issue 8262).
+- Update Vulnerabilities' references to use https links for Loosely Scoped Cookie (Issue 8262).
 
 ## [53] - 2023-11-30
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The Big Redirect scan rule will now also alert on responses that have multiple HREFs (idea from xnl-h4ck3r).
     - It also now includes example alert and alert reference functionality for documentation generation purposes (Issues 6119, 7100, and 8189).
 - Update reference for X-Content-Type-Options Header Missing and Content-Type Header Missing (Issue 8262).
-- Update Vulnerabilities' references to use https links for Loosely Scoped Cookie (Issue 8262).
+- Update reference for Loosely Scoped Cookie (Issue 8262).
+
 
 ## [53] - 2023-11-30
 ### Changed

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -80,7 +80,7 @@ pscanrules.cookielooselyscoped.desc = Cookies can be scoped by domain or path. T
 pscanrules.cookielooselyscoped.extrainfo = The origin domain used for comparison was: \r\n{0}\r\n{1}
 pscanrules.cookielooselyscoped.extrainfo.cookie = {0}\r\n
 pscanrules.cookielooselyscoped.name = Loosely Scoped Cookie
-pscanrules.cookielooselyscoped.refs = https://tools.ietf.org/html/rfc6265#section-4.1\nhttps://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.html\nhttp://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies
+pscanrules.cookielooselyscoped.refs = https://tools.ietf.org/html/rfc6265#section-4.1\nhttps://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes.html\nhttps://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies
 pscanrules.cookielooselyscoped.soln = Always scope cookies to a FQDN (Fully Qualified Domain Name).
 
 pscanrules.cookiesamesite.badval.desc = A cookie has been set with an invalid SameSite attribute value, which means that the cookie can be sent as a result of a 'cross-site' request. The SameSite attribute is an effective counter measure to cross-site request forgery, cross-site script inclusion, and timing attacks.

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
@@ -303,4 +303,10 @@ class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLoose
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
     }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
+    }
 }


### PR DESCRIPTION
## Overview
Update Vulnerabilities' references to use https links for Loosely Scoped Cookie (Issue 8262).
I have only replaced http with https, the actual link has remained the same.

## Related Issues
Related to: https://github.com/zaproxy/zaproxy/issues/8262

## Checklist
- [ ] Update help
- [x] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
