### PR TITLE
ascanrulesBeta: Update reference links (http -> https) Alert: 90025 and  20014

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Update reference for Expression Language Injection (Issue 8262).
 
 ### Removed
 - Help entry for the Spring Actuators scan rule (missed during previous removal/promotion).

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.14.0.
 - Update reference for Expression Language Injection (Issue 8262).
+- Update reference for HTTP Parameter Pollution (Issue 8262).
 
 ### Removed
 - Help entry for the Spring Actuators scan rule (missed during previous removal/promotion).

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -49,7 +49,7 @@ ascanbeta.desc = Beta status active scan rules
 
 ascanbeta.elinjection.desc = The software constructs all or part of an expression language (EL) statement in a Java Server Page (JSP) using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended EL statement before it is executed. In certain versions of Spring 3.0.5 and earlier, there was a vulnerability (CVE-2011-2730) in which Expression Language tags would be evaluated twice, which effectively exposed any application to EL injection. However, even for later versions, this weakness is still possible depending on configuration.
 ascanbeta.elinjection.name = Expression Language Injection
-ascanbeta.elinjection.refs = https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection\nhttp://cwe.mitre.org/data/definitions/917.html
+ascanbeta.elinjection.refs = https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection\nhttps://cwe.mitre.org/data/definitions/917.html
 ascanbeta.elinjection.soln = Perform data validation best practice against untrusted input and to ensure that output encoding is applied when data arrives on the EL layer, so that no metacharacter is found by the interpreter within the user content before evaluation. The most obvious patterns to detect include ${ and #{, but it may be possible to encode or fragment this data.
 
 ascanbeta.entityExpansion.desc = An exponential entity expansion, or "billion laughs" attack is a type of denial-of-service (DoS) attack. It is aimed at parsers of markup languages like XML or YAML that allow macro expansions.

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -1,6 +1,6 @@
 ascanbeta.HTTPParamPoll.alert.attack = HTTP Parameter Pollution
 ascanbeta.HTTPParamPoll.desc = HTTP Parameter Pollution (HPP) attacks consist of injecting encoded query string delimiters into other existing parameters. If a web application does not properly sanitize the user input, a malicious user can compromise the logic of the application to perform either client-side or server-side attacks. One consequence of HPP attacks is that the attacker can potentially override existing hard-coded HTTP parameters to modify the behavior of an application, bypass input validation checkpoints, and access and possibly exploit variables that may be out of direct reach.
-ascanbeta.HTTPParamPoll.extrainfo = http://www.google.com/search?q=http+parameter+pollution
+ascanbeta.HTTPParamPoll.extrainfo = https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
 ascanbeta.HTTPParamPoll.name = HTTP Parameter Pollution
 ascanbeta.HTTPParamPoll.sol = Properly sanitize the user input for parameter delimiters
 

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -1,6 +1,6 @@
 ascanbeta.HTTPParamPoll.alert.attack = HTTP Parameter Pollution
 ascanbeta.HTTPParamPoll.desc = HTTP Parameter Pollution (HPP) attacks consist of injecting encoded query string delimiters into other existing parameters. If a web application does not properly sanitize the user input, a malicious user can compromise the logic of the application to perform either client-side or server-side attacks. One consequence of HPP attacks is that the attacker can potentially override existing hard-coded HTTP parameters to modify the behavior of an application, bypass input validation checkpoints, and access and possibly exploit variables that may be out of direct reach.
-ascanbeta.HTTPParamPoll.extrainfo = https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
+ascanbeta.HTTPParamPoll.extrainfo = https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution
 ascanbeta.HTTPParamPoll.name = HTTP Parameter Pollution
 ascanbeta.HTTPParamPoll.sol = Properly sanitize the user input for parameter delimiters
 


### PR DESCRIPTION
## Overview
I have only replaced http with https, the actual link has remained the same. 
https://www.zaproxy.org/docs/alerts/90025/ 
https://www.zaproxy.org/docs/alerts/20014/

In Alert 20014 the reference was a Google search - I have amended this with a link to OWASP. This should take users directly to the reference without having to go through Google.

## Related Issues
Related to: https://github.com/zaproxy/zaproxy/issues/8262

## Checklist
- [ ] Update help
- [x] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
