### PR TITLE
pscanrules: CSRF Countermeasures rule accounts for partial match setting

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update reference for X-Content-Type-Options Header Missing and Content-Type Header Missing (Issue 8262).
     - They now also include example alerts for documentation generation and cross linking purposes (Issues 6119, 7100, and 8189).
 - Update reference for Loosely Scoped Cookie (Issue 8262).
+- The Absence of Anti-CSRF Tokens scan rule now takes into account the Partial Match settings from the Anti-CSRF Options (Issue 8280).
 
 ## [53] - 2023-11-30
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.BiPredicate;
 import net.htmlparser.jericho.Attribute;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
@@ -40,6 +41,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
 import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
+import org.zaproxy.zap.extension.anticsrf.AntiCsrfParam;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
@@ -104,6 +106,8 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
 
         List<Element> formElements = source.getAllElements(HTMLElementName.FORM);
         List<String> tokenNames = extAntiCSRF.getAntiCsrfTokenNames();
+        // TODO: Update to use extensionAntiCSRF.isAntiCsrfToken(String) after 2.15
+        BiPredicate<String, String> matcher = getMatcher();
 
         if (formElements != null && formElements.size() > 0) {
             boolean hasSecurityAnnotation = false;
@@ -167,7 +171,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                         if (attId != null) {
                             elementNames.add(attId);
                             for (String tokenName : tokenNames) {
-                                if (tokenName.equalsIgnoreCase(attId)) {
+                                if (matcher.test(attId, tokenName)) {
                                     foundCsrfToken = true;
                                     break;
                                 }
@@ -180,7 +184,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                                 elementNames.add(name);
                             }
                             for (String tokenName : tokenNames) {
-                                if (tokenName.equalsIgnoreCase(name)) {
+                                if (matcher.test(name, tokenName)) {
                                     foundCsrfToken = true;
                                     break;
                                 }
@@ -245,6 +249,16 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
             }
         }
         return false;
+    }
+
+    private static BiPredicate<String, String> getMatcher() {
+        if (Model.getSingleton()
+                .getOptionsParam()
+                .getParamSet(AntiCsrfParam.class)
+                .isPartialMatchingEnabled()) {
+            return StringUtils::containsIgnoreCase;
+        }
+        return String::equalsIgnoreCase;
     }
 
     @Override

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -184,7 +184,9 @@ Post 2.5.0 you can specify a comma separated list of identifiers in the
 <code>rules.csrf.ignorelist</code> parameter via the Options 'Rule configuration' panel.
 Any FORMs with a name or ID that matches one of these identifiers will be ignored when scanning for missing Anti-CSRF tokens.
 Only use this feature to ignore FORMs that you know are safe, for example search forms.
-Form element names are sorted and de-duplicated when they are printed in the Zap Report.
+Form element names are sorted and de-duplicated when they are printed in the ZAP Report.
+<br>
+Note: The rule also takes into account the Partial match setting within the Anti-CSRF Options.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java">CsrfCountermeasuresScanRule.java</a>
 


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- CsrfCountermeasuresScanRule > Updated to check either equals or contains (ignoring case) depending upon the ANti-CSRF Options setting.
- CsrfCountermeasuresScanRuleUnitTest > Added tests to assert the new behavior.
- pscanrules.html > Add note to rule's entry.

## Related Issues
Fixes zaproxy/zaproxy#8280

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
