### PR TITLE
ascanrules: Update reference links (http -> https) Alert: 90020

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Leave data empty instead of adding "N/A" for the scan rules:
   - Cross Site Scripting (Persistent) - Prime
   - Cross Site Scripting (Persistent) - Spider
+- Update reference for Remote OS Command Injection (Issue 8262).  
 
 ### Fixed
 - Threshold handling in the Hidden File Finder scan rule.

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -22,7 +22,7 @@ ascanrules.commandinjection.desc = Attack technique used for unauthorized execut
 ascanrules.commandinjection.name = Remote OS Command Injection
 ascanrules.commandinjection.otherinfo.feedback-based = The scan rule was able to retrieve the content of a file or command by sending [{0}] to the operating system running this application
 ascanrules.commandinjection.otherinfo.time-based = The scan rule was able to control the timing of the application response by sending [{0}] to the operating system running this application
-ascanrules.commandinjection.refs = http://cwe.mitre.org/data/definitions/78.html\nhttps://owasp.org/www-community/attacks/Command_Injection
+ascanrules.commandinjection.refs = https://cwe.mitre.org/data/definitions/78.html\nhttps://owasp.org/www-community/attacks/Command_Injection
 
 ascanrules.crlfinjection.desc = Cookie can be set via CRLF injection.  It may also be possible to set arbitrary HTTP response headers. In addition, by carefully crafting the injected response using cross-site script, cache poisoning vulnerability may also exist.
 ascanrules.crlfinjection.name = CRLF Injection


### PR DESCRIPTION
## Overview
I have only replaced http with https, the actual link has remained the same.
https://www.zaproxy.org/docs/alerts/90020/

## Related Issues
Related to: https://github.com/zaproxy/zaproxy/issues/8262

## Checklist
- [ ] Update help
- [x] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
