### PR TITLE
pscanrules: PII scan rule checks for HTML, JSON, XML on Non-Low Threshold

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Content-Type Header Missing
     - Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s)
 - The Absence of Anti-CSRF Tokens scan rule now takes into account the Partial Match settings from the Anti-CSRF Options (Issue 8280).
+- On Non-LOW threshold, PII Scan rule only evaluates HTML, JSON and XML responses (Issue 8264).
 - Maintenance changes.
 - The following rules now include example alert functionality for documentation generation and cross linking purposes (Issues 6119, and 8189).
     - Big Redirect

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.PiiUtils;
 import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
@@ -93,7 +94,8 @@ public class PiiScanRule extends PluginPassiveScanner {
         if (ResourceIdentificationUtils.isCss(msg) || ResourceIdentificationUtils.isImage(msg)) {
             return;
         }
-        if (!getAlertThreshold().equals(AlertThreshold.LOW) && isPdfMessage(msg)) {
+        if (!getAlertThreshold().equals(AlertThreshold.LOW)
+                && !isMessageSuitableForNonLowThreshold(msg)) {
             return;
         }
 
@@ -267,6 +269,12 @@ public class PiiScanRule extends PluginPassiveScanner {
             return PATH_PATTERN.matcher(path).find();
         }
         return false;
+    }
+
+    private static boolean isMessageSuitableForNonLowThreshold(HttpMessage msg) {
+        HttpResponseHeader responseHeader = msg.getResponseHeader();
+        return (responseHeader.isHtml() || responseHeader.isJson() || responseHeader.isXml())
+                && !isPdfMessage(msg);
     }
 
     private static class Candidate {

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -284,12 +284,19 @@ This check looks at user-supplied input in query string parameters and POST data
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledOpenRedirectScanRule.java">UserControlledOpenRedirectScanRule.java</a>
 
 <H2>PII Disclosure</H2>
-PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number (images and CSS are ignored).
+PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number.
 <br>
 At MEDIUM and HIGH threshold it attempts to use three characters of context on each side of potential matches to exclude matches within decimal like content.
 At LOW threshold, alerts will be raised for such matches.
 <p>
-PDFs are only evaluated at LOW threshold.
+At MEDIUM and HIGH threshold, the following content types are evaluated:
+<ul>
+    <li>HTML</li>
+    <li>JSON</li>
+    <li>XML</li>
+</ul>
+Image and CSS files are always ignored.
+Every other content type is evaluated at LOW threshold.
 <p>
 Note: In the case of suspected credit card values, the potential credit card numbers are looked up against a Bank Identification Number List 
 (BINList). If a match is found the alert is raised at High confidence and additional details are added to the 'Other Information' field in the 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PiiScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PiiScanRuleUnitTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -75,7 +76,10 @@ class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
-        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Server: Apache-Coyote/1.1\r\n");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Content-Type: application/json \r\n");
         msg.setResponseBody("{\"cc\": \"" + cardNumber + "\"}");
 
         // When
@@ -364,6 +368,77 @@ class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
         assertThat(alertsRaised.get(0).getEvidence(), is(equalTo(ccNum)));
     }
 
+    @ParameterizedTest
+    @EnumSource(names = {"HIGH", "MEDIUM"})
+    void shouldNotRaiseAlertWhenPiiIsInJavascriptContentTypeOnNonLowThreshold(
+            AlertThreshold threshold) throws Exception {
+        // Given
+        String ccNum = "4111 1111 1111 1111";
+        HttpMessage msg = createMsg(ccNum);
+        msg.getRequestHeader().setURI(new URI("http://example.com/generate/", true));
+        msg.getResponseHeader()
+                .setHeader(HttpResponseHeader.CONTENT_TYPE, "application/javascript");
+        rule.setAlertThreshold(threshold);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    void shouldRaiseAlertWhenPiiInJavascriptContentTypeOnLOWThreshold() throws Exception {
+        String ccNum = "4111 1111 1111 1111";
+        HttpMessage msg = createMsg(ccNum);
+        msg.getRequestHeader().setURI(new URI("http://example.com/generate/", true));
+        msg.getResponseHeader()
+                .setHeader(HttpResponseHeader.CONTENT_TYPE, "application/javascript");
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+    }
+
+    private static Stream<Arguments> provideContentTypeAndThreshold() {
+        return Stream.of(
+                Arguments.of("application/json", AlertThreshold.MEDIUM),
+                Arguments.of("application/json", AlertThreshold.HIGH),
+                Arguments.of("application/xml", AlertThreshold.MEDIUM),
+                Arguments.of("application/xml", AlertThreshold.HIGH),
+                Arguments.of("text/html", AlertThreshold.MEDIUM),
+                Arguments.of("text/html", AlertThreshold.HIGH));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideContentTypeAndThreshold")
+    void shouldRaiseAlertsOnPiiWithHtmlOrJsonOrXmlOnNonLowThreshold(
+            String contentType, AlertThreshold threshold) throws Exception {
+        String ccNum = "4111 1111 1111 1111";
+        HttpMessage msg = createMsg(ccNum);
+        msg.getRequestHeader().setURI(new URI("http://example.com/generate/", true));
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, contentType);
+        rule.setAlertThreshold(threshold);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"application/json", "application/xml", "text/plain", "text/html"})
+    void shouldRaiseAlertsOnPiiWithTextOrHtmlOrJsonOrXmlOnLowThreshold(String contentType)
+            throws Exception {
+        String ccNum = "4111 1111 1111 1111";
+        HttpMessage msg = createMsg(ccNum);
+        msg.getRequestHeader().setURI(new URI("http://example.com/generate/", true));
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, contentType);
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+    }
+
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
@@ -412,7 +487,10 @@ class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     private HttpMessage createMsg(String cardNumber) throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
-        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Server: Apache-Coyote/1.1\r\n");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Content-Type: text/html \r\n");
         msg.setResponseBody("{\"cc\": \"" + cardNumber + "\"}");
         return msg;
     }


### PR DESCRIPTION

## Overview
PII Scan Rule checks only for Html, Json and Xml content types on Non-LOW threshold. This Pull request fixes zaproxy/zaproxy#8264

## Related Issues
[Issue 8264](https://github.com/zaproxy/zaproxy/issues/8264)

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
