### PR TITLE
Ignore Eclipse / jdtls .factorypath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 *.classpath
 *.project
 *.settings
+.factorypath
 /bin
 /buildSrc/bin
 /addOns/**/bin


### PR DESCRIPTION
## Overview
Ignore Eclipse (and Neovim jdtls language server) `.factorypath` files which are auto generated by the IDE.

## Related Issues
N/A

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
