### PR TITLE
ascanrules: Update reference links (http -> https) Alert: 90019

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Leave data empty instead of adding "N/A" for the scan rules:
   - Cross Site Scripting (Persistent) - Prime
   - Cross Site Scripting (Persistent) - Spider
+- Update reference for Server Side Code Injection - ASP Code Injection (Issue 8262).
 
 ### Fixed
 - Threshold handling in the Hidden File Finder scan rule.

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Leave data empty instead of adding "N/A" for the scan rules:
   - Cross Site Scripting (Persistent) - Prime
   - Cross Site Scripting (Persistent) - Spider
-- Update reference for Server Side Code Injection - ASP Code Injection (Issue 8262).
+- Update reference for Server Side Code Injection (Issue 8262).
 
 ### Fixed
 - Threshold handling in the Hidden File Finder scan rule.

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -15,7 +15,7 @@ ascanrules.codeinjection.desc = A code injection may be possible including custo
 ascanrules.codeinjection.name = Server Side Code Injection
 ascanrules.codeinjection.name.asp = Server Side Code Injection - ASP Code Injection
 ascanrules.codeinjection.name.php = Server Side Code Injection - PHP Code Injection
-ascanrules.codeinjection.refs = http://cwe.mitre.org/data/definitions/94.html\nhttps://owasp.org/www-community/attacks/Direct_Dynamic_Code_Evaluation_Eval%20Injection
+ascanrules.codeinjection.refs = https://cwe.mitre.org/data/definitions/94.html\nhttps://owasp.org/www-community/attacks/Direct_Dynamic_Code_Evaluation_Eval%20Injection
 ascanrules.codeinjection.soln = Do not trust client side input, even if there is client side validation in place.\nIn general, type check all data on the server side and escape all data received from the client.\n Avoid the use of eval() functions combined with user input data.
 
 ascanrules.commandinjection.desc = Attack technique used for unauthorized execution of operating system commands. This attack is possible when an application accepts untrusted input to build operating system commands in an insecure manner involving improper data sanitization, and/or improper calling of external programs.


### PR DESCRIPTION
## Overview
I have only replaced http with https, the actual link has remained the same.
https://www.zaproxy.org/docs/alerts/90019-2/

## Related Issues
https://github.com/zaproxy/zaproxy/issues/8262

## Checklist
- [ ] Update help
- [x] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
