### PR TITLE
pscanrules: Clean Code for CsrfCounterMeasuresScanRule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - They now also include example alerts for documentation generation and cross linking purposes (Issues 6119, 7100, and 8189).
 - Update reference for Loosely Scoped Cookie (Issue 8262).
 - The Absence of Anti-CSRF Tokens scan rule now takes into account the Partial Match settings from the Anti-CSRF Options (Issue 8280).
+- Maintenance changes.
 
 ## [53] - 2023-11-30
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -109,7 +109,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
         // TODO: Update to use extensionAntiCSRF.isAntiCsrfToken(String) after 2.15
         BiPredicate<String, String> matcher = getMatcher();
 
-        if (formElements != null && formElements.size() > 0) {
+        if (formElements != null && !formElements.isEmpty()) {
             boolean hasSecurityAnnotation = false;
 
             // Loop through all of the FORM tags
@@ -119,11 +119,11 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
 
             List<String> ignoreList = new ArrayList<>();
             String ignoreConf = getCSRFIgnoreList();
-            if (ignoreConf != null && ignoreConf.length() > 0) {
+            if (ignoreConf != null && !ignoreConf.isEmpty()) {
                 LOGGER.debug("Using ignore list: {}", ignoreConf);
                 for (String str : ignoreConf.split(",")) {
                     String strTrim = str.trim();
-                    if (strTrim.length() > 0) {
+                    if (!strTrim.isEmpty()) {
                         ignoreList.add(strTrim);
                     }
                 }
@@ -163,7 +163,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                 sbForm.append("[Form " + numberOfFormsPassed + ": \"");
                 boolean foundCsrfToken = false;
 
-                if (inputElements != null && inputElements.size() > 0) {
+                if (inputElements != null && !inputElements.isEmpty()) {
                     // Loop through all of the INPUT elements
                     LOGGER.debug("Found {} inputs", inputElements.size());
                     for (Element inputElement : inputElements) {

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -131,7 +131,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 0);
+        assertEquals(0, alertsRaised.size());
     }
 
     @Test
@@ -141,7 +141,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 0);
+        assertEquals(0, alertsRaised.size());
     }
 
     @Test
@@ -151,7 +151,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 0);
+        assertEquals(0, alertsRaised.size());
     }
 
     @Test
@@ -162,7 +162,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 0);
+        assertEquals(0, alertsRaised.size());
     }
 
     @Test
@@ -172,9 +172,9 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 1);
-        assertEquals(alertsRaised.get(0).getWascId(), 9);
-        assertEquals(alertsRaised.get(0).getEvidence(), "<form id=\"no_csrf_token\">");
+        assertEquals(1, alertsRaised.size());
+        assertEquals(9, alertsRaised.get(0).getWascId());
+        assertEquals("<form id=\"no_csrf_token\">", alertsRaised.get(0).getEvidence());
     }
 
     @Test
@@ -193,7 +193,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 1);
+        assertEquals(1, alertsRaised.size());
         assertTrue(
                 alertsRaised
                         .get(0)
@@ -220,7 +220,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 1);
+        assertEquals(1, alertsRaised.size());
         assertTrue(
                 alertsRaised
                         .get(0)
@@ -236,7 +236,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 0);
+        assertEquals(0, alertsRaised.size());
     }
 
     @ParameterizedTest
@@ -276,7 +276,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 0);
+        assertEquals(0, alertsRaised.size());
     }
 
     @Test
@@ -287,7 +287,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertEquals(alertsRaised.size(), 0);
+        assertEquals(0, alertsRaised.size());
     }
 
     @Test
@@ -334,9 +334,9 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         // Then
         assertEquals(2, alertsRaised.size());
         assertEquals(
-                alertsRaised.get(0).getEvidence(),
-                "<form id=\"zeroth_form\" action=\"someaction\">");
-        assertEquals(alertsRaised.get(1).getEvidence(), "<form id=\"second_form\">");
+                "<form id=\"zeroth_form\" action=\"someaction\">",
+                alertsRaised.get(0).getEvidence());
+        assertEquals("<form id=\"second_form\">", alertsRaised.get(1).getEvidence());
     }
 
     @Test


### PR DESCRIPTION
## Overview
- CsrfCounterMeasuresScanRule > Use isEmpty vs length/size checks.
- CsrfCounterMeasuresScanRuleUnitTest > Ensure assertEquals parameters are in the correct order.
- CHANGELOG > Add maintenance note.

## Related Issues
N/A

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [NA] Write tests
- [NA] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
