### PR TITLE
authhelper: Handle JS cookies

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Dropped "to Clipboard" from ZAP copy menu items or buttons (Issue 8179).
+- Update cookies in header based session management, to cope with apps that set them via JavaScript.
 
 ## [0.10.0] - 2023-10-12
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
@@ -130,6 +130,10 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
         @Override
         public HttpHeaderBasedSession extractWebSession(HttpMessage msg) {
             Map<String, SessionToken> tokens = AuthUtils.getAllTokens(msg);
+            LOGGER.debug(
+                    "extractWebSession {} # tokens {}",
+                    msg.getRequestHeader().getURI(),
+                    tokens.size());
 
             // Add env vars
             envVars.forEach(
@@ -180,6 +184,10 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
                 throws UnsupportedWebSessionException {
             if (session instanceof HttpHeaderBasedSession) {
                 HttpHeaderBasedSession hbSession = (HttpHeaderBasedSession) session;
+                LOGGER.debug(
+                        "processMessageToMatchSession {} # headers {} ",
+                        message.getRequestHeader().getURI(),
+                        hbSession.getHeaders().size());
                 for (Pair<String, String> header : hbSession.getHeaders()) {
                     Stats.incCounter("stats.auth.session.set.header");
                     message.getRequestHeader().setHeader(header.first, header.second);
@@ -207,7 +215,17 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
                     } catch (Exception e) {
                         LOGGER.error(e.getMessage(), e);
                     }
+                } else if (context.getAuthenticationMethod() == null) {
+                    LOGGER.debug("processMessageToMatchSession no auth type set");
+                } else {
+                    LOGGER.debug(
+                            "processMessageToMatchSession unexpected auth type: {}",
+                            context.getAuthenticationMethod().getClass().getCanonicalName());
                 }
+            } else {
+                LOGGER.debug(
+                        "processMessageToMatchSession unexpected session type: {}",
+                        session.getClass().getCanonicalName());
             }
         }
 

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -85,7 +85,7 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
             // The request is using at least one session token, do we know where they come from?
             List<SessionToken> foundTokens = new ArrayList<>();
             for (SessionToken st : requestTokens) {
-                SessionToken sourceToken = AuthUtils.containsSessionToken(st.getToken());
+                SessionToken sourceToken = AuthUtils.containsSessionToken(st.getValue());
                 if (sourceToken != null) {
                     foundTokens.add(sourceToken);
                     LOGGER.debug("Found source of {}", st.getKey());
@@ -135,7 +135,7 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                                 new HeaderBasedSessionManagementMethodType();
                         HeaderBasedSessionManagementMethod method =
                                 type.createSessionManagementMethod(context.getId());
-                        method.setHeaderConfigs(AuthUtils.getHeaderTokens(msg, foundTokens, false));
+                        method.setHeaderConfigs(AuthUtils.getHeaderTokens(msg, foundTokens, true));
 
                         context.setSessionManagementMethod(method);
                         Stats.incCounter("stats.auth.configure.session.header");

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/SessionDetectionScanRuleUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/SessionDetectionScanRuleUnitTest.java
@@ -19,11 +19,111 @@
  */
 package org.zaproxy.addon.authhelper;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.quality.Strictness;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.addon.authhelper.HeaderBasedSessionManagementMethodType.HeaderBasedSessionManagementMethod;
+import org.zaproxy.zap.authentication.AuthenticationMethod;
+import org.zaproxy.zap.authentication.AuthenticationMethod.AuthCheckingStrategy;
+import org.zaproxy.zap.extension.pscan.PassiveScanData;
+import org.zaproxy.zap.extension.pscan.PassiveScanTaskHelper;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.network.HttpRequestBody;
+import org.zaproxy.zap.network.HttpResponseBody;
+import org.zaproxy.zap.session.SessionManagementMethod;
+import org.zaproxy.zap.utils.I18N;
+
 /** Unit test for {@link SessionDetectionScanRule}. */
 class SessionDetectionScanRuleUnitTest extends PassiveScannerTest<SessionDetectionScanRule> {
 
     @Override
     protected SessionDetectionScanRule createScanner() {
         return new SessionDetectionScanRule();
+    }
+
+    private ExtensionLoader extensionLoader;
+
+    private Context context;
+    private Model model;
+
+    @Test
+    void shouldSetHeaderBasedSessionManagment() throws Exception {
+        // Given
+        Constant.messages = mock(I18N.class);
+        model = mock(Model.class);
+        extensionLoader =
+                mock(ExtensionLoader.class, withSettings().strictness(Strictness.LENIENT));
+        context = mock(Context.class);
+        AutoDetectSessionManagementMethodType adsmt = new AutoDetectSessionManagementMethodType();
+        AuthenticationMethod authMethod = mock(AuthenticationMethod.class);
+        given(context.getSessionManagementMethod())
+                .willReturn(adsmt.createSessionManagementMethod(1));
+        given(context.getAuthenticationMethod()).willReturn(authMethod);
+        given(authMethod.getAuthCheckingStrategy()).willReturn(mock(AuthCheckingStrategy.class));
+
+        Control.initSingletonForTesting(model, extensionLoader);
+        Model.setSingletonForTesting(model);
+
+        Session session = mock(Session.class);
+        given(session.getContextsForUrl(anyString())).willReturn(Arrays.asList(context));
+        given(model.getSession()).willReturn(session);
+
+        String body = "Response Body";
+        String token = "12345678901234567890";
+        HttpMessage msg =
+                new HttpMessage(
+                        new HttpRequestHeader(
+                                "GET / HTTP/1.1\r\n"
+                                        + "Header1: Value1\r\n"
+                                        + "Header2: Value2\r\n"
+                                        + "Authorization: "
+                                        + token
+                                        + "\r\n"
+                                        + "Host: example.com\r\n\r\n"),
+                        new HttpRequestBody("Request Body"),
+                        new HttpResponseHeader("HTTP/1.1 200 OK\r\n"),
+                        new HttpResponseBody(body));
+
+        AuthUtils.recordSessionToken(
+                new SessionToken(SessionToken.HEADER_SOURCE, "Authorization", token));
+        PassiveScanData helper = mock(PassiveScanData.class);
+        PassiveScanTaskHelper taskHelper = mock(PassiveScanTaskHelper.class);
+        SessionDetectionScanRule rule = this.createScanner();
+        rule.setHelper(helper);
+        rule.setTaskHelper(taskHelper);
+
+        // When
+        rule.scanHttpResponseReceive(msg, 1, null);
+
+        // Then
+        ArgumentCaptor<SessionManagementMethod> captor =
+                ArgumentCaptor.forClass(SessionManagementMethod.class);
+        verify(context).setSessionManagementMethod(captor.capture());
+
+        assertThat(captor.getValue(), instanceOf(HeaderBasedSessionManagementMethod.class));
+        HeaderBasedSessionManagementMethod hbsmm =
+                (HeaderBasedSessionManagementMethod) captor.getValue();
+        assertThat(hbsmm.getHeaderConfigs().size(), is(equalTo(1)));
+        assertThat(hbsmm.getHeaderConfigs().get(0).first, is(equalTo("Authorization")));
+        assertThat(hbsmm.getHeaderConfigs().get(0).second, is(equalTo("{%header:Authorization%}")));
     }
 }

--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Auth page which uses header and a cookie set via JavaScript.
 
 ## [0.4.0] - 2023-12-19
 ### Changed

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestProxyServer.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestProxyServer.java
@@ -40,6 +40,7 @@ import org.zaproxy.addon.dev.auth.passwordNewPage.PasswordNewPageDir;
 import org.zaproxy.addon.dev.auth.simpleJson.SimpleJsonDir;
 import org.zaproxy.addon.dev.auth.simpleJsonBearer.SimpleJsonBearerDir;
 import org.zaproxy.addon.dev.auth.simpleJsonBearerCookie.SimpleJsonBearerCookieDir;
+import org.zaproxy.addon.dev.auth.simpleJsonBearerJsCookie.SimpleJsonBearerJsCookieDir;
 import org.zaproxy.addon.dev.auth.simpleJsonCookie.SimpleJsonCookieDir;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
@@ -73,6 +74,7 @@ public class TestProxyServer {
         authDir.addDirectory(new SimpleJsonBearerDir(this, "simple-json-bearer"));
         authDir.addDirectory(new NonStdJsonBearerDir(this, "non-std-json-bearer"));
         authDir.addDirectory(new SimpleJsonBearerCookieDir(this, "simple-json-bearer-cookie"));
+        authDir.addDirectory(new SimpleJsonBearerJsCookieDir(this, "simple-json-bearer-js-cookie"));
         authDir.addDirectory(new SimpleJsonCookieDir(this, "simple-json-cookie"));
         authDir.addDirectory(new PasswordAddedJsonDir(this, "password-added-json"));
         authDir.addDirectory(new PasswordHiddenJsonDir(this, "password-hidden-json"));

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonBearerCookie/SimpleJsonBearerCookieVerificationPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonBearerCookie/SimpleJsonBearerCookieVerificationPage.java
@@ -52,7 +52,7 @@ public class SimpleJsonBearerCookieVerificationPage extends TestPage {
         String cookie = null;
         List<HttpCookie> cookieList = msg.getRequestHeader().getHttpCookies();
         for (HttpCookie hc : cookieList) {
-            if (hc.getName().equals("token")) {
+            if ("token".equals(hc.getName())) {
                 cookie = hc.getValue();
             }
         }

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonBearerJsCookie/SimpleJsonBearerJsCookieDir.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonBearerJsCookie/SimpleJsonBearerJsCookieDir.java
@@ -1,0 +1,36 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev.auth.simpleJsonBearerJsCookie;
+
+import org.zaproxy.addon.dev.TestAuthDirectory;
+import org.zaproxy.addon.dev.TestProxyServer;
+
+/**
+ * A login page which uses one JSON request to login endpoint. The token is returned in a standard
+ * field but is submitted with the "Bearer" prefix and in a cookie which is set via JavaScript.
+ */
+public class SimpleJsonBearerJsCookieDir extends TestAuthDirectory {
+
+    public SimpleJsonBearerJsCookieDir(TestProxyServer server, String name) {
+        super(server, name);
+        this.addPage(new SimpleJsonBearerJsCookieLoginPage(server));
+        this.addPage(new SimpleJsonBearerJsCookieVerificationPage(server));
+    }
+}

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonBearerJsCookie/SimpleJsonBearerJsCookieVerificationPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonBearerJsCookie/SimpleJsonBearerJsCookieVerificationPage.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2023 The ZAP Development Team
+ * Copyright 2024 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,43 +17,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.addon.dev.auth.simpleJsonCookie;
+package org.zaproxy.addon.dev.auth.simpleJsonBearerJsCookie;
 
 import java.net.HttpCookie;
 import java.util.List;
 import net.sf.json.JSONObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.dev.TestPage;
 import org.zaproxy.addon.dev.TestProxyServer;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 
-public class SimpleJsonCookieVerificationPage extends TestPage {
+public class SimpleJsonBearerJsCookieVerificationPage extends TestPage {
 
     private static final Logger LOGGER =
-            LogManager.getLogger(SimpleJsonCookieVerificationPage.class);
+            LogManager.getLogger(SimpleJsonBearerJsCookieVerificationPage.class);
 
-    public SimpleJsonCookieVerificationPage(TestProxyServer server) {
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    public SimpleJsonBearerJsCookieVerificationPage(TestProxyServer server) {
         super(server, "user");
     }
 
     @Override
     public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        String token = msg.getRequestHeader().getHeader(HttpHeader.AUTHORIZATION);
+        if (token != null && token.startsWith(BEARER_PREFIX)) {
+            token = token.substring(BEARER_PREFIX.length());
+        } else {
+            token = null;
+        }
         String cookie = null;
         List<HttpCookie> cookieList = msg.getRequestHeader().getHttpCookies();
         for (HttpCookie hc : cookieList) {
-            if ("sid".equals(hc.getName())) {
+            if ("token".equals(hc.getName())) {
                 cookie = hc.getValue();
             }
         }
-        String user = getParent().getUser(cookie);
-        LOGGER.debug("Token: {} user: {}", cookie, user);
+        String user = getParent().getUser(token);
+        LOGGER.debug("Token: {} user: {}", token, user);
 
         JSONObject response = new JSONObject();
         String status = TestProxyServer.STATUS_FORBIDDEN;
         if (cookie == null) {
             response.put("result", "FAIL (no cookie)");
+        } else if (!cookie.equals(token)) {
+            response.put("result", "FAIL (bad cookie)");
         } else if (user != null) {
             response.put("result", "OK");
             response.put("user", user);
@@ -65,7 +76,7 @@ public class SimpleJsonCookieVerificationPage extends TestPage {
     }
 
     @Override
-    public SimpleJsonCookieDir getParent() {
-        return (SimpleJsonCookieDir) super.getParent();
+    public SimpleJsonBearerJsCookieDir getParent() {
+        return (SimpleJsonBearerJsCookieDir) super.getParent();
     }
 }

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-bearer-js-cookie/home.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-bearer-js-cookie/home.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<h1>Simple Home Page</H1>
+<div class="roundContainer">
+	<div id="message"></div>
+</div>
+
+<script>
+function getuser() {
+	var xhr = new XMLHttpRequest();
+	var url = "user";
+	var token = sessionStorage.getItem("accesstoken");
+	xhr.open("GET", url, true);
+	xhr.setRequestHeader("Authorization", "Bearer " + token);
+	xhr.onreadystatechange = function () {
+	    if (xhr.readyState === 4 && xhr.status === 200) {
+	        var json = JSON.parse(xhr.responseText);
+	        
+	        if (json.result === "OK") {
+	        	const h2 = document.createElement("h2");
+	        	const textNode = document.createTextNode("Hello " + json.user);
+	        	h2.appendChild(textNode);
+	        	document.getElementById("message").appendChild(h2);
+	        } else {
+	        	window.location.replace("index.html");
+	        }
+	    }
+	};
+	xhr.send(null);
+}
+window.addEventListener("load", (event) => {
+	  getuser();
+	});
+
+</script>
+
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-bearer-js-cookie/index.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-bearer-js-cookie/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Simple Login Page with JSON Response, uses "Bearer" and JS cookie</H1>
+	<h2>Login</h2>
+	
+	<div id="result"></div>
+
+	<form>
+	<table style="border: none;">
+	<tr>
+		<td>Username:
+		<td><input id="user" name="user" type="text"></td>
+	</tr>
+	<tr>
+		<td>Password:
+		<td><input id="password" name="password" type="password"></td>
+	</tr>
+	<tr>
+		<td></td>
+		<td><button id="login" type="button" value="submit" onclick="submitform();">Login</button></td>
+	</tr>
+	</table>
+	</form>
+	<p>
+	Test credentials:
+	<ul>
+		<li>username = test@test.com
+		<li>password = password123
+	</ul>
+	The verification URL returns JSON with the username and a 200 response if valid, otherwise a 403 response.
+	
+</div>
+<script>
+function submitform() {
+	// Remove previous messages
+	let element = document.getElementById("result");
+	while (element.firstChild) {
+		element.removeChild(element.firstChild);
+	}
+
+	// Make the login request
+	var xhr = new XMLHttpRequest();
+	var url = "login";
+	xhr.open("POST", url, true);
+	xhr.setRequestHeader("Content-Type", "application/json");
+	xhr.onreadystatechange = function () {
+	    if (xhr.readyState === 4 && xhr.status === 200) {
+	        var json = JSON.parse(xhr.responseText);
+	        
+	        if (json.result === "OK") {
+	        	sessionStorage.setItem("accesstoken", json.accesstoken);
+	        	// Set the cookie which is required on the user check
+	        	document.cookie = "token=" + json.accesstoken + "; path=/";
+	        	window.location.replace("home.html");
+	        } else {
+	        	const h3 = document.createElement("h3");
+	        	const textNode = document.createTextNode("Username or password incorrect");
+	        	h3.appendChild(textNode);
+	        	document.getElementById("result").appendChild(h3);
+	        }
+	    }
+	};
+	var data = JSON.stringify({
+		"user": document.getElementById("user").value,
+		"password": document.getElementById("password").value});
+	xhr.send(data);
+}
+
+document.getElementById('password').onkeydown = function(e){
+	if (e.keyCode == 13) {
+		// Handle return key
+		submitform();
+	}
+};
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Overview
Handle cookies set via JavaScript in session management detection.
An example of an app that does this is OWASP Juice shop 😁 
Also adds a dev test page which works in that way for integration testing.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
