### PR TITLE
bugtracker: prevent UI init without view

### DIFF
--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
+### Fixed
+- Prevent exception if no display (Issue 3798).
+
 ## [4] - 2022-09-23
 ### Changed
 - Update minimum ZAP version to 2.11.1.

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzilla.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzilla.java
@@ -74,16 +74,11 @@ public class BugTrackerBugzilla extends BugTracker {
         this.dialog = dialog;
     }
 
-    public BugTrackerBugzilla() {
-        initializeConfigTable();
-    }
-
-    public void initializeConfigTable() {
-        bugzillaPanel = new BugTrackerBugzillaMultipleOptionsPanel(getBugzillaModel());
-    }
-
     @Override
     public JPanel getConfigPanel() {
+        if (bugzillaPanel == null) {
+            bugzillaPanel = new BugTrackerBugzillaMultipleOptionsPanel(getBugzillaModel());
+        }
         return bugzillaPanel;
     }
 

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithub.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithub.java
@@ -61,10 +61,6 @@ public class BugTrackerGithub extends BugTracker {
 
     private static final Logger LOGGER = LogManager.getLogger(BugTrackerGithub.class);
 
-    public BugTrackerGithub() {
-        initializeConfigTable();
-    }
-
     @Override
     public void setDetails(Set<Alert> alerts) {
         setTitle(alerts);
@@ -77,12 +73,11 @@ public class BugTrackerGithub extends BugTracker {
         this.dialog = dialog;
     }
 
-    public void initializeConfigTable() {
-        githubPanel = new BugTrackerGithubMultipleOptionsPanel(getGithubModel());
-    }
-
     @Override
     public JPanel getConfigPanel() {
+        if (githubPanel == null) {
+            githubPanel = new BugTrackerGithubMultipleOptionsPanel(getGithubModel());
+        }
         return githubPanel;
     }
 

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/ExtensionBugTracker.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/ExtensionBugTracker.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.view.View;
 
 /** A ZAP Extension to help user raise issues in bug trackers from within ZAP. */
 public class ExtensionBugTracker extends ExtensionAdaptor {
@@ -60,18 +59,15 @@ public class ExtensionBugTracker extends ExtensionAdaptor {
         if (hasView()) {
             addBugTracker(githubTracker);
             addBugTracker(bugzillaTracker);
-            View.getSingleton()
-                    .getOptionsDialog("")
-                    .addParamPanel(
-                            new String[] {Constant.messages.getString("bugtracker.name")},
-                            githubTracker.getOptionsPanel(),
-                            true);
-            View.getSingleton()
-                    .getOptionsDialog("")
-                    .addParamPanel(
-                            new String[] {Constant.messages.getString("bugtracker.name")},
-                            bugzillaTracker.getOptionsPanel(),
-                            true);
+            String[] parent = new String[] {Constant.messages.getString("bugtracker.name")};
+            extensionHook
+                    .getView()
+                    .getOptionsDialog()
+                    .addParamPanel(parent, githubTracker.getOptionsPanel(), true);
+            extensionHook
+                    .getView()
+                    .getOptionsDialog()
+                    .addParamPanel(parent, bugzillaTracker.getOptionsPanel(), true);
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMsgRaiseSemiAuto());
         }
     }
@@ -88,8 +84,8 @@ public class ExtensionBugTracker extends ExtensionAdaptor {
         if (hasView()) {
             bugTrackers.forEach(
                     bugTracker ->
-                            View.getSingleton()
-                                    .getOptionsDialog("")
+                            getView()
+                                    .getOptionsDialog()
                                     .removeParamPanel(bugTracker.getOptionsPanel()));
         }
     }


### PR DESCRIPTION
Lazily initialize the options panels.
Replace view singleton usage in the extension with a getter.