### PR TITLE
authhelper: fix user NPE

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dropped "to Clipboard" from ZAP copy menu items or buttons (Issue 8179).
 - Update cookies in header based session management, to cope with apps that set them via JavaScript.
 
+### Fixed
+- Read the user details from the session rather than the individual messages, which could cause an NPE.
+
 ## [0.10.0] - 2023-10-12
 ### Changed
 - Update minimum ZAP version to 2.14.0.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
@@ -56,7 +56,6 @@ import org.zaproxy.zap.session.AbstractSessionManagementMethodOptionsPanel;
 import org.zaproxy.zap.session.SessionManagementMethod;
 import org.zaproxy.zap.session.SessionManagementMethodType;
 import org.zaproxy.zap.session.WebSession;
-import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.ApiUtils;
 import org.zaproxy.zap.utils.EncodingUtils;
 import org.zaproxy.zap.utils.Pair;
@@ -196,8 +195,6 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
                 AuthenticationMethod am = context.getAuthenticationMethod();
                 if (am instanceof BrowserBasedAuthenticationMethod) {
                     BrowserBasedAuthenticationMethod bbam = (BrowserBasedAuthenticationMethod) am;
-                    User user = message.getRequestingUser();
-                    WebSession ws = user.getAuthenticatedSession();
 
                     try {
                         Method method =
@@ -209,7 +206,7 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
 
                         method.invoke(
                                 null,
-                                ws.getHttpState(),
+                                session.getHttpState(),
                                 ((BrowserBasedAuthenticationMethodType) bbam.getType())
                                         .getCookieStore());
                     } catch (Exception e) {


### PR DESCRIPTION
## Overview
Read the user details from the session rather than the individual messages, which could cause an NPE.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [ ] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
