### PR TITLE
pscanrules: update reference from http to https

### DIFF
--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -120,7 +120,7 @@ pscanrules.csp.notices.infoitems = Info Items:
 pscanrules.csp.notices.name = Notices
 pscanrules.csp.notices.warnings = Warnings:
 pscanrules.csp.otherinfo.extended = \n\nThe directive(s): {0} are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.
-pscanrules.csp.refs = http://www.w3.org/TR/CSP2/\nhttp://www.w3.org/TR/CSP/\nhttp://caniuse.com/#search=content+security+policy\nhttp://content-security-policy.com/\nhttps://github.com/shapesecurity/salvation\nhttps://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
+pscanrules.csp.refs = https://www.w3.org/TR/CSP2/\nhttps://www.w3.org/TR/CSP/\nhttp://caniuse.com/#search=content+security+policy\nhttp://content-security-policy.com/\nhttps://github.com/shapesecurity/salvation\nhttps://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
 pscanrules.csp.scriptsrc.unsafe.eval.name = script-src unsafe-eval
 pscanrules.csp.scriptsrc.unsafe.eval.otherinfo = script-src includes unsafe-eval.
 pscanrules.csp.scriptsrc.unsafe.hashes.name = script-src unsafe-hashes
@@ -151,7 +151,7 @@ pscanrules.directorybrowsing.soln = Configure the web server to disable director
 
 pscanrules.hashdisclosure.desc = A hash was disclosed by the web server.
 pscanrules.hashdisclosure.name = Hash Disclosure
-pscanrules.hashdisclosure.refs = http://projects.webappsec.org/w/page/13246936/Information%20Leakage\nhttp://openwall.info/wiki/john/sample-hashes
+pscanrules.hashdisclosure.refs = http://projects.webappsec.org/w/page/13246936/Information%20Leakage\nhttps://openwall.info/wiki/john/sample-hashes
 pscanrules.hashdisclosure.soln = Ensure that hashes that are used to protect credentials or other resources are not leaked by the web server or database. There is typically no requirement for password hashes to be accessible to the web browser.      
 
 pscanrules.heartbleed.desc = The TLS and DTLS implementations in OpenSSL 1.0.1 before 1.0.1g do not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory via crafted packets that trigger a buffer over-read, potentially disclosing sensitive information.\t
@@ -200,7 +200,7 @@ pscanrules.infosessionidurl.name = Session ID in URL Rewrite
 pscanrules.infosessionidurl.referrer.alert = Referer Exposes Session ID
 pscanrules.infosessionidurl.referrer.desc = A hyperlink pointing to another host name was found. As session ID URL rewrite is used, it may be disclosed in referer header to external hosts.
 pscanrules.infosessionidurl.referrer.soln = This is a risk if the session ID is sensitive and the hyperlink refers to an external or third party host. For secure content, put session ID in secured session cookie.
-pscanrules.infosessionidurl.refs = http://seclists.org/lists/webappsec/2002/Oct-Dec/0111.html
+pscanrules.infosessionidurl.refs = https://seclists.org/webappsec/2002/q4/111
 pscanrules.infosessionidurl.soln = For secure content, put session ID in a cookie. To be even more secure consider using a combination of cookie and URL rewrite.
 
 pscanrules.insecureauthentication.desc = HTTP basic or digest authentication has been used over an unsecured connection. The credentials can be read and then reused by someone with access to the network.

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -362,18 +362,18 @@ pscanrules.usernameidor.soln = Use per user or session indirect object reference
 
 pscanrules.viewstate.content.email.desc = The following emails were found being serialized in the viewstate field:
 pscanrules.viewstate.content.email.name = Emails Found in the Viewstate
-pscanrules.viewstate.content.email.pattern.source = Email pattern - http://www.regular-expressions.info/regexbuddy/email.html
+pscanrules.viewstate.content.email.pattern.source = Email pattern - https://www.regular-expressions.info/regexbuddy/email.html
 pscanrules.viewstate.content.ip.desc = The following potential IP addresses were found being serialized in the viewstate field:
 pscanrules.viewstate.content.ip.name = Potential IP Addresses Found in the Viewstate
-pscanrules.viewstate.content.ip.pattern.source = IP pattern - http://www.regular-expressions.info/examples.html
+pscanrules.viewstate.content.ip.pattern.source = IP pattern - https://www.regular-expressions.info/examples.html
 pscanrules.viewstate.name = Viewstate
 pscanrules.viewstate.nomac.sure.desc = This website uses ASP.NET's Viewstate but without any MAC.\n\n
 pscanrules.viewstate.nomac.sure.name = Viewstate without MAC Signature (Sure)
-pscanrules.viewstate.nomac.sure.refs = http://msdn.microsoft.com/en-us/library/ff649308.aspx
+pscanrules.viewstate.nomac.sure.refs = https://msdn.microsoft.com/en-us/library/ff649308.aspx
 pscanrules.viewstate.nomac.sure.soln = Ensure the MAC is set for all pages on this website.
 pscanrules.viewstate.nomac.unsure.desc = This website uses ASP.NET's Viewstate but maybe without any MAC.\n\n
 pscanrules.viewstate.nomac.unsure.name = Viewstate without MAC Signature (Unsure)
-pscanrules.viewstate.nomac.unsure.refs = http://msdn.microsoft.com/en-us/library/ff649308.aspx
+pscanrules.viewstate.nomac.unsure.refs = https://msdn.microsoft.com/en-us/library/ff649308.aspx
 pscanrules.viewstate.nomac.unsure.soln = Ensure the MAC is set for all pages on this website.
 pscanrules.viewstate.oldver.desc = This website uses ASP.NET version 1.0 or 1.1.\n\n
 pscanrules.viewstate.oldver.name = Old Asp.Net Version in Use
@@ -410,7 +410,7 @@ pscanrules.xcontenttypeoptions.soln = Ensure that the application/web server set
 
 pscanrules.xdebugtoken.desc = The response contained an X-Debug-Token or X-Debug-Token-Link header. This indicates that Symfony's Profiler may be in use and exposing sensitive data.
 pscanrules.xdebugtoken.name = X-Debug-Token Information Leak
-pscanrules.xdebugtoken.otherinfo = By accessing a URL in the form http://target_host/_profiler/token_value (i.e.: http://example.com/_profiler_/123ab4), you may gain access to the profiler and further leaked information.
+pscanrules.xdebugtoken.otherinfo = By accessing a URL in the form https://target_host/_profiler/token_value (i.e.: http://example.com/_profiler_/123ab4), you may gain access to the profiler and further leaked information.
 pscanrules.xdebugtoken.refs = https://symfony.com/doc/current/cookbook/profiler/profiling_data.html\nhttps://symfony.com/blog/new-in-symfony-2-4-quicker-access-to-the-profiler-when-working-on-an-api
 pscanrules.xdebugtoken.soln = Limit access to Symfony's Profiler, either via authentication/authorization or limiting inclusion of the header to specific clients (by IP, etc.).
 


### PR DESCRIPTION
## Overview
**fixed from HTTP to HTTPS**
https://www.zaproxy.org/docs/alerts/10050/

## Related Issues
https://github.com/zaproxy/zaproxy/issues/8262

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
