### PR TITLE
Reports: AF job fixes

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Default to same dir as plan if none specified.
+
 ### Fixed
 - Ensure the Sections' options are fully shown always in Generate Report Dialog (Issue 8259).
+- Replace env vars in URL when used for report file name.
 
 ## [0.27.0] - 2023-12-19
 ### Changed

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -59,7 +59,6 @@ public class ReportJob extends AutomationJob {
     public ReportJob() {
         data = new Data(this, this.parameters);
         this.getParameters().setTemplate(ReportParam.DEFAULT_TEMPLATE);
-        this.getParameters().setReportDir(System.getProperty("user.home"));
         this.getParameters().setReportTitle(this.getExtReport().getReportParam().getTitle());
         this.getParameters()
                 .setReportDescription(this.getExtReport().getReportParam().getDescription());
@@ -105,9 +104,6 @@ public class ReportJob extends AutomationJob {
                             this.getName(),
                             getParameters().getTemplate(),
                             getExtReport().getTemplateConfigNames()));
-        }
-        if (StringUtils.isEmpty(this.getParameters().getReportDir())) {
-            this.getParameters().setReportDir(System.getProperty("user.home"));
         }
 
         list = getJobDataList(jobData, "sections", progress);
@@ -170,9 +166,13 @@ public class ReportJob extends AutomationJob {
         if (StringUtils.isEmpty(filePattern)) {
             filePattern = ReportParam.DEFAULT_NAME_PATTERN;
         }
+        // Replace envs in the URL first so that the site sanitization is used, then replace in the
+        // full pattern
         String fileName =
-                ExtensionReports.getNameFromPattern(
-                        filePattern, env.getDefaultContextWrapper().getUrls().get(0));
+                env.replaceVars(
+                        ExtensionReports.getNameFromPattern(
+                                filePattern,
+                                env.replaceVars(env.getDefaultContextWrapper().getUrls().get(0))));
 
         if (!fileName.endsWith("." + template.getExtension())) {
             fileName += "." + template.getExtension();

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
@@ -46,7 +46,6 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.addon.reports.ExtensionReports;
 import org.zaproxy.addon.reports.ReflectionUtils;
-import org.zaproxy.addon.reports.ReportParam;
 import org.zaproxy.addon.reports.Template;
 import org.zaproxy.addon.reports.automation.ReportJob.Parameters;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -107,17 +106,18 @@ public class ReportJobDialog extends StandardFieldsDialog {
 
         this.addTextField(TAB_SCOPE, FIELD_NAME, this.job.getData().getName());
         this.addTextField(TAB_SCOPE, FIELD_TITLE, params.getReportTitle());
-
         this.addTextField(TAB_SCOPE, FIELD_REPORT_NAME, params.getReportFile());
 
-        String dir = params.getReportDir();
-        if (StringUtils.isEmpty(dir)) {
-            dir = ReportParam.DEFAULT_TEMPLATES_DIR;
+        String dirName = params.getReportDir();
+        File dir = null;
+
+        if (!StringUtils.isEmpty(dirName)) {
+            dir = new File(dirName);
         }
         this.addFileSelectField(
-                TAB_SCOPE, FIELD_REPORT_DIR, new File(dir), JFileChooser.DIRECTORIES_ONLY, null);
-        if (JobUtils.containsVars(dir)) {
-            setFieldValue(FIELD_REPORT_DIR, dir);
+                TAB_SCOPE, FIELD_REPORT_DIR, dir, JFileChooser.DIRECTORIES_ONLY, null);
+        if (!StringUtils.isEmpty(dirName) && JobUtils.containsVars(dirName)) {
+            setFieldValue(FIELD_REPORT_DIR, dirName);
         }
         this.addMultilineField(TAB_SCOPE, FIELD_DESCRIPTION, params.getReportDescription());
         this.addMultilineField(TAB_SCOPE, FIELD_SITES, listToString(job.getData().getSites()));


### PR DESCRIPTION
## Overview
Fixes a counple of problems with the AF report job:

- Replace env vars in URLs used in the plan name (otherwise end up with names like `ZAP-Report-${ZAP_TARGET}.html
`
- Default to use same dir as plan if no dir set

## Related Issues


## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
