### PR TITLE
automation: support list var in context techs

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ContextWrapper.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ContextWrapper.java
@@ -173,7 +173,7 @@ public class ContextWrapper {
                     data.setSessionManagement(new SessionManagementData(value, progress));
                     break;
                 case "technology":
-                    data.setTechnology(new TechnologyData(value, progress));
+                    data.setTechnology(new TechnologyData(value, env, progress));
                     break;
                 case "users":
                     if (!(value instanceof ArrayList)) {

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/TechnologyUtilsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/TechnologyUtilsUnitTest.java
@@ -325,7 +325,8 @@ class TechnologyUtilsUnitTest {
     @Test
     void shouldReturnIncludedTechs() {
         // Given
-        TechnologyData source = new TechnologyData(Map.of("include", List.of("Windows")), null);
+        TechnologyData source =
+                new TechnologyData(Map.of("include", List.of("Windows")), null, null);
 
         // When
         TechSet set = TechnologyUtils.getTechSet(source);
@@ -340,7 +341,9 @@ class TechnologyUtilsUnitTest {
         // Given
         TechnologyData source =
                 new TechnologyData(
-                        Map.of("include", List.of("OS"), "exclude", List.of("Windows")), null);
+                        Map.of("include", List.of("OS"), "exclude", List.of("Windows")),
+                        null,
+                        null);
 
         // When
         TechSet set = TechnologyUtils.getTechSet(source);
@@ -370,7 +373,9 @@ class TechnologyUtilsUnitTest {
         // Given
         TechnologyData source =
                 new TechnologyData(
-                        Map.of("include", List.of("OS"), "exclude", List.of("Windows")), null);
+                        Map.of("include", List.of("OS"), "exclude", List.of("Windows")),
+                        null,
+                        null);
 
         // When
         source.setExclude(List.of("C"));


### PR DESCRIPTION
Allow to specify a list var for includes/excludes.

A list var (e.g. `${[VAR_NAME]}`) is replaced and parsed as a list before being further processed.
Example value using flow sequence: `[MacOS, Db, Java]`.