### PR TITLE
openapi: When importing indicate success

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Dependency updates.
+- When no errors are encountered during import the API will now respond with content indicating things are okay (Issue 3951).
+    - When errors are encountered a 'Bad External Data' response is provided listing the issues.
 
 ## [38] - 2023-10-23
 ### Changed

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
@@ -101,13 +101,7 @@ public class OpenApiAPI extends ApiImplementor {
                 throw new ApiException(ApiException.Type.BAD_EXTERNAL_DATA, PARAM_FILE);
             }
 
-            ApiResponseList result = new ApiResponseList(name);
-            for (String error : errors) {
-                result.addItem(new ApiResponseElement("warning", error));
-            }
-
-            return result;
-
+            return createResponse(name, errors);
         } else if (ACTION_IMPORT_URL.equals(name)) {
 
             try {
@@ -124,13 +118,7 @@ public class OpenApiAPI extends ApiImplementor {
                     throw new ApiException(
                             ApiException.Type.ILLEGAL_PARAMETER, "Failed to access the target.");
                 }
-
-                ApiResponseList result = new ApiResponseList(name);
-                for (String error : errors) {
-                    result.addItem(new ApiResponseElement("warning", error));
-                }
-
-                return result;
+                return createResponse(name, errors);
             } catch (URIException e) {
                 throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL);
             } catch (InvalidUrlException e) {
@@ -141,6 +129,19 @@ public class OpenApiAPI extends ApiImplementor {
         } else {
             throw new ApiException(ApiException.Type.BAD_ACTION);
         }
+    }
+
+    private static ApiResponseList createResponse(String name, List<String> errors)
+            throws ApiException {
+        if (!errors.isEmpty()) {
+            throw new ApiException(ApiException.Type.BAD_EXTERNAL_DATA, String.join(",", errors));
+        }
+
+        ApiResponseList result = new ApiResponseList(name);
+        if (errors.isEmpty()) {
+            result.addItem(ApiResponseElement.OK);
+        }
+        return result;
     }
 
     private static int getContextId(JSONObject params) throws ApiException {


### PR DESCRIPTION
I've had this sitting around since May 2022, I'm not sure why I never submitted it. Found it this evening while I was pruning/cleaning-up branches.

## Overview
When no import errors occur `{"importUrl":["ok"]}`

- CHANGELOG.md > Add change note.
- OpenApiAPI.java > Indicate success when no errors occur. Respond 400 when an error does occur.

Example when "Report error details via API":
`{"code":"bad_external_data","message":"The external data provided is not valid.","detail":"attribute paths.'/store/order'(post).operationId is repeated"}`

## Related Issues
- zaproxy/zaproxy#3951

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

<details>
<summary>400 Warning details screenshot</summary>

![image](https://github.com/zaproxy/zap-extensions/assets/7570458/46c24bb0-a291-4840-abc5-32d4f8e2d143)
<sub>Yes I know my apikey is in the screenshot, it's local and I've rolled it 👼 </sub>

</details>

