### PR TITLE
ascanrulesAlpha: add rule for MongoDB time tests

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Move MongoDB time based tests to its own scan rule, NoSQL Injection - MongoDB (Time Based) with ID 90039 (Issue 7341).
+- Depend on newer version of Common Library add-on.
 
 ## [45] - 2024-01-16
 ### Changed

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -10,7 +10,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.20.0 & < 2.0.0")
+                    version.set(">= 1.22.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionTimingScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionTimingScanRule.java
@@ -1,0 +1,268 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.configuration.ConversionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.timing.TimingUtils;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+
+/**
+ * The MongoInjection scan rule identifies MongoDB injection vulnerabilities
+ *
+ * @author l.casciaro
+ */
+public class MongoDbInjectionTimingScanRule extends AbstractAppParamPlugin
+        implements CommonActiveScanRuleInfo {
+
+    // Prefix for internationalised messages used by this rule
+    private static final String MESSAGE_PREFIX = "ascanalpha.mongodb.";
+
+    private static final String RULE_SLEEP_TIME = RuleConfigParam.RULE_COMMON_SLEEP_TIME;
+
+    private static final int BLIND_REQUEST_LIMIT = 4;
+    private static final int DEFAULT_TIME_SLEEP_SEC = 5;
+    private static final double TIME_CORRELATION_ERROR_RANGE = 0.15;
+    private static final double TIME_SLOPE_ERROR_RANGE = 0.30;
+
+    private static final List<String> SLEEP_INJECTION =
+            List.of(
+                    // Attacking $where clause
+                    // function() { var x = md5( some_input ); return this.password == x;}
+                    "\"); sleep({0}); print(\"",
+                    "'; sleep({0}); print(\'",
+                    "0); sleep({0}); print(\"",
+                    // function() { var x = this.value == some_input; return x;}
+                    "'; sleep({0}); var x='",
+                    "\"; sleep({0}); var x=\"",
+                    "0; sleep({0})",
+                    // function() { return this.value == some_input }
+                    "zap' || sleep({0}) && 'zap'=='zap",
+                    "zap\" || sleep({0}) && \"zap\"==\"zap",
+                    "0 || sleep({0})",
+                    // function() { return this.value == some_function(some_imput) }
+                    "zap') || sleep({0}) && hex_md5('zap",
+                    "zap\") || sleep({0}) && md5(\"zap",
+                    "0)  || sleep({0})",
+                    // Attacking mapReduce clause (only for old versions of mongodb)
+                    "_id);}, function(inj) { sleep({0});return 1;}, { out: 'x'}); db.injection.mapReduce(function() { emit(1,1");
+
+    private static final Logger LOGGER = LogManager.getLogger(MongoDbInjectionTimingScanRule.class);
+    private static final Map<String, String> ALERT_TAGS =
+            CommonAlertTag.toMap(
+                    CommonAlertTag.OWASP_2021_A03_INJECTION,
+                    CommonAlertTag.OWASP_2017_A01_INJECTION,
+                    CommonAlertTag.WSTG_V42_INPV_05_SQLI,
+                    CommonAlertTag.TEST_TIMING);
+
+    private int timeSleepSeconds = DEFAULT_TIME_SLEEP_SEC;
+
+    private int blindTargetCount = SLEEP_INJECTION.size();
+
+    @Override
+    public int getCweId() {
+        return 943;
+    }
+
+    @Override
+    public int getWascId() {
+        return 19;
+    }
+
+    @Override
+    public int getId() {
+        return 90039;
+    }
+
+    @Override
+    public boolean targets(TechSet technologies) {
+        return technologies.includes(Tech.MongoDB);
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name.timebased");
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_HIGH;
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INJECTION;
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return ALERT_TAGS;
+    }
+
+    @Override
+    public void init() {
+        LOGGER.debug("Initialising MongoDB penetration tests");
+
+        switch (getAttackStrength()) {
+            case LOW:
+                blindTargetCount = 6;
+                break;
+
+            default:
+            case MEDIUM:
+                blindTargetCount = 10;
+                break;
+
+            case HIGH:
+                blindTargetCount = 12;
+                break;
+
+            case INSANE:
+                blindTargetCount = SLEEP_INJECTION.size();
+                break;
+        }
+
+        try {
+            timeSleepSeconds = this.getConfig().getInt(RULE_SLEEP_TIME, DEFAULT_TIME_SLEEP_SEC);
+        } catch (ConversionException e) {
+            LOGGER.debug(
+                    "Invalid value for '{}': {}",
+                    RULE_SLEEP_TIME,
+                    this.getConfig().getString(RULE_SLEEP_TIME));
+        }
+    }
+
+    @Override
+    public void scan(HttpMessage msg, String param, String value) {
+        LOGGER.debug(
+                "Scanning URL [{}] [{}] on param: [{}] with value: [{}] for MongoDB Injection",
+                msg.getRequestHeader().getMethod(),
+                msg.getRequestHeader().getURI(),
+                param,
+                value);
+
+        // injection attack to $Where and $mapReduce clauses
+        // The $where clause executes associated JS function one time for each tuple --> sleep time
+        // = interval * nTuples
+        LOGGER.debug("Starting with the javascript code injection payloads:");
+
+        Iterator<String> it = SLEEP_INJECTION.iterator();
+        for (int i = 0; !isStop() && it.hasNext() && i < blindTargetCount; i++) {
+            String sleepPayload = it.next();
+            AtomicReference<HttpMessage> message = new AtomicReference<>();
+            String paramValue = sleepPayload.replace("{0}", String.valueOf(timeSleepSeconds));
+            LOGGER.debug("Trying with the value: {}", sleepPayload);
+
+            TimingUtils.RequestSender requestSender =
+                    x -> {
+                        HttpMessage timedMsg = getNewMsg();
+                        message.set(timedMsg);
+                        String finalPayload =
+                                value + sleepPayload.replace("{0}", String.valueOf(x));
+                        setParameter(timedMsg, param, finalPayload);
+                        LOGGER.debug("Testing [{}] = [{}]", param, finalPayload);
+
+                        // send the request and retrieve the response
+                        sendAndReceive(timedMsg, false);
+                        return TimeUnit.MILLISECONDS.toSeconds(timedMsg.getTimeElapsedMillis());
+                    };
+
+            try {
+                // use TimingUtils to detect a response to sleep payloads
+                boolean isInjectable =
+                        TimingUtils.checkTimingDependence(
+                                BLIND_REQUEST_LIMIT,
+                                timeSleepSeconds,
+                                requestSender,
+                                TIME_CORRELATION_ERROR_RANGE,
+                                TIME_SLOPE_ERROR_RANGE);
+
+                if (isInjectable) {
+                    // We Found IT!
+                    LOGGER.debug(
+                            "[NOSQL Injection Found] on parameter [{}] with value [{}]",
+                            param,
+                            paramValue);
+
+                    // just attach this alert to the last sent message
+                    buildAlert(param, paramValue, message.get()).raise();
+                    break;
+                }
+            } catch (SocketException ex) {
+                LOGGER.debug(
+                        "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        message.get().getRequestHeader().getURI());
+            } catch (IOException ex) {
+                LOGGER.warn(
+                        "Mongo DB Injection vulnerability check failed for parameter [{}] and payload [{}] due to an I/O error",
+                        param,
+                        paramValue,
+                        ex);
+            }
+        }
+    }
+
+    private AlertBuilder buildAlert(String param, String attack, HttpMessage msg) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setParam(param)
+                .setAttack(attack)
+                .setMessage(msg)
+                .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "extrainfo.sleep"));
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(buildAlert("qry", "a&sleep 5&", null).build());
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -32,11 +32,18 @@ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40015/">40015</a>.
 
 <H2 id="id-40033">NoSQL Injection - MongoDB</H2>
 This rule attempts to identify MongoDB specific NoSQL Injection vulnerabilities. It attempts various types of attacks including: boolean based, error based, time based, and authentication bypass. 
-It will also attempt JSON parameter specific payloads if the scan is configured to include JSON parameter variants.
+It does not include time based attacks. It will also attempt JSON parameter specific payloads if the scan is configured to include JSON parameter variants.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java">MongoDbInjectionScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40033/">40033</a>.
+
+<H2 id="id-90039">NoSQL Injection - MongoDB (Time Based)</H2>
+This rule attempts to identify MongoDB specific NoSQL Injection vulnerabilities using only time based attacks.
+<p>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionTimingScanRule.java">MongoDbInjectionTimingScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90039/">90039</a>.
 
 <H2 id="id-40039">Web Cache Deception</H2>
 This rule attempts to identify Web Cache Deception vulnerabilities. It checks whether a static path appended to original URIs can be used to leak sensitive user information or not.

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -25,6 +25,7 @@ ascanalpha.mongodb.extrainfo.crash = A MongoDB exception hasn't been properly ha
 ascanalpha.mongodb.extrainfo.json = In some NodeJS based back end implementations, messages having the JSON format as content-type are expected. In order to obtain sensitive data it is possible to attack these applications injecting the "{$ne:}" string (or other similar ones) that is processed as an associative array rather than a simple text.\nThrough this, the queries made to MongoDB will always be true.
 ascanalpha.mongodb.extrainfo.sleep = Through the where or group MongoDB clauses, Javascript sleep function is probably executable.
 ascanalpha.mongodb.name = NoSQL Injection - MongoDB
+ascanalpha.mongodb.name.timebased = NoSQL Injection - MongoDB (Time Based)
 ascanalpha.mongodb.refs = https://arxiv.org/pdf/1506.04082.pdf\nhttps://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection.html
 ascanalpha.mongodb.soln = Do not trust client side input and escape all data on the server side. \nAvoid to use the query input directly into the where and group clauses and upgrade all drivers at the latest available version.
 

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRuleUnitTest.java
@@ -19,26 +19,14 @@
  */
 package org.zaproxy.zap.extension.ascanrulesAlpha;
 
-import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import fi.iki.elonen.NanoHTTPD.IHTTPSession;
-import fi.iki.elonen.NanoHTTPD.Response;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Plugin;
-import org.parosproxy.paros.network.HttpMalformedHeaderException;
-import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link MongoDbInjectionScanRule}. */
 class MongoDbInjectionScanRuleUnitTest extends ActiveScannerTest<MongoDbInjectionScanRule> {
@@ -90,77 +78,5 @@ class MongoDbInjectionScanRuleUnitTest extends ActiveScannerTest<MongoDbInjectio
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_INPV_05_SQLI.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_INPV_05_SQLI.getValue())));
-    }
-
-    @Test
-    void shouldDetectTimeBasedInjection() throws HttpMalformedHeaderException {
-        // Given
-        Pattern sleepPattern = Pattern.compile("0\\s+\\|\\|\\s+sleep\\((\\d+)(?:\\.\\d+)?\\)");
-        String regularContent = "<!DOCTYPE html><html><body>Nothing to see here.</body></html>";
-        Set<String> payloadSet = new HashSet<>();
-        nano.addHandler(
-                new NanoServerHandler("/") {
-                    @Override
-                    protected Response serve(IHTTPSession session) {
-                        String value = getFirstParamValue(session, "p");
-                        if (value == null) {
-                            return newFixedLengthResponse(regularContent);
-                        }
-                        if (value.contains("sleep(")) {
-                            payloadSet.add(value);
-                        }
-                        Matcher match = sleepPattern.matcher(value);
-                        if (!match.find()) {
-                            return newFixedLengthResponse(regularContent);
-                        }
-                        try {
-                            int sleepInput = Integer.parseInt(match.group(1));
-                            Thread.sleep(sleepInput * 1000L);
-                        } catch (InterruptedException ex) {
-                            // Ignore
-                        }
-                        return newFixedLengthResponse(regularContent);
-                    }
-                });
-        rule.init(getHttpMessage("/?p=a"), parent);
-        // When
-        rule.scan();
-        // Then
-        assertThat(payloadSet, hasSize(greaterThanOrEqualTo(10)));
-        assertThat(alertsRaised, hasSize(1));
-        assertThat(sleepPattern.matcher(alertsRaised.get(0).getAttack()).find(), is(true));
-    }
-
-    @Test
-    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
-        String test = "/shouldNotReportGeneralTimingIssue/";
-
-        this.nano.addHandler(
-                new NanoServerHandler(test) {
-                    private int time = 100;
-
-                    @Override
-                    protected Response serve(IHTTPSession session) {
-                        String response =
-                                "<!DOCTYPE html><html><body>Nothing to see here.</body></html>";
-                        try {
-                            if (getFirstParamValue(session, "name").contains("sleep(")) {
-                                Thread.sleep(time);
-                                time += 1000;
-                            }
-
-                        } catch (InterruptedException e) {
-                            // Ignore
-                        }
-                        return newFixedLengthResponse(response);
-                    }
-                });
-
-        HttpMessage msg = this.getHttpMessage(test + "?name=test");
-
-        this.rule.init(msg, this.parent);
-        this.rule.scan();
-
-        assertThat(alertsRaised.size(), equalTo(0));
     }
 }

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionTimingScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionTimingScanRuleUnitTest.java
@@ -1,0 +1,191 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Unit test for {@link MongoDbInjectionTimingScanRule}. */
+class MongoDbInjectionTimingScanRuleUnitTest
+        extends ActiveScannerTest<MongoDbInjectionTimingScanRule> {
+
+    @Override
+    protected MongoDbInjectionTimingScanRule createScanner() {
+        return new MongoDbInjectionTimingScanRule();
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
+    }
+
+    @Test
+    void shouldReturnExpectedMappings() {
+        // Given / When
+        int cwe = rule.getCweId();
+        int wasc = rule.getWascId();
+        Map<String, String> tags = rule.getAlertTags();
+        // Then
+        assertThat(cwe, is(equalTo(943)));
+        assertThat(wasc, is(equalTo(19)));
+        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(
+                tags.containsKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
+                is(equalTo(true)));
+        assertThat(
+                tags.containsKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
+                is(equalTo(true)));
+        assertThat(
+                tags.containsKey(CommonAlertTag.WSTG_V42_INPV_05_SQLI.getTag()), is(equalTo(true)));
+        assertThat(
+                tags.get(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2021_A03_INJECTION.getValue())));
+        assertThat(
+                tags.get(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2017_A01_INJECTION.getValue())));
+        assertThat(
+                tags.get(CommonAlertTag.WSTG_V42_INPV_05_SQLI.getTag()),
+                is(equalTo(CommonAlertTag.WSTG_V42_INPV_05_SQLI.getValue())));
+        assertThat(tags.containsKey(CommonAlertTag.TEST_TIMING.getTag()), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldTargetExpectedTech() {
+        // Given / When
+        TechSet allButMongoDb = techSetWithout(Tech.MongoDB);
+        TechSet justMongoDb = techSet(Tech.MongoDB);
+
+        // Then
+        assertThat(rule.targets(allButMongoDb), is(equalTo(false)));
+        assertThat(rule.targets(justMongoDb), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / WHen
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getParam(), is(equalTo("qry")));
+        assertThat(alert.getAttack(), is(equalTo("a&sleep 5&")));
+        assertThat(alert.getEvidence(), is(equalTo("")));
+        assertThat(
+                alert.getOtherInfo(),
+                is(
+                        equalTo(
+                                "Through the where or group MongoDB clauses, Javascript sleep function is probably executable.")));
+    }
+
+    @Test
+    void shouldDetectTimeBasedInjection() throws HttpMalformedHeaderException {
+        // Given
+        Pattern sleepPattern = Pattern.compile("0\\s+\\|\\|\\s+sleep\\((\\d+)(?:\\.\\d+)?\\)");
+        String regularContent = "<!DOCTYPE html><html><body>Nothing to see here.</body></html>";
+        Set<String> payloadSet = new HashSet<>();
+        nano.addHandler(
+                new NanoServerHandler("/") {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String value = getFirstParamValue(session, "p");
+                        if (value == null) {
+                            return newFixedLengthResponse(regularContent);
+                        }
+                        if (value.contains("sleep(")) {
+                            payloadSet.add(value);
+                        }
+                        Matcher match = sleepPattern.matcher(value);
+                        if (!match.find()) {
+                            return newFixedLengthResponse(regularContent);
+                        }
+                        try {
+                            int sleepInput = Integer.parseInt(match.group(1));
+                            Thread.sleep(sleepInput * 1000L);
+                        } catch (InterruptedException ex) {
+                            // Ignore
+                        }
+                        return newFixedLengthResponse(regularContent);
+                    }
+                });
+        rule.init(getHttpMessage("/?p=a"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(payloadSet, hasSize(greaterThanOrEqualTo(10)));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(sleepPattern.matcher(alertsRaised.get(0).getAttack()).find(), is(true));
+    }
+
+    @Test
+    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
+        String test = "/shouldNotReportGeneralTimingIssue/";
+
+        this.nano.addHandler(
+                new NanoServerHandler(test) {
+                    private int time = 100;
+
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String response =
+                                "<!DOCTYPE html><html><body>Nothing to see here.</body></html>";
+                        try {
+                            if (getFirstParamValue(session, "name").contains("sleep(")) {
+                                Thread.sleep(time);
+                                time += 500;
+                            }
+
+                        } catch (InterruptedException e) {
+                            // Ignore
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = this.getHttpMessage(test + "?name=test");
+
+        this.rule.init(msg, this.parent);
+        this.rule.scan();
+
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+}

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Add alert tag for scan rules that use time based tests.
 
 ## [1.21.0] - 2024-01-16
 ### Added

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
@@ -380,7 +380,14 @@ public enum CommonAlertTag {
      *
      * @since 1.10.0
      */
-    CUSTOM_PAYLOADS("CUSTOM_PAYLOADS", "");
+    CUSTOM_PAYLOADS("CUSTOM_PAYLOADS", ""),
+
+    /**
+     * Indicates that the scan rule does time based tests.
+     *
+     * @since 1.22.0
+     */
+    TEST_TIMING("TEST_TIMING", "");
 
     private String tag;
     private String value;


### PR DESCRIPTION
Move time based tests to its own rule, ID 90039.

Part of zaproxy/zaproxy#7341.

---
Extracted from #4316.