### PR TITLE
ascanrules: update reference from http to https 40009

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Cross Site Scripting (Persistent) - Prime
   - Cross Site Scripting (Persistent) - Spider
 - Update reference for Server Side Code Injection (Issue 8262).
+  - Server Side Include
 - Now depends on minimum Common Library version 1.21.0.
 
 ### Fixed

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed 
+- Update reference for Server Side Include
 
 
 ## [60] - 2024-01-16
@@ -12,7 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Cross Site Scripting (Persistent) - Prime
   - Cross Site Scripting (Persistent) - Spider
 - Update reference for Server Side Code Injection (Issue 8262).
-  - Server Side Include
 - Now depends on minimum Common Library version 1.21.0.
 
 ### Fixed

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed 
-- Update reference for Server Side Include
+- Update reference for Server Side Include (Issue 8262) 
 
 
 ## [60] - 2024-01-16

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -137,7 +137,7 @@ ascanrules.remotefileinclude.name = Remote File Inclusion
 
 ascanrules.serversideinclude.desc = Certain parameters may cause Server Side Include commands to be executed.  This may allow database connection or arbitrary code to be executed.
 ascanrules.serversideinclude.name = Server Side Include
-ascanrules.serversideinclude.refs = http://www.carleton.ca/~dmcfet/html/ssi.html
+ascanrules.serversideinclude.refs = https://httpd.apache.org/docs/current/howto/ssi.html
 ascanrules.serversideinclude.soln = Do not trust client side input and enforce a tight check in the server side. Disable server side includes.\nRefer to manual to disable Sever Side Include.\nUse least privilege to run your web server or application server.\nFor Apache, disable the following:\nOptions Indexes FollowSymLinks Includes\nAddType application/x-httpd-cgi .cgi\nAddType text/x-server-parsed-html .html
 
 ascanrules.sourcecodedisclosurecve-2012-1823.desc = Some PHP versions, when configured to run using CGI, do not correctly handle query strings that lack an unescaped "=" character, enabling PHP source code disclosure, and arbitrary code execution. In this case, the contents of the PHP file were served directly to the web browser. This output will typically contain PHP, although it may also contain straight HTML.


### PR DESCRIPTION
Signed-off-by: Aditya Parihar <97739299+PariharAditya@users.noreply.github.com>

## Overview
fixed from HTTP to HTTPS
https://www.zaproxy.org/docs/alerts/40009/

## Related Issues
zaproxy/zaproxy#8262

## Checklist
- [ ] Update help
- [x] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
