### PR TITLE
pscanrules: Content Security Policy scan rule now uses htmlunit library

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The Salvation2 library used by the CSP scan rule has been replaced by htmlunit-csp.
 
 ## [54] - 2024-01-16
 ### Changed

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -37,7 +37,7 @@ zapAddOn {
 
 dependencies {
     implementation("com.google.re2j:re2j:1.7")
-    implementation("com.shapesecurity:salvation2:3.0.1")
+    implementation("org.htmlunit:htmlunit-csp:3.10.0")
 
     zapAddOn("commonlib")
     zapAddOn("custompayloads")

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -19,14 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
-import com.shapesecurity.salvation2.Directives.SourceExpressionDirective;
-import com.shapesecurity.salvation2.FetchDirectiveKind;
-import com.shapesecurity.salvation2.Policy;
-import com.shapesecurity.salvation2.Policy.PolicyErrorConsumer;
-import com.shapesecurity.salvation2.Policy.Severity;
-import com.shapesecurity.salvation2.PolicyInOrigin;
-import com.shapesecurity.salvation2.URLs.URI;
-import com.shapesecurity.salvation2.URLs.URLWithScheme;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -43,6 +35,13 @@ import net.htmlparser.jericho.Source;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.htmlunit.csp.FetchDirectiveKind;
+import org.htmlunit.csp.Policy;
+import org.htmlunit.csp.Policy.PolicyErrorConsumer;
+import org.htmlunit.csp.PolicyInOrigin;
+import org.htmlunit.csp.directive.SourceExpressionDirective;
+import org.htmlunit.csp.url.URI;
+import org.htmlunit.csp.url.URLWithScheme;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -85,7 +84,6 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                     // TODO: Remove once https://github.com/shapesecurity/salvation/issues/232 is
                     // addressed
                     "require-trusted-types-for", "trusted-types");
-    private static final String PREFETCH_SRC_WARNING = "The prefetch-src directive is deprecated";
 
     private static final String RAND_FQDN = "7963124546083337415.owasp.org";
     private static final Optional<URLWithScheme> HTTP_URI =
@@ -133,9 +131,6 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                 Policy policy = parsePolicy(csp, consumer, msg, id);
                 if (policy == null) {
                     continue;
-                }
-                if (policy.getFetchDirective(FetchDirectiveKind.PrefetchSrc).isPresent()) {
-                    consumer.add(Severity.Warning, PREFETCH_SRC_WARNING, 0, -1);
                 }
 
                 if (!observedErrors.isEmpty()) {
@@ -220,11 +215,6 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                 Policy parsedMetaPolicy = parsePolicy(metaPolicy, metaConsumer, msg, id);
                 if (parsedMetaPolicy == null) {
                     continue;
-                }
-                if (parsedMetaPolicy
-                        .getFetchDirective(FetchDirectiveKind.PrefetchSrc)
-                        .isPresent()) {
-                    metaConsumer.add(Severity.Warning, PREFETCH_SRC_WARNING, 0, -1);
                 }
                 checkObservedErrors(metaObservedErrors, msg, metaPolicy, true);
                 List<String> metaWildcardSources = getAllowedWildcardSources(metaPolicy);

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -168,7 +168,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <H2>CSP (Content Security Policy)</H2>
 
 The Content Security Policy (CSP) passive scan rule parses and analyzes CSP headers and META definitions for potential misconfiguration
-or weakness. This rule leverages Shape Security's <a href="https://github.com/shapesecurity/salvation">Salvation</a> 
+or weakness. This rule leverages HtmlUnit's <a href="https://github.com/HtmlUnit/htmlunit-csp">htmlunit-csp</a> 
 library to perform it's parsing and assessment of CSPs.
 <p>
 If a response has multiple CSPs they are analyzed individually, as there is no sure way to intersect/merge the policies and further different browsers have varying levels of CSP support and enforcement.

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -120,7 +120,7 @@ pscanrules.csp.notices.infoitems = Info Items:
 pscanrules.csp.notices.name = Notices
 pscanrules.csp.notices.warnings = Warnings:
 pscanrules.csp.otherinfo.extended = \n\nThe directive(s): {0} are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.
-pscanrules.csp.refs = https://www.w3.org/TR/CSP/\nhttps://caniuse.com/#search=content+security+policy\nhttps://content-security-policy.com/\nhttps://github.com/shapesecurity/salvation\nhttps://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
+pscanrules.csp.refs = https://www.w3.org/TR/CSP/\nhttps://caniuse.com/#search=content+security+policy\nhttps://content-security-policy.com/\nhttps://github.com/HtmlUnit/htmlunit-csp\nhttps://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
 pscanrules.csp.scriptsrc.unsafe.eval.name = script-src unsafe-eval
 pscanrules.csp.scriptsrc.unsafe.eval.otherinfo = script-src includes unsafe-eval.
 pscanrules.csp.scriptsrc.unsafe.hashes.name = script-src unsafe-hashes

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -333,7 +333,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getOtherInfo(),
-                is("Warnings:\n" + "The prefetch-src directive is deprecated\n"));
+                is("Warnings:\n" + "The prefetch-src directive has been deprecated\n"));
     }
 
     @Test
@@ -650,7 +650,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         assertThat(alertsRaised.size(), is(equalTo(1)));
         assertThat(
                 alertsRaised.get(0).getOtherInfo(),
-                is(equalTo("Warnings:\nThe prefetch-src directive is deprecated\n")));
+                is(equalTo("Warnings:\nThe prefetch-src directive has been deprecated\n")));
     }
 
     private HttpMessage createHttpMessageWithReasonableCsp(String cspHeaderName) {


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- ContentSecurityPolicyScanRule > Updated to use new library. (Which has handling for some deprecated directives the rule had been handling locally.)
- ContentSecurityPolicyScanRuleUnitTest > Updated assertions to match the notices provided by the new library.
- Messages.properties > Updated reference.
- pscanrules.gradle.kts > Change library dependency.
- pscanrules.html > Updated library note.

## Related Issues
NA

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
