### PR TITLE
network: remove legacy options panels

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Notify proxy listeners concurrently, might break listeners that do not correctly handle concurrency.
 
+### Removed
+- Remove legacy options panels that helped the user find the new options panels:
+  - Client Certificate
+  - Connection
+  - Dynamic SSL Certificates
+  - Local Proxies
+
 ### Fixed
 - Accept rate limit rule's group by in lower case, when handling the API requests.
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -611,19 +611,12 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                     new LocalServerInfoLabel(
                             getView().getMainFrame().getMainFooterPanel(), localServersOptions);
 
-            hookView.addOptionPanel(
-                    new LegacyOptionsPanel("dynssl", serverCertificatesOptionsPanel));
-            hookView.addOptionPanel(new LegacyOptionsPanel("proxies", localServersOptionsPanel));
-
             connectionOptionsPanel = new ConnectionOptionsPanel();
             optionsDialog.addParamPanel(networkNode, connectionOptionsPanel, true);
-            hookView.addOptionPanel(new LegacyOptionsPanel("connection", connectionOptionsPanel));
 
             clientCertificatesOptionsPanel =
                     new ClientCertificatesOptionsPanel(View.getSingleton());
             optionsDialog.addParamPanel(networkNode, clientCertificatesOptionsPanel, true);
-            hookView.addOptionPanel(
-                    new LegacyOptionsPanel("clientcerts", clientCertificatesOptionsPanel));
 
             optionsDialog.addParamPanel(
                     networkNode, rateLimitExtensionHelper.getRateLimitOptionsPanel(), true);

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -295,17 +295,9 @@ network.ui.options.globalexclusions.table.header.name = Name
 network.ui.options.globalexclusions.warn.invalidregex.message = The provided regular expression is not valid:\n{0}
 network.ui.options.globalexclusions.warn.invalidregex.title = Invalid Regular Expression
 
-network.ui.options.legacy.clientcerts = Client Certificate
-network.ui.options.legacy.clientcerts.moved = These options have been moved to Network > Client Certificates.
-network.ui.options.legacy.connection = Connection
-network.ui.options.legacy.connection.moved = These options have been moved to Network > Connection.
-network.ui.options.legacy.dynssl = Dynamic SSL Certificates
-network.ui.options.legacy.dynssl.moved = These options have been moved to Network > Server Certificates.
 network.ui.options.legacy.globalexcludeurl = Global Exclude URL
 network.ui.options.legacy.globalexcludeurl.moved = These options have been moved to Network > Global Exclusions.
 network.ui.options.legacy.opennew = Go to New Screen
-network.ui.options.legacy.proxies = Local Proxies
-network.ui.options.legacy.proxies.moved = These options have been moved to Network > Local Servers/Proxies.
 network.ui.options.legacy.ratelimit = Rate Limit
 
 network.ui.options.localservers.add.button = Add


### PR DESCRIPTION
Remove legacy options panels that helped the user find the new options panels:
 - Client Certificate
 - Connection
 - Dynamic SSL Certificates
 - Local Proxies