### PR TITLE
network: prevent proxy misconfiguration (GUI)

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Accept rate limit rule's group by in lower case, when handling the API requests.
+- Prevent configuration of the outgoing HTTP/SOCKS Proxy with the address of one of the Local Servers/Proxies, as it would lead to unintended request loops (Issue 5308).
 
 ## [0.13.0] - 2023-11-17
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -611,7 +611,8 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                     new LocalServerInfoLabel(
                             getView().getMainFrame().getMainFooterPanel(), localServersOptions);
 
-            connectionOptionsPanel = new ConnectionOptionsPanel();
+            connectionOptionsPanel =
+                    new ConnectionOptionsPanel(localServersOptionsPanel::isConfiguredAddress);
             optionsDialog.addParamPanel(networkNode, connectionOptionsPanel, true);
 
             clientCertificatesOptionsPanel =

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptionsPanel.java
@@ -117,6 +117,10 @@ class LocalServersOptionsPanel extends AbstractParamPanel {
         return "addon.network.options.localservers";
     }
 
+    boolean isConfiguredAddress(String address, int port) {
+        return serversPanel.isConfiguredAddress(address, port);
+    }
+
     private static class ServersPanel {
 
         private final ExtensionNetwork extensionNetwork;
@@ -182,10 +186,14 @@ class LocalServersOptionsPanel extends AbstractParamPanel {
                             .addComponent(localServersTablePanel));
         }
 
-        private boolean validateAddress(Component parent, String address, int port) {
-            if (hasSameAddress(address, port, mainProxyPanel.getServerConfig())
+        boolean isConfiguredAddress(String address, int port) {
+            return hasSameAddress(address, port, mainProxyPanel.getServerConfig())
                     || localServersTableModel.getElements().stream()
-                            .anyMatch(e -> hasSameAddress(address, port, e))) {
+                            .anyMatch(e -> hasSameAddress(address, port, e));
+        }
+
+        private boolean validateAddress(Component parent, String address, int port) {
+            if (isConfiguredAddress(address, port)) {
                 JOptionPane.showMessageDialog(
                         parent,
                         Constant.messages.getString(

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -263,6 +263,7 @@ network.ui.options.connection.httpproxy.realm = Realm:
 network.ui.options.connection.httpproxy.tab = HTTP Proxy
 network.ui.options.connection.httpproxy.username = User Name:
 network.ui.options.connection.httpproxy.username.empty = The HTTP proxy user name is empty.
+network.ui.options.connection.httpproxy.zapaddress = The HTTP Proxy is configured to one of the Local Servers/Proxies, which would lead to unintended request loops.
 
 network.ui.options.connection.name = Connection
 
@@ -276,6 +277,7 @@ network.ui.options.connection.socksproxy.port = Port:
 network.ui.options.connection.socksproxy.tab = SOCKS Proxy
 network.ui.options.connection.socksproxy.username = User Name:
 network.ui.options.connection.socksproxy.version = Version:
+network.ui.options.connection.socksproxy.zapaddress = The SOCKS Proxy is configured to one of the Local Servers/Proxies, which would lead to unintended request loops.
 
 network.ui.options.globalexclusions.add.button = Add
 network.ui.options.globalexclusions.add.title = Add Global Exclusion


### PR DESCRIPTION
Do not allow the outgoing proxies (HTTP/SOCKS) to be configured through the GUI with one of the local servers/proxies as this is unintended and leads to request loops.

Part of zaproxy/zaproxy#5308.