### PR TITLE
graphql: Fix parameter injection in url query

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - Video link in help for Automation Framework job.
 
+### Fixed
+- Fix graphql parameter injection in URL query.
+
 ## [0.22.0] - 2023-12-19
 ### Added
 - Fingerprinting check for the GraphQL.NET engine.

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/InlineInjector.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/InlineInjector.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.addon.graphql;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeJson;
+
 import graphql.language.Argument;
 import graphql.language.AstPrinter;
 import graphql.language.Definition;
@@ -215,6 +217,7 @@ public final class InlineInjector {
                                         && argValueString.endsWith("\"")) {
                                     ivStartPos++;
                                     ivEndPos--;
+                                    value = escapeJson(value);
                                 }
 
                                 queryBuilder.replace(ivStartPos, ivEndPos, value);

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/VariantGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/VariantGraphQl.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.graphql;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.TreeSet;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URI;
@@ -139,12 +140,14 @@ public class VariantGraphQl implements Variant {
                 msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
             }
         } else if (HttpRequestHeader.GET.equals(header.getMethod())) {
-            for (HtmlParameter param : msg.getUrlParams()) {
+            TreeSet<HtmlParameter> urlParams = msg.getUrlParams();
+            for (HtmlParameter param : urlParams) {
                 if (QUERY_KEY.equals(param.getName())) {
                     param.setValue(query);
                     break;
                 }
             }
+            msg.setGetParams(urlParams);
         }
     }
 

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/InlineInjectorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/InlineInjectorUnitTest.java
@@ -144,6 +144,14 @@ class InlineInjectorUnitTest extends TestUtils {
     }
 
     @Test
+    void injectInputObjectArgumentCorrectlyEscaped() {
+        String query = "{sqlInjection(expression: \"1\")}";
+        String sqliPaylaod = "\"or 1=1--";
+        String expectedQuery = "{sqlInjection(expression:\"\\\"or 1=1--\")}";
+        assertEquals(expectedQuery, injector.inject(query, "sqlInjection.expression", sqliPaylaod));
+    }
+
+    @Test
     void injectInlineFragmentArguments() {
         String query = "{...on field1{name(id:1)}}";
         String expectedQuery = "{...on field1{name(id:55)}}";

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/VariantGraphQIUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/VariantGraphQIUnitTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -125,6 +127,29 @@ class VariantGraphQlUnitTest {
         variant.setMessage(msg);
         // Then
         assertThat(logMessages.size(), is(1));
+    }
+
+    @Test
+    void shouldSetGraphqlQueryParametersCorrectlyOnTheUrl()
+            throws HttpMalformedHeaderException, URIException {
+        // Given
+        HttpRequestHeader httpReqHeader = new HttpRequestHeader();
+        httpReqHeader.setMessage(
+                "GET /graphql/?x=1&query=%7BsqlInjection(expression:%20%221%22)%7D&y=2 HTTP/1.1");
+        HttpMessage msg = new HttpMessage(httpReqHeader);
+
+        // When
+        variant.setMessage(msg);
+        NameValuePair param = variant.getParamList().get(0);
+        String sqliPaylaod = "\"or 1=1--";
+        variant.setParameter(msg, param, param.getName(), sqliPaylaod);
+        // Then
+        assertThat(
+                msg.getRequestHeader()
+                        .getURI()
+                        .getQuery()
+                        .contains("query={sqlInjection(expression:\"\\\"or 1=1--\")}"),
+                is(true));
     }
 
     private static void handleError(String message) {


### PR DESCRIPTION
## Overview
The Graphql variant wasn't changing the request when the Graphql query was on the URL. It was also not escaping the parameter values when inserted.

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

Thanks
