### PR TITLE
pscanrulesBeta: add website links to help pages 

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+- Website alert links (Issue 8189).
 
 ## [36] - 2024-01-16
 ### Changed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRule.java
@@ -75,7 +75,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class CacheableScanRule extends PluginPassiveScanner {
+public class CacheableScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX_STORABILITY_CACHEABILITY =
             "pscanbeta.storabilitycacheability.";

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CommonPassiveScanRuleInfo.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CommonPassiveScanRuleInfo.java
@@ -1,3 +1,22 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zaproxy.zap.extension.pscanrulesBeta;
 
 public interface CommonPassiveScanRuleInfo {

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CommonPassiveScanRuleInfo.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CommonPassiveScanRuleInfo.java
@@ -1,0 +1,10 @@
+package org.zaproxy.zap.extension.pscanrulesBeta;
+
+public interface CommonPassiveScanRuleInfo {
+    public int getPluginId();
+
+    public default String getHelpLink() {
+        return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-beta/#id-"
+                + getPluginId();
+    }
+}

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRule.java
@@ -37,7 +37,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 /**
  * In Page Banner Information Leak passive scan rule https://github.com/zaproxy/zaproxy/issues/178
  */
-public class InPageBannerInfoLeakScanRule extends PluginPassiveScanner {
+public class InPageBannerInfoLeakScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     private static final Logger LOGGER = LogManager.getLogger(InPageBannerInfoLeakScanRule.class);
     private static final int PLUGIN_ID = 10009;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRule.java
@@ -37,7 +37,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 /**
  * In Page Banner Information Leak passive scan rule https://github.com/zaproxy/zaproxy/issues/178
  */
-public class InPageBannerInfoLeakScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
+public class InPageBannerInfoLeakScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final Logger LOGGER = LogManager.getLogger(InPageBannerInfoLeakScanRule.class);
     private static final int PLUGIN_ID = 10009;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRule.java
@@ -43,7 +43,7 @@ import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** Passive Scan Rule for Dangerous JS Functions https://github.com/zaproxy/zaproxy/issues/5673 */
-public class JsFunctionScanRule extends PluginPassiveScanner {
+public class JsFunctionScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanbeta.jsfunction.";

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsoScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsoScanRule.java
@@ -33,7 +33,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** Java Serialized Objects (JSO) scan rule. Detect the magic sequence and generate an alert */
-public class JsoScanRule extends PluginPassiveScanner {
+public class JsoScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanbeta.jso.";

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PermissionsPolicyScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PermissionsPolicyScanRule.java
@@ -38,7 +38,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Permissions Policy Header Missing passive scan rule
  * https://github.com/zaproxy/zaproxy/issues/4885
  */
-public class PermissionsPolicyScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
+public class PermissionsPolicyScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String PERMISSIONS_POLICY_HEADER = "Permissions-Policy";
     private static final String DEPRECATED_HEADER = "Feature-Policy";

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PermissionsPolicyScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PermissionsPolicyScanRule.java
@@ -38,7 +38,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Permissions Policy Header Missing passive scan rule
  * https://github.com/zaproxy/zaproxy/issues/4885
  */
-public class PermissionsPolicyScanRule extends PluginPassiveScanner {
+public class PermissionsPolicyScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     private static final String PERMISSIONS_POLICY_HEADER = "Permissions-Policy";
     private static final String DEPRECATED_HEADER = "Feature-Policy";

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
@@ -41,7 +41,7 @@ import org.zaproxy.zap.model.Tech;
  *
  * @author psiinon
  */
-public class ServletParameterPollutionScanRule extends PluginPassiveScanner {
+public class ServletParameterPollutionScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanbeta.servletparameterpollution.";
     private static final int PLUGIN_ID = 10026;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
@@ -41,7 +41,8 @@ import org.zaproxy.zap.model.Tech;
  *
  * @author psiinon
  */
-public class ServletParameterPollutionScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
+public class ServletParameterPollutionScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanbeta.servletparameterpollution.";
     private static final int PLUGIN_ID = 10026;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
@@ -64,7 +64,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * @see <a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header">COOP Specs</a>
  * @see <a href="https://html.spec.whatwg.org/multipage/origin.html#coep">COEP Specs</a>
  */
-public class SiteIsolationScanRule extends PluginPassiveScanner {
+public class SiteIsolationScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
     /** Prefix for internationalized messages used by this rule */
     private static final String SITE_ISOLATION_MESSAGE_PREFIX = "pscanbeta.site-isolation.";
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
@@ -64,7 +64,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * @see <a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header">COOP Specs</a>
  * @see <a href="https://html.spec.whatwg.org/multipage/origin.html#coep">COEP Specs</a>
  */
-public class SiteIsolationScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
+public class SiteIsolationScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
     /** Prefix for internationalized messages used by this rule */
     private static final String SITE_ISOLATION_MESSAGE_PREFIX = "pscanbeta.site-isolation.";
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
@@ -40,7 +40,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class SourceCodeDisclosureScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
+public class SourceCodeDisclosureScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final Logger LOGGER = LogManager.getLogger(SourceCodeDisclosureScanRule.class);
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
@@ -40,7 +40,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
+public class SourceCodeDisclosureScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     private static final Logger LOGGER = LogManager.getLogger(SourceCodeDisclosureScanRule.class);
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java
@@ -48,7 +48,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 
 /** Detect missing attribute integrity in supported elements */
-public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
+public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final Logger LOGGER =
             LogManager.getLogger(SubResourceIntegrityAttributeScanRule.class);

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java
@@ -48,7 +48,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 
 /** Detect missing attribute integrity in supported elements */
-public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner {
+public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     private static final Logger LOGGER =
             LogManager.getLogger(SubResourceIntegrityAttributeScanRule.class);

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -33,7 +33,7 @@ Alerts generated:
  <li><b>Storable and Cacheable Content</b></li>
 </ul>
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRule.java">CacheableScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRule.java">CacheableScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10049/">10049</a>
 
 <H2 id="id-10110">Dangerous JS Functions</H2>
@@ -43,7 +43,7 @@ They will also be searched for in responses as they're passively scanned. Keep i
 <br>
 <strong>Note:</strong> &dollar; is stripped from the start of the strings/payloads and is optionally included when the patterns are assembled.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRule.java">JsFunctionScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRule.java">JsFunctionScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10110/">10110</a>
 
 <H2 id="id-10009">In Page Banner Information Leak</H2>
@@ -51,7 +51,7 @@ Analyzes response body content for the presence of web or application server ban
 If the Threshold is Low then status 200 - Ok responses are analyzed as well.<br>
 The presence of such banners may facilitate more targeted attacks against known vulnerabilities.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRule.java">InPageBannerInfoLeakScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRule.java">InPageBannerInfoLeakScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10009/">10009</a>
 
 <H2 id="id-90002">Java Serialization Object</H2>
@@ -61,7 +61,7 @@ An attacker can also modify the data and exploit JSO to do a Remote Code Executi
 JSO should not be used by Java programs. Strong controls must be done on serialized data.<br>
 JSO are a type of vulnerabilities associated to A8:2017-Insecure Deserialization.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsoScanRule.java">JsoScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsoScanRule.java">JsoScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90002/">90002</a>
 
 <H2 id="id-10063">Permissions Policy Header Not Set</H2>
@@ -69,7 +69,7 @@ This rule checks the HTTP response headers (on HTML and JavaScript responses) fo
 and alerts if one is not found. It also alerts if the deprecated header "Feature-Policy" is found.<br>
 Redirects are ignored except at the Low threshold.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PermissionsPolicyScanRule.java">PermissionsPolicyScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PermissionsPolicyScanRule.java">PermissionsPolicyScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10063/">10063</a>
 
 <H2 id="id-90004">Site Isolation Scan Rule</H2>
@@ -111,7 +111,7 @@ mechanism managed independently by the browser.
  <li><b>Cross-Origin-Opener-Policy Header Missing or Invalid</b></li>
 </ul>
 <p>
- Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java">SiteIsolationScanRule.java</a>
+ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java">SiteIsolationScanRule.java</a><br>
  Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90004/">90004</a>
 
 <H2 id="id-10026">Servlet Parameter Pollution</H2>
@@ -120,14 +120,14 @@ Java Servlet spec calls for aggregation of query string and post data elements w
 unintended handling of user controlled data. This may impact other frameworks and technologies as well.
 <strong>Note:</strong> This scan rule will only analyze responses on LOW Threshold, and in Context URLs for which the Tech JSP/Servlet is applicable.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java">ServletParameterPollutionScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java">ServletParameterPollutionScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10026/">10026</a>
 
 <H2 id="id-10099">Source Code Disclosure</H2>
 Application Source Code was disclosed by the web server.<br>
 NOTE: Ignores CSS, JavaScript, images, font files, and responses that contain ISO control characters (those which are likely binary files).
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10099/">10099</a>
 
 <H2 id="id-90003">Sub Resource Integrity Attribute Missing</H2>
@@ -137,7 +137,7 @@ Note: A suggested integrity hash value will be present in the relevant Alert's O
 <p>
 This rule supports <b>Trusted Domains</b>, check "General Configuration" for more information.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java">SubResourceIntegrityAttributeScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java">SubResourceIntegrityAttributeScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90003/">90003</a>
 
 </BODY>

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -23,7 +23,7 @@ Following rules supports <b>Trusted Domains</b> :
 
 The following beta status passive scan rules are included in this add-on:
 
-<H2>Content Cacheability</H2>
+<H2 id="id-10049">Content Cacheability</H2>
 This scan rule analyzes the cache control and pragma headers in HTTP traffic and reports on the cacheability of the requests from a RFC7234 point of view.
 <p>
 Alerts generated:
@@ -35,7 +35,7 @@ Alerts generated:
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRule.java">CacheableScanRule.java</a>
 
-<H2>Dangerous JS Functions</H2>
+<H2 id="id-10110">Dangerous JS Functions</H2>
 This scan rule checks for any dangerous JS functions present in a site response.<br>
 <strong>Note:</strong> If the Custom Payloads addon is installed you can add your own function names (payloads) in the Custom Payloads options panel.
 They will also be searched for in responses as they're passively scanned. Keep in mind that the greater the number of payloads the greater the amount of time needed to passively scan.
@@ -44,14 +44,14 @@ They will also be searched for in responses as they're passively scanned. Keep i
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRule.java">JsFunctionScanRule.java</a>
 
-<H2>In Page Banner Information Leak</H2>
+<H2 id="id-10009">In Page Banner Information Leak</H2>
 Analyzes response body content for the presence of web or application server banners (when the responses have error status codes).<br>
 If the Threshold is Low then status 200 - Ok responses are analyzed as well.<br>
 The presence of such banners may facilitate more targeted attacks against known vulnerabilities.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRule.java">InPageBannerInfoLeakScanRule.java</a>
 
-<H2>Java Serialization Object</H2>
+<H2 id="id-90002">Java Serialization Object</H2>
 Java Serialization Object (JSO) is a way to save and exchange objects between Java applications.<br>
 Different problems are associated with JSO. Sensitive data can leak to the stream of bytes.<br>
 An attacker can also modify the data and exploit JSO to do a Remote Code Execution on the server.<br>
@@ -60,14 +60,14 @@ JSO are a type of vulnerabilities associated to A8:2017-Insecure Deserialization
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsoScanRule.java">JsoScanRule.java</a>
 
-<H2>Permissions Policy Header Not Set</H2>
+<H2 id="id-10063">Permissions Policy Header Not Set</H2>
 This rule checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Permissions-Policy" header, 
 and alerts if one is not found. It also alerts if the deprecated header "Feature-Policy" is found.<br>
 Redirects are ignored except at the Low threshold.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PermissionsPolicyScanRule.java">PermissionsPolicyScanRule.java</a>
 
-<H2>Site Isolation Scan Rule</H2>
+<H2 id="id-90004">Site Isolation Scan Rule</H2>
 Spectre is a side-channel attack allowing an attacker to read data
 from memory. One of the counter-measures is to prevent sensitive data
 from entering the memory and to separate trusted and untrusted documents in
@@ -108,7 +108,7 @@ mechanism managed independently by the browser.
 <p>
  Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java">SiteIsolationScanRule.java</a>
 
-<H2>Servlet Parameter Pollution</H2>
+<H2 id="id-10026">Servlet Parameter Pollution</H2>
 Searches response content for HTML forms which fail to specify an action element. Version 3 of the 
 Java Servlet spec calls for aggregation of query string and post data elements which may result in 
 unintended handling of user controlled data. This may impact other frameworks and technologies as well.
@@ -116,13 +116,13 @@ unintended handling of user controlled data. This may impact other frameworks an
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java">ServletParameterPollutionScanRule.java</a>
 
-<H2>Source Code Disclosure</H2>
+<H2 id="id-10099">Source Code Disclosure</H2>
 Application Source Code was disclosed by the web server.<br>
 NOTE: Ignores CSS, JavaScript, images, font files, and responses that contain ISO control characters (those which are likely binary files).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a>
 
-<H2>Sub Resource Integrity Attribute Missing</H2>
+<H2 id="id-90003">Sub Resource Integrity Attribute Missing</H2>
 This rule checks whether the integrity attribute in the script or the link element served by an external resource (for example: CDN) is missing.<br>
 It helps mitigate an attack where the CDN has been compromised and content has been replaced by malicious content.<br>
 Note: A suggested integrity hash value will be present in the relevant Alert's Other Info details if it can be resolved to a script in the Sites Tree.

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -34,6 +34,7 @@ Alerts generated:
 </ul>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRule.java">CacheableScanRule.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10049/">10049</a>
 
 <H2 id="id-10110">Dangerous JS Functions</H2>
 This scan rule checks for any dangerous JS functions present in a site response.<br>
@@ -43,6 +44,7 @@ They will also be searched for in responses as they're passively scanned. Keep i
 <strong>Note:</strong> &dollar; is stripped from the start of the strings/payloads and is optionally included when the patterns are assembled.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRule.java">JsFunctionScanRule.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10110/">10110</a>
 
 <H2 id="id-10009">In Page Banner Information Leak</H2>
 Analyzes response body content for the presence of web or application server banners (when the responses have error status codes).<br>
@@ -50,6 +52,7 @@ If the Threshold is Low then status 200 - Ok responses are analyzed as well.<br>
 The presence of such banners may facilitate more targeted attacks against known vulnerabilities.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRule.java">InPageBannerInfoLeakScanRule.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10009/">10009</a>
 
 <H2 id="id-90002">Java Serialization Object</H2>
 Java Serialization Object (JSO) is a way to save and exchange objects between Java applications.<br>
@@ -59,6 +62,7 @@ JSO should not be used by Java programs. Strong controls must be done on seriali
 JSO are a type of vulnerabilities associated to A8:2017-Insecure Deserialization.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsoScanRule.java">JsoScanRule.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90002/">90002</a>
 
 <H2 id="id-10063">Permissions Policy Header Not Set</H2>
 This rule checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Permissions-Policy" header, 
@@ -66,6 +70,7 @@ and alerts if one is not found. It also alerts if the deprecated header "Feature
 Redirects are ignored except at the Low threshold.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PermissionsPolicyScanRule.java">PermissionsPolicyScanRule.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10063/">10063</a>
 
 <H2 id="id-90004">Site Isolation Scan Rule</H2>
 Spectre is a side-channel attack allowing an attacker to read data
@@ -107,6 +112,7 @@ mechanism managed independently by the browser.
 </ul>
 <p>
  Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java">SiteIsolationScanRule.java</a>
+ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90004/">90004</a>
 
 <H2 id="id-10026">Servlet Parameter Pollution</H2>
 Searches response content for HTML forms which fail to specify an action element. Version 3 of the 
@@ -115,12 +121,14 @@ unintended handling of user controlled data. This may impact other frameworks an
 <strong>Note:</strong> This scan rule will only analyze responses on LOW Threshold, and in Context URLs for which the Tech JSP/Servlet is applicable.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java">ServletParameterPollutionScanRule.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10026/">10026</a>
 
 <H2 id="id-10099">Source Code Disclosure</H2>
 Application Source Code was disclosed by the web server.<br>
 NOTE: Ignores CSS, JavaScript, images, font files, and responses that contain ISO control characters (those which are likely binary files).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10099/">10099</a>
 
 <H2 id="id-90003">Sub Resource Integrity Attribute Missing</H2>
 This rule checks whether the integrity attribute in the script or the link element served by an external resource (for example: CDN) is missing.<br>
@@ -130,6 +138,7 @@ Note: A suggested integrity hash value will be present in the relevant Alert's O
 This rule supports <b>Trusted Domains</b>, check "General Configuration" for more information.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java">SubResourceIntegrityAttributeScanRule.java</a>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90003/">90003</a>
 
 </BODY>
 </HTML>


### PR DESCRIPTION
Signed-off-by: Aditya Parihar <97739299+PariharAditya@users.noreply.github.com>

## Overview
Implemented a new interface for linking to website
updated help with there respective ID
## Related Issues
zaproxy/zaproxy#8189

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
