### PR TITLE
retire: Only target relevant responses

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,25 +4,20 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Now only targets relevant responses (HTML and JS).
 
 ## [0.29.0] - 2024-01-03
 ### Changed
 - Updated with upstream retire.js pattern changes.
 
-
-
 ## [0.28.0] - 2023-12-04
 ### Changed
 - Updated with upstream retire.js pattern changes.
 
-
-
 ## [0.27.0] - 2023-11-03
 ### Changed
 - Updated with upstream retire.js pattern changes.
-
-
 
 ## [0.26.0] - 2023-10-12
 ### Changed
@@ -39,25 +34,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.13.0.
 - Updated with upstream retire.js pattern changes.
 
-
-
 ## [0.23.0] - 2023-06-02
 ### Changed
 - Updated with upstream retire.js pattern changes.
-
-
 
 ## [0.22.0] - 2023-05-03
 ### Changed
 - Updated with upstream retire.js pattern changes.
 
-
-
 ## [0.21.0] - 2023-04-04
 ### Changed
 - Updated with upstream retire.js pattern changes.
-
-
 
 ## [0.20.0] - 2023-03-03
 ### Changed
@@ -73,13 +60,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated with upstream retire.js pattern changes.
 
-
-
 ## [0.17.0] - 2022-11-14
 ### Changed
 - Updated with upstream retire.js pattern changes.
-
-
 
 ## [0.16.0] - 2022-10-27
 ### Changed

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -33,7 +33,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
 import org.zaproxy.addon.retire.model.Repo;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -61,16 +60,15 @@ public class RetireScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (!getHelper().isPage200(msg) || getRepo() == null) {
+        Repo scanRepo = getRepo();
+        if (!getHelper().isPage200(msg) || scanRepo == null) {
+            if (scanRepo == null) {
+                LOGGER.error("\tThe Retire.js repository was null.");
+            }
             return;
         }
         String uri = msg.getRequestHeader().getURI().toString();
-        if (!ResourceIdentificationUtils.isImage(msg) && !ResourceIdentificationUtils.isCss(msg)) {
-            Repo scanRepo = getRepo();
-            if (scanRepo == null) {
-                LOGGER.error("\tThe Retire.js repository was null.");
-                return;
-            }
+        if (msg.getResponseHeader().isHtml() || msg.getResponseHeader().isJavaScript()) {
             Result result = scanRepo.scanJS(msg, source);
             if (result == null) {
                 LOGGER.debug("\tNo vulnerabilities found in record {} with URL {}", id, uri);


### PR DESCRIPTION
## Overview
To avoid things like:
`353477 [ZAP-PassiveScan-1] WARN org.zaproxy.zap.extension.pscan.PassiveScanTask - Passive Scan rule Vulnerable JS Library (Powered by Retire.js) took 6 seconds to scan https://juice-shop.herokuapp.com/video?__ecma.String= video/mp4 10075518`

- CHANGELOG > Add change note.
- RetireScanRule > Target responses that are relevant (HTML and JS).
- RetireScanRuleUnitTest > Updated to assert the latest behavior, example alert, and valid references

## Checklist
- [NA] Update help
- [x] Update changelog - Also tidied up quad blanks.
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
