### PR TITLE
authhelper: correct HTTP field names in diag data

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct HTTP field names shown in diagnostic data.
 
 ## [0.11.0] - 2024-01-10
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollector.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollector.java
@@ -86,7 +86,7 @@ public class AuthDiagnosticCollector implements HttpSenderListener {
 
             appendExactHeaders(msg.getRequestHeader(), HttpHeader.CONTENT_TYPE, sb);
             appendSanitisedHeaders(msg.getRequestHeader(), HttpHeader.AUTHORIZATION, sb);
-            appendCookies(msg.getRequestHeader().getHttpCookies(), HttpHeader.SET_COOKIE, sb);
+            appendCookies(msg.getRequestHeader().getHttpCookies(), HttpHeader.COOKIE, sb);
             appendStructuredData(msg.getRequestHeader(), msg.getRequestBody(), sb);
 
             // The response
@@ -100,7 +100,7 @@ public class AuthDiagnosticCollector implements HttpSenderListener {
 
             appendExactHeaders(msg.getResponseHeader(), HttpHeader.CONTENT_TYPE, sb);
             appendSanitisedHeaders(msg.getResponseHeader(), HttpHeader.AUTHORIZATION, sb);
-            appendCookies(msg.getResponseHeader().getHttpCookies(null), HttpHeader.COOKIE, sb);
+            appendCookies(msg.getResponseHeader().getHttpCookies(null), HttpHeader.SET_COOKIE, sb);
             appendStructuredData(msg.getResponseHeader(), msg.getResponseBody(), sb);
             logString(sb.toString());
         } catch (URIException e) {


### PR DESCRIPTION
Swap cookie and set-cookie to match the name used in the request and response respectively.