### PR TITLE
automation: correct threshold/strength parsing

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct parsing of attack strength and alert threshold in some locales.
 
 ## [0.35.0] - 2024-01-16
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -87,7 +87,7 @@ public class JobUtils {
         }
         if (o instanceof String) {
             try {
-                strength = AttackStrength.valueOf(((String) o).toUpperCase());
+                strength = AttackStrength.valueOf(((String) o).toUpperCase(Locale.ROOT));
             } catch (Exception e) {
                 progress.warn(
                         Constant.messages.getString("automation.error.ascan.strength", jobName, o));
@@ -107,7 +107,7 @@ public class JobUtils {
         }
         if (o instanceof String) {
             try {
-                threshold = AlertThreshold.valueOf(((String) o).toUpperCase());
+                threshold = AlertThreshold.valueOf(((String) o).toUpperCase(Locale.ROOT));
             } catch (Exception e) {
                 progress.warn(
                         Constant.messages.getString(

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
@@ -39,11 +39,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.automation.AutomationEnvironment;
@@ -407,6 +412,47 @@ class JobUtilsUnitTest extends TestUtils {
         File f = JobUtils.getFile(path, plan);
         // Then
         assertFilePath(f, "/full/path/dir/relative/path/to/file");
+    }
+
+    static Stream<Locale> locales() {
+        return Stream.of(
+                Locale.ROOT, Locale.ENGLISH, new Locale.Builder().setLanguage("TR").build());
+    }
+
+    @ParameterizedTest
+    @MethodSource("locales")
+    void shouldParseAttackStrengthInDifferentLocales(Locale locale) {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            // Given
+            Locale.setDefault(locale);
+            AutomationProgress progress = mock(AutomationProgress.class);
+            // When
+            AttackStrength attackStrength = JobUtils.parseAttackStrength("medium", "job", progress);
+            // Then
+            assertThat(attackStrength, is(equalTo(AttackStrength.MEDIUM)));
+            verifyNoInteractions(progress);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("locales")
+    void shouldParseAlertThresholdInDifferentLocales(Locale locale) {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            // Given
+            Locale.setDefault(locale);
+            AutomationProgress progress = mock(AutomationProgress.class);
+            // When
+            AlertThreshold alertThreshold = JobUtils.parseAlertThreshold("medium", "job", progress);
+            // Then
+            assertThat(alertThreshold, is(equalTo(AlertThreshold.MEDIUM)));
+            verifyNoInteractions(progress);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     private static void assertFilePath(File file, String path) {


### PR DESCRIPTION
Use neutral locale to upper case the values before creating the enums, otherwise in some locales it could fail to match the enum name.