### PR TITLE
ascanrulesBeta: add alert links to website help pages

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - The Backup File Disclosure scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 - Updated reference for scan rule: Session Fixation (Issue 8262)
+- Add website alert links to the help page (Issue 8189).
 
 ## [50] - 2024-01-26
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
@@ -44,7 +44,8 @@ import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
  *
  * @author 70pointer
  */
-public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
+public class BackupFileDisclosureScanRule extends AbstractAppPlugin
+        implements CommonActiveScanRuleInfo {
 
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CommonActiveScanRuleInfo.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CommonActiveScanRuleInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesBeta;
+
+public interface CommonActiveScanRuleInfo {
+
+    public int getId();
+
+    public default String getHelpLink() {
+        return "https://www.zaproxy.org/docs/desktop/addons/active-scan-rules-beta/#id-" + getId();
+    }
+}

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CorsScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CorsScanRule.java
@@ -44,7 +44,7 @@ import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
  *
  * @author CravateRouge
  */
-public class CorsScanRule extends AbstractAppPlugin {
+public class CorsScanRule extends AbstractAppPlugin implements CommonActiveScanRuleInfo {
     private static final Logger LOGGER = LogManager.getLogger(CorsScanRule.class);
     private static final String RANDOM_NAME = RandomStringUtils.random(8, true, true);
     private static final Map<String, String> ALERT_TAGS =

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java
@@ -51,7 +51,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
  *
  * @author 70pointer@gmail.com
  */
-public class CrossDomainScanRule extends AbstractHostPlugin {
+public class CrossDomainScanRule extends AbstractHostPlugin implements CommonActiveScanRuleInfo {
 
     /** the logger object */
     private static final Logger LOGGER = LogManager.getLogger(CrossDomainScanRule.class);

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
@@ -51,7 +51,7 @@ import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
  * CsrfTokenScanRule is an effort to improve the anti-CSRF token detection of ZAP It is based on
  * previous plugins such as csrfcountermeasuresscan and sessionfixation
  */
-public class CsrfTokenScanRule extends AbstractAppPlugin {
+public class CsrfTokenScanRule extends AbstractAppPlugin implements CommonActiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "ascanbeta.csrftoken.";
     private static final int PLUGIN_ID = 20012;

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExponentialEntityExpansionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExponentialEntityExpansionScanRule.java
@@ -34,7 +34,8 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 
-public class ExponentialEntityExpansionScanRule extends AbstractAppPlugin {
+public class ExponentialEntityExpansionScanRule extends AbstractAppPlugin
+        implements CommonActiveScanRuleInfo {
 
     private static final Logger LOGGER =
             LogManager.getLogger(ExponentialEntityExpansionScanRule.class);

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
@@ -41,7 +41,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
  *
  * @author yhawke (2014)
  */
-public class ExpressionLanguageInjectionScanRule extends AbstractAppParamPlugin {
+public class ExpressionLanguageInjectionScanRule extends AbstractAppParamPlugin
+        implements CommonActiveScanRuleInfo {
 
     // Logger object
     private static final Logger LOGGER =

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttPoxyScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttPoxyScanRule.java
@@ -38,7 +38,7 @@ import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.addon.network.server.Server;
 
-public class HttPoxyScanRule extends AbstractAppPlugin {
+public class HttPoxyScanRule extends AbstractAppPlugin implements CommonActiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanbeta.httpoxy.";

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java
@@ -45,7 +45,7 @@ import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
  *
  * @author sanchitlucknow@gmail.com
  */
-public class HttpOnlySiteScanRule extends AbstractHostPlugin {
+public class HttpOnlySiteScanRule extends AbstractHostPlugin implements CommonActiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanbeta.httponlysite.";

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
@@ -42,7 +42,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 /**
  * TODO note that this should extend AbstractAppParamPlugin rather than find parameters internally
  */
-public class HttpParameterPollutionScanRule extends AbstractAppPlugin {
+public class HttpParameterPollutionScanRule extends AbstractAppPlugin
+        implements CommonActiveScanRuleInfo {
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A03_INJECTION,

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
@@ -37,7 +37,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
  * Active scan rule which checks whether or not HTTPS content is also available via HTTP
  * https://github.com/zaproxy/zaproxy/issues/174
  */
-public class HttpsAsHttpScanRule extends AbstractAppPlugin {
+public class HttpsAsHttpScanRule extends AbstractAppPlugin implements CommonActiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanbeta.httpsashttp.";

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
@@ -63,7 +63,8 @@ import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
  *
  * @author 70pointer
  */
-public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
+public class InsecureHttpMethodScanRule extends AbstractAppPlugin
+        implements CommonActiveScanRuleInfo {
 
     /* These are the 'default' HTTP methods which are considered as insecure */
     private static final List<String> INSECURE_DEFAULT_METHODS =

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
@@ -35,7 +35,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
-public class IntegerOverflowScanRule extends AbstractAppParamPlugin {
+public class IntegerOverflowScanRule extends AbstractAppParamPlugin
+        implements CommonActiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanbeta.integeroverflow.";

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/OutOfBandXssScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/OutOfBandXssScanRule.java
@@ -36,7 +36,8 @@ import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
 import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 import org.zaproxy.addon.oast.ExtensionOast;
 
-public class OutOfBandXssScanRule extends AbstractAppParamPlugin {
+public class OutOfBandXssScanRule extends AbstractAppParamPlugin
+        implements CommonActiveScanRuleInfo {
 
     private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_8");
     private static final int PLUGIN_ID = 40031;

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
@@ -52,7 +52,7 @@ import org.zaproxy.addon.network.common.ZapSocketTimeoutException;
  *
  * @author 70pointer
  */
-public class ProxyDisclosureScanRule extends AbstractAppPlugin {
+public class ProxyDisclosureScanRule extends AbstractAppPlugin implements CommonActiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanbeta.proxydisclosure.";

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -52,7 +52,8 @@ import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
  *
  * @author 70pointer
  */
-public class RelativePathConfusionScanRule extends AbstractAppPlugin {
+public class RelativePathConfusionScanRule extends AbstractAppPlugin
+        implements CommonActiveScanRuleInfo {
 
     /** the logger object */
     private static final Logger LOGGER = LogManager.getLogger(RelativePathConfusionScanRule.class);

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
@@ -65,7 +65,7 @@ import org.zaproxy.zap.model.Context;
  *
  * @author 70pointer
  */
-public class SessionFixationScanRule extends AbstractAppPlugin {
+public class SessionFixationScanRule extends AbstractAppPlugin implements CommonActiveScanRuleInfo {
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A01_BROKEN_AC,

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanRule.java
@@ -40,7 +40,7 @@ import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
  *
  * @author psiinon
  */
-public class ShellShockScanRule extends AbstractAppParamPlugin {
+public class ShellShockScanRule extends AbstractAppParamPlugin implements CommonActiveScanRuleInfo {
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A06_VULN_COMP,

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
@@ -51,7 +51,7 @@ import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
  *
  * <p>With thanks to Kaiser Permanente CyberSecurity comrades for using and feedback.
  */
-public class SlackerCookieScanRule extends AbstractAppPlugin {
+public class SlackerCookieScanRule extends AbstractAppPlugin implements CommonActiveScanRuleInfo {
     // http://projects.webappsec.org/w/page/13246978/Threat%20Classification
     // going to classify this as #45, Fingerprinting.
     // #01, Authentication could be applicable.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -43,7 +43,8 @@ import org.zaproxy.zap.model.Tech;
  *
  * @author 70pointer
  */
-public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamPlugin {
+public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamPlugin
+        implements CommonActiveScanRuleInfo {
 
     // use a random file name which is very unlikely to exist
     private static final String NON_EXISTANT_FILENAME =

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
@@ -44,7 +44,8 @@ import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
  *
  * @author 70pointer
  */
-public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
+public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin
+        implements CommonActiveScanRuleInfo {
 
     /**
      * details of the vulnerability which we are attempting to find 34 = "Predictable Resource

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
@@ -50,7 +50,8 @@ import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
  *
  * @author 70pointer
  */
-public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
+public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin
+        implements CommonActiveScanRuleInfo {
 
     /**
      * if we got a 404 or a redirect specifically, then this is NOT a match note that since we are

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SsrfScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SsrfScanRule.java
@@ -36,7 +36,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.oast.ExtensionOast;
 import org.zaproxy.addon.oast.OastPayload;
 
-public class SsrfScanRule extends AbstractAppParamPlugin {
+public class SsrfScanRule extends AbstractAppParamPlugin implements CommonActiveScanRuleInfo {
 
     private static final int PLUGIN_ID = 40046;
     private static final Logger LOGGER = LogManager.getLogger(SsrfScanRule.class);

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Text4ShellScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Text4ShellScanRule.java
@@ -37,7 +37,7 @@ import org.zaproxy.addon.oast.ExtensionOast;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
-public class Text4ShellScanRule extends AbstractAppParamPlugin {
+public class Text4ShellScanRule extends AbstractAppParamPlugin implements CommonActiveScanRuleInfo {
 
     private static final Logger LOGGER = LogManager.getLogger(Text4ShellScanRule.class);
     private static final String PREFIX = "ascanbeta.text4shell.";

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
@@ -58,7 +58,8 @@ import org.zaproxy.zap.utils.HirshbergMatcher;
  *
  * @author 70pointer
  */
-public class UsernameEnumerationScanRule extends AbstractAppPlugin {
+public class UsernameEnumerationScanRule extends AbstractAppPlugin
+        implements CommonActiveScanRuleInfo {
 
     private static final Logger LOGGER = LogManager.getLogger(UsernameEnumerationScanRule.class);
 

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -10,29 +10,37 @@ Active Scan Rules - Beta
 <H1>Active Scan Rules - Beta</H1>
 The following beta status active scan rules are included in this add-on:
 
-<H2>Backup File Disclosure</H2>
+<H2 id="id-10095">Backup File Disclosure</H2>
 Scans for commonly-named backup copies of files on the web server, which may reveal sensitive information.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java">BackupFileDisclosureScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10095/">10095</a>.
 
-<H2>Cookie Slack Detector</H2>
+<H2 id="id-90027">Cookie Slack Detector</H2>
 Tests cookies to detect if some have no effect on response size when omitted, especially cookies containing the name "session" or "userid".
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieDetector.java">SlackerCookieDetector.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90027/">90027</a>.
 
-<H2>CORS Header</H2>
+<H2 id="id-40040">CORS Header</H2>
 This rule attempts to identify CORS headers and also CORS misconfiguration. The CORS is considered as misconfigured when it allows all origins, origins with weaker protocols and null origin.<br>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CorsScanRule.java">CorsScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40040/">40040</a>.
 
-<H2>Cross-Domain Misconfiguration</H2>
+<H2 id="id-20016">Cross-Domain Misconfiguration</H2>
 Checks if the web server is configured to allow Cross Domain access, from a malicious
 third party service, for instance. Currently checks for wildcards in Adobe's crossdomain.xml, and in
 SilverLight's clientaccesspolicy.xml. 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java">CrossDomainScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/20016/">20016</a>.
 
-<H2>CSRF Token</H2>
+<H2 id="id-10202">CSRF Token</H2>
 Scans HTML based messages for the existence of Anti-CSRF tokens. <br>
 Alerts on requests which do not appear to contain Anti-CSRF tokens.<br>
 At HIGH alert threshold only scans messages which are in scope.<br>
@@ -42,25 +50,33 @@ Any FORMs with a name or ID that matches one of these identifiers will be ignore
 Only use this feature to ignore FORMs that you know are safe, for example search forms.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java">CsrfTokenScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10202/">10202</a>.
 
-<H2>Exponential Entity Expansion (Billion Laughs Attack)</H2>
+<H2 id="id-40044">Exponential Entity Expansion (Billion Laughs Attack)</H2>
 This rule attempts to identify the "Billion Laughs" vulnerability in servers that accept XML or YAML files.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExponentialEntityExpansionScanRule.java">ExponentialEntityExpansionScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40044/">40044</a>.
 
-<H2>Expression Language Injection</H2>
+<H2 id="id-90025">Expression Language Injection</H2>
 Checks if the web application is subject to Expression Language (EL) injection attacks, which occur
 when an application fails to sufficiently neutralize special elements that could modify the intended EL 
 statement before it is executed.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java">ExpressionLanguageInjectionScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90025/">90025</a>.
 
-<H2>HTTP Only Site</H2>
+<H2 id="id-10106">HTTP Only Site</H2>
 This active scan rule checks whether an HTTP site is served under HTTPS.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRule.java">HttpOnlySiteScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10106/">10106</a>.
 
-<H2>HttPoxy - Proxy Header Misuse</H2>
+<H2 id="id-10107">HttPoxy - Proxy Header Misuse</H2>
 This active scan rule checks whether a site is using the HTTP Proxy header specified in the request.<br>
 It sets up an HTTP proxy which listens to all interfaces on a randomly assigned free port.
 It then sends a series of requests to the target server with the HTTP Proxy header set to each of the available
@@ -70,37 +86,49 @@ If a request is received on the new port then the server is very likely to be vu
 if a firewall prevents incoming connections then this rule will not work. 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttPoxyScanRule.java">HttPoxyScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10107/">10107</a>.
 
-<H2>HTTPS Content Available via HTTP</H2>
+<H2 id="id-10047">HTTPS Content Available via HTTP</H2>
 This active scan rule attempts to access content that was originally accessed via HTTPS (SSL/TLS) via HTTP.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java">HttpsAsHttpScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10047/">10047</a>.
 
-<H2>HTTP Parameter Pollution (HPP)</H2>
+<H2 id="id-20014">HTTP Parameter Pollution (HPP)</H2>
 Supplying duplicate or numerous HTTP parameters with the same name may cause an application or website
 to interpret values in unintended ways. By leveraging these effects, a malicious individual
 may be able to bypass input validation, trigger errors or modify internal variable values. 
 There are difference in treatment of duplicate parameters impacting both clients (browsers) and servers.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java">HttpParameterPollutionScanRule.java</a> 
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/20014/">20014</a>.
 
-<H2>Insecure HTTP Method</H2>
+<H2 id="id-90028">Insecure HTTP Method</H2>
 Detects (and exploits, depending on the scan settings) known insecure HTTP methods enabled for the URL. It considers PUT/PATCH as insecure methods by default, but allows them if they return structured data like JSON or XML in response.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java">InsecureHttpMethodScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90028/">90028</a>.
 
-<H2>Integer Overflow Error</H2>
+<H2 id="id-30003">Integer Overflow Error</H2>
 Looks for indicators of integer overflows in compiled code that causes the web server to crash.  It does 
 this by putting out multiple strings of integers designed to try and stimulate bad responses.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java">IntegerOverflowScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/30003/">30003</a>.
 
-<H2>Out of Band XSS</H2>
+<H2 id="id-40031">Out of Band XSS</H2>
 This rule attempts to discover Out-of-band XSS vulnerabilities.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/OutOfBandXssScanRule.java">OutOfBandXssScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40031/">40031</a>.
 
-<H2>Proxy Disclosure</H2>
+<H2 id="id-40025">Proxy Disclosure</H2>
 Attempts to detect and fingerprint proxy server(s). This information helps a potential attacker to determine:
 <ul>
 <li>A list of targets for an attack against the application.</li>
@@ -109,19 +137,26 @@ Attempts to detect and fingerprint proxy server(s). This information helps a pot
 </ul>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java">ProxyDisclosureScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40025/">40025</a>.
 
-<H2>Relative Path Confusion</H2>
+<H2 id="id-10051">Relative Path Confusion</H2>
 Tests if the web server is configured to serve responses to ambiguous URLs in a manner that is likely to lead to confusion about the correct "relative path" for the URL. 
 If resources (CSS, images, etc.) are references in the response using relative, rather than absolute URLs. In an attack, if the web browser parses the "cross-content" response in a permissive manner, or can be tricked into 
 permissively parsing the "cross-content" response, using techniques such as framing, then the web browser may be fooled into interpreting HTML as CSS (or other content types), leading to an XSS vulnerability.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java">RelativePathConfusionScanRule.java</a>
-<H2>Session Fixation</H2>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10051/">10051</a>.
+
+<H2 id="id-40013">Session Fixation</H2>
 Session Fixation may be possible. If this issue occurs with a login URL (where the user authenticates themselves to the application), then the URL may be given by an attacker, along with a fixed session id, to a victim, in order to later assume the identity of the victim using the given session id. If the issue occurs with a non-login page, the URL and fixed session id may only be used by an attacker to track an unauthenticated user's actions. If the vulnerability occurs on a cookie field or a form field (POST parameter) rather than on a URL (GET) parameter, then some other vulnerability may also be required in order to set the cookie field on the victim's browser, to allow the vulnerability to be exploited.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java">SessionFixationScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40013/">40013</a>.
 
-<H2>ShellShock - CVE-2014-6271</H2>
+<H2 id="id-10048">ShellShock - CVE-2014-6271</H2>
 
 This rule perform 2 attacks to detect servers vulnerable to CVE-2014-6271 aka ShellShock.<br>
 The first is a simple reflected attack and the second is a time based attack.<br>
@@ -129,39 +164,53 @@ The first is a simple reflected attack and the second is a time based attack.<br
 Post 2.5.0 you can change the length of time used for the attack by changing the <code>rules.common.sleep</code> parameter via the Options 'Rule configuration' panel.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanRule.java">ShellShockScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10048/">10048</a>.
 
-<H2>Source Code Disclosure - SVN</H2>
+<H2 id="id-42">Source Code Disclosure - SVN</H2>
 Uses Subversion source code repository metadata to scan for files containing source code on the web server.<br>
 At LOW alert threshold the rule will require less evidence to identify potential code, which could result in more false positives.<br>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java">SourceCodeDisclosureSvnScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/42/">42</a>.
 
-<H2>Source Code Disclosure - File Inclusion</H2>
+<H2 id="id-43">Source Code Disclosure - File Inclusion</H2>
 Uses local file inclusion techniques to scan for files containing source code on the web server.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java">SourceCodeDisclosureFileInclusionScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/43/">43</a>.
 
-<H2>Source Code Disclosure - Git</H2>
+<H2 id="id-41">Source Code Disclosure - Git</H2>
 Uses Git source code repository metadata to scan for files containing source code on the web server.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java">SourceCodeDisclosureGitScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/41/">41</a>.
 
-<H2>Server Side Request Forgery</H2>
+<H2 id="id-40046">Server Side Request Forgery</H2>
 This rule attempts to find Server Side Request Forgery vulnerabilities by injecting out-of-band payloads in request parameters.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SsrfScanRule.java">SsrfScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40046/">40046</a>.
 
-<H2>Text4shell (CVE-2022-42889)</H2>
+<H2 id="id-40047">Text4shell (CVE-2022-42889)</H2>
 This rule attempts to discover the Text4shell (<a href="https://nvd.nist.gov/vuln/detail/CVE-2022-42889">CVE-2022-42889</a>) vulnerability.
 It relies on the OAST add-on to generate out-of-band payloads and verify DNS interactions.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Text4ShellScanRule.java">Text4ShellScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40047/">40047</a>.
 
-<H2>Username Enumeration</H2>
+<H2 id="id-40023">Username Enumeration</H2>
 It may be possible to enumerate usernames, based on differing HTTP responses when valid and invalid usernames are provided. This would greatly increase the probability of success of password brute-forcing attacks against the system. Note that false positives may sometimes be minimised by increasing the 'Attack Strength' Option in ZAP.  Please manually check the 'Other Info' field to confirm if this is actually an issue.
 This rule is skipped if there are no contexts defined that use Form-based Authentication, and only runs against the URL identified as the login URL of a context.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java">UsernameEnumerationScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/40023/">40023</a>.
 
 </BODY>
 </HTML>

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -40,7 +40,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/20016/">20016</a>.
 
-<H2 id="id-10202">CSRF Token</H2>
+<H2 id="id-20012">CSRF Token</H2>
 Scans HTML based messages for the existence of Anti-CSRF tokens. <br>
 Alerts on requests which do not appear to contain Anti-CSRF tokens.<br>
 At HIGH alert threshold only scans messages which are in scope.<br>
@@ -51,7 +51,7 @@ Only use this feature to ignore FORMs that you know are safe, for example search
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java">CsrfTokenScanRule.java</a>
 <br>
-Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10202/">10202</a>.
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/20012/">20012</a>.
 
 <H2 id="id-40044">Exponential Entity Expansion (Billion Laughs Attack)</H2>
 This rule attempts to identify the "Billion Laughs" vulnerability in servers that accept XML or YAML files.


### PR DESCRIPTION
## Overview
added alert links to website help pages
fixes part of [zaproxy/zaproxy/issues/8189](https://github.com/zaproxy/zaproxy/issues/8189).

## Related Issues
[zaproxy/zaproxy/issues/8189](https://github.com/zaproxy/zaproxy/issues/8189)

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
