### PR TITLE
network: prevent NPE when proxying NTLM auth

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Accept rate limit rule's group by in lower case, when handling the API requests.
 - Prevent configuration of the outgoing HTTP/SOCKS Proxy with the address of one of the Local Servers/Proxies, as it would lead to unintended request loops (Issue 5308).
+- Fix exception while proxying NTLM authentication (Issue 7685).
 
 ## [0.13.0] - 2023-11-17
 ### Added

--- a/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/ZapProtocolExec.java
+++ b/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/ZapProtocolExec.java
@@ -71,6 +71,7 @@ public final class ZapProtocolExec implements ExecChainHandler {
     private static final Logger LOG = LoggerFactory.getLogger(ZapProtocolExec.class);
 
     public static final String PROXY_AUTH_DISABLED_ATTR = "zap.proxy_auth_disabled";
+    public static final String AUTH_DISABLED_ATTR = "zap.auth_disabled";
 
     private final AuthenticationStrategy targetAuthStrategy;
     private final AuthenticationStrategy proxyAuthStrategy;
@@ -250,10 +251,11 @@ public final class ZapProtocolExec implements ExecChainHandler {
         final RequestConfig config = context.getRequestConfig();
         if (config.isAuthenticationEnabled()) {
             final boolean proxyAuthEnabled = !Boolean.TRUE.equals(context.getAttribute(PROXY_AUTH_DISABLED_ATTR));
+            final boolean authEnabled = !Boolean.TRUE.equals(context.getAttribute(AUTH_DISABLED_ATTR));
             final boolean targetAuthRequested = authenticator.isChallenged(
                     target, ChallengeType.TARGET, response, targetAuthExchange, context);
 
-            if (authCacheKeeper != null) {
+            if (authCacheKeeper != null && authEnabled) {
                 if (targetAuthRequested) {
                     authCacheKeeper.updateOnChallenge(target, pathPrefix, targetAuthExchange, context);
                 } else {
@@ -272,7 +274,7 @@ public final class ZapProtocolExec implements ExecChainHandler {
                 }
             }
 
-            if (targetAuthRequested) {
+            if (targetAuthRequested && authEnabled) {
                 final boolean updated = authenticator.updateAuthState(target, ChallengeType.TARGET, response,
                         targetAuthStrategy, targetAuthExchange, context);
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -395,6 +395,7 @@ public class HttpSenderApache
                 RequestConfig.copy(requestCtx.getRequestConfig());
 
         boolean reauthenticate = false;
+        requestCtx.setAttribute(ZapProtocolExec.AUTH_DISABLED_ATTR, Boolean.TRUE);
         boolean reauthenticateProxy =
                 ctx.isRemoveUserDefinedAuthHeaders()
                         && credentialsProvider.hasProxyAuth()
@@ -418,6 +419,7 @@ public class HttpSenderApache
             if (!authHeaderPresent) {
                 requestCtx.setCredentialsProvider(
                         new HttpStateCredentialsProvider(user.getCorrespondingHttpState()));
+                requestCtx.setAttribute(ZapProtocolExec.AUTH_DISABLED_ATTR, Boolean.FALSE);
             }
         } else {
             switch (ctx.getCookieUsage()) {
@@ -639,6 +641,7 @@ public class HttpSenderApache
         request.removeHeaders(HttpHeader.AUTHORIZATION);
         requestCtx.setCredentialsProvider(
                 new HttpStateCredentialsProvider(user.getCorrespondingHttpState()));
+        requestCtx.setAttribute(ZapProtocolExec.AUTH_DISABLED_ATTR, Boolean.FALSE);
         return true;
     }
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
@@ -570,6 +570,118 @@ class HttpSenderImplUnitTest {
                 assertRequest(receivedMessage, requestMethod, requestBody);
             }
         }
+
+        @Test
+        void shouldBeSentWithExistingNtlmAuthentication() throws Exception {
+            // Given
+            AtomicInteger requestCount = new AtomicInteger();
+            server.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        var response = "HTTP/1.1 200 OK";
+
+                        int current = requestCount.getAndIncrement();
+                        if (current == 0) {
+                            response =
+                                    "HTTP/1.1 401 Unauthorized\n"
+                                            + "WWW-Authenticate: Negotiate\n"
+                                            + "WWW-Authenticate: NTLM\n";
+                        } else if (current == 1) {
+                            response =
+                                    "HTTP/1.1 401 Unauthorized\n"
+                                            + "WWW-Authenticate: NTLM TlRMTVNTUAACAAAAHAAcADgAAAAFgooCSahi6Sp2OccAAAAAAAAAAJAAkABUAAAACgBdWAAAAA9XAEkATgBEAEUAVgAyADMAMQAxAEUAVgBBAEwAAgAcAFcASQBOAEQARQBWADIAMwAxADEARQBWAEEATAABABwAVwBJAE4ARABFAFYAMgAzADEAMQBFAFYAQQBMAAQAHABXAGkAbgBEAGUAdgAyADMAMQAxAEUAdgBhAGwAAwAcAFcAaQBuAEQAZQB2ADIAMwAxADEARQB2AGEAbAAHAAgAs59Pa0JY2gEAAAAA\n";
+                        }
+                        msg.getResponseHeader().setMessage(response);
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+
+            HttpMessage initialRequest = createMessage(HttpRequestHeader.GET, "/");
+            String challenge = "NTLM TlRMTVNTUAABAAAAB4IIAAAAAAAAAAAAAAAAAAAAAAA=";
+            HttpMessage challengeRequest = createMessage(HttpRequestHeader.GET, "/");
+            challengeRequest.getRequestHeader().setHeader(HttpHeader.AUTHORIZATION, challenge);
+            String credentials =
+                    "NTLM TlRMTVNTUAADAAAAGAAYAF4AAAC8ALwAdgAAAAAAAABAAAAACAAIAEAAAAAWABYASAAAAAAAAAAAAAAABYIIAFUAcwBlAHIAVwBPAFIASwBTAFQAQQBUAEkATwBOAHizK+ek+7dlUzjnzJbXZRPGU9/At2s/Pl3sNL5zHWFfZkQYYCyprcMBAQAAAAAAAIBdvo1CWNoB4SlHsS/Dj0EAAAAAAgAcAFcASQBOAEQARQBWADIAMwAxADEARQBWAEEATAABABwAVwBJAE4ARABFAFYAMgAzADEAMQBFAFYAQQBMAAQAHABXAGkAbgBEAGUAdgAyADMAMQAxAEUAdgBhAGwAAwAcAFcAaQBuAEQAZQB2ADIAMwAxADEARQB2AGEAbAAHAAgAs59Pa0JY2gEAAAAA";
+            HttpMessage credentialsRequest = createMessage(HttpRequestHeader.GET, "/");
+            credentialsRequest.getRequestHeader().setHeader(HttpHeader.AUTHORIZATION, credentials);
+            // When
+            httpSender.sendAndReceive(initialRequest);
+            httpSender.sendAndReceive(challengeRequest);
+            httpSender.sendAndReceive(credentialsRequest);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(3));
+            assertThat(
+                    server.getReceivedMessages()
+                            .get(0)
+                            .getRequestHeader()
+                            .getHeader(HttpHeader.AUTHORIZATION),
+                    is(nullValue()));
+            assertThat(
+                    server.getReceivedMessages()
+                            .get(1)
+                            .getRequestHeader()
+                            .getHeader(HttpHeader.AUTHORIZATION),
+                    is(equalTo(challenge)));
+            assertThat(
+                    server.getReceivedMessages()
+                            .get(2)
+                            .getRequestHeader()
+                            .getHeader(HttpHeader.AUTHORIZATION),
+                    is(equalTo(credentials)));
+            assertThat(message.getResponseBody().toString(), is(not(equalTo(SERVER_RESPONSE))));
+        }
+
+        @Test
+        void shouldBeSentWithExistingIncorrectNtlmAuthentication() throws Exception {
+            // Given
+            AtomicInteger requestCount = new AtomicInteger();
+            server.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        var response =
+                                "HTTP/1.1 401 Unauthorized\n"
+                                        + "WWW-Authenticate: Negotiate\n"
+                                        + "WWW-Authenticate: NTLM\n";
+                        if (requestCount.getAndIncrement() == 1) {
+                            response =
+                                    "HTTP/1.1 401 Unauthorized\n"
+                                            + "WWW-Authenticate: NTLM TlRMTVNTUAACAAAAHAAcADgAAAAFgooCpgp96tbFDRsAAAAAAAAAAJAAkABUAAAACgBdWAAAAA9XAEkATgBEAEUAVgAyADMAMQAxAEUAVgBBAEwAAgAcAFcASQBOAEQARQBWADIAMwAxADEARQBWAEEATAABABwAVwBJAE4ARABFAFYAMgAzADEAMQBFAFYAQQBMAAQAHABXAGkAbgBEAGUAdgAyADMAMQAxAEUAdgBhAGwAAwAcAFcAaQBuAEQAZQB2ADIAMwAxADEARQB2AGEAbAAHAAgA2oCaJUNY2gEAAAAA";
+                        }
+                        msg.getResponseHeader().setMessage(response);
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+
+            HttpMessage initialRequest = createMessage(HttpRequestHeader.GET, "/");
+            String challenge = "NTLM TlRMTVNTUAABAAAAB4IIAAAAAAAAAAAAAAAAAAAAAAA=";
+            HttpMessage challengeRequest = createMessage(HttpRequestHeader.GET, "/");
+            challengeRequest.getRequestHeader().setHeader(HttpHeader.AUTHORIZATION, challenge);
+            String credentials =
+                    "NTLM TlRMTVNTUAADAAAAGAAYAFgAAAC8ALwAcAAAAAAAAABAAAAAAgACAEAAAAAWABYAQgAAAAAAAAAAAAAABYIIAFgAVwBPAFIASwBTAFQAQQBUAEkATwBOAP6yoXsqfSJ6sdpm5BsUKdLlurkW6n/9a5cWdamhy5bZRNgkApsZKiIBAQAAAAAAAIC+SixDWNoBSh9I+fDqnVEAAAAAAgAcAFcASQBOAEQARQBWADIAMwAxADEARQBWAEEATAABABwAVwBJAE4ARABFAFYAMgAzADEAMQBFAFYAQQBMAAQAHABXAGkAbgBEAGUAdgAyADMAMQAxAEUAdgBhAGwAAwAcAFcAaQBuAEQAZQB2ADIAMwAxADEARQB2AGEAbAAHAAgA2oCaJUNY2gEAAAAA";
+            HttpMessage credentialsRequest = createMessage(HttpRequestHeader.GET, "/");
+            credentialsRequest.getRequestHeader().setHeader(HttpHeader.AUTHORIZATION, credentials);
+            // When
+            httpSender.sendAndReceive(initialRequest);
+            httpSender.sendAndReceive(challengeRequest);
+            httpSender.sendAndReceive(credentialsRequest);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(3));
+            assertThat(
+                    server.getReceivedMessages()
+                            .get(0)
+                            .getRequestHeader()
+                            .getHeader(HttpHeader.AUTHORIZATION),
+                    is(nullValue()));
+            assertThat(
+                    server.getReceivedMessages()
+                            .get(1)
+                            .getRequestHeader()
+                            .getHeader(HttpHeader.AUTHORIZATION),
+                    is(equalTo(challenge)));
+            assertThat(
+                    server.getReceivedMessages()
+                            .get(2)
+                            .getRequestHeader()
+                            .getHeader(HttpHeader.AUTHORIZATION),
+                    is(equalTo(credentials)));
+            assertThat(message.getResponseBody().toString(), is(not(equalTo(SERVER_RESPONSE))));
+        }
     }
 
     static Stream<Arguments> chunkSizesAndSendAndReceiveMethods() {


### PR DESCRIPTION
Do not attempt to track NTLM auth being proxied, only do that when doing the authentication programmatically (e.g. user set).

Fix zaproxy/zaproxy#7685.