### PR TITLE
Authhelper: trad app auth detection improvements

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+
+### Changed
+- Handle traditional apps better in authentication detection dialog.
+- Make cookies set in auth request available to header based session management.
+
 ### Fixed
 - Correct HTTP field names shown in diagnostic data.
 

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -339,6 +339,8 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
                             .getExtensionLoader()
                             .getExtension(ExtensionSelenium.class);
 
+            Context context = Model.getSingleton().getSession().getContext(user.getContextId());
+
             try {
                 proxyPort = getProxy(user.getContext()).start(proxyHost, 0);
 
@@ -353,6 +355,7 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
 
                     if (AuthUtils.authenticateAsUser(
                             wd,
+                            context,
                             loginPageUrl,
                             userCreds.getUsername(),
                             userCreds.getPassword(),

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -347,6 +347,32 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldExtractCookies() throws Exception {
+        // Given
+        HttpMessage msg =
+                new HttpMessage(
+                        new HttpRequestHeader(
+                                "GET https://example.com/ HTTP/1.1\r\n"
+                                        + "Host: example.com\r\n"
+                                        + "Cookie: aaa=bbb\r\n\r\n"),
+                        new HttpRequestBody("Request Body"),
+                        new HttpResponseHeader(
+                                "HTTP/1.1 200 OK\r\n" + "Set-Cookie: ccc=ddd; HttpOnly; Secure"),
+                        new HttpResponseBody("Response Body"));
+        // When
+        Map<String, SessionToken> tokens = AuthUtils.getAllTokens(msg);
+
+        // Then
+        System.out.println(tokens);
+        assertThat(tokens.size(), is(equalTo(3)));
+        assertThat(tokens.get("cookie:aaa").getValue(), is(equalTo("bbb")));
+        assertThat(tokens.get("cookie:ccc").getValue(), is(equalTo("ddd")));
+        assertThat(
+                tokens.get("header:Set-Cookie").getValue(),
+                is(equalTo("ccc=ddd; HttpOnly; Secure")));
+    }
+
+    @Test
     void shouldGetEmptyHeaderTokens() throws Exception {
         // Given
         HttpMessage msg =


### PR DESCRIPTION
## Overview
If we fail to identify the session management then request the current page again - this can work well for more traditional web apps.
Also make cookies set in auth request available to header based session management.
These 2 changes mean that auth autodetection now works with both Bodgeit and DVWA.

## Related Issues


## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
