### PR TITLE
spider: fix exception in HTML parser

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Fix exception that happened with absolute dotted URLs in inlined content.
 
 ## [0.9.0] - 2024-01-26
 ### Added

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHtmlParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHtmlParser.java
@@ -331,7 +331,10 @@ public class SpiderHtmlParser extends SpiderParser {
                     }
 
                     if (foundMatch.startsWith(".")) {
-                        foundMatch = foundMatch.substring(foundMatch.indexOf('/'));
+                        int idx = foundMatch.indexOf('/');
+                        if (idx != -1) {
+                            foundMatch = foundMatch.substring(idx);
+                        }
                     }
 
                     processUrl(ctx, foundMatch, baseUrlForText);

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SpiderHtmlParserUnitTest.java
@@ -665,13 +665,13 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils<SpiderHtmlParser> {
         boolean completelyParsed = parser.parseResource(ctx);
         // Then
         assertThat(completelyParsed, is(equalTo(false)));
-        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(6)));
         assertThat(
                 listener.getUrlsFound(),
                 contains(
                         "http://example.com/sample",
                         "http://example2.com/test/p/string/fullUrl",
                         "http://example.com/sample/with/base/tag",
+                        "http://example.com/sample/.absolute-dotted",
                         "http://string.example.com:8443/inline/string",
                         "http://example.com/dot-prefix/inline/string",
                         "http://example.com/dot-dot-prefix/inline/string"));

--- a/addOns/spider/src/test/resources/org/zaproxy/addon/spider/parser/html/StringSpiderHtmlParser.html
+++ b/addOns/spider/src/test/resources/org/zaproxy/addon/spider/parser/html/StringSpiderHtmlParser.html
@@ -9,6 +9,7 @@
 
 <p>The test contains an inline string (http) - http://example2.com/test/p/string/fullUrl</p></br>
 <p>The test contains an inline string (absolute) - /with/base/tag</p></br>
+<p>The test contains an inline string (absolute dotted) - /.absolute-dotted</p></br>
 <p>The test contains an inline string (sub-domain using base scheme) - //string.example.com:8443/inline/string</p></br>
 <p>The test contains an inline string (dot prefix) - ./dot-prefix/inline/string</p></br>
 <p>The test contains an inline string (dot dot prefix) - ../dot-dot-prefix/inline/string</p></br>


### PR DESCRIPTION
Check the `/` is actually present in the string before obtaining the substring otherwise it would lead to an exception.

From logs in zaproxy/zaproxy#8327.

---
Log excerpt:
```
7186921 [ZAP-SpiderThreadPool-0-thread-2] ERROR org.zaproxy.zap.ZAP.UncaughtExceptionLogger - Exception in thread "ZAP-SpiderThreadPool-0-thread-2"
java.lang.StringIndexOutOfBoundsException: Range [-1, 13) out of bounds for length 13
        at jdk.internal.util.Preconditions$1.apply(Preconditions.java:55) ~[?:?]
        at jdk.internal.util.Preconditions$1.apply(Preconditions.java:52) ~[?:?]
        at jdk.internal.util.Preconditions$4.apply(Preconditions.java:213) ~[?:?]
        at jdk.internal.util.Preconditions$4.apply(Preconditions.java:210) ~[?:?]
        at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98) ~[?:?]
        at jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112) ~[?:?]
        at jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349) ~[?:?]
        at java.lang.String.checkBoundsBeginEnd(String.java:4861) ~[?:?]
        at java.lang.String.substring(String.java:2830) ~[?:?]
        at java.lang.String.substring(String.java:2803) ~[?:?]
        at org.zaproxy.addon.spider.parser.SpiderHtmlParser.parseSource(SpiderHtmlParser.java:334) ~[?:?]
        at org.zaproxy.addon.spider.parser.SpiderHtmlParser.parseResource(SpiderHtmlParser.java:113) ~[?:?]
        at org.zaproxy.addon.spider.SpiderTask.processResource(SpiderTask.java:389) ~[?:?]
        at org.zaproxy.addon.spider.SpiderTask.runImpl(SpiderTask.java:239) ~[?:?]
        at org.zaproxy.addon.spider.SpiderTask.run(SpiderTask.java:157) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.lang.Thread.run(Thread.java:1583) [?:?]
```