### PR TITLE
spider: skip parsing of empty SVGs

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Skip parsing of empty SVGs.
+
 ### Fixed
 - Fix exception that happened with absolute dotted URLs in inlined content.
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SvgHrefParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SvgHrefParser.java
@@ -205,6 +205,10 @@ public class SvgHrefParser extends SpiderParser {
     }
 
     private static boolean isSvg(HttpMessage msg) {
+        if (msg.getResponseBody().length() == 0) {
+            return false;
+        }
+
         if (msg.getResponseHeader().hasContentType("svg")) {
             return true;
         }

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SvgHrefParserUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SvgHrefParserUnitTest.java
@@ -56,6 +56,17 @@ class SvgHrefParserUnitTest extends SpiderParserTestUtils<SvgHrefParser> {
     }
 
     @Test
+    void shouldNotBeAbleToParseEmptySvg() {
+        // Given
+        messageWith("test.svg");
+        msg.setResponseBody("");
+        // When
+        boolean canParse = parser.canParseResource(ctx, false);
+        // Then
+        assertFalse(canParse);
+    }
+
+    @Test
     void shouldNotBeAbleToParseIrrelevantRequest() {
         // Given
         messageWith("test.test");
@@ -92,6 +103,17 @@ class SvgHrefParserUnitTest extends SpiderParserTestUtils<SvgHrefParser> {
         // Given
         messageWith("test");
         msg.setResponseBody("Foo Bar");
+        // When
+        boolean parse = parser.parseResource(ctx);
+        // Then
+        assertFalse(parse);
+    }
+
+    @Test
+    void shouldNotParseResourceWhenEmptySvg() {
+        // Given
+        messageWith("test.svg");
+        msg.setResponseBody("");
         // When
         boolean parse = parser.parseResource(ctx);
         // Then
@@ -293,6 +315,8 @@ class SvgHrefParserUnitTest extends SpiderParserTestUtils<SvgHrefParser> {
         } catch (HttpMalformedHeaderException e) {
             // ignore
         }
+
+        msg.setResponseBody("Non-SVG content by default.");
 
         try {
             msg.setResponseHeader(


### PR DESCRIPTION
Avoid unnecessary warnings from attempting to parse empty SVGs, which could happen when what looked like a SVG was actually a redirect with empty body.

From logs in zaproxy/zaproxy#8327.

---
Log excerpt:
```
6983864 [ZAP-SpiderThreadPool-0-thread-5] WARN  org.zaproxy.addon.spider.parser.SvgHrefParser - An error occurred trying to parse https://example.com/_autoindex/assets/icons/file.svg
org.xml.sax.SAXParseException: Premature end of file.
        at com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:262) ~[?:?]
        at com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:342) ~[?:?]
        at org.zaproxy.addon.spider.parser.SvgHrefParser.parseResource(SvgHrefParser.java:84) ~[?:?]
        at org.zaproxy.addon.spider.SpiderTask.processResource(SpiderTask.java:389) ~[?:?]
        at org.zaproxy.addon.spider.SpiderTask.runImpl(SpiderTask.java:239) ~[?:?]
        at org.zaproxy.addon.spider.SpiderTask.run(SpiderTask.java:157) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.lang.Thread.run(Thread.java:1583) [?:?]
```