### PR TITLE
spider: Change param Enum automation handling to be more forgiving

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Skip parsing of empty SVGs.
 - Maintenance changes.
+- Setting "Query Parameters Handling" via automation framework should now be more forgiving as to the case of the values (enums).
 
 ### Fixed
 - Ensure issues in one parser don't break the whole parsing process.

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJob.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJob.java
@@ -29,7 +29,10 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -50,6 +53,7 @@ import org.zaproxy.addon.automation.tests.AbstractAutomationTest;
 import org.zaproxy.addon.automation.tests.AutomationStatisticTest;
 import org.zaproxy.addon.network.common.ZapUnknownHostException;
 import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.addon.spider.SpiderParam.HandleParametersOption;
 import org.zaproxy.addon.spider.SpiderScan;
 import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.users.User;
@@ -461,6 +465,10 @@ public class SpiderJob extends AutomationJob {
         private Boolean failIfFoundUrlsLessThan;
         private Boolean warnIfFoundUrlsLessThan;
 
+        private static final HandleParametersOption HANDLE_PARAMETERS_OPTION_DEFAULT =
+                HandleParametersOption.USE_ALL;
+        private static final Logger LOGGER = LogManager.getLogger(Parameters.class);
+
         public Parameters() {
             super();
         }
@@ -538,7 +546,21 @@ public class SpiderJob extends AutomationJob {
         }
 
         public void setHandleParameters(String handleParameters) {
-            this.handleParameters = handleParameters;
+            this.handleParameters = getHandleParamsOptionEnum(handleParameters).name();
+        }
+
+        private HandleParametersOption getHandleParamsOptionEnum(String handleParametersVisited) {
+            HandleParametersOption option =
+                    EnumUtils.getEnumIgnoreCase(
+                            HandleParametersOption.class, handleParametersVisited);
+            if (option == null) {
+                LOGGER.warn(
+                        "\"{}\" is not a valid HandleParametersOption value, defaulting to \"{}\"",
+                        handleParametersVisited,
+                        HANDLE_PARAMETERS_OPTION_DEFAULT);
+                option = HANDLE_PARAMETERS_OPTION_DEFAULT;
+            }
+            return option;
         }
 
         public Integer getMaxParseSizeBytes() {

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
@@ -23,6 +23,7 @@ import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -49,6 +50,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentMatcher;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -69,7 +72,9 @@ import org.zaproxy.addon.automation.tests.AutomationStatisticTest;
 import org.zaproxy.addon.network.common.ZapUnknownHostException;
 import org.zaproxy.addon.spider.ExtensionSpider2;
 import org.zaproxy.addon.spider.SpiderParam;
+import org.zaproxy.addon.spider.SpiderParam.HandleParametersOption;
 import org.zaproxy.addon.spider.SpiderScan;
+import org.zaproxy.addon.spider.automation.SpiderJob.Parameters;
 import org.zaproxy.addon.spider.automation.SpiderJob.UrlRequester;
 import org.zaproxy.zap.extension.stats.ExtensionStats;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
@@ -685,7 +690,7 @@ class SpiderJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getMaxChildren(), is(equalTo(2)));
         assertThat(job.getParameters().getAcceptCookies(), is(equalTo(true)));
         assertThat(job.getParameters().getHandleODataParametersVisited(), is(equalTo(true)));
-        assertThat(job.getParameters().getHandleParameters(), is(equalTo("ignore_completely")));
+        assertThat(job.getParameters().getHandleParameters(), is(equalTo("IGNORE_COMPLETELY")));
         assertThat(job.getParameters().getMaxParseSizeBytes(), is(equalTo(2)));
         assertThat(job.getParameters().getParseComments(), is(equalTo(true)));
         assertThat(job.getParameters().getParseGit(), is(equalTo(true)));
@@ -765,6 +770,25 @@ class SpiderJobUnitTest extends TestUtils {
         assertThat(progress.getWarnings().size(), is(equalTo(1)));
         assertThat(
                 progress.getWarnings().get(0), is(equalTo("!automation.error.options.unknown!")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ignore_value", "USE_ALL", "IGnoRe_compLETELY"})
+    void shouldSetHandleParamOptionInAnyCase(String optValue) {
+        Parameters params = new Parameters();
+        assertDoesNotThrow(() -> params.setHandleParameters(optValue));
+    }
+
+    @Test
+    void shouldDefaultHandleParamOptionIfValueInvalid() {
+        // Given
+        String optValue = "invalid";
+        Parameters params = new Parameters();
+        // When
+        params.setHandleParameters(optValue);
+        String hpo = params.getHandleParameters();
+        // Then
+        assertThat(hpo, is(equalTo(HandleParametersOption.USE_ALL.name())));
     }
 
     private static class TestServerHandler extends NanoServerHandler {


### PR DESCRIPTION
## Overview
- CHANGELOG > Add change note.
- SpiderJob > Tweak handling to ignore case.
- SpiderJobUnitTest > Tweak test to use enum.
- SpiderJobDialog > Changed to use the enum values.
- spider.gradle.kts > Tweaked to exclude the automation sub-package from japicmp.

## Related Issues
Per: https://groups.google.com/g/zaproxy-users/c/zhQCsrBlh5g

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests (updated)
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
