### PR TITLE
reports: fix illegal chrs in pdf reports

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-### Changed
-- Maintenance changes.
+### Fixed
+- Error message to give report name.
+- Issues with illegal XML characters in pdf reports (Issue 8330).
+- Corrected pdf report href from #olugin to #plugin.
+- Deprecated syntax in risk-confidence report.
 
 ## [0.28.0] - 2024-01-16
 ### Changed

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
@@ -509,9 +509,7 @@ public class ReportDialog extends StandardFieldsDialog {
                             Constant.messages.getString(
                                     "reports.dialog.error.generate", e.getMessage()));
             LOGGER.error(
-                    "Failed to generate a report using template {}",
-                    extension.getTemplateByDisplayName(getStringValue(FIELD_TEMPLATE)),
-                    e);
+                    "Failed to generate a report using template {}", template.getDisplayName(), e);
         }
     }
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportHelper.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportHelper.java
@@ -241,4 +241,11 @@ public class ReportHelper {
                 .replace("&lt;p&gt;", "<p>")
                 .replace("&lt;/p&gt;", "</p>");
     }
+
+    public static String escapeXml(String text) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        return XMLStringUtil.escapeControlChrs(text);
+    }
 }

--- a/addOns/reports/src/main/zapHomeFiles/reports/risk-confidence-html/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/risk-confidence-html/report.html
@@ -120,7 +120,7 @@
 				<h3 data-th-text="#{report.template.section.reportDescription}">Report
 					description</h3>
 				<div class="report-description--container">
-					<th-block data-th-replace="::nl2pbr(text=${description})">
+					<th-block data-th-replace="~{::nl2pbr(text=${description})}">
 					<p>Report description</p>
 					</th-block>
 				</div>

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-pdf/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-pdf/report.html
@@ -124,7 +124,7 @@ td {
 	<p />
 	<th:block
 		th:each="desc, state: ${#strings.arraySplit(description, '\n')}">
-		<th:block th:text="${desc}"></th:block>
+		<th:block th:text="${helper.escapeXml(desc)}"></th:block>
 		<br th:if="${!state.last}" />
 	</th:block>
 
@@ -179,7 +179,8 @@ td {
 			</tr>
 			<tr th:each="alert: ${alertTree.children}">
 				<td><a th:href="'#' + ${alert.userObject.pluginId}"
-					th:text="${alert.nodeName}" href="#oluginId">Alert Name</a></td>
+					th:text="${helper.escapeXml(alert.nodeName)}" href="#pluginId">Alert
+						Name</a></td>
 				<td align="center" th:class="${'risk-' + alert.risk}"
 					th:text="${helper.getRiskString(alert.risk)}">Risk</td>
 				<td align="center" th:text="${alert.childCount}">Count</td>
@@ -196,14 +197,14 @@ td {
 					<th width="20%" th:class="${'risk-' + alert.risk}"><a
 						th:id="${alert.userObject.pluginId}"></a>
 						<div th:text="${helper.getRiskString(alert.risk)}">Risk</div></th>
-					<th th:text="${alert.nodeName}" th:class="${'risk-' + alert.risk}">Alert
-						Name</th>
+					<th th:text="${helper.escapeXml(alert.nodeName)}"
+						th:class="${'risk-' + alert.risk}">Alert Name</th>
 				</tr>
 				<tr>
 					<td th:text="#{report.alerts.detail.description}" width="20%">Description</td>
 					<td width="80%"><th:block
 							th:each="desc, state: ${#strings.arraySplit(alert.userObject.description, '\n')}">
-							<div th:text="${desc}">Description</div>
+							<div th:text="${helper.escapeXml(desc)}">Description</div>
 							<br th:if="${!state.last}" />
 						</th:block></td>
 				</tr>
@@ -247,7 +248,7 @@ td {
 					<td th:text="#{report.alerts.detail.solution}" width="20%">Solution</td>
 					<td width="80%"><th:block
 							th:each="soln, state: ${#strings.arraySplit(alert.userObject.solution, '\n')}">
-							<div th:text="${soln}">Solution</div>
+							<div th:text="${helper.escapeXml(soln)}">Solution</div>
 							<br th:if="${!state.last}" />
 						</th:block></td>
 				</tr>
@@ -255,7 +256,8 @@ td {
 					<td th:text="#{report.alerts.detail.reference}" width="20%">Reference</td>
 					<td width="80%"><th:block
 							th:each="ref, state: ${#strings.arraySplit(alert.userObject.reference, '\n')}">
-							<a th:href="${ref}" th:text="${ref}" href="ref.html">Ref</a>
+							<a th:href="${helper.escapeXml(ref)}"
+								th:text="${helper.escapeXml(ref)}" href="ref.html">Ref</a>
 							<br th:if="${!state.last}" />
 						</th:block></td>
 				</tr>


### PR DESCRIPTION
## Overview
Now fixes the pdf issues, hopefully!

## Related Issues
Fixes https://github.com/zaproxy/zaproxy/issues/8330

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
