### PR TITLE
graaljs: verify script templates can be parsed

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.5.0] - 2023-10-12
 ### Changed

--- a/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/ExtensionGraalJs.java
+++ b/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/ExtensionGraalJs.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.zaproxy.zap.control.AddOn;
+import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
@@ -69,14 +70,11 @@ public class ExtensionGraalJs extends ExtensionAdaptor {
 
     @Override
     public void hook(ExtensionHook extensionHook) {
-        ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-        try {
-            engineWrapper =
-                    new GraalJsEngineWrapper(getDefaultTemplates(), createScriptEngineIcon());
-        } finally {
-            Thread.currentThread().setContextClassLoader(previousContextClassLoader);
-        }
+        engineWrapper =
+                new GraalJsEngineWrapper(
+                        ExtensionFactory.getAddOnLoader(),
+                        getDefaultTemplates(),
+                        createScriptEngineIcon());
         getExtScript().registerScriptEngineWrapper(engineWrapper);
     }
 

--- a/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/GraalJsEngineWrapper.java
+++ b/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/GraalJsEngineWrapper.java
@@ -29,18 +29,20 @@ import javax.swing.ImageIcon;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
-import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.script.DefaultEngineWrapper;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
 public class GraalJsEngineWrapper extends DefaultEngineWrapper {
 
+    private final ClassLoader hostClassLoader;
     private final List<Path> defaultTemplates;
     private final ImageIcon icon;
 
-    public GraalJsEngineWrapper(List<Path> defaultTemplates, ImageIcon icon) {
+    public GraalJsEngineWrapper(
+            ClassLoader hostClassLoader, List<Path> defaultTemplates, ImageIcon icon) {
         super(new GraalJSEngineFactory());
 
+        this.hostClassLoader = hostClassLoader;
         this.defaultTemplates = Objects.requireNonNull(defaultTemplates);
         this.icon = icon;
     }
@@ -76,7 +78,7 @@ public class GraalJsEngineWrapper extends DefaultEngineWrapper {
                         .option("js.print", "true")
                         .option("js.nashorn-compat", "true")
                         .allowAllAccess(true)
-                        .hostClassLoader(ExtensionFactory.getAddOnLoader());
+                        .hostClassLoader(hostClassLoader);
 
         return GraalJSScriptEngine.create(engine, contextBuilder);
     }

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/VerifyScriptTemplates.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/VerifyScriptTemplates.java
@@ -1,0 +1,64 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.graaljs;
+
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
+import org.junit.jupiter.api.BeforeAll;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.testutils.AbstractVerifyScriptTemplates;
+
+/** Verifies that the Kotlin script templates are parsed without errors. */
+public class VerifyScriptTemplates extends AbstractVerifyScriptTemplates {
+
+    private static ScriptEngine se;
+
+    @BeforeAll
+    static void setUp() {
+        se =
+                new GraalJsEngineWrapper(
+                                VerifyScriptTemplates.class.getClassLoader(), List.of(), null)
+                        .getEngine();
+    }
+
+    @Override
+    protected String getScriptExtension() {
+        return ".js";
+    }
+
+    @Override
+    protected void parseTemplate(Path template) throws Exception {
+        se.put("control", Control.getSingleton());
+        se.put("model", Model.getSingleton());
+
+        try (Reader reader = Files.newBufferedReader(template, StandardCharsets.UTF_8)) {
+            Compilable c = (Compilable) se;
+            CompiledScript cs = c.compile(reader);
+            cs.eval();
+        }
+    }
+}

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/AbstractVerifyScriptTemplates.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/AbstractVerifyScriptTemplates.java
@@ -35,10 +35,17 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Verifies that script templates are parsed without errors. */
-public abstract class AbstractVerifyScriptTemplates {
+public abstract class AbstractVerifyScriptTemplates extends TestUtils {
+
+    @Override
+    @BeforeEach
+    protected void setUpZap() throws Exception {
+        super.setUpZap();
+    }
 
     @Test
     public void shouldParseTemplates() throws Exception {


### PR DESCRIPTION
Add tests to verify that the JavaScript templates are parsed without errors.
Remove workaround that reset the class loader as it's no longer needed.