### PR TITLE
scripts: Enable save button on script creation

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - The scan rule functionality of scripts was moved from the ZAP core to this add-on (Related to Issue 7105).
 
+### Fixed
+- The save button was not enabled for new scripts upon creation.
+
 ## [44] - 2023-12-19
 ### Changed
 - Rename "Script Console" in the Options panel list to "Console".

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -254,6 +254,7 @@ public class NewScriptDialog extends StandardFieldsDialog {
         script.setDescription(this.getStringValue(FIELD_DESC));
         script.setLoadOnStart(this.getBoolValue(FIELD_LOAD));
         script.setEnabled(getBoolValue(FIELD_ENABLED));
+        script.setChanged(true);
 
         extension.getExtScript().addScript(script);
     }


### PR DESCRIPTION
## Overview
The save button was not enabled for new scripts upon creation.
Mark the script as changed when it is created.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
