### PR TITLE
automation: use newer core code

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Maintenance changes.
+
 ### Fixed
 - Correct parsing of attack strength and alert threshold in some locales.
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/VerificationData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/VerificationData.java
@@ -67,6 +67,9 @@ public class VerificationData extends AutomationData {
     public VerificationData(Context context) {
         AuthenticationMethod authMethod = context.getAuthenticationMethod();
         switch (authMethod.getAuthCheckingStrategy()) {
+            case AUTO_DETECT:
+                this.setMethod(METHOD_AUTO_DETECT);
+                break;
             case EACH_REQ:
                 this.setMethod(METHOD_REQUEST);
                 break;
@@ -80,10 +83,6 @@ public class VerificationData extends AutomationData {
             default:
                 this.setMethod(METHOD_POLL);
                 break;
-        }
-        if ("AUTO_DETECT".equals(authMethod.getAuthCheckingStrategy().name())) {
-            // Available in the latest weeklies and 2.13+
-            this.setMethod(METHOD_AUTO_DETECT);
         }
 
         if (authMethod.getLoggedInIndicatorPattern() != null) {
@@ -192,6 +191,9 @@ public class VerificationData extends AutomationData {
         AuthenticationMethod authMethod = context.getAuthenticationMethod();
         String planMethod = this.getMethod().toLowerCase(Locale.ROOT);
         switch (planMethod) {
+            case METHOD_AUTO_DETECT:
+                authMethod.setAuthCheckingStrategy(AuthCheckingStrategy.AUTO_DETECT);
+                break;
             case METHOD_BOTH:
                 authMethod.setAuthCheckingStrategy(AuthCheckingStrategy.EACH_REQ_RESP);
                 break;
@@ -205,14 +207,6 @@ public class VerificationData extends AutomationData {
             default:
                 authMethod.setAuthCheckingStrategy(AuthCheckingStrategy.POLL_URL);
                 break;
-        }
-        if ("autodetect".equals(planMethod)) {
-            // Available in the latest weeklies and 2.13+
-            try {
-                authMethod.setAuthCheckingStrategy(AuthCheckingStrategy.valueOf("AUTO_DETECT"));
-            } catch (Exception e) {
-                // Ignore - not yet supported so will default to "poll"
-            }
         }
 
         if (POLL_UNIT_REQUESTS.equalsIgnoreCase(this.getPollUnits())) {


### PR DESCRIPTION
Use already available core code as the add-on is already targeting newer core version.