### PR TITLE
Normalize extension's dependency declaration

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Maintenance changes.
 
 ## [9] - 2023-09-08
 ### Added

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
@@ -95,16 +95,11 @@ public class ExtensionAccessControl extends ExtensionAdaptor
     public static final String NAME = "ExtensionAccessControl";
 
     /** The list of extensions this depends on. */
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
-
-    static {
-        // Prepare a list of Extensions on which this extension depends
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionUserManagement.class);
-        dependencies.add(ExtensionAuthentication.class);
-        dependencies.add(ExtensionAuthorization.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(
+                    ExtensionUserManagement.class,
+                    ExtensionAuthentication.class,
+                    ExtensionAuthorization.class);
 
     /** The status panel used by the extension. */
     private AccessControlStatusPanel statusPanel;

--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Reword label in the automation job to prevent any confusion between the Alert Filters and the Alerts.
+- Maintenance changes.
 
 ## [19] - 2023-11-16
 ### Changed

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/ExtensionAlertFiltersAutomation.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/ExtensionAlertFiltersAutomation.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.alertFilters.automation;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,16 +32,10 @@ public class ExtensionAlertFiltersAutomation extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionAlertFiltersAutomation";
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionAlertFilters.class, ExtensionAutomation.class);
 
     private AlertFilterJob job;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionAlertFilters.class);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionAlertFiltersAutomation() {
         super(NAME);

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [62] - 2024-01-26
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/payloader/ExtensionPayloader.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/payloader/ExtensionPayloader.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrules.payloader;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -35,16 +33,11 @@ import org.zaproxy.zap.extension.custompayloads.PayloadCategory;
 public class ExtensionPayloader extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionPayloaderAscanRules";
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionCustomPayloads.class);
     private static ExtensionCustomPayloads ecp;
     private PayloadCategory uaCategory;
     private PayloadCategory hfCategory;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionCustomPayloads.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionPayloader() {
         super(NAME);

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [1.22.0] - 2024-01-26
 ### Added

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/formhandler/ExtensionCommonlibFormHandler.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/formhandler/ExtensionCommonlibFormHandler.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.commonlib.formhandler;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,8 +32,7 @@ import org.zaproxy.zap.model.ValueGenerator;
 public class ExtensionCommonlibFormHandler extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(
-                    Arrays.asList(ExtensionFormHandler.class, ExtensionCommonlib.class));
+            List.of(ExtensionFormHandler.class, ExtensionCommonlib.class);
 
     @Override
     public String getUIName() {

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [18] - 2023-10-12
 ### Changed

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/ExtensionDomXSS.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/ExtensionDomXSS.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.domxss;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,15 +42,8 @@ public class ExtensionDomXSS extends ExtensionAdaptor {
 
     private static final Logger LOGGER = LogManager.getLogger(ExtensionDomXSS.class);
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionNetwork.class);
-        dependencies.add(ExtensionSelenium.class);
-
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionNetwork.class, ExtensionSelenium.class);
 
     private DomXssScanRule scanner;
 

--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [1.4.0] - 2023-10-12
 ### Changed

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/ExtensionEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/ExtensionEncoder.java
@@ -23,7 +23,6 @@ import java.awt.Frame;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.ImageIcon;
 import javax.swing.KeyStroke;
@@ -51,14 +50,12 @@ public class ExtensionEncoder extends ExtensionAdaptor {
     public static final ImageIcon ICON;
 
     private static final Logger LOGGER = LogManager.getLogger(ExtensionEncoder.class);
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(ExtensionScript.class);
     private static final String CORE_MENU_IDENTIFIER = "enc2.tools.menu.encdec";
     private static final String ENCODER_MENU_IDENTIFIER = "encoder.tools.menu.encdec";
 
     static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
         ICON = createIcon("encoder.png");
     }
 

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Initial PCAP import support (Issue 4812).
 
+### Changed
+- Maintenance changes.
 
 ## [0.8.0] - 2023-11-10
 ### Changed

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.exim;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.JMenu;
 import org.parosproxy.paros.Constant;
@@ -46,7 +44,7 @@ public class ExtensionExim extends ExtensionAdaptor {
     public static final String EXIM_OUTPUT_ERROR = "exim.output.error";
     private static final String NAME = "ExtensionExim";
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(Arrays.asList(ExtensionCommonlib.class));
+            List.of(ExtensionCommonlib.class);
 
     private JMenu menuExport;
 

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ExtensionEximAutomation.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ExtensionEximAutomation.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.exim.automation;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,16 +32,10 @@ public class ExtensionEximAutomation extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionEximAutomation";
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionExim.class, ExtensionAutomation.class);
 
     private ImportJob importJob;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionExim.class);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionEximAutomation() {
         super(NAME);

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/ExtensionFrontEndScanner.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/ExtensionFrontEndScanner.java
@@ -27,8 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -78,15 +76,8 @@ public class ExtensionFrontEndScanner extends ExtensionAdaptor {
 
     private static final Logger LOGGER = LogManager.getLogger(ExtensionFrontEndScanner.class);
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionAlert.class);
-        dependencies.add(ExtensionScript.class);
-
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionAlert.class, ExtensionScript.class);
 
     public ExtensionFrontEndScanner() {
         super(NAME);

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [13.12.0] - 2023-10-12
 ### Changed

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.fuzz.httpfuzzer;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.swing.ImageIcon;
@@ -57,13 +56,8 @@ import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 
 public class ExtensionHttpFuzzer extends ExtensionAdaptor {
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionFuzz.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionFuzz.class);
 
     private HttpFuzzerHandler httpFuzzerHandler;
 

--- a/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/ExtensionGraalJs.java
+++ b/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/ExtensionGraalJs.java
@@ -39,13 +39,8 @@ public class ExtensionGraalJs extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionGraalJs";
 
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(ExtensionScript.class);
 
     private GraalJsEngineWrapper engineWrapper;
 

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - Video link in help for Automation Framework job.
 
+### Changed
+- Maintenance changes.
+
 ## [0.22.0] - 2023-12-19
 ### Added
 - Fingerprinting check for the GraphQL.NET engine.

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/ExtensionGraphQlAutomation.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/ExtensionGraphQlAutomation.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.graphql.automation;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,16 +32,10 @@ public class ExtensionGraphQlAutomation extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionGraphQlAutomation";
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionGraphQl.class, ExtensionAutomation.class);
 
     private GraphQlJob job;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionGraphQl.class);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionGraphQlAutomation() {
         super(NAME);

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/spider/ExtensionGraphQlSpider.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/spider/ExtensionGraphQlSpider.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.graphql.spider;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -35,8 +33,7 @@ import org.zaproxy.addon.spider.parser.SpiderParser;
 public class ExtensionGraphQlSpider extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(
-                    Arrays.asList(ExtensionSpider2.class, ExtensionGraphQl.class));
+            List.of(ExtensionSpider2.class, ExtensionGraphQl.class);
 
     private SpiderParser spiderParser;
     private ParseFilter parseFilter;

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Maintenance changes.
 - Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 - Dependency updates.
 

--- a/addOns/groovy/src/main/java/org/zaproxy/zap/extension/groovy/ExtensionGroovy.java
+++ b/addOns/groovy/src/main/java/org/zaproxy/zap/extension/groovy/ExtensionGroovy.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.groovy;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.ImageIcon;
 import org.parosproxy.paros.Constant;
@@ -36,13 +34,10 @@ public class ExtensionGroovy extends ExtensionAdaptor {
     public static final String NAME = "ExtensionGroovy";
     public static final int EXTENSION_ORDER = 83;
     public static final ImageIcon GROOVY_ICON;
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(ExtensionScript.class);
 
     static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-
         GROOVY_ICON =
                 View.isInitialised()
                         ? new ImageIcon(

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Maintenance changes.
 - This add-on now depends on the Scripts add-on for providing scanning related functionality.
 - The active and passive scan rule templates were updated to import classes from the scripts add-on.
 

--- a/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
+++ b/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
@@ -45,13 +45,10 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
     public static final String NAME = "ExtensionJruby";
     public static final ImageIcon RUBY_ICON;
 
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(ExtensionScript.class);
 
     static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-
         RUBY_ICON =
                 View.isInitialised()
                         ? new ImageIcon(

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [14] - 2023-12-19
 ### Changed

--- a/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/ExtensionJython.java
+++ b/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/ExtensionJython.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.jython;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.ImageIcon;
 import org.parosproxy.paros.Constant;
@@ -37,13 +35,10 @@ public class ExtensionJython extends ExtensionAdaptor {
     public static final String NAME = "ExtensionJython";
     public static final ImageIcon PYTHON_ICON;
 
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(ExtensionScript.class);
 
     static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-
         PYTHON_ICON =
                 View.isInitialised()
                         ? new ImageIcon(

--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.14.0.
+- Maintenance changes.
 
 ### Added
 - Script template: encode-decode-template.kts, for the Encoder (encode/decode/hash) add-on (Issue 5996).

--- a/addOns/kotlin/src/main/java/org/zaproxy/addon/kotlin/ExtensionKotlin.java
+++ b/addOns/kotlin/src/main/java/org/zaproxy/addon/kotlin/ExtensionKotlin.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.kotlin;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.ImageIcon;
 import org.parosproxy.paros.Constant;
@@ -36,13 +34,10 @@ public class ExtensionKotlin extends ExtensionAdaptor {
     public static final String NAME = "ExtensionKotlin";
 
     static final ImageIcon KOTLIN_ICON;
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(ExtensionScript.class);
 
     static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-
         KOTLIN_ICON =
                 View.isInitialised()
                         ? new ImageIcon(ExtensionKotlin.class.getResource("resources/kotlin.png"))

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.17.0] - 2023-10-12
 ### Changed

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -21,7 +21,6 @@ package org.zaproxy.addon.oast;
 
 import static java.util.Collections.synchronizedMap;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +71,7 @@ public class ExtensionOast extends ExtensionAdaptor {
     private static final String OAST_PERSISTENCE_UNIT_NAME = "oast";
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(Arrays.asList(ExtensionNetwork.class));
+            List.of(ExtensionNetwork.class);
 
     private final Map<String, OastService> services = new HashMap<>();
 

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/scripts/ExtensionOastScripts.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/scripts/ExtensionOastScripts.java
@@ -21,8 +21,6 @@ package org.zaproxy.addon.oast.scripts;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,21 +37,14 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 
 public class ExtensionOastScripts extends ExtensionAdaptor {
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionOast.class, ExtensionScript.class, ExtensionGraalJs.class);
     private static final Logger LOGGER = LogManager.getLogger(ExtensionOastScripts.class);
     private static final String TEMPLATE_REGISTER_REQUEST_HANDLER = "OAST Request Handler.js";
     private static final String SCRIPT_GET_BOAST_SERVERS = "OAST Get BOAST Servers.js";
     private static final String SCRIPT_GET_INTERACTSH_PAYLOADS = "OAST Get Interactsh Payloads.js";
 
     private ExtensionScript extScript;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(3);
-        dependencies.add(ExtensionOast.class);
-        dependencies.add(ExtensionScript.class);
-        dependencies.add(ExtensionGraalJs.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     @Override
     public String getName() {

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [39] - 2024-01-26
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -83,7 +83,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     private static final String THREAD_PREFIX = "ZAP-Import-OpenAPI-";
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(Arrays.asList(ExtensionCommonlib.class));
+            List.of(ExtensionCommonlib.class);
 
     private ZapMenuItem menuImportOpenApi;
     private ImportDialog importDialog;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/ExtensionOpenApiAutomation.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/ExtensionOpenApiAutomation.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.openapi.automation;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,16 +32,10 @@ public class ExtensionOpenApiAutomation extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionOpenApiAutomation";
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionOpenApi.class, ExtensionAutomation.class);
 
     private OpenApiJob job;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionOpenApi.class);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionOpenApiAutomation() {
         super(NAME);

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/ExtensionOpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/ExtensionOpenApiSpider.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.openapi.spider;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,8 +36,7 @@ public class ExtensionOpenApiSpider extends ExtensionAdaptor {
     public static final String NAME = "ExtensionOpenApiSpider";
     private static final Logger LOGGER = LogManager.getLogger(ExtensionOpenApiSpider.class);
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(
-                    Arrays.asList(ExtensionSpider2.class, ExtensionOpenApi.class));
+            List.of(ExtensionSpider2.class, ExtensionOpenApi.class);
 
     private SpiderParser customSpider;
 

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +84,7 @@ public class ExtensionPlugNHack extends ExtensionAdaptor
     private static final Logger LOGGER = LogManager.getLogger(ExtensionPlugNHack.class);
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(Arrays.asList(ExtensionNetwork.class));
+            List.of(ExtensionNetwork.class);
 
     private static final String REPLACE_ROOT_TOKEN = "__REPLACE_ROOT__";
     private static final String REPLACE_ID_TOKEN = "__REPLACE_ID__";

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/manualsend/ExtensionPlugNHackManualSend.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/manualsend/ExtensionPlugNHackManualSend.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.plugnhack.manualsend;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,7 +32,7 @@ import org.zaproxy.zap.extension.plugnhack.ExtensionPlugNHack;
 public class ExtensionPlugNHackManualSend extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(Arrays.asList(ExtensionPlugNHack.class));
+            List.of(ExtensionPlugNHack.class);
 
     private ExtensionPlugNHack extensionPlugNHack;
 

--- a/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
+++ b/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.portscan;
 
 import java.awt.EventQueue;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import javax.swing.tree.TreeNode;
@@ -51,7 +50,7 @@ public class ExtensionPortScan extends ExtensionAdaptor
     private static final Logger LOGGER = LogManager.getLogger(ExtensionPortScan.class);
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.singletonList(ExtensionNetwork.class);
+            List.of(ExtensionNetwork.class);
 
     // Could be after the last one that saves the HttpMessage, as this ProxyListener doesn't change
     // the HttpMessage.

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Changed
+- Maintenance changes.
 - The following rules now include example alert functionality for documentation generation purposes (Issue 6119):
     - Timestamp Disclosure - Unix
     - Hash Disclosure

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/payloader/ExtensionPayloader.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscanrules.payloader;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -36,17 +34,12 @@ import org.zaproxy.zap.extension.pscanrules.UsernameIdorScanRule;
 public class ExtensionPayloader extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionPayloaderPscanRulesRelease";
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionCustomPayloads.class);
     private static ExtensionCustomPayloads ecp;
     private PayloadCategory idorCategory;
     private PayloadCategory errorCategory;
     private PayloadCategory suspiciousCommentsCategory;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionCustomPayloads.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionPayloader() {
         super(NAME);

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Website alert links (Issue 8189).
 
+### Changed
+- Maintenance changes.
+
 ## [36] - 2024-01-16
 ### Changed
 - Update minimum ZAP version to 2.14.0.

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/payloader/ExtensionPayloader.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscanrulesBeta.payloader;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,15 +32,10 @@ import org.zaproxy.zap.extension.pscanrulesBeta.JsFunctionScanRule;
 public class ExtensionPayloader extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionPayloaderPscanRulesBeta";
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionCustomPayloads.class);
     private static ExtensionCustomPayloads ecp;
     private PayloadCategory jsFuncCategory;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionCustomPayloads.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionPayloader() {
         super(NAME);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/ExtensionQuickStartAjaxSpider.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/ExtensionQuickStartAjaxSpider.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart.ajaxspider;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -40,16 +38,10 @@ public class ExtensionQuickStartAjaxSpider extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionQuickStartAjaxSpider";
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionAjax.class, ExtensionSelenium.class);
 
     private AjaxSpiderExplorer ase;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionAjax.class);
-        dependencies.add(ExtensionSelenium.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionQuickStartAjaxSpider() {
         super(NAME);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart.launch;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -58,14 +56,8 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
 
     private JButton launchToolbarButton;
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionQuickStart.class);
-        dependencies.add(ExtensionSelenium.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionQuickStart.class, ExtensionSelenium.class);
 
     private ImageIcon chromeIcon;
     private ImageIcon chromiumIcon;

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/spider/ExtensionQuickStartSpider.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/spider/ExtensionQuickStartSpider.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart.spider;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.JCheckBox;
 import org.parosproxy.paros.Constant;
@@ -38,8 +36,7 @@ import org.zaproxy.zap.model.Target;
 public class ExtensionQuickStartSpider extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(
-                    Arrays.asList(ExtensionQuickStart.class, ExtensionSpider2.class));
+            List.of(ExtensionQuickStart.class, ExtensionSpider2.class);
 
     private TraditionalSpiderImpl traditionalSpider;
 

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.28.0] - 2024-01-16
 ### Changed

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ExtensionReportAutomation.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ExtensionReportAutomation.java
@@ -22,8 +22,6 @@ package org.zaproxy.addon.reports.automation;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -48,7 +46,8 @@ public class ExtensionReportAutomation extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionReportAutomation";
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionAutomation.class);
 
     private static final String RESOURCES_DIR = "/org/zaproxy/addon/reports/resources/";
 
@@ -56,12 +55,6 @@ public class ExtensionReportAutomation extends ExtensionAdaptor {
     private OutputSummaryJob outputSummaryJob;
 
     private ReportDataHandler reportDataHandler;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionReportAutomation() {
         super(NAME);

--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.8.0] - 2023-10-12
 ### Changed

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/ExtensionRetest.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/ExtensionRetest.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.retest;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control.Mode;
@@ -43,13 +41,8 @@ public class ExtensionRetest extends ExtensionAdaptor {
     private ZapMenuItem menuItemRetest;
     private RetestDialog retestDialog;
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionAutomation.class);
 
     public ExtensionRetest() {
         super(NAME);

--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [5] - 2023-10-23
 ### Changed

--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
@@ -78,7 +78,8 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
 
     // The name is public so that other extensions can access it
     public static final String NAME = "ExtensionRevisit";
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionHistory.class, ExtensionAntiCSRF.class);
 
     // The i18n prefix, by default the package name - defined in one place to make it easier
     // to copy and change this example
@@ -86,13 +87,6 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
 
     public static final String ICON_RESOURCE = "/resource/icon/16/026.png";
     public static DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionHistory.class);
-        dependencies.add(ExtensionAntiCSRF.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     private Logger LOGGER = LogManager.getLogger(this.getClass());
 

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - The scan rule functionality of scripts was moved from the ZAP core to this add-on (Related to Issue 7105).
 
+### Changed
+- Maintenance changes.
+
 ### Fixed
 - The save button was not enabled for new scripts upon creation.
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -24,8 +24,6 @@ import java.awt.event.MouseAdapter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,7 +93,8 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     private Map<String, ExtenderScript> installedExtenderScripts = new HashMap<>();
     private ScriptEngineWrapper nullEngineWrapper = null;
 
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(ExtensionScript.class);
 
     private ScriptsListPanel scriptsPanel = null;
     private ConsolePanel consolePanel = null;
@@ -121,14 +120,6 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     private boolean lockOutputToDisplayedScript = false;
 
     // private ZapMenuItem menuEnableScripts = null;
-
-    // private static final Logger LOGGER = Logger.getLogger(ExtensionScriptsUI.class);
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionScriptsUI() {
         super(NAME);

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ExtensionScriptAutomation.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ExtensionScriptAutomation.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.scripts.automation;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.parosproxy.paros.CommandLine;
@@ -42,14 +40,8 @@ public class ExtensionScriptAutomation extends ExtensionAdaptor {
 
     private ScriptJob job;
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionScript.class);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionScript.class, ExtensionAutomation.class);
 
     public ExtensionScriptAutomation() {
         super(NAME);

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [15.18.0] - 2024-01-26
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -25,7 +25,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -90,7 +89,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
     private static final Logger LOGGER = LogManager.getLogger(ExtensionSelenium.class);
 
     private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
-            Collections.unmodifiableList(Arrays.asList(ExtensionNetwork.class));
+            List.of(ExtensionNetwork.class);
 
     private static final int MIN_PORT = 1;
 

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [7] - 2023-10-23
 ### Changed

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/ExtensionSequence.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/ExtensionSequence.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.sequence;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import javax.swing.ImageIcon;
@@ -44,18 +43,13 @@ import org.zaproxy.zap.extension.script.SequenceScript;
 
 public class ExtensionSequence extends ExtensionAdaptor implements ScannerHook {
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionScript.class);
 
     private ExtensionScript extScript;
     private ExtensionActiveScan extActiveScan;
     private static final Logger LOGGER = LogManager.getLogger(ExtensionSequence.class);
     public static final String TYPE_SEQUENCE = "sequence";
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     private List<ScriptWrapper> directScripts = null;
     private SequenceAscanPanel sequencePanel;

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Video link in help for Automation Framework job.
 
+### Changed
+- Maintenance changes.
+
 ## [21] - 2023-12-19
 ### Fixed
 - Use empty values as defined by the Value Generator configuration (Issue 8202).

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/ExtensionSoapAutomation.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/ExtensionSoapAutomation.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.soap.automation;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,16 +32,10 @@ public class ExtensionSoapAutomation extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionSoapAutomation";
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionImportWSDL.class, ExtensionAutomation.class);
 
     private SoapJob job;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionImportWSDL.class);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionSoapAutomation() {
         super(NAME);

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/spider/ExtensionSoapSpider.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/spider/ExtensionSoapSpider.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.soap.spider;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,8 +32,7 @@ import org.zaproxy.zap.extension.soap.ExtensionImportWSDL;
 public class ExtensionSoapSpider extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(
-                    Arrays.asList(ExtensionSpider2.class, ExtensionImportWSDL.class));
+            List.of(ExtensionSpider2.class, ExtensionImportWSDL.class);
 
     private SpiderParser spiderParser;
 

--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Skip parsing of empty SVGs.
+- Maintenance changes.
 
 ### Fixed
 - Fix exception that happened with absolute dotted URLs in inlined content.

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/ExtensionSpiderAutomation.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/ExtensionSpiderAutomation.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.addon.spider.automation;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -33,8 +31,7 @@ import org.zaproxy.addon.spider.ExtensionSpider2;
 public class ExtensionSpiderAutomation extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(
-                    Arrays.asList(ExtensionSpider2.class, ExtensionAutomation.class));
+            List.of(ExtensionSpider2.class, ExtensionAutomation.class);
 
     private SpiderJob job;
 

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Video link in help for Automation Framework job.
 
+### Changed
+- Maintenance changes.
+
 ## [23.18.0] - 2023-11-10
 ### Added
 - Add context menu item to Contexts tree to show the AJAX Spider dialogue with the selected Context.

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.spiderAjax;
 import java.awt.event.KeyEvent;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -68,8 +67,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
     public static final String NAME = "ExtensionSpiderAjax";
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(
-                    Arrays.asList(ExtensionSelenium.class, ExtensionNetwork.class));
+            List.of(ExtensionSelenium.class, ExtensionNetwork.class);
 
     private SpiderPanel spiderPanel = null;
     private PopupMenuAjaxSite popupMenuSpiderSite = null;

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/ExtensionAjaxAutomation.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/ExtensionAjaxAutomation.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.spiderAjax.automation;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.parosproxy.paros.CommandLine;
@@ -41,16 +39,10 @@ public class ExtensionAjaxAutomation extends ExtensionAdaptor {
 
     private static final String RESOURCES_DIR = "/org/zaproxy/zap/extension/spiderAjax/resources/";
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionAjax.class, ExtensionAutomation.class);
 
     private AjaxSpiderJob job;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionAjax.class);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionAjaxAutomation() {
         super(NAME);

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated with enthec upstream icon and pattern changes.
-
-
+- Maintenance changes.
 
 ## [21.30.0] - 2024-02-05
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -82,13 +82,8 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     private static final Logger LOGGER = LogManager.getLogger(ExtensionWappalyzer.class);
 
     /** The dependencies of the extension. */
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionPassiveScan.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            List.of(ExtensionPassiveScan.class);
 
     private WappalyzerPassiveScanner passiveScanner;
     private WappalyzerAPI api;

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/ExtensionWappalyzerAutomation.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/ExtensionWappalyzerAutomation.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.wappalyzer.automation;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -36,14 +34,8 @@ public class ExtensionWappalyzerAutomation extends ExtensionAdaptor {
 
     private WappalyzerJob job;
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionWappalyzer.class);
-        dependencies.add(ExtensionAutomation.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionWappalyzer.class, ExtensionAutomation.class);
 
     public ExtensionWappalyzerAutomation() {
         super(NAME);

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [30] - 2023-10-12
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.websocket.fuzz;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,14 +47,8 @@ import org.zaproxy.zap.extension.websocket.ui.WebSocketPanel;
 
 public class ExtensionWebSocketFuzzer extends ExtensionAdaptor {
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionFuzz.class);
-        dependencies.add(ExtensionWebSocket.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionFuzz.class, ExtensionWebSocket.class);
 
     private WebSocketFuzzerHandler websocketFuzzerHandler;
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/ExtensionWebSocketManualSend.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/ExtensionWebSocketManualSend.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.websocket.manualsend;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -34,7 +32,7 @@ import org.zaproxy.zap.extension.websocket.ExtensionWebSocket;
 public class ExtensionWebSocketManualSend extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            Collections.unmodifiableList(Arrays.asList(ExtensionWebSocket.class));
+            List.of(ExtensionWebSocket.class);
 
     private ExtensionWebSocket extensionWebSocket;
 

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum Scripts add-on version to 45.
+- Maintenance changes.
 
 ## [43] - 2023-12-19
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -112,11 +111,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     private static final Logger LOGGER = LogManager.getLogger(ExtensionZest.class);
 
     private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
-            Collections.unmodifiableList(
-                    Arrays.asList(
-                            ExtensionScript.class,
-                            ExtensionNetwork.class,
-                            ExtensionSelenium.class));
+            List.of(ExtensionScript.class, ExtensionNetwork.class, ExtensionSelenium.class);
 
     private ZestParam param = null;
     private OptionsZestPanel optionsZestPanel = null;


### PR DESCRIPTION
Use `List.of(…)` instead of static blocks and other types, more concise and uniform dependency declarations.