### PR TITLE
spider: handle parsers' exceptions

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip parsing of empty SVGs.
 
 ### Fixed
+- Ensure issues in one parser don't break the whole parsing process.
 - Fix exception that happened with absolute dotted URLs in inlined content.
 
 ## [0.9.0] - 2024-01-26

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderTask.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderTask.java
@@ -384,15 +384,28 @@ public class SpiderTask implements Runnable {
                         depth);
         boolean alreadyConsumed = false;
         for (SpiderParser parser : parsers) {
-            if (parser.canParseResource(ctx, alreadyConsumed)) {
-                LOGGER.debug("Parser {} can parse resource '{}'", parser, path);
-                if (parser.parseResource(ctx)) {
-                    alreadyConsumed = true;
-                }
-            } else {
-                LOGGER.debug("Parser {} cannot parse resource '{}'", parser, path);
+            try {
+                alreadyConsumed |= parse(ctx, alreadyConsumed, parser, path);
+            } catch (Exception e) {
+                LOGGER.error(
+                        "An error occurred while parsing the resource [{}] with [{}]: {}",
+                        path,
+                        parser.getClass(),
+                        e.getMessage(),
+                        e);
             }
         }
+    }
+
+    private static boolean parse(
+            ParseContext ctx, boolean alreadyConsumed, SpiderParser parser, String path) {
+        if (!parser.canParseResource(ctx, alreadyConsumed)) {
+            LOGGER.debug("Parser {} cannot parse resource '{}'", parser, path);
+            return false;
+        }
+
+        LOGGER.debug("Parser {} can parse resource '{}'", parser, path);
+        return parser.parseResource(ctx);
     }
 
     private ExtensionHistory getExtensionHistory() {


### PR DESCRIPTION
Ensure issues in one parser don't break the whole parsing process.

Related to #5274.