### PR TITLE
authhelper: use newer core code

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.12.0] - 2024-02-06
 

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import net.htmlparser.jericho.Source;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -32,7 +31,6 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.authhelper.HeaderBasedSessionManagementMethodType.HeaderBasedSessionManagementMethod;
-import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.authentication.AuthenticationMethod.AuthCheckingStrategy;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.model.Context;
@@ -140,7 +138,8 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                         context.setSessionManagementMethod(method);
                         Stats.incCounter("stats.auth.configure.session.header");
 
-                        if (isAutoDetectCheckingStrategy(context.getAuthenticationMethod())) {
+                        if (context.getAuthenticationMethod().getAuthCheckingStrategy()
+                                == AuthCheckingStrategy.AUTO_DETECT) {
                             AuthUtils.setVerificationDetailsForContext(
                                     context.getId(), new VerificationRequestDetails());
                         }
@@ -169,18 +168,6 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
         SessionManagementRequestDetails currentReq =
                 AuthUtils.getSessionManagementDetailsForContext(context.getId());
         return currentReq != null && smDetails.getTokens().size() > currentReq.getTokens().size();
-    }
-
-    /**
-     * Returns true if the authentication strategy is set to "auto detect". Prior to ZAP 2.13 this
-     * was indicated by setting the strategy to "POLL" but with no pollUrl. From 2.13 a new
-     * AUTO_DETECT enum will be available.
-     */
-    protected boolean isAutoDetectCheckingStrategy(AuthenticationMethod authMethod) {
-        String authStrategyName = authMethod.getAuthCheckingStrategy().name();
-        return "AUTO_DETECT".equals(authStrategyName)
-                || (AuthCheckingStrategy.POLL_URL.name().equals(authStrategyName)
-                        && StringUtils.isEmpty(authMethod.getPollUrl()));
     }
 
     protected AlertBuilder getAlert(SessionManagementRequestDetails smDetails) {


### PR DESCRIPTION
Use already available core code as the add-on is already targeting newer core version.