### PR TITLE
wappalyzer: correct changelog entry

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [21.31.0] - 2024-02-09
 ### Changed
 - Updated with enthec upstream icon and pattern changes.
-- Maintenance changes.
 
 ## [21.30.0] - 2024-02-05
 ### Changed


### PR DESCRIPTION
Move previous change to the Unreleased section, as it happened a release in the meantime.