### PR TITLE
ascanrules: Add generic MySQL/ MariaDB error message

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Added
+- The SQL Injection scan rule now includes a MySQL/MariaDB generic error message.
+
 ## [62] - 2024-01-26
 ### Changed
 - The Source Code Disclosure - /WEB-INF Folder rule now includes example alert functionality for documentation generation purposes (Issue 6119).

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -142,17 +142,15 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
         MySQL(
                 "MySQL",
                 Tech.MySQL,
-                Arrays.asList(
-                        new String[] {
-                            "\\Qcom.mysql.jdbc.exceptions\\E",
-                            "\\Qorg.gjt.mm.mysql\\E",
-                            "\\QODBC driver does not support\\E",
-                            "\\QThe used SELECT statements have a different number of columns\\E"
-                        }),
-                Arrays.asList(
-                        new String[] {
-                            "\\QThe used SELECT statements have a different number of columns\\E"
-                        })),
+                List.of(
+                        "\\QYou have an error in your SQL syntax\\E",
+                        "\\Qcom.mysql.jdbc.exceptions\\E",
+                        "\\Qorg.gjt.mm.mysql\\E",
+                        "\\QODBC driver does not support\\E",
+                        "\\QThe used SELECT statements have a different number of columns\\E"),
+                List.of(
+                        "\\QYou have an error in your SQL syntax\\E",
+                        "\\QThe used SELECT statements have a different number of columns\\E")),
 
         // TODO: Move this to the Microsoft SQL specific scan rule?
         // Injection vulnerabilities


### PR DESCRIPTION
## Overview
- CHANGELOG > Added note.
- SqlInjectionScanRule > Add simple generic error message to MySQL grouping.

## Related Issues
As discussed on IRC.

## Checklist
- [NA] Update help
- [X] Update changelog
- [X] Run `./gradlew spotlessApply` for code formatting
- [NA] Write tests
- [NA] Check code coverage
- [X] Sign-off commits
- [X] Squash commits
- [X] Use a descriptive title
