### PR TITLE
spider: Change param Enum automation handling to be more forgiving

### DIFF
--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -1,3 +1,4 @@
+import me.champeau.gradle.japicmp.JapicmpTask
 import org.zaproxy.gradle.addon.AddOnStatus
 
 description = "Spider used for automatically finding URIs on a site."
@@ -61,6 +62,10 @@ dependencies {
     implementation("io.kaitai:kaitai-struct-runtime:0.10")
 
     testImplementation(project(":testutils"))
+}
+
+val japicmp by tasks.existing(JapicmpTask::class) {
+    packageExcludes = listOf("org.zaproxy.addon.spider.automation")
 }
 
 spotless {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJob.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJob.java
@@ -29,10 +29,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
-import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -447,7 +444,7 @@ public class SpiderJob extends AutomationJob {
         private Integer maxChildren;
         private Boolean acceptCookies;
         private Boolean handleODataParametersVisited;
-        private String handleParameters;
+        private HandleParametersOption handleParameters;
         private Integer maxParseSizeBytes;
         private Boolean parseComments;
         private Boolean parseGit;
@@ -464,10 +461,6 @@ public class SpiderJob extends AutomationJob {
         // These 2 fields are deprecated
         private Boolean failIfFoundUrlsLessThan;
         private Boolean warnIfFoundUrlsLessThan;
-
-        private static final HandleParametersOption HANDLE_PARAMETERS_OPTION_DEFAULT =
-                HandleParametersOption.USE_ALL;
-        private static final Logger LOGGER = LogManager.getLogger(Parameters.class);
 
         public Parameters() {
             super();
@@ -541,26 +534,12 @@ public class SpiderJob extends AutomationJob {
             this.maxDuration = maxDuration;
         }
 
-        public String getHandleParameters() {
+        public HandleParametersOption getHandleParameters() {
             return handleParameters;
         }
 
-        public void setHandleParameters(String handleParameters) {
-            this.handleParameters = getHandleParamsOptionEnum(handleParameters).name();
-        }
-
-        private HandleParametersOption getHandleParamsOptionEnum(String handleParametersVisited) {
-            HandleParametersOption option =
-                    EnumUtils.getEnumIgnoreCase(
-                            HandleParametersOption.class, handleParametersVisited);
-            if (option == null) {
-                LOGGER.warn(
-                        "\"{}\" is not a valid HandleParametersOption value, defaulting to \"{}\"",
-                        handleParametersVisited,
-                        HANDLE_PARAMETERS_OPTION_DEFAULT);
-                option = HANDLE_PARAMETERS_OPTION_DEFAULT;
-            }
-            return option;
+        public void setHandleParameters(HandleParametersOption handleParameters) {
+            this.handleParameters = handleParameters;
         }
 
         public Integer getMaxParseSizeBytes() {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJobDialog.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJobDialog.java
@@ -193,12 +193,8 @@ public class SpiderJobDialog extends StandardFieldsDialog {
                     }
                 };
 
-        SpiderParam.HandleParametersOption hpo = null;
         if (this.job.getParameters().getHandleParameters() != null) {
-            hpo =
-                    SpiderParam.HandleParametersOption.valueOf(
-                            this.job.getParameters().getHandleParameters());
-            handleParamsModel.setSelectedItem(hpo);
+            handleParamsModel.setSelectedItem(this.job.getParameters().getHandleParameters());
         }
         this.addComboField(2, HANDLE_PARAMS_PARAM, handleParamsModel);
         Component acField = this.getField(HANDLE_PARAMS_PARAM);
@@ -290,7 +286,7 @@ public class SpiderJobDialog extends StandardFieldsDialog {
             if (hpoObj instanceof SpiderParam.HandleParametersOption) {
                 SpiderParam.HandleParametersOption hpo =
                         (SpiderParam.HandleParametersOption) hpoObj;
-                this.job.getParameters().setHandleParameters(hpo.name());
+                this.job.getParameters().setHandleParameters(hpo);
             }
 
         } else {

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
@@ -23,7 +23,6 @@ import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -50,8 +49,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentMatcher;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -74,7 +71,6 @@ import org.zaproxy.addon.spider.ExtensionSpider2;
 import org.zaproxy.addon.spider.SpiderParam;
 import org.zaproxy.addon.spider.SpiderParam.HandleParametersOption;
 import org.zaproxy.addon.spider.SpiderScan;
-import org.zaproxy.addon.spider.automation.SpiderJob.Parameters;
 import org.zaproxy.addon.spider.automation.SpiderJob.UrlRequester;
 import org.zaproxy.zap.extension.stats.ExtensionStats;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
@@ -690,7 +686,9 @@ class SpiderJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getMaxChildren(), is(equalTo(2)));
         assertThat(job.getParameters().getAcceptCookies(), is(equalTo(true)));
         assertThat(job.getParameters().getHandleODataParametersVisited(), is(equalTo(true)));
-        assertThat(job.getParameters().getHandleParameters(), is(equalTo("IGNORE_COMPLETELY")));
+        assertThat(
+                job.getParameters().getHandleParameters(),
+                is(equalTo(HandleParametersOption.IGNORE_COMPLETELY)));
         assertThat(job.getParameters().getMaxParseSizeBytes(), is(equalTo(2)));
         assertThat(job.getParameters().getParseComments(), is(equalTo(true)));
         assertThat(job.getParameters().getParseGit(), is(equalTo(true)));
@@ -770,25 +768,6 @@ class SpiderJobUnitTest extends TestUtils {
         assertThat(progress.getWarnings().size(), is(equalTo(1)));
         assertThat(
                 progress.getWarnings().get(0), is(equalTo("!automation.error.options.unknown!")));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"ignore_value", "USE_ALL", "IGnoRe_compLETELY"})
-    void shouldSetHandleParamOptionInAnyCase(String optValue) {
-        Parameters params = new Parameters();
-        assertDoesNotThrow(() -> params.setHandleParameters(optValue));
-    }
-
-    @Test
-    void shouldDefaultHandleParamOptionIfValueInvalid() {
-        // Given
-        String optValue = "invalid";
-        Parameters params = new Parameters();
-        // When
-        params.setHandleParameters(optValue);
-        String hpo = params.getHandleParameters();
-        // Then
-        assertThat(hpo, is(equalTo(HandleParametersOption.USE_ALL.name())));
     }
 
     private static class TestServerHandler extends NanoServerHandler {


### PR DESCRIPTION
Yes this is kind of a [repeat](https://github.com/zaproxy/zap-extensions/pull/5278), I flubbed a branch change and rebase 🤦‍♂️

## Overview
- CHANGELOG > Add change note.
- SpiderJob > Tweak handling to ignore case.
- SpiderJobDialog > Changed to use the enum values.
- SpiderJobUnitTest > Tweak test to use enum.
- spider.gradle.kts > Tweaked to exclude the automation sub-package from japicmp.

## Related Issues
Per: https://groups.google.com/g/zaproxy-users/c/zhQCsrBlh5g

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [NA] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
