### PR TITLE
pscanrules: add website links to help pages 

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+- Website alert links for Passive Scan Rules (Issue 8189).
+
 ### Changed
 - Maintenance changes.
 - The following rules now include example alert functionality for documentation generation purposes (Issue 6119):

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java
@@ -34,7 +34,8 @@ import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class AntiClickjackingScanRule extends PluginPassiveScanner {
+public class AntiClickjackingScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.anticlickjacking.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -49,7 +49,8 @@ import org.zaproxy.zap.utils.ContentMatcher;
  *
  * @author yhawke 2013
  */
-public class ApplicationErrorScanRule extends PluginPassiveScanner {
+public class ApplicationErrorScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.applicationerrors.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java
@@ -35,7 +35,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** Big Redirects passive scan rule https://github.com/zaproxy/zaproxy/issues/1257 */
-public class BigRedirectsScanRule extends PluginPassiveScanner {
+public class BigRedirectsScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.bigredirects.";
     private static final int PLUGIN_ID = 10044;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java
@@ -163,9 +163,4 @@ public class BigRedirectsScanRule extends PluginPassiveScanner
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }
-
-    public String getHelpLink() {
-        return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules/#id-"
-                + getPluginId();
-    }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
@@ -32,7 +32,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class CacheControlScanRule extends PluginPassiveScanner {
+public class CacheControlScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.cachecontrol.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
@@ -37,7 +37,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * A port from a Watcher passive scanner (http://websecuritytool.codeplex.com/) rule {@code
  * CasabaSecurity.Web.Watcher.Checks.CheckPasvCharsetMismatch}
  */
-public class CharsetMismatchScanRule extends PluginPassiveScanner {
+public class CharsetMismatchScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.charsetmismatch.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CommonPassiveScanRuleInfo.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CommonPassiveScanRuleInfo.java
@@ -1,0 +1,30 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+public interface CommonPassiveScanRuleInfo {
+
+    public int getPluginId();
+
+    public default String getHelpLink() {
+        return "https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules/#id-"
+                + getPluginId();
+    }
+}

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRule.java
@@ -38,7 +38,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Content Security Policy Header Missing passive scan rule
  * https://github.com/zaproxy/zaproxy/issues/1169
  */
-public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
+public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.contentsecuritypolicymissing.";
     private static final int PLUGIN_ID = 10038;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -54,7 +54,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Content Security Policy Header passive scan rule https://github.com/zaproxy/zaproxy/issues/527
  * Meant to complement the CSP Header Missing passive scan rule
  */
-public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
+public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.csp.";
     private static final int PLUGIN_ID = 10055;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
@@ -29,7 +29,8 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class ContentTypeMissingScanRule extends PluginPassiveScanner {
+public class ContentTypeMissingScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.contenttypemissing.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -34,7 +34,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.CookieUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
+public class CookieHttpOnlyScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.cookiehttponly.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -39,7 +39,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * <p>http://websecuritytool.codeplex.com/SourceControl/changeset/view/17f2e3ded58f#Watcher%20Check%20Library%2fCheck.Pasv.Cookie.LooselyScoped.cs
  */
-public class CookieLooselyScopedScanRule extends PluginPassiveScanner {
+public class CookieLooselyScopedScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.cookielooselyscoped.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
@@ -33,7 +33,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.CookieUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class CookieSameSiteScanRule extends PluginPassiveScanner {
+public class CookieSameSiteScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.cookiesamesite.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
@@ -34,7 +34,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.CookieUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class CookieSecureFlagScanRule extends PluginPassiveScanner {
+public class CookieSecureFlagScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.cookiesecureflag.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
@@ -40,7 +40,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner {
+public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** the logger. it logs stuff. */
     private static final Logger LOGGER =

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
@@ -39,7 +39,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Context;
 
-public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner {
+public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.crossdomainscriptinclusion.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -52,7 +52,8 @@ import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
  *
  * @author 70pointer
  */
-public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
+public class CsrfCountermeasuresScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** contains the base vulnerability that this plugin refers to */
     private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_9");

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
@@ -38,7 +38,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
+public class DirectoryBrowsingScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /**
      * a consistently ordered map of: a regular expression pattern, mapping to the Web server to

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
@@ -41,7 +41,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class HashDisclosureScanRule extends PluginPassiveScanner {
+public class HashDisclosureScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final HashAlert MD4_MD5_HASH_ALERT =
             new HashAlert("MD4 / MD5", Alert.RISK_LOW, Alert.CONFIDENCE_LOW);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java
@@ -37,7 +37,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class HeartBleedScanRule extends PluginPassiveScanner {
+public class HeartBleedScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     /**
      * a pattern to identify the version reported in the header. This works for Apache2 (subject to

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
@@ -50,7 +50,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Checks content for private IP V4 addresses as well as Amazon EC2 private hostnames (for example,
  * ip-10-34-56-78).
  */
-public class InfoPrivateAddressDisclosureScanRule extends PluginPassiveScanner {
+public class InfoPrivateAddressDisclosureScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.infoprivateaddressdisclosure.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
@@ -60,7 +60,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * @author yhawke
  * @author kingthorin+owaspzap
  */
-public class InfoSessionIdUrlScanRule extends PluginPassiveScanner {
+public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.infosessionidurl.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
@@ -40,7 +40,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScanner {
+public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.informationdisclosuredebugerrors.";
     private static final int PLUGIN_ID = 10023;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
@@ -38,7 +38,8 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner {
+public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     public static final String MESSAGE_PREFIX = "pscanrules.informationdisclosureinurl.";
     private static final int PLUGIN_ID = 10024;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
@@ -42,7 +42,8 @@ import org.zaproxy.addon.commonlib.binlist.BinList;
 import org.zaproxy.addon.commonlib.binlist.BinRecord;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner {
+public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     protected static final String MESSAGE_PREFIX = "pscanrules.informationdisclosurereferrer.";
     private static final int PLUGIN_ID = 10025;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
@@ -39,7 +39,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassiveScanner {
+public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX =
             "pscanrules.informationdisclosuresuspiciouscomments.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
@@ -39,7 +39,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 /*
  * passively scans requests for insecure authentication
  */
-public class InsecureAuthenticationScanRule extends PluginPassiveScanner {
+public class InsecureAuthenticationScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRule.java
@@ -35,7 +35,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Port for the Watcher passive scan (http://websecuritytool.codeplex.com/) rule {@code
  * CasabaSecurity.Web.Watcher.Checks.CheckPasvSSLInsecureFormLoad}
  */
-public class InsecureFormLoadScanRule extends PluginPassiveScanner {
+public class InsecureFormLoadScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.insecureformload.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRule.java
@@ -35,7 +35,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Port for the Watcher passive scanner (http://websecuritytool.codeplex.com/) rule {@code
  * CasabaSecurity.Web.Watcher.Checks.CheckPasvSSLInsecureFormPost}
  */
-public class InsecureFormPostScanRule extends PluginPassiveScanner {
+public class InsecureFormPostScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.insecureformpost.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
@@ -64,7 +64,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * with the gzip algorithm (which is the default).
  * </pre>
  */
-public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner {
+public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.insecurejsfviewstate.";
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRule.java
@@ -41,7 +41,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Context;
 
-public class LinkTargetScanRule extends PluginPassiveScanner {
+public class LinkTargetScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     public static final String TRUSTED_DOMAINS_PROPERTY = RuleConfigParam.RULE_DOMAINS_TRUSTED;
     private static final String MESSAGE_PREFIX = "pscanrules.linktarget.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
@@ -31,7 +31,8 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class MixedContentScanRule extends PluginPassiveScanner {
+public class MixedContentScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.mixedcontent.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java
@@ -29,7 +29,8 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** A class to passively scan responses for indications that this is a modern web application. */
-public class ModernAppDetectionScanRule extends PluginPassiveScanner {
+public class ModernAppDetectionScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.modernapp.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java
@@ -47,7 +47,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author Michael Kruglos (@michaelkruglos)
  */
-public class PiiScanRule extends PluginPassiveScanner {
+public class PiiScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.pii.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRule.java
@@ -35,7 +35,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
+public class RetrievedFromCacheScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.retrievedfromcache.";
     private static final int PLUGIN_ID = 10050;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRule.java
@@ -37,7 +37,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Server Header Version Information Leak passive scan rule
  * https://github.com/zaproxy/zaproxy/issues/1169
  */
-public class ServerHeaderInfoLeakScanRule extends PluginPassiveScanner {
+public class ServerHeaderInfoLeakScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final int PLUGIN_ID = 10036;
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRule.java
@@ -42,7 +42,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Strict-Transport-Security Header Not Set passive scan rule
  * https://github.com/zaproxy/zaproxy/issues/1169
  */
-public class StrictTransportSecurityScanRule extends PluginPassiveScanner {
+public class StrictTransportSecurityScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.stricttransportsecurity.";
     private static final int PLUGIN_ID = 10035;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -50,7 +50,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class TimestampDisclosureScanRule extends PluginPassiveScanner {
+public class TimestampDisclosureScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     // We are only interested in events within a 10 year span
     private static final long EPOCH_Y2038 = 2147483647L;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCharsetScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCharsetScanRule.java
@@ -41,7 +41,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Port for the Watcher passive scanner (http://websecuritytool.codeplex.com/) rule {@code
  * CasabaSecurity.Web.Watcher.Checks.CheckPasvUserControlledCharset}
  */
-public class UserControlledCharsetScanRule extends PluginPassiveScanner {
+public class UserControlledCharsetScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.usercontrolledcharset.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCookieScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCookieScanRule.java
@@ -44,7 +44,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Port for the Watcher passive scanner (http://websecuritytool.codeplex.com/) rule {@code
  * CasabaSecurity.Web.Watcher.Checks.CheckPasvUserControlledCookie}
  */
-public class UserControlledCookieScanRule extends PluginPassiveScanner {
+public class UserControlledCookieScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.usercontrolledcookie.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledHTMLAttributesScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledHTMLAttributesScanRule.java
@@ -43,7 +43,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Port for the Watcher passive scanner (http://websecuritytool.codeplex.com/) rule {@code
  * CasabaSecurity.Web.Watcher.Checks.CheckPasvUserControlledHTMLAttributes}
  */
-public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner {
+public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.usercontrolledhtmlattributes.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledJavascriptEventScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledJavascriptEventScanRule.java
@@ -40,7 +40,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Port for the Watcher passive scanner (http://websecuritytool.codeplex.com/) rule {@code
  * CasabaSecurity.Web.Watcher.Checks.CheckPasvUserControlledJavascriptEvent}
  */
-public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner {
+public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String[] JAVASCRIPT_EVENTS =
             new String[] {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledOpenRedirectScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledOpenRedirectScanRule.java
@@ -44,7 +44,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Port for the Watcher passive scanner (http://websecuritytool.codeplex.com/) rule {@code
  * CasabaSecurity.Web.Watcher.Checks.CheckPasvUserControlledOpenRedirect}
  */
-public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner {
+public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final Logger LOGGER =
             LogManager.getLogger(UserControlledOpenRedirectScanRule.class);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
@@ -39,7 +39,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.users.User;
 
-public class UsernameIdorScanRule extends PluginPassiveScanner {
+public class UsernameIdorScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.usernameidor.";
     private static final int PLUGIN_ID = 10057;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
@@ -39,7 +39,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class ViewstateScanRule extends PluginPassiveScanner {
+public class ViewstateScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.viewstate.";
     private static final int PLUGIN_ID = 10032;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
@@ -33,7 +33,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * a scan rule to passively scan for the presence of the X-AspNet-Version/X-AspNetMvc-Version
  * response header
  */
-public class XAspNetVersionScanRule extends PluginPassiveScanner {
+public class XAspNetVersionScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.xaspnetversion.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRule.java
@@ -34,7 +34,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * X-Backend-Server header information leak passive scan rule
  * https://github.com/zaproxy/zaproxy/issues/1169
  */
-public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner {
+public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.xbackendserver.";
     private static final int PLUGIN_ID = 10039;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java
@@ -34,7 +34,8 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** X-ChromeLogger-Data header information leak passive scan rule */
-public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner {
+public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.xchromeloggerdata.";
     private static final int PLUGIN_ID = 10052;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
@@ -31,7 +31,8 @@ import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-public class XContentTypeOptionsScanRule extends PluginPassiveScanner {
+public class XContentTypeOptionsScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.xcontenttypeoptions.";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
@@ -34,7 +34,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** X-Debug-Token passive scan rule https://github.com/zaproxy/zaproxy/issues/2452 */
-public class XDebugTokenScanRule extends PluginPassiveScanner {
+public class XDebugTokenScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.xdebugtoken.";
     private static final int PLUGIN_ID = 10056;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
@@ -36,7 +36,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 /**
  * X-Powered-By Information Leak passive scan rule https://github.com/zaproxy/zaproxy/issues/1169
  */
-public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner {
+public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner
+        implements CommonPassiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "pscanrules.xpoweredbyheaderinfoleak.";
     private static final String HEADER_NAME = "X-Powered-By";

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -24,7 +24,7 @@ Following rules supports <b>Trusted Domains</b> :
 
 The following release status passive scan rules are included in this add-on:
 
-<H2 id = "id-10020">Anti-clickjacking Header</H2>
+<H2 id="id-10020">Anti-clickjacking Header</H2>
 This scan rule checks for the existence and validity of the X-Frame-Options header, or Content-Security-Policy 'frame-ancestors' directive.<br> 
 At MEDIUM and HIGH thresholds this only looks at non-error or non-redirect HTML responses.<br>
 At LOW threshold it looks at all text responses including errors and redirects.<br>
@@ -40,8 +40,7 @@ However at LOW threshold the above issues will still be reported but at a LOW ri
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java">AntiClickjackingScanRule.java</a><br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10020/">10020</a>
-
-<H2 id = "id-90022">Application Errors</H2>
+<H2 id="id-90022">Application Errors</H2>
 Check server responses for HTTP 500 - Internal Server Error type responses or those that contain a known error string. <br>
 <strong>Note:</strong> Matches made within script blocks or files are against the entire content not only comments.<br>
 Skips responses that contain ISO control characters (those which are likely binary files).<br>
@@ -56,7 +55,6 @@ amount of time needed to passively scan.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java">ApplicationErrorScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90022/">90022</a>.
-
 <H2 id="id-10044">Big Redirect Detected (Potential Sensitive Information Leak)</H2>
 This check predicts the size of various redirect type responses and generates an alert if the response is greater than the predicted size. 
 A large redirect response may indicate that although a redirect has taken place the page actually contained content (which may reveal sensitive information, PII, etc.).
@@ -65,8 +63,7 @@ It will also raise an alert if the body of the redirect response contains multip
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java">BigRedirectsScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10044/">10044</a>.
-
-<H2 id = "id-10015">Cache Control</H2>
+<H2 id="id-10015">Cache Control</H2>
 Checks "Cache-Control" response headers against general industry best practice settings for protection of sensitive content.<br>
 At MEDIUM and HIGH thresholds only non-error or non-redirect text responses (excluding JavaScript and CSS) are considered.<br>
 At LOW threshold all responses are considered including errors and redirects.
@@ -74,8 +71,7 @@ At LOW threshold all responses are considered including errors and redirects.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java">CacheControlScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10015/">10015</a>.
-
-<H2 id = "id-90011">Charset Mismatch</H2>
+<H2 id="id-90011">Charset Mismatch</H2>
 <p>This check identifies responses where the HTTP Content-Type header declares a charset different from the charset defined by the body of the HTML or XML. When there's a charset mismatch between the HTTP header and content body Web browsers can be forced into an undesirable content-sniffing mode to determine the content's correct character set.</p>
 <p>The scan rule handles various conditions depending on the Threshold set for the rule, as follows:</p>
 <ul>
@@ -99,8 +95,7 @@ Further reference:<br>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java">CharsetMismatchScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90011/">90011</a>.
-
-<H2 id = "id-10038">Content Security Policy (CSP) Header Not Set</H2>
+<H2 id="id-10038">Content Security Policy (CSP) Header Not Set</H2>
 This checks HTML response headers for the presence of a Content Security Policy header, or the response body for CSP specified via META tag.<br>
 By default this rule checks for the presence of the "Content-Security-Policy", "X-Content-Security-Policy",
 and "X-WebKit-CSP" headers. Redirects and non-HTML responses are ignored except at the Low threshold.
@@ -117,46 +112,40 @@ Note: This rule does not perform any actual analysis of the specified policy, fo
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRule.java">ContentSecurityPolicyMissingScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10038/">10038</a>.
-
-<H2 id = "id-10019">Content Type Missing</H2>
+<H2 id="id-10019">Content Type Missing</H2>
 Raises an alert if the response is lacking a Content-Type header or if the header exists but the value is empty.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java">ContentTypeMissingScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10019/">10019</a>.
-
-<H2 id = "id-10010">Cookie HttpOnly</H2>
+<H2 id="id-10010">Cookie HttpOnly</H2>
 Ensures that as cookies are set they are flagged HttpOnly. The HttpOnly flag indicates to browsers that the cookie 
 being set should not be acted upon by client side script (such as JavaScript).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java">CookieHttpOnlyScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10010/">10010</a>.
-
-<H2 id = "id-90033">Cookie - Loosely Scoped</H2>
+<H2 id="id-90033">Cookie - Loosely Scoped</H2>
 Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. <code>www.nottrusted.com</code>, or loosely scoped to a parent domain e.g. <code>nottrusted.com</code>. In the latter case, any subdomain of <code>nottrusted.com</code> can access the cookie. Loosely scoped cookies are common in mega-applications like <code>google.com</code> and <code>live.com</code>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java">CookieLooselyScopedScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90033/">90033</a>.
-
-<H2 id = "id-10029">Cookie Poisoning</H2>
+<H2 id="id-10029">Cookie Poisoning</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where cookie parameters might be controlled. 
 This is called a cookie poisoning attack, and becomes exploitable when an attacker can manipulate the cookie in various ways. In some cases this will not be exploitable, however, allowing URL parameters to set cookie values is generally considered a bug.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCookieScanRule.java">UserControlledCookieScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10029/">10029</a>.
-
-<H2 id = "id-10011">Cookie Secure Flag</H2>
+<H2 id="id-10011">Cookie Secure Flag</H2>
 Looks for cookies set during HTTPS sessions, raises an alert for those that are set but do not include the secure flag.
 A cookie set with the secure flag will not be sent during a plain HTTP session.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java">CookieSecureFlagScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10011/">10011</a>.
-
-<H2 id = "id-10054">Cookie Without SameSite Attribute</H2>
+<H2 id="id-10054">Cookie Without SameSite Attribute</H2>
 This reports any cookies that:
 <ul>
   <li>do not have the SameSite attribute</li>
@@ -167,8 +156,7 @@ This reports any cookies that:
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java">CookieSameSiteScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10054/">10054</a>.
-
-<H2 id = "id-10017">Cross Domain Script Inclusion</H2>
+<H2 id="id-10017">Cross Domain Script Inclusion</H2>
 Validates whether or not scripts are included from domains other than the domain hosting the content. 
 By looking at the "src" attributes of "script" tags in HTML responses.<br>
 Allowed Cross-Domain scripts:  
@@ -181,17 +169,14 @@ Allowed Cross-Domain scripts:
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java">CrossDomainScriptInclusionScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10017/">10017</a>.
-
-<H2 id = "id-10098">Cross Domain Misconfiguration</H2>
+<H2 id="id-10098">Cross Domain Misconfiguration</H2>
 Passively scan responses for Cross Domain MisConfigurations, which relax the Same Origin Policy in the web browser, for instance.<br>
 The current implementation looks at excessively permissive CORS headers.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java">CrossDomainMisconfigurationScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10098/">10098</a>.
-
-<H2 id = "id-10055">CSP (Content Security Policy)</H2>
-
+<H2 id="id-10055">CSP (Content Security Policy)</H2>
 The Content Security Policy (CSP) passive scan rule parses and analyzes CSP headers and META definitions for potential misconfiguration
 or weakness. This rule leverages HtmlUnit's <a href="https://github.com/HtmlUnit/htmlunit-csp">htmlunit-csp</a> 
 library to perform it's parsing and assessment of CSPs.
@@ -201,8 +186,7 @@ If a response has multiple CSPs they are analyzed individually, as there is no s
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java">ContentSecurityPolicyScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10055/">10055</a>.
-
-<H2 id = "id-10202">CSRF Countermeasures</H2>
+<H2 id="id-10202">CSRF Countermeasures</H2>
 This rule identifies "potential" vulnerabilities with the lack of known CSRF 
 countermeasures in HTML pages with forms.<br>
 The rule does not scan messages that are not HTML pages.<br>
@@ -218,15 +202,13 @@ Note: The rule also takes into account the Partial match setting within the Anti
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java">CsrfCountermeasuresScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/100202/">100202</a>.
-
-<H2 id = "id-10033">Directory Browsing</H2>
+<H2 id="id-10033">Directory Browsing</H2>
 Passively scans responses for signatures that are indicative that Directory Browsing is possible.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java">DirectoryBrowsingScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10033/">10033</a>.
-
-<H2 id = "id-10097">Hash Disclosure</H2>
+<H2 id="id-10097">Hash Disclosure</H2>
 Passively scans for password hashes disclosed by the web server. <br>
 Various formats are including, including some formats such as MD4, MD5, and SHA*, which are sometimes used for purposes other than to contain password hashes.
 <br>
@@ -235,37 +217,32 @@ Various formats are including, including some formats such as MD4, MD5, and SHA*
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java">HashDisclosureScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10097/">10097</a>.
-
-<H2 id = "id-10034">Heartbleed OpenSSL Vulnerability (Indicative)</H2>
+<H2 id="id-10034">Heartbleed OpenSSL Vulnerability (Indicative)</H2>
 Passively scans for HTTP header responses that may indicate that the server is vulnerable to the critical HeartBleed OpenSSL vulnerability. 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java">HeartBleedScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10034/">10034</a>.
-
-<H2 id = "id-10036">HTTP Server Response Header</H2>
+<H2 id="id-10036">HTTP Server Response Header</H2>
 This checks response headers for the presence of a server header that contains version details.
 At LOW Threshold will raise an alert based on presence of the header field whether or not a version string is detected.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRule.java">ServerHeaderInfoLeakScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10036/">10036</a>.
-
-<H2 id = "id-10041">HTTP to HTTPS Insecure Transition in Form Post</H2>
+<H2 id="id-10041">HTTP to HTTPS Insecure Transition in Form Post</H2>
 This check looks for insecure HTTP pages that host HTTPS forms. The issue is that an insecure HTTP page can easily be hijacked through MITM and the secure HTTPS form can be replaced or spoofed.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRule.java">InsecureFormLoadScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10041/">10041</a>.
-
-<H2 id = "id-10042">HTTPS to HTTP Insecure Transition in Form Post</H2>
+<H2 id="id-10042">HTTPS to HTTP Insecure Transition in Form Post</H2>
 This check identifies secure HTTPS pages that host insecure HTTP forms. The issue is that a secure page is transitioning to an insecure page when data is uploaded through a form. The user may think they're submitting data to a secure page when in fact they are not.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRule.java">InsecureFormPostScanRule.java</a>
 <br> 
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10042/">10042</a>.
-
-<H2 id = "id-10023">Information Disclosure: Debug Errors</H2>
+<H2 id="id-10023">Information Disclosure: Debug Errors</H2>
 This passive scan rule checks the content of web responses for known Debug Error message fragments.
 Access to such details may provide a malicious individual with means by which to further abuse the web site.
 They may also leak data not specifically meant for end user consumption.<br>
@@ -274,16 +251,14 @@ Note: Javascript responses are only assessed at LOW threshold.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java">InformationDisclosureDebugErrorsScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10023/">10023</a>.
-
-<H2 id = "id-10024">Information Disclosure: In URL</H2>
+<H2 id="id-10024">Information Disclosure: In URL</H2>
 Attempts to identify the existence of sensitive details within the visited URIs themselves 
 (this may include parameters, document names, directory names, etc.).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java">InformationDisclosureInUrlScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10024/">10024</a>.
-
-<H2 id = "id-10025">Information Disclosure: Referrer</H2>
+<H2 id="id-10025">Information Disclosure: Referrer</H2>
 Identifies the existence of sensitive details within the Referrer header field of HTTP requests
 (this may include parameters, document names, directory names, etc.).
 <p>
@@ -295,8 +270,7 @@ See: <a href="https://github.com/iannuttall/binlist-data">binlist-data</a> for m
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java">InformationDisclosureReferrerScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10025/">10025</a>.
-
-<H2 id = "id-10027">Information Disclosure: Suspicious Comments</H2>
+<H2 id="id-10027">Information Disclosure: Suspicious Comments</H2>
 Analyzes web content to identify comments which contain potentially sensitive details. Which may lead to 
 further attack or exposure of unintended data.
 <p><strong>Note:</strong> The strings to look for can be extended by using the Custom Payloads addon.
@@ -304,44 +278,39 @@ further attack or exposure of unintended data.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java">InformationDisclosureSuspiciousCommentsScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10027/">10027</a>.
-
-<H2 id = "id-10105">Insecure Authentication</H2>
+<H2 id="id-10105">Insecure Authentication</H2>
 HTTP basic or digest authentication has been used over an unsecured connection. The credentials can be read and then reused by someone with access to the network.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java">InsecureAuthenticationScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10105/">10105</a>.
-
-<H2 id = "id-90001">Insecure JSF ViewState</H2>
+<H2 id="id-90001">Insecure JSF ViewState</H2>
 The response contains a Java Server Faces (JSF) ViewState value that has no cryptographic protections.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java">InsecureJsfViewStatePassiveScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90001/">90001</a>.
-
-<H2 id = "id-10040">Mixed Content</H2>
+<H2 id="id-10040">Mixed Content</H2>
 For content served via HTTPS analyse all the src attributes in the response looking for those sourced
 via plain HTTP.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java">MixedContentScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10040/">10040</a>.
-
-<H2 id = "id-10109">Modern Web Application</H2>
+<H2 id="id-10109">Modern Web Application</H2>
 This raises an informational alert if a site appears to be a modern web application.<br>
 It does not indicate any potential vulnerabilities but it could indicate that the ajax spider might be more effective at exploring this site compared to the traditional spider.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java">ModernAppDetectionScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/100109/">100109</a>.
-
-<H2 id = "id-10028">Open Redirect</H2>
+<H2 id="id-10028">Open Redirect</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledOpenRedirectScanRule.java">UserControlledOpenRedirectScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10028/">10028</a>.
-<H2 id = "id-10062">PII Disclosure</H2>
+<H2 id="id-10062">PII Disclosure</H2>
 PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number.
 <br>
 At MEDIUM and HIGH threshold it attempts to use three characters of context on each side of potential matches to exclude matches within decimal like content.
@@ -364,8 +333,7 @@ See: <a href="https://github.com/iannuttall/binlist-data">binlist-data</a> for m
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java">PiiScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10062/">10062</a>.
-
-<H2 id = "id-00002">Private Address Disclosure</H2>
+<H2 id="id-00002">Private Address Disclosure</H2>
 Checks the response content for inclusion of RFC 1918 IPv4 addresses as well as 
 Amazon EC2 private hostnames (for example, ip-10-0-56-78). This information can give an attacker 
 useful information about the IP address scheme of the internal network, and might be helpful for 
@@ -379,15 +347,13 @@ repeated scans the "Context Alert Filters" add-on could be leveraged.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java">InfoPrivateAddressDisclosureScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/00002/">00002</a>.
-
-<H2 id = "id-10050">Retrieved from Cache</H2>
+<H2 id="id-10050">Retrieved from Cache</H2>
 This scan rule detects content that has been served from a shared cache.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRule.java">RetrievedFromCacheScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10050/">10050</a>.
-
-<H2 id = "id-10108">Reverse Tabnabbing</H2>
+<H2 id="id-10108">Reverse Tabnabbing</H2>
 This checks to see if any links use a target attribute using "opener" keyword in the "rel" attribute, as this may allow target pages to take over the page that opens them.<br>
 By default this rule will ignore all links that are in the same context as the page. At the LOW threshold it will only ignore links that are on the same host.<br>
 At HIGH threshold it will only report links that use the "_blank" target.<br>
@@ -396,15 +362,13 @@ At HIGH threshold it will only report links that use the "_blank" target.<br>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRule.java">LinkTargetScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10108/">10108</a>.
-
 <H2 id="id-10037">Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s)</H2>
 This checks response headers for the presence of X-Powered-By details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java">XPoweredByHeaderInfoLeakScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10037/">10037</a>.
-
-<H2 id = "id-00003">Session ID in URL Rewrite</H2>
+<H2 id="id-00003">Session ID in URL Rewrite</H2>
 This scan rule checks for the existence of session token type parameters being rewritten to the URL. 
 To help reduce false positives the rule checks the length of the token value,  if the value of the parameter 
 is not greater than 8 characters in length then the parameter is ignored 
@@ -413,7 +377,7 @@ is not greater than 8 characters in length then the parameter is ignored
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java">InfoSessionIdUrlScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/00003/">00003</a>.
-<H2 id = "id-10035">Strict Transport Security Header</H2>
+<H2 id="id-10035">Strict Transport Security Header</H2>
 This rule checks HTTPS responses for the presence of a HTTP Strict Transport Security (HSTS) header and tests for various implementation concerns, 
 alerting if they're found.
 
@@ -434,8 +398,7 @@ Redirects to HTTPS URLs on the same domain will only be reported at Low threshol
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRule.java">StrictTransportSecurityScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10035/">10035</a>.
-
-<H2 id = "id-10096">Timestamp Disclosure</H2>
+<H2 id="id-10096">Timestamp Disclosure</H2>
 A timestamp was disclosed by the application/web server.<br>
 At HIGH threshold this rule does not alert on potential timestamps that are not within a range of plus or minus one year.<br>
 At MEDIUM threshold this rule does not alert on potential timestamps beyond 10 years.<br>
@@ -445,28 +408,25 @@ At all thresholds, this rule will not alert on timestamps beyond the Y2038 epoch
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java">TimestampDisclosureScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10096/">10096</a>.
-<H2 id = "id-10030">User Controllable Charset</H2>
+<H2 id="id-10030">User Controllable Charset</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where Content-Type or meta tag charset declarations might be user-controlled. Such charset declarations should always be declared by the application. If an attacker can control the response charset, they could manipulate the HTML to perform XSS or other attacks.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCharsetScanRule.java">UserControlledCharsetScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10030/">10030</a>.
-
-<H2 id = "id-10031">User Controllable HTML Element Attribute (Potential XSS)</H2>
+<H2 id="id-10031">User Controllable HTML Element Attribute (Potential XSS)</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledHTMLAttributesScanRule.java">UserControlledHTMLAttributesScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10031/">10031</a>.
-
-<H2 id = "id-10043">User Controllable Javascript Event (XSS)</H2>
+<H2 id="id-10043">User Controllable Javascript Event (XSS)</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.            
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledJavascriptEventScanRule.java">UserControlledJavascriptEventScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10043/">10043</a>.
-
-<H2 id = "id-10057">Username Hash Found</H2>
+<H2 id="id-10057">Username Hash Found</H2>
 If any context contains defined users this scan rule checks all responses for the presence of hashed values representing those usernames.
 <p><strong>Note:</strong> If the Custom Payloads addon is installed you can add your own Username strings (payloads) in the Custom Payloads options panel. 
 They will also be hashed and searched for in responses as they're passively scanned. Keep in mind that the greater the number of payloads the greater the 
@@ -476,7 +436,7 @@ amount of time needed to passively scan. (The default payloads are "Admin" and "
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java">UsernameIdorScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10057/">10057</a>.
-<H2 id = "id-10032">VIEWSTATE</H2>
+<H2 id="id-10032">VIEWSTATE</H2>
 Attempts to identify VIEWSTATE parameters and analyze said parameters for various best practices or protective 
 measures such as: 
 <ul>
@@ -490,29 +450,25 @@ The "Viewstate without MAC Signature (Unsure)" alert will only be raised at LOW 
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java">ViewstateScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10032/">10032</a>.
-
-<H2 id = "id-10061">X-AspNet-Version Response Header</H2>
+<H2 id="id-10061">X-AspNet-Version Response Header</H2>
 This checks response headers for the presence of X-AspNet-Version/X-AspNetMvc-Version details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java">XAspNetVersionScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10061/">10061</a>.
-
-<H2 id = "id-10039">X-Backend-Server Header Information Leak</H2>
+<H2 id="id-10039">X-Backend-Server Header Information Leak</H2>
 This checks response headers for the presence of X-Backend-Server details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeak.java">XBackendServerInformationLeak.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10039/">10039</a>.
-
-<H2 id = "id-10052">X-ChromeLogger-Data Header Information Leak</H2>
+<H2 id="id-10052">X-ChromeLogger-Data Header Information Leak</H2>
 This checks response headers for the presence of X-ChromeLogger-Data or X-ChromePhp-Data details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java">XChromeLoggerDataInfoLeakScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10052/">10052</a>.
-
-<H2 id = "id-10021">X-Content-Type-Options</H2>
+<H2 id="id-10021">X-Content-Type-Options</H2>
 This scan rule check for the Anti-MIME-Sniffing header X-Content-Type-Options and ensures it is set to 'nosniff'.<br>
 At MEDIUM and HIGH thresholds this rule does not alert on client or server error responses or redirects.<br> 
 At LOW threshold it will alert on all responses including errors and redirects.<br>
@@ -520,13 +476,12 @@ At LOW threshold it will alert on all responses including errors and redirects.<
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java">XContentTypeOptionsScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10021/">10021</a>.
-
-<H2 id = "id-10052">X-Debug-Token Information Leak</H2>
+<H2 id="id-10052">X-Debug-Token Information Leak</H2>
 This checks response headers for the presence of X-Debug-Token and X-Debug-Token-Link details.
 Which indicates the use/exposure of Symfony's Profiler. Symfony's Profiler provides access to a significant amount of information of interest to malicious individuals and Security Testers.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java">XDebugTokenScanRule.java</a>
 <br>
-
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10052/">10052</a>.
 </BODY>
 </HTML>

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -38,8 +38,10 @@ The following conditions may result in an alert:
 By default no alerts will be raised in the response includes a Content-Security-Policy 'frame-ancestors' element as this take precedence over the X-Frame-Options header.
 However at LOW threshold the above issues will still be reported but at a LOW risk. 
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java">AntiClickjackingScanRule.java</a><br>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java">AntiClickjackingScanRule.java</a>
+<br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10020/">10020</a>
+
 <H2 id="id-90022">Application Errors</H2>
 Check server responses for HTTP 500 - Internal Server Error type responses or those that contain a known error string. <br>
 <strong>Note:</strong> Matches made within script blocks or files are against the entire content not only comments.<br>
@@ -55,6 +57,7 @@ amount of time needed to passively scan.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java">ApplicationErrorScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90022/">90022</a>.
+
 <H2 id="id-10044">Big Redirect Detected (Potential Sensitive Information Leak)</H2>
 This check predicts the size of various redirect type responses and generates an alert if the response is greater than the predicted size. 
 A large redirect response may indicate that although a redirect has taken place the page actually contained content (which may reveal sensitive information, PII, etc.).
@@ -63,6 +66,7 @@ It will also raise an alert if the body of the redirect response contains multip
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java">BigRedirectsScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10044/">10044</a>.
+
 <H2 id="id-10015">Cache Control</H2>
 Checks "Cache-Control" response headers against general industry best practice settings for protection of sensitive content.<br>
 At MEDIUM and HIGH thresholds only non-error or non-redirect text responses (excluding JavaScript and CSS) are considered.<br>
@@ -71,6 +75,7 @@ At LOW threshold all responses are considered including errors and redirects.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java">CacheControlScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10015/">10015</a>.
+
 <H2 id="id-90011">Charset Mismatch</H2>
 <p>This check identifies responses where the HTTP Content-Type header declares a charset different from the charset defined by the body of the HTML or XML. When there's a charset mismatch between the HTTP header and content body Web browsers can be forced into an undesirable content-sniffing mode to determine the content's correct character set.</p>
 <p>The scan rule handles various conditions depending on the Threshold set for the rule, as follows:</p>
@@ -95,6 +100,7 @@ Further reference:<br>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java">CharsetMismatchScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90011/">90011</a>.
+
 <H2 id="id-10038">Content Security Policy (CSP) Header Not Set</H2>
 This checks HTML response headers for the presence of a Content Security Policy header, or the response body for CSP specified via META tag.<br>
 By default this rule checks for the presence of the "Content-Security-Policy", "X-Content-Security-Policy",
@@ -112,12 +118,14 @@ Note: This rule does not perform any actual analysis of the specified policy, fo
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRule.java">ContentSecurityPolicyMissingScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10038/">10038</a>.
+
 <H2 id="id-10019">Content Type Missing</H2>
 Raises an alert if the response is lacking a Content-Type header or if the header exists but the value is empty.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java">ContentTypeMissingScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10019/">10019</a>.
+
 <H2 id="id-10010">Cookie HttpOnly</H2>
 Ensures that as cookies are set they are flagged HttpOnly. The HttpOnly flag indicates to browsers that the cookie 
 being set should not be acted upon by client side script (such as JavaScript).
@@ -125,12 +133,14 @@ being set should not be acted upon by client side script (such as JavaScript).
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java">CookieHttpOnlyScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10010/">10010</a>.
+
 <H2 id="id-90033">Cookie - Loosely Scoped</H2>
 Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. <code>www.nottrusted.com</code>, or loosely scoped to a parent domain e.g. <code>nottrusted.com</code>. In the latter case, any subdomain of <code>nottrusted.com</code> can access the cookie. Loosely scoped cookies are common in mega-applications like <code>google.com</code> and <code>live.com</code>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java">CookieLooselyScopedScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90033/">90033</a>.
+
 <H2 id="id-10029">Cookie Poisoning</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where cookie parameters might be controlled. 
 This is called a cookie poisoning attack, and becomes exploitable when an attacker can manipulate the cookie in various ways. In some cases this will not be exploitable, however, allowing URL parameters to set cookie values is generally considered a bug.
@@ -138,6 +148,7 @@ This is called a cookie poisoning attack, and becomes exploitable when an attack
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCookieScanRule.java">UserControlledCookieScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10029/">10029</a>.
+
 <H2 id="id-10011">Cookie Secure Flag</H2>
 Looks for cookies set during HTTPS sessions, raises an alert for those that are set but do not include the secure flag.
 A cookie set with the secure flag will not be sent during a plain HTTP session.
@@ -145,6 +156,7 @@ A cookie set with the secure flag will not be sent during a plain HTTP session.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java">CookieSecureFlagScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10011/">10011</a>.
+
 <H2 id="id-10054">Cookie Without SameSite Attribute</H2>
 This reports any cookies that:
 <ul>
@@ -156,6 +168,7 @@ This reports any cookies that:
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java">CookieSameSiteScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10054/">10054</a>.
+
 <H2 id="id-10017">Cross Domain Script Inclusion</H2>
 Validates whether or not scripts are included from domains other than the domain hosting the content. 
 By looking at the "src" attributes of "script" tags in HTML responses.<br>
@@ -169,6 +182,7 @@ Allowed Cross-Domain scripts:
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java">CrossDomainScriptInclusionScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10017/">10017</a>.
+
 <H2 id="id-10098">Cross Domain Misconfiguration</H2>
 Passively scan responses for Cross Domain MisConfigurations, which relax the Same Origin Policy in the web browser, for instance.<br>
 The current implementation looks at excessively permissive CORS headers.
@@ -176,6 +190,7 @@ The current implementation looks at excessively permissive CORS headers.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java">CrossDomainMisconfigurationScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10098/">10098</a>.
+
 <H2 id="id-10055">CSP (Content Security Policy)</H2>
 The Content Security Policy (CSP) passive scan rule parses and analyzes CSP headers and META definitions for potential misconfiguration
 or weakness. This rule leverages HtmlUnit's <a href="https://github.com/HtmlUnit/htmlunit-csp">htmlunit-csp</a> 
@@ -186,6 +201,7 @@ If a response has multiple CSPs they are analyzed individually, as there is no s
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java">ContentSecurityPolicyScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10055/">10055</a>.
+
 <H2 id="id-10202">CSRF Countermeasures</H2>
 This rule identifies "potential" vulnerabilities with the lack of known CSRF 
 countermeasures in HTML pages with forms.<br>
@@ -202,12 +218,14 @@ Note: The rule also takes into account the Partial match setting within the Anti
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java">CsrfCountermeasuresScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/100202/">100202</a>.
+
 <H2 id="id-10033">Directory Browsing</H2>
 Passively scans responses for signatures that are indicative that Directory Browsing is possible.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java">DirectoryBrowsingScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10033/">10033</a>.
+
 <H2 id="id-10097">Hash Disclosure</H2>
 Passively scans for password hashes disclosed by the web server. <br>
 Various formats are including, including some formats such as MD4, MD5, and SHA*, which are sometimes used for purposes other than to contain password hashes.
@@ -217,12 +235,14 @@ Various formats are including, including some formats such as MD4, MD5, and SHA*
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java">HashDisclosureScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10097/">10097</a>.
+
 <H2 id="id-10034">Heartbleed OpenSSL Vulnerability (Indicative)</H2>
 Passively scans for HTTP header responses that may indicate that the server is vulnerable to the critical HeartBleed OpenSSL vulnerability. 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java">HeartBleedScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10034/">10034</a>.
+
 <H2 id="id-10036">HTTP Server Response Header</H2>
 This checks response headers for the presence of a server header that contains version details.
 At LOW Threshold will raise an alert based on presence of the header field whether or not a version string is detected.
@@ -230,18 +250,21 @@ At LOW Threshold will raise an alert based on presence of the header field wheth
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRule.java">ServerHeaderInfoLeakScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10036/">10036</a>.
+
 <H2 id="id-10041">HTTP to HTTPS Insecure Transition in Form Post</H2>
 This check looks for insecure HTTP pages that host HTTPS forms. The issue is that an insecure HTTP page can easily be hijacked through MITM and the secure HTTPS form can be replaced or spoofed.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRule.java">InsecureFormLoadScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10041/">10041</a>.
+
 <H2 id="id-10042">HTTPS to HTTP Insecure Transition in Form Post</H2>
 This check identifies secure HTTPS pages that host insecure HTTP forms. The issue is that a secure page is transitioning to an insecure page when data is uploaded through a form. The user may think they're submitting data to a secure page when in fact they are not.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRule.java">InsecureFormPostScanRule.java</a>
 <br> 
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10042/">10042</a>.
+
 <H2 id="id-10023">Information Disclosure: Debug Errors</H2>
 This passive scan rule checks the content of web responses for known Debug Error message fragments.
 Access to such details may provide a malicious individual with means by which to further abuse the web site.
@@ -251,6 +274,7 @@ Note: Javascript responses are only assessed at LOW threshold.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java">InformationDisclosureDebugErrorsScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10023/">10023</a>.
+
 <H2 id="id-10024">Information Disclosure: In URL</H2>
 Attempts to identify the existence of sensitive details within the visited URIs themselves 
 (this may include parameters, document names, directory names, etc.).
@@ -258,6 +282,7 @@ Attempts to identify the existence of sensitive details within the visited URIs 
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java">InformationDisclosureInUrlScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10024/">10024</a>.
+
 <H2 id="id-10025">Information Disclosure: Referrer</H2>
 Identifies the existence of sensitive details within the Referrer header field of HTTP requests
 (this may include parameters, document names, directory names, etc.).
@@ -270,6 +295,7 @@ See: <a href="https://github.com/iannuttall/binlist-data">binlist-data</a> for m
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java">InformationDisclosureReferrerScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10025/">10025</a>.
+
 <H2 id="id-10027">Information Disclosure: Suspicious Comments</H2>
 Analyzes web content to identify comments which contain potentially sensitive details. Which may lead to 
 further attack or exposure of unintended data.
@@ -278,18 +304,21 @@ further attack or exposure of unintended data.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java">InformationDisclosureSuspiciousCommentsScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10027/">10027</a>.
+
 <H2 id="id-10105">Insecure Authentication</H2>
 HTTP basic or digest authentication has been used over an unsecured connection. The credentials can be read and then reused by someone with access to the network.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java">InsecureAuthenticationScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10105/">10105</a>.
+
 <H2 id="id-90001">Insecure JSF ViewState</H2>
 The response contains a Java Server Faces (JSF) ViewState value that has no cryptographic protections.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java">InsecureJsfViewStatePassiveScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90001/">90001</a>.
+
 <H2 id="id-10040">Mixed Content</H2>
 For content served via HTTPS analyse all the src attributes in the response looking for those sourced
 via plain HTTP.
@@ -297,6 +326,7 @@ via plain HTTP.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java">MixedContentScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10040/">10040</a>.
+
 <H2 id="id-10109">Modern Web Application</H2>
 This raises an informational alert if a site appears to be a modern web application.<br>
 It does not indicate any potential vulnerabilities but it could indicate that the ajax spider might be more effective at exploring this site compared to the traditional spider.
@@ -304,12 +334,14 @@ It does not indicate any potential vulnerabilities but it could indicate that th
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java">ModernAppDetectionScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/100109/">100109</a>.
+
 <H2 id="id-10028">Open Redirect</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledOpenRedirectScanRule.java">UserControlledOpenRedirectScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10028/">10028</a>.
+
 <H2 id="id-10062">PII Disclosure</H2>
 PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number.
 <br>
@@ -333,6 +365,7 @@ See: <a href="https://github.com/iannuttall/binlist-data">binlist-data</a> for m
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java">PiiScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10062/">10062</a>.
+
 <H2 id="id-00002">Private Address Disclosure</H2>
 Checks the response content for inclusion of RFC 1918 IPv4 addresses as well as 
 Amazon EC2 private hostnames (for example, ip-10-0-56-78). This information can give an attacker 
@@ -347,12 +380,14 @@ repeated scans the "Context Alert Filters" add-on could be leveraged.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java">InfoPrivateAddressDisclosureScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/00002/">00002</a>.
+
 <H2 id="id-10050">Retrieved from Cache</H2>
 This scan rule detects content that has been served from a shared cache.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRule.java">RetrievedFromCacheScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10050/">10050</a>.
+
 <H2 id="id-10108">Reverse Tabnabbing</H2>
 This checks to see if any links use a target attribute using "opener" keyword in the "rel" attribute, as this may allow target pages to take over the page that opens them.<br>
 By default this rule will ignore all links that are in the same context as the page. At the LOW threshold it will only ignore links that are on the same host.<br>
@@ -362,12 +397,14 @@ At HIGH threshold it will only report links that use the "_blank" target.<br>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRule.java">LinkTargetScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10108/">10108</a>.
+
 <H2 id="id-10037">Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s)</H2>
 This checks response headers for the presence of X-Powered-By details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java">XPoweredByHeaderInfoLeakScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10037/">10037</a>.
+
 <H2 id="id-00003">Session ID in URL Rewrite</H2>
 This scan rule checks for the existence of session token type parameters being rewritten to the URL. 
 To help reduce false positives the rule checks the length of the token value,  if the value of the parameter 
@@ -377,6 +414,7 @@ is not greater than 8 characters in length then the parameter is ignored
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java">InfoSessionIdUrlScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/00003/">00003</a>.
+
 <H2 id="id-10035">Strict Transport Security Header</H2>
 This rule checks HTTPS responses for the presence of a HTTP Strict Transport Security (HSTS) header and tests for various implementation concerns, 
 alerting if they're found.
@@ -398,6 +436,7 @@ Redirects to HTTPS URLs on the same domain will only be reported at Low threshol
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRule.java">StrictTransportSecurityScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10035/">10035</a>.
+
 <H2 id="id-10096">Timestamp Disclosure</H2>
 A timestamp was disclosed by the application/web server.<br>
 At HIGH threshold this rule does not alert on potential timestamps that are not within a range of plus or minus one year.<br>
@@ -408,24 +447,28 @@ At all thresholds, this rule will not alert on timestamps beyond the Y2038 epoch
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java">TimestampDisclosureScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10096/">10096</a>.
+
 <H2 id="id-10030">User Controllable Charset</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where Content-Type or meta tag charset declarations might be user-controlled. Such charset declarations should always be declared by the application. If an attacker can control the response charset, they could manipulate the HTML to perform XSS or other attacks.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCharsetScanRule.java">UserControlledCharsetScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10030/">10030</a>.
+
 <H2 id="id-10031">User Controllable HTML Element Attribute (Potential XSS)</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledHTMLAttributesScanRule.java">UserControlledHTMLAttributesScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10031/">10031</a>.
+
 <H2 id="id-10043">User Controllable Javascript Event (XSS)</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.            
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledJavascriptEventScanRule.java">UserControlledJavascriptEventScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10043/">10043</a>.
+
 <H2 id="id-10057">Username Hash Found</H2>
 If any context contains defined users this scan rule checks all responses for the presence of hashed values representing those usernames.
 <p><strong>Note:</strong> If the Custom Payloads addon is installed you can add your own Username strings (payloads) in the Custom Payloads options panel. 
@@ -436,6 +479,7 @@ amount of time needed to passively scan. (The default payloads are "Admin" and "
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java">UsernameIdorScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10057/">10057</a>.
+
 <H2 id="id-10032">VIEWSTATE</H2>
 Attempts to identify VIEWSTATE parameters and analyze said parameters for various best practices or protective 
 measures such as: 
@@ -450,24 +494,28 @@ The "Viewstate without MAC Signature (Unsure)" alert will only be raised at LOW 
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java">ViewstateScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10032/">10032</a>.
+
 <H2 id="id-10061">X-AspNet-Version Response Header</H2>
 This checks response headers for the presence of X-AspNet-Version/X-AspNetMvc-Version details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java">XAspNetVersionScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10061/">10061</a>.
+
 <H2 id="id-10039">X-Backend-Server Header Information Leak</H2>
 This checks response headers for the presence of X-Backend-Server details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeak.java">XBackendServerInformationLeak.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10039/">10039</a>.
+
 <H2 id="id-10052">X-ChromeLogger-Data Header Information Leak</H2>
 This checks response headers for the presence of X-ChromeLogger-Data or X-ChromePhp-Data details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java">XChromeLoggerDataInfoLeakScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10052/">10052</a>.
+
 <H2 id="id-10021">X-Content-Type-Options</H2>
 This scan rule check for the Anti-MIME-Sniffing header X-Content-Type-Options and ensures it is set to 'nosniff'.<br>
 At MEDIUM and HIGH thresholds this rule does not alert on client or server error responses or redirects.<br> 
@@ -476,12 +524,13 @@ At LOW threshold it will alert on all responses including errors and redirects.<
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java">XContentTypeOptionsScanRule.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10021/">10021</a>.
-<H2 id="id-10052">X-Debug-Token Information Leak</H2>
+
+<H2 id="id-10056">X-Debug-Token Information Leak</H2>
 This checks response headers for the presence of X-Debug-Token and X-Debug-Token-Link details.
 Which indicates the use/exposure of Symfony's Profiler. Symfony's Profiler provides access to a significant amount of information of interest to malicious individuals and Security Testers.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java">XDebugTokenScanRule.java</a>
 <br>
-Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10052/">10052</a>.
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10056/">10056</a>.
 </BODY>
 </HTML>

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -24,7 +24,7 @@ Following rules supports <b>Trusted Domains</b> :
 
 The following release status passive scan rules are included in this add-on:
 
-<H2>Anti-clickjacking Header</H2>
+<H2 id = "id-10020">Anti-clickjacking Header</H2>
 This scan rule checks for the existence and validity of the X-Frame-Options header, or Content-Security-Policy 'frame-ancestors' directive.<br> 
 At MEDIUM and HIGH thresholds this only looks at non-error or non-redirect HTML responses.<br>
 At LOW threshold it looks at all text responses including errors and redirects.<br>
@@ -38,9 +38,10 @@ The following conditions may result in an alert:
 By default no alerts will be raised in the response includes a Content-Security-Policy 'frame-ancestors' element as this take precedence over the X-Frame-Options header.
 However at LOW threshold the above issues will still be reported but at a LOW risk. 
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java">AntiClickjackingScanRule.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java">AntiClickjackingScanRule.java</a><br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10020/">10020</a>
 
-<H2>Application Errors</H2>
+<H2 id = "id-90022">Application Errors</H2>
 Check server responses for HTTP 500 - Internal Server Error type responses or those that contain a known error string. <br>
 <strong>Note:</strong> Matches made within script blocks or files are against the entire content not only comments.<br>
 Skips responses that contain ISO control characters (those which are likely binary files).<br>
@@ -53,6 +54,8 @@ amount of time needed to passively scan.
 <p>It is also possible to add patterns to the <code>xml/application_errors.xml</code> file in ZAP's user directory.<br>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java">ApplicationErrorScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90022/">90022</a>.
 
 <H2 id="id-10044">Big Redirect Detected (Potential Sensitive Information Leak)</H2>
 This check predicts the size of various redirect type responses and generates an alert if the response is greater than the predicted size. 
@@ -63,14 +66,16 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10044/">10044</a>.
 
-<H2>Cache Control</H2>
+<H2 id = "id-10015">Cache Control</H2>
 Checks "Cache-Control" response headers against general industry best practice settings for protection of sensitive content.<br>
 At MEDIUM and HIGH thresholds only non-error or non-redirect text responses (excluding JavaScript and CSS) are considered.<br>
 At LOW threshold all responses are considered including errors and redirects.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java">CacheControlScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10015/">10015</a>.
 
-<H2>Charset Mismatch</H2>
+<H2 id = "id-90011">Charset Mismatch</H2>
 <p>This check identifies responses where the HTTP Content-Type header declares a charset different from the charset defined by the body of the HTML or XML. When there's a charset mismatch between the HTTP header and content body Web browsers can be forced into an undesirable content-sniffing mode to determine the content's correct character set.</p>
 <p>The scan rule handles various conditions depending on the Threshold set for the rule, as follows:</p>
 <ul>
@@ -92,8 +97,10 @@ Further reference:<br>
 <a href="http://www.w3.org/TR/html5/document-metadata.html#charset">http://www.w3.org/TR/html5/document-metadata.html#charset</a>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java">CharsetMismatchScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90011/">90011</a>.
 
-<H2>Content Security Policy (CSP) Header Not Set</H2>
+<H2 id = "id-10038">Content Security Policy (CSP) Header Not Set</H2>
 This checks HTML response headers for the presence of a Content Security Policy header, or the response body for CSP specified via META tag.<br>
 By default this rule checks for the presence of the "Content-Security-Policy", "X-Content-Security-Policy",
 and "X-WebKit-CSP" headers. Redirects and non-HTML responses are ignored except at the Low threshold.
@@ -108,36 +115,48 @@ that is actively being refined or developed, or one which is only partially impl
 Note: This rule does not perform any actual analysis of the specified policy, for that please ensure the CSP scan rule is enabled.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRule.java">ContentSecurityPolicyMissingScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10038/">10038</a>.
 
-<H2>Content Type Missing</H2>
+<H2 id = "id-10019">Content Type Missing</H2>
 Raises an alert if the response is lacking a Content-Type header or if the header exists but the value is empty.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java">ContentTypeMissingScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10019/">10019</a>.
 
-<H2>Cookie HttpOnly</H2>
+<H2 id = "id-10010">Cookie HttpOnly</H2>
 Ensures that as cookies are set they are flagged HttpOnly. The HttpOnly flag indicates to browsers that the cookie 
 being set should not be acted upon by client side script (such as JavaScript).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java">CookieHttpOnlyScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10010/">10010</a>.
 
-<H2>Cookie - Loosely Scoped</H2>
+<H2 id = "id-90033">Cookie - Loosely Scoped</H2>
 Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. <code>www.nottrusted.com</code>, or loosely scoped to a parent domain e.g. <code>nottrusted.com</code>. In the latter case, any subdomain of <code>nottrusted.com</code> can access the cookie. Loosely scoped cookies are common in mega-applications like <code>google.com</code> and <code>live.com</code>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java">CookieLooselyScopedScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90033/">90033</a>.
 
-<H2>Cookie Poisoning</H2>
+<H2 id = "id-10029">Cookie Poisoning</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where cookie parameters might be controlled. 
 This is called a cookie poisoning attack, and becomes exploitable when an attacker can manipulate the cookie in various ways. In some cases this will not be exploitable, however, allowing URL parameters to set cookie values is generally considered a bug.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCookieScanRule.java">UserControlledCookieScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10029/">10029</a>.
 
-<H2>Cookie Secure Flag</H2>
+<H2 id = "id-10011">Cookie Secure Flag</H2>
 Looks for cookies set during HTTPS sessions, raises an alert for those that are set but do not include the secure flag.
 A cookie set with the secure flag will not be sent during a plain HTTP session.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java">CookieSecureFlagScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10011/">10011</a>.
 
-<H2>Cookie Without SameSite Attribute</H2>
+<H2 id = "id-10054">Cookie Without SameSite Attribute</H2>
 This reports any cookies that:
 <ul>
   <li>do not have the SameSite attribute</li>
@@ -146,8 +165,10 @@ This reports any cookies that:
 </ul>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java">CookieSameSiteScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10054/">10054</a>.
 
-<H2>Cross Domain Script Inclusion</H2>
+<H2 id = "id-10017">Cross Domain Script Inclusion</H2>
 Validates whether or not scripts are included from domains other than the domain hosting the content. 
 By looking at the "src" attributes of "script" tags in HTML responses.<br>
 Allowed Cross-Domain scripts:  
@@ -158,14 +179,18 @@ Allowed Cross-Domain scripts:
 </ul> 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java">CrossDomainScriptInclusionScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10017/">10017</a>.
 
-<H2>Cross Domain Misconfiguration</H2>
+<H2 id = "id-10098">Cross Domain Misconfiguration</H2>
 Passively scan responses for Cross Domain MisConfigurations, which relax the Same Origin Policy in the web browser, for instance.<br>
 The current implementation looks at excessively permissive CORS headers.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java">CrossDomainMisconfigurationScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10098/">10098</a>.
 
-<H2>CSP (Content Security Policy)</H2>
+<H2 id = "id-10055">CSP (Content Security Policy)</H2>
 
 The Content Security Policy (CSP) passive scan rule parses and analyzes CSP headers and META definitions for potential misconfiguration
 or weakness. This rule leverages HtmlUnit's <a href="https://github.com/HtmlUnit/htmlunit-csp">htmlunit-csp</a> 
@@ -174,8 +199,10 @@ library to perform it's parsing and assessment of CSPs.
 If a response has multiple CSPs they are analyzed individually, as there is no sure way to intersect/merge the policies and further different browsers have varying levels of CSP support and enforcement.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java">ContentSecurityPolicyScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10055/">10055</a>.
 
-<H2>CSRF Countermeasures</H2>
+<H2 id = "id-10202">CSRF Countermeasures</H2>
 This rule identifies "potential" vulnerabilities with the lack of known CSRF 
 countermeasures in HTML pages with forms.<br>
 The rule does not scan messages that are not HTML pages.<br>
@@ -189,56 +216,74 @@ Form element names are sorted and de-duplicated when they are printed in the ZAP
 Note: The rule also takes into account the Partial match setting within the Anti-CSRF Options.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java">CsrfCountermeasuresScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/100202/">100202</a>.
 
-<H2>Directory Browsing</H2>
+<H2 id = "id-10033">Directory Browsing</H2>
 Passively scans responses for signatures that are indicative that Directory Browsing is possible.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java">DirectoryBrowsingScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10033/">10033</a>.
 
-<H2>Hash Disclosure</H2>
+<H2 id = "id-10097">Hash Disclosure</H2>
 Passively scans for password hashes disclosed by the web server. <br>
 Various formats are including, including some formats such as MD4, MD5, and SHA*, which are sometimes used for purposes other than to contain password hashes.
 <br>
 <strong>Note:</strong> This scan rule will only analyze JavaScript responses on LOW Threshold. 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java">HashDisclosureScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10097/">10097</a>.
 
-<H2>Heartbleed OpenSSL Vulnerability (Indicative)</H2>
+<H2 id = "id-10034">Heartbleed OpenSSL Vulnerability (Indicative)</H2>
 Passively scans for HTTP header responses that may indicate that the server is vulnerable to the critical HeartBleed OpenSSL vulnerability. 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java">HeartBleedScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10034/">10034</a>.
 
-<H2>HTTP Server Response Header</H2>
+<H2 id = "id-10036">HTTP Server Response Header</H2>
 This checks response headers for the presence of a server header that contains version details.
 At LOW Threshold will raise an alert based on presence of the header field whether or not a version string is detected.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRule.java">ServerHeaderInfoLeakScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10036/">10036</a>.
 
-<H2>HTTP to HTTPS Insecure Transition in Form Post</H2>
+<H2 id = "id-10041">HTTP to HTTPS Insecure Transition in Form Post</H2>
 This check looks for insecure HTTP pages that host HTTPS forms. The issue is that an insecure HTTP page can easily be hijacked through MITM and the secure HTTPS form can be replaced or spoofed.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRule.java">InsecureFormLoadScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10041/">10041</a>.
 
-<H2>HTTPS to HTTP Insecure Transition in Form Post</H2>
+<H2 id = "id-10042">HTTPS to HTTP Insecure Transition in Form Post</H2>
 This check identifies secure HTTPS pages that host insecure HTTP forms. The issue is that a secure page is transitioning to an insecure page when data is uploaded through a form. The user may think they're submitting data to a secure page when in fact they are not.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRule.java">InsecureFormPostScanRule.java</a>
+<br> 
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10042/">10042</a>.
 
-<H2>Information Disclosure: Debug Errors</H2>
+<H2 id = "id-10023">Information Disclosure: Debug Errors</H2>
 This passive scan rule checks the content of web responses for known Debug Error message fragments.
 Access to such details may provide a malicious individual with means by which to further abuse the web site.
 They may also leak data not specifically meant for end user consumption.<br>
 Note: Javascript responses are only assessed at LOW threshold.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java">InformationDisclosureDebugErrorsScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10023/">10023</a>.
 
-<H2>Information Disclosure: In URL</H2>
+<H2 id = "id-10024">Information Disclosure: In URL</H2>
 Attempts to identify the existence of sensitive details within the visited URIs themselves 
 (this may include parameters, document names, directory names, etc.).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java">InformationDisclosureInUrlScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10024/">10024</a>.
 
-<H2>Information Disclosure: Referrer</H2>
+<H2 id = "id-10025">Information Disclosure: Referrer</H2>
 Identifies the existence of sensitive details within the Referrer header field of HTTP requests
 (this may include parameters, document names, directory names, etc.).
 <p>
@@ -248,42 +293,55 @@ otherwise the alerts will have Medium confidence.
 See: <a href="https://github.com/iannuttall/binlist-data">binlist-data</a> for more information.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java">InformationDisclosureReferrerScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10025/">10025</a>.
 
-<H2>Information Disclosure: Suspicious Comments</H2>
+<H2 id = "id-10027">Information Disclosure: Suspicious Comments</H2>
 Analyzes web content to identify comments which contain potentially sensitive details. Which may lead to 
 further attack or exposure of unintended data.
 <p><strong>Note:</strong> The strings to look for can be extended by using the Custom Payloads addon.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java">InformationDisclosureSuspiciousCommentsScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10027/">10027</a>.
 
-<H2>Insecure Authentication</H2>
+<H2 id = "id-10105">Insecure Authentication</H2>
 HTTP basic or digest authentication has been used over an unsecured connection. The credentials can be read and then reused by someone with access to the network.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java">InsecureAuthenticationScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10105/">10105</a>.
 
-<H2>Insecure JSF ViewState</H2>
+<H2 id = "id-90001">Insecure JSF ViewState</H2>
 The response contains a Java Server Faces (JSF) ViewState value that has no cryptographic protections.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java">InsecureJsfViewStatePassiveScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90001/">90001</a>.
 
-<H2>Mixed Content</H2>
+<H2 id = "id-10040">Mixed Content</H2>
 For content served via HTTPS analyse all the src attributes in the response looking for those sourced
 via plain HTTP.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java">MixedContentScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10040/">10040</a>.
 
-<H2>Modern Web Application</H2>
+<H2 id = "id-10109">Modern Web Application</H2>
 This raises an informational alert if a site appears to be a modern web application.<br>
 It does not indicate any potential vulnerabilities but it could indicate that the ajax spider might be more effective at exploring this site compared to the traditional spider.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java">ModernAppDetectionScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/100109/">100109</a>.
 
-<H2>Open Redirect</H2>
+<H2 id = "id-10028">Open Redirect</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledOpenRedirectScanRule.java">UserControlledOpenRedirectScanRule.java</a>
-
-<H2>PII Disclosure</H2>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10028/">10028</a>.
+<H2 id = "id-10062">PII Disclosure</H2>
 PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number.
 <br>
 At MEDIUM and HIGH threshold it attempts to use three characters of context on each side of potential matches to exclude matches within decimal like content.
@@ -304,8 +362,10 @@ alert, otherwise the alerts will have Medium confidence.
 See: <a href="https://github.com/iannuttall/binlist-data">binlist-data</a> for more information.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java">PiiScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10062/">10062</a>.
 
-<H2>Private Address Disclosure</H2>
+<H2 id = "id-00002">Private Address Disclosure</H2>
 Checks the response content for inclusion of RFC 1918 IPv4 addresses as well as 
 Amazon EC2 private hostnames (for example, ip-10-0-56-78). This information can give an attacker 
 useful information about the IP address scheme of the internal network, and might be helpful for 
@@ -317,34 +377,43 @@ After review an analyst can mark such alerts as False Positives in ZAP. For hand
 repeated scans the "Context Alert Filters" add-on could be leveraged.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java">InfoPrivateAddressDisclosureScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/00002/">00002</a>.
 
-<H2>Retrieved from Cache</H2>
+<H2 id = "id-10050">Retrieved from Cache</H2>
 This scan rule detects content that has been served from a shared cache.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRule.java">RetrievedFromCacheScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10050/">10050</a>.
 
-<H2>Reverse Tabnabbing</H2>
+<H2 id = "id-10108">Reverse Tabnabbing</H2>
 This checks to see if any links use a target attribute using "opener" keyword in the "rel" attribute, as this may allow target pages to take over the page that opens them.<br>
 By default this rule will ignore all links that are in the same context as the page. At the LOW threshold it will only ignore links that are on the same host.<br>
 At HIGH threshold it will only report links that use the "_blank" target.<br>
  This rule supports <b>Trusted Domains</b>, check "General Configuration" for more information.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRule.java">LinkTargetScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10108/">10108</a>.
 
-<H2>Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s)</H2>
+<H2 id="id-10037">Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s)</H2>
 This checks response headers for the presence of X-Powered-By details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java">XPoweredByHeaderInfoLeakScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10037/">10037</a>.
 
-<H2>Session ID in URL Rewrite</H2>
+<H2 id = "id-00003">Session ID in URL Rewrite</H2>
 This scan rule checks for the existence of session token type parameters being rewritten to the URL. 
 To help reduce false positives the rule checks the length of the token value,  if the value of the parameter 
 is not greater than 8 characters in length then the parameter is ignored 
 (i.e.: survey?sId=5 would not be flagged as vulnerable).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java">InfoSessionIdUrlScanRule.java</a>
-
-<H2>Strict Transport Security Header</H2>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/00003/">00003</a>.
+<H2 id = "id-10035">Strict Transport Security Header</H2>
 This rule checks HTTPS responses for the presence of a HTTP Strict Transport Security (HSTS) header and tests for various implementation concerns, 
 alerting if they're found.
 
@@ -363,8 +432,10 @@ Alerts generated:
 Redirects to HTTPS URLs on the same domain will only be reported at Low threshold.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRule.java">StrictTransportSecurityScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10035/">10035</a>.
 
-<H2>Timestamp Disclosure</H2>
+<H2 id = "id-10096">Timestamp Disclosure</H2>
 A timestamp was disclosed by the application/web server.<br>
 At HIGH threshold this rule does not alert on potential timestamps that are not within a range of plus or minus one year.<br>
 At MEDIUM threshold this rule does not alert on potential timestamps beyond 10 years.<br>
@@ -372,23 +443,30 @@ At all thresholds, this rule will not alert on timestamps beyond the Y2038 epoch
 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java">TimestampDisclosureScanRule.java</a>
-
-<H2>User Controllable Charset</H2>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10096/">10096</a>.
+<H2 id = "id-10030">User Controllable Charset</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where Content-Type or meta tag charset declarations might be user-controlled. Such charset declarations should always be declared by the application. If an attacker can control the response charset, they could manipulate the HTML to perform XSS or other attacks.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCharsetScanRule.java">UserControlledCharsetScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10030/">10030</a>.
 
-<H2>User Controllable HTML Element Attribute (Potential XSS)</H2>
+<H2 id = "id-10031">User Controllable HTML Element Attribute (Potential XSS)</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledHTMLAttributesScanRule.java">UserControlledHTMLAttributesScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10031/">10031</a>.
 
-<H2>User Controllable Javascript Event (XSS)</H2>
+<H2 id = "id-10043">User Controllable Javascript Event (XSS)</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.            
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledJavascriptEventScanRule.java">UserControlledJavascriptEventScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10043/">10043</a>.
 
-<H2>Username Hash Found</H2>
+<H2 id = "id-10057">Username Hash Found</H2>
 If any context contains defined users this scan rule checks all responses for the presence of hashed values representing those usernames.
 <p><strong>Note:</strong> If the Custom Payloads addon is installed you can add your own Username strings (payloads) in the Custom Payloads options panel. 
 They will also be hashed and searched for in responses as they're passively scanned. Keep in mind that the greater the number of payloads the greater the 
@@ -396,8 +474,9 @@ amount of time needed to passively scan. (The default payloads are "Admin" and "
 <p>Discovery of any such value may represent an Insecure Direct Object Reference (IDOR) vulnerability. Alerts are only raised as informational items as further manual testing is required in order to confirm and assess impact.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java">UsernameIdorScanRule.java</a>
-
-<H2>VIEWSTATE</H2>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10057/">10057</a>.
+<H2 id = "id-10032">VIEWSTATE</H2>
 Attempts to identify VIEWSTATE parameters and analyze said parameters for various best practices or protective 
 measures such as: 
 <ul>
@@ -409,34 +488,45 @@ measures such as:
 The "Viewstate without MAC Signature (Unsure)" alert will only be raised at LOW threshold.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java">ViewstateScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10032/">10032</a>.
 
-<H2>X-AspNet-Version Response Header</H2>
+<H2 id = "id-10061">X-AspNet-Version Response Header</H2>
 This checks response headers for the presence of X-AspNet-Version/X-AspNetMvc-Version details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java">XAspNetVersionScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10061/">10061</a>.
 
-<H2>X-Backend-Server Header Information Leak</H2>
+<H2 id = "id-10039">X-Backend-Server Header Information Leak</H2>
 This checks response headers for the presence of X-Backend-Server details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeak.java">XBackendServerInformationLeak.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10039/">10039</a>.
 
-<H2>X-ChromeLogger-Data Header Information Leak</H2>
+<H2 id = "id-10052">X-ChromeLogger-Data Header Information Leak</H2>
 This checks response headers for the presence of X-ChromeLogger-Data or X-ChromePhp-Data details.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java">XChromeLoggerDataInfoLeakScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10052/">10052</a>.
 
-<H2>X-Content-Type-Options</H2>
+<H2 id = "id-10021">X-Content-Type-Options</H2>
 This scan rule check for the Anti-MIME-Sniffing header X-Content-Type-Options and ensures it is set to 'nosniff'.<br>
 At MEDIUM and HIGH thresholds this rule does not alert on client or server error responses or redirects.<br> 
 At LOW threshold it will alert on all responses including errors and redirects.<br>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java">XContentTypeOptionsScanRule.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10021/">10021</a>.
 
-<H2>X-Debug-Token Information Leak</H2>
+<H2 id = "id-10052">X-Debug-Token Information Leak</H2>
 This checks response headers for the presence of X-Debug-Token and X-Debug-Token-Link details.
 Which indicates the use/exposure of Symfony's Profiler. Symfony's Profiler provides access to a significant amount of information of interest to malicious individuals and Security Testers.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java">XDebugTokenScanRule.java</a>
+<br>
 
 </BODY>
 </HTML>

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -333,7 +333,7 @@ It does not indicate any potential vulnerabilities but it could indicate that th
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java">ModernAppDetectionScanRule.java</a>
 <br>
-Alert ID: <a href="https://www.zaproxy.org/docs/alerts/100109/">100109</a>.
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10109/">10109</a>.
 
 <H2 id="id-10028">Open Redirect</H2>
 This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks.
@@ -366,7 +366,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10062/">10062</a>.
 
-<H2 id="id-00002">Private Address Disclosure</H2>
+<H2 id="id-2">Private Address Disclosure</H2>
 Checks the response content for inclusion of RFC 1918 IPv4 addresses as well as 
 Amazon EC2 private hostnames (for example, ip-10-0-56-78). This information can give an attacker 
 useful information about the IP address scheme of the internal network, and might be helpful for 
@@ -379,7 +379,7 @@ repeated scans the "Context Alert Filters" add-on could be leveraged.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java">InfoPrivateAddressDisclosureScanRule.java</a>
 <br>
-Alert ID: <a href="https://www.zaproxy.org/docs/alerts/00002/">00002</a>.
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/2/">2</a>.
 
 <H2 id="id-10050">Retrieved from Cache</H2>
 This scan rule detects content that has been served from a shared cache.
@@ -405,7 +405,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10037/">10037</a>.
 
-<H2 id="id-00003">Session ID in URL Rewrite</H2>
+<H2 id="id-3">Session ID in URL Rewrite</H2>
 This scan rule checks for the existence of session token type parameters being rewritten to the URL. 
 To help reduce false positives the rule checks the length of the token value,  if the value of the parameter 
 is not greater than 8 characters in length then the parameter is ignored 
@@ -413,7 +413,7 @@ is not greater than 8 characters in length then the parameter is ignored
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java">InfoSessionIdUrlScanRule.java</a>
 <br>
-Alert ID: <a href="https://www.zaproxy.org/docs/alerts/00003/">00003</a>.
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/3/">3</a>.
 
 <H2 id="id-10035">Strict Transport Security Header</H2>
 This rule checks HTTPS responses for the presence of a HTTP Strict Transport Security (HSTS) header and tests for various implementation concerns, 


### PR DESCRIPTION
Signed-off-by: Aditya Parihar <97739299+PariharAditya@users.noreply.github.com>

## Overview
Implemented a new interface for linking to website
updated help with there respective ID

## Related Issues
zaproxy/zaproxy#8189

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
