### PR TITLE
graphql: add help link to alert page

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## Unreleased
 ### Added
 - Video link in help for Automation Framework job.
+- Website alert links to the help page (Issue 8189).
 
 ### Changed
 - Maintenance changes.

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -66,7 +66,6 @@ public class ExtensionGraphQl extends ExtensionAdaptor
     private static final int ARG_IMPORT_FILE_IDX = 0;
     private static final int ARG_IMPORT_URL_IDX = 1;
     private static final int ARG_END_URL_IDX = 2;
-    public static final int PLUGIN_ID = 50007;
 
     public ExtensionGraphQl() {
         super(NAME);
@@ -164,14 +163,9 @@ public class ExtensionGraphQl extends ExtensionAdaptor
         parserThreads.clear();
     }
 
-    @Override
-    public int getPluginId() {
-        return PLUGIN_ID;
-    }
-
     public String getHelpLink() {
         return "https://www.zaproxy.org/docs/desktop/addons/graphql-support/alerts/#id-"
-                + getPluginId();
+                + TOOL_ALERT_ID;
     }
 
     @Override

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -66,6 +66,7 @@ public class ExtensionGraphQl extends ExtensionAdaptor
     private static final int ARG_IMPORT_FILE_IDX = 0;
     private static final int ARG_IMPORT_URL_IDX = 1;
     private static final int ARG_END_URL_IDX = 2;
+    public static final int PLUGIN_ID = 50007;
 
     public ExtensionGraphQl() {
         super(NAME);
@@ -161,6 +162,16 @@ public class ExtensionGraphQl extends ExtensionAdaptor
             }
         }
         parserThreads.clear();
+    }
+
+    @Override
+    public int getPluginId() {
+        return PLUGIN_ID;
+    }
+
+    public String getHelpLink() {
+        return "https://www.zaproxy.org/docs/desktop/addons/graphql-support/alerts/#id-"
+                + getPluginId();
     }
 
     @Override

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/alerts.html
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/alerts.html
@@ -5,7 +5,7 @@
     <title>GraphQL Alerts</title>
 </head>
 <body>
-<h1>GraphQL Alerts</h1>
+<h1 id="id-50007">GraphQL Alerts</h1>
 <p> The following alerts are raised by the GraphQL add-on. </p>
 <table>
     <tr>
@@ -22,6 +22,11 @@
         <td>This alert is raised when the GraphQL implementation used by the server is identified. It utilises
             fingerprinting techniques adapted from the tool <a href="https://github.com/dolevf/graphw00f">graphw00f</a>.
 </table>
+
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/tree/main/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java">ExtensionGraphQl.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/50007/">50007</a>.
+
 <h2>See also</h2>
 <table>
     <tr>

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/alerts.html
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/alerts.html
@@ -12,15 +12,18 @@
         <th>Alert Reference
         <th>Name
         <th>Description
+        <th>Latest Code
     <tr>
         <td><a href="https://www.zaproxy.org/docs/alerts/50007-1/">50007-1</a>
         <td>GraphQL Endpoint Supports Introspection
         <td>This alert is raised when the spider discovers a GraphQL endpoint that supports introspection.
+        <td><a href="https://github.com/zaproxy/zap-extensions/tree/main/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java">GraphQlParser.java</a>
     <tr>
         <td><a href="https://www.zaproxy.org/docs/alerts/50007-2/">50007-2</a>
         <td>GraphQL Server Implementation Identified
         <td>This alert is raised when the GraphQL implementation used by the server is identified. It utilises
             fingerprinting techniques adapted from the tool <a href="https://github.com/dolevf/graphw00f">graphw00f</a>.
+        <td><a href="https://github.com/zaproxy/zap-extensions/tree/main/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlFingerprinter.java">GraphQlFingerprinter.java</a>
 </table>
 
 <br>

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/alerts.html
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/alerts.html
@@ -23,7 +23,6 @@
             fingerprinting techniques adapted from the tool <a href="https://github.com/dolevf/graphw00f">graphw00f</a>.
 </table>
 
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/tree/main/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java">ExtensionGraphQl.java</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/50007/">50007</a>.
 


### PR DESCRIPTION
## Overview
Added alert links to website help pages.

## Related Issues
zaproxy/zaproxy#8189

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
