### PR TITLE
openapi: workaround issue importing fully resolved definitions

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -3,10 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
 ### Changed
 - Workaround issue loading fully resolved definitions that are too large by trying to use the original definition only (Issue 8193).
-
-## Unreleased
 
 ## [41] - 2024-05-10
 ### Changed

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+### Changed
+- Workaround issue loading fully resolved definitions that are too large by trying to use the original definition only (Issue 8193).
 
+## Unreleased
 
 ## [41] - 2024-05-10
 ### Changed

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -335,6 +335,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                     throw new OpenApiExceptions.EmptyDefinitionException();
                 }
             }
+            
 
             SwaggerParseResult swaggerParseResult = SwaggerConverter.parse(file);
             OpenAPI openApi = swaggerParseResult.getOpenAPI();

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -348,7 +348,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
             List<String> errors =
                     importOpenApiDefinition(
-                            !openApiString.contains("openapi:") || openApiString.contains(".yaml#")
+                            !openApiString.contains("openapi") || openApiString.contains(".yaml#")
                                     ? Json.pretty(openApi)
                                     : openApiString,
                             targetUrl,

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -348,9 +348,9 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
             List<String> errors =
                     importOpenApiDefinition(
-                            openApiString.contains("openapi:")
-                                    ? FileUtils.readFileToString(file, "UTF-8")
-                                    : Json.pretty(openApi),
+                            !openApiString.contains("openapi:") || openApiString.contains(".yaml#")
+                                    ? Json.pretty(openApi)
+                                    : openApiString,
                             targetUrl,
                             null,
                             initViaUi,

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.openapi;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
@@ -75,8 +76,6 @@ import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
-
-import com.fasterxml.jackson.databind.JsonMappingException;
 
 public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineListener {
 
@@ -351,9 +350,10 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             try {
                 openApiString = Json.mapper().writeValueAsString(openApi);
             } catch (JsonMappingException e) {
-                if(e.getOriginalMessage().contains("TextBuffer overrun")) {
-                    LOGGER.warn("Fully resolved definition is too large, trying to use original definition only.");
-                    openApiString = FileUtils.readFileToString(file,  StandardCharsets.UTF_8);
+                if (e.getOriginalMessage().contains("TextBuffer overrun")) {
+                    LOGGER.warn(
+                            "Fully resolved definition is too large, trying to use original definition only.");
+                    openApiString = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
                 } else {
                     throw e;
                 }
@@ -361,13 +361,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
             List<String> errors =
                     importOpenApiDefinition(
-                            openApiString,
-                            targetUrl,
-                            null,
-                            initViaUi,
-                            requestor,
-                            contextId,
-                            false);
+                            openApiString, targetUrl, null, initViaUi, requestor, contextId, false);
             results.setErrors(errors);
         } catch (IOException e) {
             if (initViaUi) {

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.openapi;
 
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.awt.EventQueue;
@@ -26,7 +27,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
@@ -343,9 +344,13 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                 throw new InvalidDefinitionException();
             }
 
+            String openApiString = FileUtils.readFileToString(file, "UTF-8");
+
             List<String> errors =
                     importOpenApiDefinition(
-                            new String(Files.readAllBytes(file.toPath())),
+                            openApiString.contains("openapi:")
+                                    ? FileUtils.readFileToString(file, "UTF-8")
+                                    : Json.pretty(openApi),
                             targetUrl,
                             null,
                             initViaUi,

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -27,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -345,7 +346,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
             List<String> errors =
                     importOpenApiDefinition(
-                            Json.pretty(openApi),
+                            new String(Files.readAllBytes(file.toPath())),
                             targetUrl,
                             null,
                             initViaUi,

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -335,7 +335,6 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                     throw new OpenApiExceptions.EmptyDefinitionException();
                 }
             }
-            
 
             SwaggerParseResult swaggerParseResult = SwaggerConverter.parse(file);
             OpenAPI openApi = swaggerParseResult.getOpenAPI();

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -352,7 +352,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                 openApiString = Json.mapper().writeValueAsString(openApi);
             } catch (JsonMappingException e) {
                 if(e.getOriginalMessage().contains("TextBuffer overrun")) {
-                    LOGGER.warn("OpenAPI definition too large, trying to read it directly from file");
+                    LOGGER.warn("Fully resolved definition is too large, trying to use original definition only.");
                     openApiString = FileUtils.readFileToString(file,  StandardCharsets.UTF_8);
                 }
                 else throw e;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -354,8 +354,9 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                 if(e.getOriginalMessage().contains("TextBuffer overrun")) {
                     LOGGER.warn("Fully resolved definition is too large, trying to use original definition only.");
                     openApiString = FileUtils.readFileToString(file,  StandardCharsets.UTF_8);
+                } else {
+                    throw e;
                 }
-                else throw e;
             }
 
             List<String> errors =

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.openapi;
 
-import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.awt.EventQueue;


### PR DESCRIPTION
## Overview
Fix import openapi definitions from files. It fails with big files.

## Related Issues
Specify any related issues or pull requests by linking to them.

https://github.com/zaproxy/zaproxy/issues/8193

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
