### PR TITLE
ascanrules : GetForPostScanRule use ComparableResponse

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Server Side Include
     - Cross Site Scripting (Reflected)
 - The Alerts from the Remote Code Execution - CVE-2012-1823 scan rule no longer have evidence duplicated in the Other Info field.
+- The GET for POST scan rule now uses a different comparison mechanism which should be more tolerant of unrelated response differences.
 
 ## [63] - 2024-02-12
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/GetForPostScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/GetForPostScanRule.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.http.ComparableResponse;
 
 /**
  * Active scan rule which checks whether or not POST requests with parameters are accepted as GET
@@ -43,6 +44,9 @@ public class GetForPostScanRule extends AbstractAppPlugin implements CommonActiv
     private static final Logger LOGGER = LogManager.getLogger(GetForPostScanRule.class);
     private static final String MESSAGE_PREFIX = "ascanrules.getforpost.";
     private static final int PLUGIN_ID = 10058;
+
+    // The required similarity ratio to consider GET and POST responses to be the same.
+    private static final double REQUIRED_SIMILARITY = 0.95;
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A04_INSECURE_DESIGN,
@@ -116,7 +120,10 @@ public class GetForPostScanRule extends AbstractAppPlugin implements CommonActiv
             return;
         }
 
-        if (newRequest.getResponseBody().equals(baseMsg.getResponseBody())) {
+        ComparableResponse baseMsgComparableResponse = createComparableResponse(baseMsg);
+        ComparableResponse newMsgComparableResponse = createComparableResponse(newRequest);
+        if (baseMsgComparableResponse.compareWith(newMsgComparableResponse)
+                >= REQUIRED_SIMILARITY) {
             buildAlert(newRequest.getRequestHeader().getPrimeHeader())
                     .setUri(baseMsg.getRequestHeader().getURI().toString())
                     .setMessage(newRequest)
@@ -126,6 +133,14 @@ public class GetForPostScanRule extends AbstractAppPlugin implements CommonActiv
 
     private AlertBuilder buildAlert(String evidence) {
         return newAlert().setConfidence(Alert.CONFIDENCE_HIGH).setEvidence(evidence);
+    }
+
+    private static ComparableResponse createComparableResponse(HttpMessage msg) {
+        return new ComparableResponse(
+                msg.getResponseHeader().getStatusCode(),
+                msg.getResponseBody().toString(),
+                Map.of(),
+                "");
     }
 
     @Override


### PR DESCRIPTION
## Overview
Changed GetForPost scan rule to use ComparableResponse. Part of zaproxy/zaproxy#7116

## Related Issues
https://github.com/zaproxy/zaproxy/issues/7116

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
