### PR TITLE
paramdigger: Handle session change & previous PR follow-up

### DIFF
--- a/addOns/paramdigger/CHANGELOG.md
+++ b/addOns/paramdigger/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Update minimum ZAP version to 2.15.0.
+- The output panel is now properly reset on ZAP session change (part of Issue 7694).
 
 ## [0.2.0] - 2023-06-06
 ### Fixed

--- a/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/CacheController.java
+++ b/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/CacheController.java
@@ -861,21 +861,19 @@ public class CacheController {
             String indicValue = msg.getResponseHeader().getHeader(cache.getIndicator());
             if (indicValue == null || indicValue.isEmpty()) {
                 return true;
-            } else {
-                if (!this.checkCacheHit(indicValue, cache) && cache.getIndicator() != null) {
-                    sleeper(2000);
-                    httpSender.sendAndReceive(msg);
-                    addCacheMessage(msg);
-                    indicValue = msg.getResponseHeader().getHeader(cache.getIndicator());
-                    if (this.checkCacheHit(indicValue, cache)) {
-                        return false;
-                    } else {
-                        return true;
-                    }
+            }
+            if (!this.checkCacheHit(indicValue, cache) && cache.getIndicator() != null) {
+                sleeper(2000);
+                httpSender.sendAndReceive(msg);
+                addCacheMessage(msg);
+                indicValue = msg.getResponseHeader().getHeader(cache.getIndicator());
+                if (this.checkCacheHit(indicValue, cache)) {
+                    return false;
                 }
-                return false;
+                return true;
             }
 
+            return false;
         } catch (Exception e) {
             return false;
         }

--- a/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/ExtensionParamDigger.java
+++ b/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/ExtensionParamDigger.java
@@ -21,9 +21,12 @@ package org.zaproxy.addon.paramdigger;
 
 import javax.swing.ImageIcon;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.parosproxy.paros.extension.SessionChangedListener;
+import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.paramdigger.gui.ParamDiggerDialog;
 import org.zaproxy.addon.paramdigger.gui.ParamDiggerPanel;
@@ -83,6 +86,8 @@ public class ExtensionParamDigger extends ExtensionAdaptor {
             extensionHook.getHookMenu().addToolsMenuItem(getMenu());
             extensionHook.getHookView().addStatusPanel(getParamDiggerPanel());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMsg());
+
+            extensionHook.addSessionListener(new SessionChangedListenerImpl());
         }
     }
 
@@ -152,5 +157,28 @@ public class ExtensionParamDigger extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
+    }
+
+    private class SessionChangedListenerImpl implements SessionChangedListener {
+
+        @Override
+        public void sessionChanged(Session session) {
+            getParamDiggerPanel().reset();
+        }
+
+        @Override
+        public void sessionAboutToChange(Session session) {
+            // Nothing to do
+        }
+
+        @Override
+        public void sessionScopeChanged(Session session) {
+            // Nothing to do
+        }
+
+        @Override
+        public void sessionModeChanged(Mode mode) {
+            // Nothing to do
+        }
     }
 }

--- a/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/HeaderGuesser.java
+++ b/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/HeaderGuesser.java
@@ -74,7 +74,7 @@ public class HeaderGuesser implements Runnable {
     private static final String POISON_DEFINITION = "paramdigger.results.poison.definition";
     private static final String POISON_DEFINITION_FIRST =
             "paramdigger.results.poison.definition.first";
-    private static List<Integer> ERROR_CODES = List.of(400, 413, 418, 429, 503);
+    private static final List<Integer> ERROR_CODES = List.of(400, 413, 418, 429, 503);
 
     private static final int PORT = 31337;
     private static final String[] PORTS = {":" + PORT, ":@" + PORT, " " + PORT};


### PR DESCRIPTION
## Overview
- CHANGELOG > Add change note.
- CacheController > Remove unnecessary else block and conditional handling. (Mentioned in https://github.com/zaproxy/zap-extensions/pull/4561/files)
- ExtensionParamDigger > Add and use SessionChangedListener.
- HeaderGuesser > Make constant final. (Mentioned in https://github.com/zaproxy/zap-extensions/pull/4561/files)

## Related Issues
- zaproxy/zaproxy#7694
- zaproxy/zap-extensions#4561

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [NA] Write tests
- [NA] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
