### PR TITLE
graphql: fix var name typo in tests

### DIFF
--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/InlineInjectorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/InlineInjectorUnitTest.java
@@ -146,9 +146,9 @@ class InlineInjectorUnitTest extends TestUtils {
     @Test
     void injectInputObjectArgumentCorrectlyEscaped() {
         String query = "{sqlInjection(expression: \"1\")}";
-        String sqliPaylaod = "\"or 1=1--";
+        String sqliPayload = "\"or 1=1--";
         String expectedQuery = "{sqlInjection(expression:\"\\\"or 1=1--\")}";
-        assertEquals(expectedQuery, injector.inject(query, "sqlInjection.expression", sqliPaylaod));
+        assertEquals(expectedQuery, injector.inject(query, "sqlInjection.expression", sqliPayload));
     }
 
     @Test

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/VariantGraphQIUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/VariantGraphQIUnitTest.java
@@ -141,8 +141,8 @@ class VariantGraphQlUnitTest {
         // When
         variant.setMessage(msg);
         NameValuePair param = variant.getParamList().get(0);
-        String sqliPaylaod = "\"or 1=1--";
-        variant.setParameter(msg, param, param.getName(), sqliPaylaod);
+        String sqliPayload = "\"or 1=1--";
+        variant.setParameter(msg, param, param.getName(), sqliPayload);
         // Then
         assertThat(
                 msg.getRequestHeader()


### PR DESCRIPTION
Correct `Payload`.

From review in #5248.