### PR TITLE
accessControl: Various tweaks or enhancements

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 - Link website alert pages and help (Issues 8189).
+- The results table now presents the same context menu as other similar tables (History, Search, etc) facilitating copying URLs, etc (Issue 8356).
+- Now has a table export button (Issue 8356).
+- Adjusted some labels/titles to use title caps (Issue 2000 & 8356).
+
+### Fixed
+- Now uses the General Font (Issue 8356), as set in the Display options.
 
 ## [9] - 2023-09-08
 ### Added

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlScanOptionsDialog.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlScanOptionsDialog.java
@@ -79,7 +79,6 @@ public class AccessControlScanOptionsDialog extends StandardFieldsDialog {
         this.addTableField(FIELD_USERS, usersSelectTable);
         this.addCheckBoxField(FIELD_RAISE_ALERTS, true);
         this.addComboField(FIELD_ALERTS_RISK, Alert.MSG_RISK, Alert.MSG_RISK[Alert.RISK_HIGH]);
-        this.addPadding();
     }
 
     @Override

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
@@ -36,7 +36,6 @@ import javax.swing.filechooser.FileFilter;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jdesktop.swingx.JXTable;
 import org.jdesktop.swingx.decorator.AbstractHighlighter;
 import org.jdesktop.swingx.decorator.ComponentAdapter;
 import org.jdesktop.swingx.renderer.DefaultTableRenderer;
@@ -62,8 +61,10 @@ import org.zaproxy.zap.extension.httpsessions.HttpSessionsPanel;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.scan.BaseScannerThreadManager;
 import org.zaproxy.zap.utils.DesktopUtils;
+import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.panels.AbstractScanToolbarStatusPanel;
+import org.zaproxy.zap.view.table.HistoryReferencesTable;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 /**
@@ -81,9 +82,10 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel
     private static final AccessControlResultsTableModel EMPTY_RESULTS_MODEL =
             new AccessControlResultsTableModel();
 
-    private JXTable resultsTable;
+    private HistoryReferencesTable resultsTable;
     private JScrollPane workPane;
     private JButton reportButton;
+    private TableExportButton<HistoryReferencesTable> exportButton = null;
 
     private Map<Integer, AccessControlResultsTableModel> resultsModels;
     private AccessControlResultsTableModel currentResultsModel;
@@ -121,7 +123,6 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel
             workPane = new JScrollPane();
             workPane.setName("AccessControlResultsPane");
             workPane.setViewportView(getScanResultsTable());
-            workPane.setFont(new java.awt.Font("Dialog", java.awt.Font.PLAIN, 11));
         }
         return workPane;
     }
@@ -131,10 +132,10 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel
      *
      * @return the scan results table
      */
-    private JXTable getScanResultsTable() {
+    private HistoryReferencesTable getScanResultsTable() {
         if (resultsTable == null) {
             // Create the table with a default, empty TableModel and the proper settings
-            resultsTable = new JXTable(EMPTY_RESULTS_MODEL);
+            resultsTable = new HistoryReferencesTable(EMPTY_RESULTS_MODEL);
             resultsTable.setColumnSelectionAllowed(false);
             resultsTable.setCellSelectionEnabled(false);
             resultsTable.setRowSelectionAllowed(true);
@@ -145,7 +146,6 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel
             this.setScanResultsTableColumnSizes();
 
             resultsTable.setName(PANEL_NAME);
-            resultsTable.setFont(new java.awt.Font("Dialog", java.awt.Font.PLAIN, 11));
             resultsTable.setDoubleBuffered(true);
             resultsTable.setSelectionMode(
                     javax.swing.ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -269,6 +269,9 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel
                         DesktopUtils.openUrlInBrowser(generatedFile.toURI());
                     });
             toolbar.add(reportButton, LayoutHelper.getGBC(gridX++, 0, 1, 0));
+            toolbar.add(
+                    new TableExportButton<>(getScanResultsTable()),
+                    LayoutHelper.getGBC(gridX++, 0, 1, 0));
         }
         return gridX;
     }

--- a/addOns/accessControl/src/main/resources/org/zaproxy/zap/extension/accessControl/resources/Messages.properties
+++ b/addOns/accessControl/src/main/resources/org/zaproxy/zap/extension/accessControl/resources/Messages.properties
@@ -21,8 +21,8 @@ accessControl.contextPanel.label.warning = Warning: Changes to the Structural Pa
 accessControl.contextPanel.title = Access Control
 accessControl.contextPanel.user.unauthenticated = <<Unauthenticated user>>
 
-accessControl.contextTree.hanging = Older rules
-accessControl.contextTree.root = Context access rules
+accessControl.contextTree.hanging = Older Rules
+accessControl.contextTree.root = Context Access Rules
 
 accessControl.desc = Add-on that adds a set of tools for testing access control in web applications.
 
@@ -55,7 +55,7 @@ accessControl.scanOptions.label.alertsRisk = Risk level for raised alerts:
 accessControl.scanOptions.label.context = Context to scan:
 accessControl.scanOptions.label.raiseAlerts = Raise alerts for identified issues:
 accessControl.scanOptions.label.users = Users to scan as (at least 1):
-accessControl.scanOptions.title = Access Control scan options 
+accessControl.scanOptions.title = Access Control Scan Options 
 accessControl.scanOptions.unauthenticatedUser = << Unauthenticated >>
 
 accessControl.scanResult.illegal = Invalid
@@ -64,7 +64,7 @@ accessControl.scanResult.valid = Valid
 
 accessControl.toolbar.button.options = Options
 accessControl.toolbar.button.pause = Pause
-accessControl.toolbar.button.report = Generate report
+accessControl.toolbar.button.report = Generate Report
 accessControl.toolbar.button.start = Start
 accessControl.toolbar.button.stop = Stop
 accessControl.toolbar.button.unpause = Unpause


### PR DESCRIPTION
## Overview
- AccessControlScanOptionsDialog > No longer padding, which simply seemed to be unused space. The user selection table could maybe use a tweak in the future, but still this is better than before.
- AccessControlStatusPanel > Now uses a HistoryReferencesTable instead of a default JXTable so that the standard history  reference container context menus apply. No longer statically assigning the font for the panel/table.
- CHANGELOG > Added notes.
- Messages.properties > Title capped some UI strings.

## Related Issues
- zaproxy/zaproxy#2000
- zaproxy/zaproxy#8356

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [NA] Write tests
- [NA] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
