### PR TITLE
Expose Active & Passive Scripts as Scan Rules

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Helper classes for scripts used as scan-rules (Issue 7105).
 
 ## [1.23.0] - 2024-03-25
 ### Added

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/Category.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/Category.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2023 The ZAP Development Team
+ * Copyright 2024 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.scripts.scanrules;
+package org.zaproxy.addon.commonlib.scanrules;
 
-import javax.script.ScriptException;
-import org.parosproxy.paros.network.HttpMessage;
+public enum Category {
+    INFO_GATHER(org.parosproxy.paros.core.scanner.Category.INFO_GATHER),
+    BROWSER(org.parosproxy.paros.core.scanner.Category.BROWSER),
+    SERVER(org.parosproxy.paros.core.scanner.Category.SERVER),
+    MISC(org.parosproxy.paros.core.scanner.Category.MISC),
+    INJECTION(org.parosproxy.paros.core.scanner.Category.INJECTION);
 
-public interface ActiveScript2 {
+    private final int value;
 
-    void scanNode(ActiveScriptHelper helper, HttpMessage msg) throws ScriptException;
+    Category(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getName() {
+        return org.parosproxy.paros.core.scanner.Category.getName(value);
+    }
 }

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/Confidence.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/Confidence.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2023 The ZAP Development Team
+ * Copyright 2024 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.scripts.scanrules;
+package org.zaproxy.addon.commonlib.scanrules;
 
-import javax.script.ScriptException;
-import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.core.scanner.Alert;
 
-public interface ActiveScript2 {
+public enum Confidence {
+    FALSE_POSITIVE(Alert.CONFIDENCE_FALSE_POSITIVE),
+    LOW(Alert.CONFIDENCE_LOW),
+    MEDIUM(Alert.CONFIDENCE_MEDIUM),
+    HIGH(Alert.CONFIDENCE_HIGH),
+    USER_CONFIRMED(Alert.CONFIDENCE_USER_CONFIRMED);
 
-    void scanNode(ActiveScriptHelper helper, HttpMessage msg) throws ScriptException;
+    private final int value;
+
+    Confidence(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
 }

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/Risk.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/Risk.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2023 The ZAP Development Team
+ * Copyright 2024 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.scripts.scanrules;
+package org.zaproxy.addon.commonlib.scanrules;
 
-import javax.script.ScriptException;
-import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.core.scanner.Alert;
 
-public interface ActiveScript2 {
+public enum Risk {
+    INFO(Alert.RISK_INFO),
+    LOW(Alert.RISK_LOW),
+    MEDIUM(Alert.RISK_MEDIUM),
+    HIGH(Alert.RISK_HIGH);
 
-    void scanNode(ActiveScriptHelper helper, HttpMessage msg) throws ScriptException;
+    private final int value;
+
+    Risk(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
 }

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/ScanRuleMetadata.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/ScanRuleMetadata.java
@@ -1,0 +1,188 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.scanrules;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.util.List;
+import java.util.Map;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.control.AddOn;
+
+public class ScanRuleMetadata {
+
+    private static final ObjectMapper YAML_OBJECT_MAPPER;
+
+    static {
+        YAML_OBJECT_MAPPER =
+                YAMLMapper.builder()
+                        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                        .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                        .build();
+        YAML_OBJECT_MAPPER.findAndRegisterModules();
+    }
+
+    private int id = -1;
+    private String name;
+    private String description;
+    private String solution;
+    private List<String> references;
+    private Category category;
+    private Risk risk;
+    private Confidence confidence;
+    private int cweId;
+    private int wascId;
+    private Map<String, String> alertTags;
+    private String otherInfo;
+    private AddOn.Status status = AddOn.Status.unknown;
+
+    // Required for Jackson YAML deserialization
+    private ScanRuleMetadata() {}
+
+    public ScanRuleMetadata(int id, String name) {
+        this.id = id;
+        this.name = name;
+        validateMetadata(this);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getSolution() {
+        return solution;
+    }
+
+    public void setSolution(String solution) {
+        this.solution = solution;
+    }
+
+    public List<String> getReferences() {
+        return references;
+    }
+
+    public void setReferences(List<String> references) {
+        this.references = references;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public Risk getRisk() {
+        return risk;
+    }
+
+    public void setRisk(Risk risk) {
+        this.risk = risk;
+    }
+
+    public Confidence getConfidence() {
+        return confidence;
+    }
+
+    public void setConfidence(Confidence confidence) {
+        this.confidence = confidence;
+    }
+
+    public int getCweId() {
+        return cweId;
+    }
+
+    public void setCweId(int cweId) {
+        this.cweId = cweId;
+    }
+
+    public int getWascId() {
+        return wascId;
+    }
+
+    public void setWascId(int wascId) {
+        this.wascId = wascId;
+    }
+
+    public Map<String, String> getAlertTags() {
+        return alertTags;
+    }
+
+    public void setAlertTags(Map<String, String> alertTags) {
+        this.alertTags = alertTags;
+    }
+
+    public String getOtherInfo() {
+        return otherInfo;
+    }
+
+    public void setOtherInfo(String otherInfo) {
+        this.otherInfo = otherInfo;
+    }
+
+    public AddOn.Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(AddOn.Status status) {
+        this.status = status;
+    }
+
+    public static ScanRuleMetadata fromYaml(String yaml) {
+        ScanRuleMetadata metadata;
+        try {
+            metadata = YAML_OBJECT_MAPPER.readValue(yaml, ScanRuleMetadata.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        validateMetadata(metadata);
+        return metadata;
+    }
+
+    private static void validateMetadata(ScanRuleMetadata metadata) {
+        if (metadata == null || metadata.getId() == -1 || metadata.getName() == null) {
+            throw new IllegalArgumentException(
+                    Constant.messages.getString("commonlib.scanrules.error.invalidYamlMetadata"));
+        }
+    }
+}

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/ScanRuleMetadataProvider.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/scanrules/ScanRuleMetadataProvider.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2023 The ZAP Development Team
+ * Copyright 2024 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.scripts.scanrules;
+package org.zaproxy.addon.commonlib.scanrules;
 
-import javax.script.ScriptException;
-import org.parosproxy.paros.network.HttpMessage;
-
-public interface ActiveScript2 {
-
-    void scanNode(ActiveScriptHelper helper, HttpMessage msg) throws ScriptException;
+public interface ScanRuleMetadataProvider {
+    ScanRuleMetadata getMetadata();
 }

--- a/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/resources/Messages.properties
+++ b/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/resources/Messages.properties
@@ -19,3 +19,5 @@ commonlib.progress.panel.title = Progress
 
 commonlib.readable.file.chooser.warn.dialog.message = Not readable:\n{0}\nDo you have appropriate permissions to read the file (or parent folder)?
 commonlib.readable.file.chooser.warn.dialog.title = Permissions Failure
+
+commonlib.scanrules.error.invalidYamlMetadata = Invalid metadata. A valid ID and name must be specified.

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/scanrules/ScanRuleMetadataUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/scanrules/ScanRuleMetadataUnitTest.java
@@ -1,0 +1,138 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.scanrules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.control.AddOn;
+import org.zaproxy.zap.utils.I18N;
+
+class ScanRuleMetadataUnitTest {
+
+    @BeforeEach
+    void setUp() {
+        Constant.messages = new I18N(Locale.ENGLISH);
+    }
+
+    @Test
+    void shouldParseMetadataYaml() {
+        // Given
+        String yaml =
+                "id: 12345\n"
+                        + "name: Active Vulnerability Title\n"
+                        + "description: Full description\n"
+                        + "solution: The solution\n"
+                        + "references:\n"
+                        + "  - Reference 1\n"
+                        + "  - Reference 2\n"
+                        + "category: INJECTION  # info_gather, browser, server, misc, injection\n"
+                        + "risk: INFO  # info, low, medium, high\n"
+                        + "confidence: LOW  # false_positive, low, medium, high, user_confirmed\n"
+                        + "cweId: 0\n"
+                        + "wascId: 0\n"
+                        + "alertTags:\n"
+                        + "  name1: value1\n"
+                        + "  name2: value2\n"
+                        + "otherInfo: Any other Info\n"
+                        + "status: alpha";
+        // When
+        var metadata = ScanRuleMetadata.fromYaml(yaml);
+        // Then
+        assertThat(metadata.getId(), is(equalTo(12345)));
+        assertThat(metadata.getName(), is(equalTo("Active Vulnerability Title")));
+        assertThat(metadata.getDescription(), is(equalTo("Full description")));
+        assertThat(metadata.getSolution(), is(equalTo("The solution")));
+        assertThat(metadata.getReferences(), contains("Reference 1", "Reference 2"));
+        assertThat(metadata.getCategory(), is(equalTo(Category.INJECTION)));
+        assertThat(metadata.getRisk(), is(equalTo(Risk.INFO)));
+        assertThat(metadata.getConfidence(), is(equalTo(Confidence.LOW)));
+        assertThat(metadata.getCweId(), is(equalTo(0)));
+        assertThat(metadata.getWascId(), is(equalTo(0)));
+        assertThat(
+                metadata.getAlertTags(), is(equalTo(Map.of("name1", "value1", "name2", "value2"))));
+        assertThat(metadata.getOtherInfo(), is(equalTo("Any other Info")));
+        assertThat(metadata.getStatus(), is(equalTo(AddOn.Status.alpha)));
+    }
+
+    @Test
+    void shouldWorkWithCaseInsensitiveEnumValues() {
+        // Given
+        String yaml =
+                "id: 12345\n"
+                        + "name: Test Scan Rule\n"
+                        + "category: iNjEcTiOn\n"
+                        + "risk: iNfO\n"
+                        + "confidence: lOw\n"
+                        + "status: aLpHa";
+        // When
+        var metadata = ScanRuleMetadata.fromYaml(yaml);
+        // Then
+        assertThat(metadata.getId(), is(equalTo(12345)));
+        assertThat(metadata.getName(), is(equalTo("Test Scan Rule")));
+        assertThat(metadata.getCategory(), is(equalTo(Category.INJECTION)));
+        assertThat(metadata.getRisk(), is(equalTo(Risk.INFO)));
+        assertThat(metadata.getConfidence(), is(equalTo(Confidence.LOW)));
+        assertThat(metadata.getStatus(), is(equalTo(AddOn.Status.alpha)));
+    }
+
+    @Test
+    void shouldIgnoreUnknownYamlFields() {
+        // Given
+        String yaml = "id: 12345\nname: Test Scan Rule\nsong: Never Gonna Give You Up\n";
+        // When
+        var metadata = ScanRuleMetadata.fromYaml(yaml);
+        // Then
+        assertThat(metadata.getId(), is(equalTo(12345)));
+        assertThat(metadata.getName(), is(equalTo("Test Scan Rule")));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenIdIsMissing() {
+        // Given
+        String yaml = "name: Test Scan Rule\n";
+        // When / Then
+        assertThrows(RuntimeException.class, () -> ScanRuleMetadata.fromYaml(yaml));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNameIsMissing() {
+        // Given
+        String yaml = "id: 12345\n";
+        // When / Then
+        assertThrows(RuntimeException.class, () -> ScanRuleMetadata.fromYaml(yaml));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenYamlIsInvalid() {
+        // Given
+        String yaml = "not yaml";
+        // When / Then
+        assertThrows(RuntimeException.class, () -> ScanRuleMetadata.fromYaml(yaml));
+    }
+}

--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update Active and Passive Script Templates to include a `getMetadata` function. This will allow them to be used as regular scan rules.
+- Depend on the `commonlib` and `scripts` add-ons for scan rule scripts.
 - Maintenance changes.
 
 ## [0.5.0] - 2023-10-12

--- a/addOns/graaljs/graaljs.gradle.kts
+++ b/addOns/graaljs/graaljs.gradle.kts
@@ -18,6 +18,17 @@ zapAddOn {
         bundledLibs {
             libs.from(configurations.runtimeClasspath)
         }
+
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">=1.24.0")
+                }
+                register("scripts") {
+                    version.set(">=45.2.0")
+                }
+            }
+        }
     }
 }
 
@@ -28,6 +39,9 @@ crowdin {
 }
 
 dependencies {
+    zapAddOn("commonlib")
+    zapAddOn("scripts")
+
     val graalJsVersion = "22.3.3"
     implementation("org.graalvm.js:js:$graalJsVersion")
     implementation("org.graalvm.js:js-scriptengine:$graalJsVersion")

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/active/Active default template GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/active/Active default template GraalJS.js
@@ -1,13 +1,37 @@
 // Note that new active scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+const ScanRuleMetadata = Java.type("org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata");
+
+function getMetadata() {
+	return ScanRuleMetadata.fromYaml(`
+id: 12345
+name: Active Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+category: INJECTION  # info_gather, browser, server, misc, injection
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other Info
+status: alpha
+`);
+}
+
 /**
  * Scans a "node", i.e. an individual entry in the Sites Tree.
  * The scanNode function will typically be called once for every page. 
  * 
  * @param as - the ActiveScan parent object that will do all the core interface tasks 
  *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
- *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ *     raising alerts, etc.). This is an ActiveScriptHelper object.
  * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
  */
 function scanNode(as, msg) {
@@ -47,7 +71,7 @@ function scanNode(as, msg) {
  * 
  * @param as - the ActiveScan parent object that will do all the core interface tasks 
  *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
- *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ *     raising alerts, etc.). This is an ActiveScriptHelper object.
  * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
  * @param {string} param - the name of the parameter being manipulated for this test/scan.
  * @param {string} value - the original parameter value.
@@ -68,21 +92,10 @@ function scan(as, msg, param, value) {
 	
 	// Test the response here, and make other requests as required
 	if (true) {	// Change to a test which detects the vulnerability
-		// risk: 0: info, 1: low, 2: medium, 3: high
-		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
 		as.newAlert()
-			.setRisk(1)
-			.setConfidence(1)
-			.setName('Active Vulnerability title')
-			.setDescription('Full description')
 			.setParam(param)
 			.setAttack('Your attack')
 			.setEvidence('Evidence')
-			.setOtherInfo('Any other info')
-			.setSolution('The solution')
-			.setReference('References')
-			.setCweId(0)
-			.setWascId(0)
 			.setMessage(msg)
 			.raise();
 	}

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/passive/Passive default template GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/passive/Passive default template GraalJS.js
@@ -3,7 +3,30 @@
 // Note that new passive scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-var PluginPassiveScanner = Java.type("org.zaproxy.zap.extension.pscan.PluginPassiveScanner");
+const PluginPassiveScanner = Java.type("org.zaproxy.zap.extension.pscan.PluginPassiveScanner");
+const ScanRuleMetadata = Java.type("org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata");
+
+function getMetadata() {
+	return ScanRuleMetadata.fromYaml(`
+id: 12345
+name: Passive Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other info
+status: alpha
+`);
+}
+
 
 /**
  * Passively scans an HTTP message. The scan function will be called for 
@@ -12,7 +35,7 @@ var PluginPassiveScanner = Java.type("org.zaproxy.zap.extension.pscan.PluginPass
  * 
  * @param ps - the PassiveScan parent object that will do all the core interface tasks 
  *     (i.e.: providing access to Threshold settings, raising alerts, etc.). 
- *     This is an ScriptsPassiveScanner object.
+ *     This is a PassiveScriptHelper object.
  * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
  * @param src - the Jericho Source representation of the message being scanned.
  */
@@ -22,21 +45,12 @@ function scan(ps, msg, src) {
 		// risk: 0: info, 1: low, 2: medium, 3: high
 		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
 		ps.newAlert()
-			.setRisk(1)
-			.setConfidence(1)
-			.setName('Passive Vulnerability title')
-			.setDescription('Full description')
 			.setParam('The param')
 			.setEvidence('Evidence')
-			.setOtherInfo('Any other info')
-			.setSolution('The solution')
-			.setReference('References')
-			.setCweId(0)
-			.setWascId(0)
 			.raise();
 		
-		//addTag(String tag)
-		ps.addTag('tag')			
+		//addHistoryTag(String tag)
+		ps.addHistoryTag('tag')
 	}
 	
 	// Raise less reliable alert (that is, prone to false positives) when in LOW alert threshold

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/VerifyScriptTemplates.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/VerifyScriptTemplates.java
@@ -27,23 +27,14 @@ import java.util.List;
 import javax.script.Compilable;
 import javax.script.CompiledScript;
 import javax.script.ScriptEngine;
-import org.junit.jupiter.api.BeforeAll;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.testutils.AbstractVerifyScriptTemplates;
 
-/** Verifies that the Kotlin script templates are parsed without errors. */
-public class VerifyScriptTemplates extends AbstractVerifyScriptTemplates {
+/** Verifies that the GraalJS script templates are parsed without errors. */
+class VerifyScriptTemplates extends AbstractVerifyScriptTemplates {
 
     private static ScriptEngine se;
-
-    @BeforeAll
-    static void setUp() {
-        se =
-                new GraalJsEngineWrapper(
-                                VerifyScriptTemplates.class.getClassLoader(), List.of(), null)
-                        .getEngine();
-    }
 
     @Override
     protected String getScriptExtension() {
@@ -52,6 +43,10 @@ public class VerifyScriptTemplates extends AbstractVerifyScriptTemplates {
 
     @Override
     protected void parseTemplate(Path template) throws Exception {
+        se =
+                new GraalJsEngineWrapper(
+                                VerifyScriptTemplates.class.getClassLoader(), List.of(), null)
+                        .getEngine();
         se.put("control", Control.getSingleton());
         se.put("model", Model.getSingleton());
 

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintenance changes.
 - Replace usage of singletons with injected variables (e.g. `model`, `control`) in scripts.
 - Dependency updates.
+- Update Active and Passive Script Templates to include a `getMetadata` function. This will allow them to be used as regular scan rules.
+- Depend on the `commonlib` and `scripts` add-ons for scan rule scripts.
 
 ### Fixed
 - Updated encode-decode script template to conform to the latest method signatures.

--- a/addOns/groovy/groovy.gradle.kts
+++ b/addOns/groovy/groovy.gradle.kts
@@ -9,10 +9,23 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/groovy-support/")
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">=1.24.0")
+                }
+                register("scripts") {
+                    version.set(">=45.2.0")
+                }
+            }
+        }
     }
 }
 
 dependencies {
+    zapAddOn("commonlib")
+    zapAddOn("scripts")
+
     implementation("org.codehaus.groovy:groovy-all:3.0.14")
 
     testImplementation(project(":testutils"))

--- a/addOns/groovy/src/main/zapHomeFiles/scripts/templates/active/ActiveDefaultTemplate.groovy
+++ b/addOns/groovy/src/main/zapHomeFiles/scripts/templates/active/ActiveDefaultTemplate.groovy
@@ -1,45 +1,67 @@
-import org.parosproxy.paros.core.scanner.Alert
 import org.parosproxy.paros.core.scanner.Plugin
 import org.parosproxy.paros.network.HttpMessage
-import org.zaproxy.zap.extension.ascan.ScriptsActiveScanner
+import org.zaproxy.zap.extension.scripts.scanrules.ActiveScriptHelper
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata
 
 // Note that new active scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"
+
+ScanRuleMetadata getMetadata() {
+    return ScanRuleMetadata.fromYaml("""
+id: 12345
+name: Active Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+category: INJECTION  # info_gather, browser, server, misc, injection
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other Info
+status: alpha
+""")
+}
 
 /**
  * Scans a "node", i.e. an individual entry in the Sites Tree.
  * The scanNode function will typically be called once for every page.
  *
- * @param aScan -   the ActiveScan parent object that will do all the core interface tasks
+ * @param helper -   the ActiveScan parent object that will do all the core interface tasks
  *                  (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
- *                  raising alerts, etc.). This is an ScriptsActiveScanner object.
+ *                  raising alerts, etc.). This is an ActiveScriptHelper object.
  * @param msg   -   the HTTP Message being scanned. This is an HttpMessage object.
  */
-void scanNode(ScriptsActiveScanner aScan, HttpMessage msg) {
+void scanNode(ActiveScriptHelper helper, HttpMessage msg) {
 
     println('scan called for url=' + msg.getRequestHeader().getURI().toString())
 
     // Copy requests before reusing them
     msg = msg.cloneRequest()
 
-    aScan.sendAndReceive(msg, false, false)
+    helper.sendAndReceive(msg, false, false)
 
     // Test the responses and raise alerts as below
 
     // Check if the scan was stopped before performing lengthy tasks
-    if (aScan.isStop()) {
+    if (helper.isStop()) {
         return
     }
     // Do lengthy task...
 
     // Raise less reliable alert (that is, prone to false positives) when in LOW alert threshold
-    if (aScan.getAlertThreshold() == Plugin.AlertThreshold.LOW) {
+    if (helper.getAlertThreshold() == Plugin.AlertThreshold.LOW) {
         // ...
     }
 
     // Do more tests in HIGH attack strength
     // Expected values: "LOW", "MEDIUM", "HIGH", "INSANE"
-    if (aScan.getAttackStrength() == Plugin.AttackStrength.HIGH) {
+    if (helper.getAttackStrength() == Plugin.AttackStrength.HIGH) {
         // ...
     }
 }
@@ -48,14 +70,14 @@ void scanNode(ScriptsActiveScanner aScan, HttpMessage msg) {
  * Scans a specific parameter in an HTTP message.
  * The scan function will typically be called for every parameter in every URL and Form for every page.
  *
- * @param as    -   the ActiveScan parent object that will do all the core interface tasks
+ * @param helper-   the ActiveScan parent object that will do all the core interface tasks
  *                  (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
- *                  raising alerts, etc.). This is an ScriptsActiveScanner object.
+ *                  raising alerts, etc.). This is an ActiveScriptHelper object.
  * @param msg   -   the HTTP Message being scanned. This is an HttpMessage object.
  * @param param -   the name of the parameter being manipulated for this test/scan.
  * @param value -   the original parameter value.
  */
-void scan(ScriptsActiveScanner aScan, HttpMessage msg, String param, String value) {
+void scan(ActiveScriptHelper helper, HttpMessage msg, String param, String value) {
     // Debugging can be done using println like this
     println('scan called for url=' + msg.getRequestHeader().getURI().toString() +
             ' param=' + param + ' value=' + value)
@@ -64,25 +86,17 @@ void scan(ScriptsActiveScanner aScan, HttpMessage msg, String param, String valu
     msg = msg.cloneRequest()
 
     // Inject your payload
-    aScan.setParam(msg, param, 'Your attack')
+    helper.setParam(msg, param, 'Your attack')
 
-    aScan.sendAndReceive(msg, false, false);
+    helper.sendAndReceive(msg, false, false);
 
     // Test the response here, and make other requests as required
     if (true) {	// Change to a test which detects the vulnerability
-        aScan.raiseAlert(
-                Alert.RISK_LOW,
-                Alert.CONFIDENCE_LOW,
-                'Active Vulnerability title',
-                'Full description',
-                msg.getRequestHeader().getURI().toString(),
-                param,
-                'Your attack',
-                'Any other info',
-                'The solution',
-                'The evidence',
-                0,
-                0,
-                msg)
+        helper.newAlert()
+                .setParam(param)
+                .setAttack('Your attack')
+                .setEvidence('Evidence')
+                .setMessage(msg)
+                .raise()
     }
 }

--- a/addOns/groovy/src/main/zapHomeFiles/scripts/templates/passive/PassiveDefaultTemplate.groovy
+++ b/addOns/groovy/src/main/zapHomeFiles/scripts/templates/passive/PassiveDefaultTemplate.groovy
@@ -5,48 +5,60 @@ Note that new passive scripts will initially be disabled
 Right click the script in the Scripts tree and select "enable"
 */
 
+
 import net.htmlparser.jericho.Source
-import org.parosproxy.paros.core.scanner.Alert
 import org.parosproxy.paros.core.scanner.Plugin
 import org.parosproxy.paros.network.HttpMessage
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner
-import org.zaproxy.zap.extension.pscan.scanner.ScriptsPassiveScanner
+import org.zaproxy.zap.extension.scripts.scanrules.PassiveScriptHelper
+
+ScanRuleMetadata getMetadata() {
+    return ScanRuleMetadata.fromYaml("""
+id: 12345
+name: Passive Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other info
+status: alpha
+""")
+}
 
 /**
  * Passively scans an HTTP message. The scan function will be called for 
  * request/response made via ZAP, actual messages depend on the function
  * "appliesToHistoryType", defined below.
  * 
- * @param ps - 	the PassiveScan parent object that will do all the core interface tasks
- * 				(i.e.: providing access to Threshold settings, raising alerts, etc.).
- * 				This is an ScriptsPassiveScanner object.
- * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
- * @param src - the Jericho Source representation of the message being scanned.
+ * @param helper - the PassiveScan parent object that will do all the core interface tasks
+ * 				   (i.e.: providing access to Threshold settings, raising alerts, etc.).
+ * 				   This is a PassiveScriptHelper object.
+ * @param msg -    the HTTP Message being scanned. This is an HttpMessage object.
+ * @param src -    the Jericho Source representation of the message being scanned.
  */
-void scan(ScriptsPassiveScanner ps, HttpMessage msg, Source source){
+void scan(PassiveScriptHelper helper, HttpMessage msg, Source source){
 	// Test the request and/or response here
 
 	if (true) {	// Change to a test which detects the vulnerability
-		ps.raiseAlert(
-				Alert.RISK_INFO,
-				Alert.CONFIDENCE_LOW,
-				'Passive Vulnerability title',
-				'Full description',
-				msg.getRequestHeader().getURI().toString(),
-				'The param',
-				'Your attack',
-				'Any other info',
-				'The solution',
-				'The evidence',
-				0,
-				0,
-				msg)
+		helper.newAlert()
+				.setParam('The param')
+				.setEvidence('Evidence')
+				.raise()
 
-		//Add Tag
-		ps.addTag('Your tag')
+		//Add History Tag
+		helper.addHistoryTag('Your tag')
 
 		// Raise less reliable alert (that is, prone to false positives) when in LOW alert threshold
-		if (ps.getAlertThreshold() == Plugin.AlertThreshold.LOW) {
+		if (helper.getAlertThreshold() == Plugin.AlertThreshold.LOW) {
 			// ...
 		}
 	}

--- a/addOns/jruby/jruby.gradle.kts
+++ b/addOns/jruby/jruby.gradle.kts
@@ -12,7 +12,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("scripts") {
-                    version.set(">=45.0.0")
+                    version.set(">=45.2.0")
                 }
             }
         }

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/active/Active default template.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/active/Active default template.rb
@@ -6,14 +6,14 @@
 require 'java'
 java_package 'org.zaproxy.zap.extension.ascan'
 java_import 'org.zaproxy.zap.extension.scripts.scanrules.ActiveScript'
-java_import 'org.zaproxy.zap.extension.scripts.scanrules.ScriptsActiveScanner'
+java_import 'org.zaproxy.zap.extension.scripts.scanrules.ActiveScriptHelper'
 java_import 'org.parosproxy.paros.network.HttpMessage'
 java_import 'org.parosproxy.paros.view.View'
 
 class JRubyActiveScript 
   include Java::org.zaproxy.zap.extension.scripts.scanrules.ActiveScript
 
-  java_signature 'scan(ScriptsActiveScanner, HttpMessage, String, String)'
+  java_signature 'scan(ActiveScriptHelper, HttpMessage, String, String)'
   def scan(sas, msg, param, value)
     # Debugging can be done to the Output tab like this
     # (not sure why print/puts doesnt work yet :(

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.rb
@@ -7,7 +7,7 @@ require 'java'
 java_package 'org.zaproxy.zap.extension.pscan'
 java_import 'org.zaproxy.zap.extension.scripts.scanrules.PassiveScript'
 java_import 'org.zaproxy.zap.extension.pscan.PluginPassiveScanner'
-java_import 'org.zaproxy.zap.extension.scripts.scanrules.ScriptsPassiveScanner'
+java_import 'org.zaproxy.zap.extension.scripts.scanrules.PassiveScriptHelper'
 java_import 'org.parosproxy.paros.network.HttpMessage'
 java_import 'net.htmlparser.jericho.Source'
 java_import 'org.parosproxy.paros.view.View'
@@ -15,7 +15,7 @@ java_import 'org.parosproxy.paros.view.View'
 class JRubyPassiveScript 
   include Java::org.zaproxy.zap.extension.scripts.scanrules.PassiveScript
 
-  java_signature 'scan(ScriptsPassiveScanner, HttpMessage, Source)'
+  java_signature 'scan(PassiveScriptHelper, HttpMessage, Source)'
   def scan(ps, msg, src)
     # Test the request and/or response here
     # Debugging can be done to the Output tab like this

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Update Active and Passive Script Templates to include a `getMetadata` function. This will allow them to be used as regular scan rules.
+- Depend on the `commonlib` add-on for scan rule scripts.
+- Update minimum `scripts` add-on version to 45.1.0.
 
 ## [14] - 2023-12-19
 ### Changed

--- a/addOns/jython/jython.gradle.kts
+++ b/addOns/jython/jython.gradle.kts
@@ -11,8 +11,11 @@ zapAddOn {
         url.set("https://www.zaproxy.org/docs/desktop/addons/python-scripting/")
         dependencies {
             addOns {
+                register("commonlib") {
+                    version.set(">=1.24.0")
+                }
                 register("scripts") {
-                    version.set(">=44")
+                    version.set(">=45.2.0")
                 }
             }
         }
@@ -20,6 +23,8 @@ zapAddOn {
 }
 
 dependencies {
+    zapAddOn("commonlib")
+
     implementation("org.python:jython-standalone:2.7.2")
 
     testImplementation(project(":testutils"))

--- a/addOns/jython/src/main/zapHomeFiles/scripts/templates/active/Active default template.py
+++ b/addOns/jython/src/main/zapHomeFiles/scripts/templates/active/Active default template.py
@@ -3,43 +3,60 @@ The scanNode function will typically be called once for every page
 The scan function will typically be called for every parameter in every URL and Form for every page 
 
 Note that new active scripts will initially be disabled
-Right click the script in the Scripts tree and select "enable"  
+Right-click the script in the Scripts tree and select "enable"
 """
+
+from org.zaproxy.addon.commonlib.scanrules import ScanRuleMetadata
+
+def getMetadata():
+    return ScanRuleMetadata.fromYaml("""
+id: 12345
+name: Active Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+category: INJECTION  # info_gather, browser, server, misc, injection
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other Info
+status: alpha
+""")
+
 def scanNode(sas, msg):
   # Debugging can be done using print like this
-  print('scan called for url=' + msg.getRequestHeader().getURI().toString());
+  print('scan called for url=' + msg.getRequestHeader().getURI().toString())
 
   # Copy requests before reusing them
-  msg = msg.cloneRequest();
+  msg = msg.cloneRequest()
 
   # sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
-  sas.sendAndReceive(msg, False, False);
+  sas.sendAndReceive(msg, False, False)
 
   # Test the responses and raise alerts as below
 
 
-def scan(sas, msg, param, value):
+def scan(helper, msg, param, value):
   # Debugging can be done using print like this
   print('scan called for url=' + msg.getRequestHeader().getURI().toString() + 
-    ' param=' + param + ' value=' + value);
+    ' param=' + param + ' value=' + value)
 
   # Copy requests before reusing them
-  msg = msg.cloneRequest();
+  msg = msg.cloneRequest()
 
   # setParam (message, parameterName, newValue)
-  sas.setParam(msg, param, 'Your attack');
+  helper.setParam(msg, param, 'Your attack')
 
   # sendAndReceive(msg, followRedirect, handleAntiCSRFtoken)
-  sas.sendAndReceive(msg, False, False);
+  helper.sendAndReceive(msg, False, False)
 
   # Test the response here, and make other requests as required
-  if (True):
-  	# Change to a test which detects the vulnerability
-    # raiseAlert(risk, int confidence, String name, String description, String uri, 
-    #		String param, String attack, String otherInfo, String solution, String evidence, 
-    #		int cweId, int wascId, HttpMessage msg)
-    # risk: 0: info, 1: low, 2: medium, 3: high
-    # confidence: 0: false positive, 1: low, 2: medium, 3: high
-    sas.raiseAlert(1, 1, 'Active Vulnerability title', 'Full description', 
-    msg.getRequestHeader().getURI().toString(), 
-      param, 'Your attack', 'Any other info', 'The solution ', '', 0, 0, msg);
+  if True:
+    # Change to a test which detects the vulnerability
+    helper.newAlert().setParam(param).setAttack('Your attack').setEvidence('Evidence').setMessage(msg).raise()

--- a/addOns/jython/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.py
+++ b/addOns/jython/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.py
@@ -2,11 +2,31 @@
 Passive scan rules should not make any requests.
 
 Note that new passive scripts will initially be disabled
-Right click the script in the Scripts tree and select "enable"
+Right-click the script in the Scripts tree and select "enable"
 """  
 
-from org.zaproxy.zap.extension.pscan import PluginPassiveScanner;
+from org.zaproxy.zap.extension.pscan import PluginPassiveScanner
+from org.zaproxy.addon.commonlib.scanrules import ScanRuleMetadata
 
+def getMetadata():
+    return ScanRuleMetadata.fromYaml("""
+id: 12345
+name: Passive Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other info
+status: alpha
+""")
 
 def appliesToHistoryType(historyType):
     """Tells whether or not the scanner applies to the given history type.
@@ -18,26 +38,19 @@ def appliesToHistoryType(historyType):
         True to scan the message, False otherwise.
 
     """
-    return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
+    return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType)
 
 
-def scan(ps, msg, src):
+def scan(helper, msg, src):
   """Passively scans the message sent/received through ZAP.
 
   Args:
-    ps (ScriptsPassiveScanner): The helper class to raise alerts and add tags to the message.
+    helper (PassiveScriptHelper): The helper class to raise alerts and add tags to the message.
     msg (HttpMessage): The HTTP message being scanned.
     src (Source): The HTML source of the message (if any). 
 
   """
   # Test the request and/or response here
-  if (True):
+  if True:
     # Change to a test which detects the vulnerability
-    # raiseAlert(risk, int confidence, String name, String description, String uri, 
-    # String param, String attack, String otherInfo, String solution, String evidence, 
-    # int cweId, int wascId, HttpMessage msg)
-    # risk: 0: info, 1: low, 2: medium, 3: high
-    # confidence: 0: false positive, 1: low, 2: medium, 3: high
-    ps.raiseAlert(1, 1, 'Passive Vulnerability title', 'Full description', 
-      msg.getRequestHeader().getURI().toString(), 
-      'The param', 'Your attack', 'Any other info', 'The solution', '', 0, 0, msg);
+    helper.newAlert().setParam('The param').setEvidence('Evidence').raise()

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Active and Passive Scripts with a `getMetadata()` function are now treated as first-class scan rules (Issue 7105).
+
 ### Fixed
 - Error when trying to run an unsupported script type through the Automation Framework.
 
 ## [45.1.0] - 2024-03-25
 ### Added
 - Support for menu weights (Issue 8369)
+
 ### Fixed
 - Propagate script errors to the Automation Framework when running them.
 

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -9,7 +9,11 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/script-console/")
+        // Don't search the add-on classes to prevent the inclusion
+        // of some scan rules which are loaded at runtime.
+        classpath.setFrom(files())
         extensions {
+            register("org.zaproxy.zap.extension.scripts.ExtensionScriptsUI")
             register("org.zaproxy.zap.extension.scripts.automation.ExtensionScriptAutomation") {
                 classnames {
                     allowed.set(listOf("org.zaproxy.zap.extension.scripts.automation"))
@@ -26,9 +30,15 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.23.0")
+                    version.set(">=1.24.0")
                 }
             }
+        }
+        ascanrules {
+            register("org.zaproxy.zap.extension.scripts.scanrules.ScriptsActiveScanner")
+        }
+        pscanrules {
+            register("org.zaproxy.zap.extension.scripts.scanrules.ScriptsPassiveScanner")
         }
     }
 }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -49,6 +49,7 @@ import org.parosproxy.paros.view.OptionsDialog;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.authentication.ExtensionAuthentication;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
@@ -59,6 +60,8 @@ import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptUI;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.scripts.scanrules.ActiveScriptSynchronizer;
+import org.zaproxy.zap.extension.scripts.scanrules.PassiveScriptSynchronizer;
 import org.zaproxy.zap.extension.scripts.scanrules.ScriptsPassiveScanner;
 import org.zaproxy.zap.extension.stdmenus.PopupContextMenuItemFactory;
 import org.zaproxy.zap.model.Context;
@@ -119,6 +122,9 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     private ScriptWrapper currentLockedScript = null;
     private boolean lockOutputToDisplayedScript = false;
 
+    private final ActiveScriptSynchronizer activeScriptSynchronizer;
+    private final PassiveScriptSynchronizer passiveScriptSynchronizer;
+
     // private ZapMenuItem menuEnableScripts = null;
 
     public ExtensionScriptsUI() {
@@ -131,6 +137,8 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
             LOGGER.error(
                     "Scripts UI extension's order is not higher than Authentication extension's");
         }
+        activeScriptSynchronizer = new ActiveScriptSynchronizer();
+        passiveScriptSynchronizer = new PassiveScriptSynchronizer();
     }
 
     public static ImageIcon getIcon() {
@@ -307,6 +315,9 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
             OptionsDialog optionsDialog = View.getSingleton().getOptionsDialog("");
             optionsDialog.removeParamPanel(scriptConsoleOptionsPanel);
         }
+
+        activeScriptSynchronizer.unload();
+        passiveScriptSynchronizer.unload();
 
         if (extScript != null) {
             if (hasView()) {
@@ -665,11 +676,20 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
         if (View.isInitialised() && display) {
             executeInEdt(() -> this.displayScript(script));
         }
-        if (script.getType().getName().equals(SCRIPT_EXT_TYPE) && script.isEnabled()) {
-            if (!this.installedExtenderScripts.containsKey(script.getName())) {
-                // It has been flagged as to be enabled
-                installExtenderScript(script);
-            }
+        switch (script.getType().getName()) {
+            case SCRIPT_EXT_TYPE:
+                if (script.isEnabled()
+                        && !this.installedExtenderScripts.containsKey(script.getName())) {
+                    // It has been flagged as to be enabled
+                    installExtenderScript(script);
+                }
+                break;
+            case ExtensionActiveScan.SCRIPT_TYPE_ACTIVE:
+                activeScriptSynchronizer.scriptAdded(script);
+                break;
+            case ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE:
+                passiveScriptSynchronizer.scriptAdded(script);
+                break;
         }
     }
 
@@ -690,11 +710,19 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
         if (this.isScriptDisplayed(script)) {
             executeInEdt(() -> this.getConsolePanel().clearScript());
         }
-        if (script.getType().getName().equals(SCRIPT_EXT_TYPE)) {
-            if (this.installedExtenderScripts.containsKey(script.getName())) {
-                // It has been installed so uninstall it
-                uninstallExtenderScript(script);
-            }
+        switch (script.getType().getName()) {
+            case SCRIPT_EXT_TYPE:
+                if (this.installedExtenderScripts.containsKey(script.getName())) {
+                    // It has been installed so uninstall it
+                    uninstallExtenderScript(script);
+                }
+                break;
+            case ExtensionActiveScan.SCRIPT_TYPE_ACTIVE:
+                activeScriptSynchronizer.scriptRemoved(script);
+                break;
+            case ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE:
+                passiveScriptSynchronizer.scriptRemoved(script);
+                break;
         }
         if (View.isInitialised()) {
             this.getConsolePanel().removeScript(script);
@@ -742,7 +770,16 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     }
 
     @Override
-    public void scriptSaved(ScriptWrapper script) {}
+    public void scriptSaved(ScriptWrapper script) {
+        switch (script.getType().getName()) {
+            case ExtensionActiveScan.SCRIPT_TYPE_ACTIVE:
+                activeScriptSynchronizer.scriptAdded(script);
+                break;
+            case ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE:
+                passiveScriptSynchronizer.scriptAdded(script);
+                break;
+        }
+    }
 
     public void showError(Exception e) {
         if (View.isInitialised()) {

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScript.java
@@ -24,6 +24,6 @@ import org.parosproxy.paros.network.HttpMessage;
 
 public interface ActiveScript {
 
-    void scan(ScriptsActiveScanner sas, HttpMessage msg, String param, String value)
+    void scan(ActiveScriptHelper helper, HttpMessage msg, String param, String value)
             throws ScriptException;
 }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptHelper.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptHelper.java
@@ -1,0 +1,147 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.io.IOException;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.network.HttpMessage;
+
+public abstract class ActiveScriptHelper extends AbstractAppParamPlugin {
+
+    @Override
+    public boolean isStop() {
+        return super.isStop();
+    }
+
+    public String setParam(HttpMessage msg, String param, String value) {
+        return super.setParameter(msg, param, value);
+    }
+
+    @Override
+    public void sendAndReceive(HttpMessage msg) throws IOException {
+        super.sendAndReceive(msg);
+    }
+
+    @Override
+    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect) throws IOException {
+        super.sendAndReceive(msg, isFollowRedirect);
+    }
+
+    @Override
+    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect, boolean handleAntiCSRF)
+            throws IOException {
+        super.sendAndReceive(msg, isFollowRedirect, handleAntiCSRF);
+    }
+
+    @Override
+    public AlertBuilder newAlert() {
+        return super.newAlert();
+    }
+
+    /**
+     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
+    public void raiseAlert(
+            int risk,
+            int confidence,
+            String name,
+            String description,
+            String uri,
+            String param,
+            String attack,
+            String otherInfo,
+            String solution,
+            String evidence,
+            int cweId,
+            int wascId,
+            HttpMessage msg) {
+        super.bingo(
+                risk,
+                confidence,
+                name,
+                description,
+                uri,
+                param,
+                attack,
+                otherInfo,
+                solution,
+                evidence,
+                cweId,
+                wascId,
+                msg);
+    }
+
+    /**
+     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
+    public void raiseAlert(
+            int risk,
+            int confidence,
+            String name,
+            String description,
+            String uri,
+            String param,
+            String attack,
+            String otherInfo,
+            String solution,
+            String evidence,
+            String reference,
+            int cweId,
+            int wascId,
+            HttpMessage msg) {
+        super.bingo(
+                risk,
+                confidence,
+                name,
+                description,
+                uri,
+                param,
+                attack,
+                otherInfo,
+                solution,
+                evidence,
+                reference,
+                cweId,
+                wascId,
+                msg);
+    }
+
+    @Override
+    public boolean isPage200(HttpMessage msg) {
+        return super.isPage200(msg);
+    }
+
+    @Override
+    public boolean isPage404(HttpMessage msg) {
+        return super.isPage404(msg);
+    }
+
+    @Override
+    public boolean isPage500(HttpMessage msg) {
+        return super.isPage500(msg);
+    }
+
+    @Override
+    public boolean isPageOther(HttpMessage msg) {
+        return super.isPageOther(msg);
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRule.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRule.java
@@ -1,0 +1,247 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
+import org.zaproxy.zap.control.AddOn;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+public class ActiveScriptScanRule extends ActiveScriptHelper {
+
+    private static final Logger LOGGER = LogManager.getLogger(ActiveScriptScanRule.class);
+    private static final String SCRIPT_NAME_KEY =
+            "activeScriptScanRuleReflectionWorkAround.script.name";
+    private ExtensionScript extScript;
+    private ScriptWrapper script;
+    private CachedScriptInterfaces cachedScriptInterfaces;
+    private ScanRuleMetadata metadata;
+
+    /** Used via reflection in {@link org.parosproxy.paros.core.scanner.PluginFactory} */
+    public ActiveScriptScanRule() {}
+
+    public ActiveScriptScanRule(ScriptWrapper script, ScanRuleMetadata metadata) {
+        this.script = script;
+        cachedScriptInterfaces = new CachedScriptInterfaces(script);
+        this.metadata = metadata;
+    }
+
+    @Override
+    public Configuration getConfig() {
+        var config = super.getConfig();
+        if (config != null && script != null) {
+            // FIXME: Do not clone the configuration.
+            //   See https://github.com/zaproxy/zap-extensions/pull/5322#discussion_r1525238566.
+            config = ConfigurationUtils.cloneConfiguration(config);
+            config.addProperty(SCRIPT_NAME_KEY, script.getName());
+        }
+        return config;
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        if (script == null) {
+            // This is a workaround for the case when the instance is created via reflection in the
+            // HostProcess class.
+            String scriptName = getConfig().getString(SCRIPT_NAME_KEY, null);
+            if (scriptName == null) {
+                throw new RuntimeException("No linked script found for scan rule.");
+            }
+            script = getExtScript().getScript(scriptName);
+            if (script == null) {
+                throw new RuntimeException("Script not found: \"" + scriptName + "\".");
+            }
+            cachedScriptInterfaces = new CachedScriptInterfaces(script);
+            try {
+                var metadataProvider =
+                        getExtScript().getInterface(script, ScanRuleMetadataProvider.class);
+                metadata = metadataProvider.getMetadata();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public void scan() {
+        try {
+            if (!script.isEnabled()) {
+                getParent()
+                        .pluginSkipped(
+                                this,
+                                Constant.messages.getString(
+                                        "scripts.scanRules.ascan.disabledSkipReason"));
+                return;
+            }
+            ActiveScript2 s = cachedScriptInterfaces.getInterface(script, ActiveScript2.class);
+            if (s != null) {
+                HttpMessage msg = getNewMsg();
+                LOGGER.debug(
+                        "Calling script {} scanNode for {}",
+                        script.getName(),
+                        msg.getRequestHeader().getURI());
+                s.scanNode(this, msg);
+            }
+        } catch (Exception e) {
+            getExtScript().handleScriptException(script, e);
+        }
+        super.scan();
+    }
+
+    @Override
+    public void scan(HttpMessage msg, String param, String value) {
+        try {
+            if (!script.isEnabled()) {
+                // The script was disabled while the scan was running (intentionally or otherwise).
+                getParent()
+                        .pluginSkipped(
+                                this,
+                                Constant.messages.getString(
+                                        "scripts.scanRules.ascan.disabledSkipReason"));
+                return;
+            }
+            ActiveScript s = cachedScriptInterfaces.getInterface(script, ActiveScript.class);
+            if (s != null) {
+                s.scan(this, msg, param, value);
+            }
+        } catch (Exception e) {
+            getExtScript().handleScriptException(script, e);
+        }
+    }
+
+    @Override
+    public void cloneInto(Plugin other) {
+        if (!(other instanceof ActiveScriptScanRule)) {
+            throw new IllegalArgumentException(
+                    "Expected a ActiveScriptScanRule, but got " + other.getClass().getName());
+        }
+        var otherRule = (ActiveScriptScanRule) other;
+        otherRule.script = script;
+        otherRule.metadata = metadata;
+        otherRule.setConfig(getConfig());
+    }
+
+    final ScriptWrapper getScript() {
+        return script;
+    }
+
+    void setMetadata(ScanRuleMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public AlertBuilder newAlert() {
+        return super.newAlert()
+                .setConfidence(metadata.getConfidence().getValue())
+                .setOtherInfo(metadata.getOtherInfo());
+    }
+
+    @Override
+    public int getId() {
+        return metadata.getId();
+    }
+
+    @Override
+    public String getName() {
+        return metadata.getName();
+    }
+
+    @Override
+    public String getDescription() {
+        return metadata.getDescription();
+    }
+
+    @Override
+    public int getCategory() {
+        return metadata.getCategory().getValue();
+    }
+
+    @Override
+    public String getSolution() {
+        return metadata.getSolution();
+    }
+
+    @Override
+    public String getReference() {
+        return String.join("\n", metadata.getReferences());
+    }
+
+    @Override
+    public int getRisk() {
+        return metadata.getRisk().getValue();
+    }
+
+    @Override
+    public int getCweId() {
+        return metadata.getCweId();
+    }
+
+    @Override
+    public int getWascId() {
+        return metadata.getWascId();
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return metadata.getAlertTags();
+    }
+
+    @Override
+    public AddOn.Status getStatus() {
+        return metadata.getStatus();
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(newAlert().build());
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        script.setEnabled(enabled);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return script.isEnabled();
+    }
+
+    private ExtensionScript getExtScript() {
+        if (extScript == null) {
+            extScript =
+                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        }
+        return extScript;
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptSynchronizer.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptSynchronizer.java
@@ -1,0 +1,111 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.PluginFactory;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+public class ActiveScriptSynchronizer {
+
+    private static final Logger LOGGER = LogManager.getLogger(ActiveScriptSynchronizer.class);
+
+    private ExtensionScript extScript;
+    private final Map<ScriptWrapper, ActiveScriptScanRule> scriptToScanRuleMap = new HashMap<>();
+
+    public void scriptAdded(ScriptWrapper script) {
+        try {
+            ActiveScriptScanRule scanRule = scriptToScanRuleMap.get(script);
+
+            var metadata = ScriptSynchronizerUtils.getMetadataForScript(script);
+            if (metadata == null) {
+                if (scanRule != null) {
+                    // The metadata function was removed from the script
+                    scriptRemoved(script);
+                }
+                return;
+            }
+
+            if (scanRule != null) {
+                if (scanRule.getId() == metadata.getId()) {
+                    scanRule.setMetadata(metadata);
+                    return;
+                }
+                if (unloadScanRule(scanRule)) {
+                    scriptToScanRuleMap.remove(script);
+                }
+            }
+
+            if (ScriptSynchronizerUtils.hasClashingId(metadata.getId(), script)) {
+                return;
+            }
+
+            scanRule = new ActiveScriptScanRule(script, metadata);
+            PluginFactory.loadedPlugin(scanRule);
+            if (!PluginFactory.isPluginLoaded(scanRule)) {
+                LOGGER.error("Failed to install script scan rule: {}", scanRule.getName());
+                return;
+            }
+            scriptToScanRuleMap.put(script, scanRule);
+        } catch (Exception e) {
+            getExtScript().handleScriptException(script, e);
+        }
+    }
+
+    public void scriptRemoved(ScriptWrapper script) {
+        try {
+            ActiveScriptScanRule scanRule = scriptToScanRuleMap.get(script);
+            if (scanRule == null) {
+                return;
+            }
+            if (unloadScanRule(scanRule)) {
+                scriptToScanRuleMap.remove(script);
+            }
+        } catch (Exception e) {
+            extScript.handleScriptException(script, e);
+        }
+    }
+
+    public void unload() {
+        scriptToScanRuleMap.values().forEach(this::unloadScanRule);
+    }
+
+    private boolean unloadScanRule(ActiveScriptScanRule scanRule) {
+        PluginFactory.unloadedPlugin(scanRule);
+        if (PluginFactory.isPluginLoaded(scanRule)) {
+            LOGGER.error("Failed to uninstall script scan rule: {}", scanRule.getName());
+            return false;
+        }
+        return true;
+    }
+
+    private ExtensionScript getExtScript() {
+        if (extScript == null) {
+            extScript =
+                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        }
+        return extScript;
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/CachedScriptInterfaces.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/CachedScriptInterfaces.java
@@ -1,0 +1,69 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.script.ScriptException;
+import org.parosproxy.paros.control.Control;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+class CachedScriptInterfaces {
+
+    private ExtensionScript extScript;
+    private final ScriptWrapper script;
+    private int currentModCount;
+    private final Map<Class<?>, Object> interfaces = new HashMap<>();
+
+    CachedScriptInterfaces(ScriptWrapper script) {
+        this.script = script;
+        this.currentModCount = script.getModCount();
+    }
+
+    <T> T getInterface(ScriptWrapper script, Class<T> clazz) throws ScriptException, IOException {
+        Object iface;
+        if (hasChanged() || !interfaces.containsKey(clazz)) {
+            iface = getExtScript().getInterface(script, clazz);
+            interfaces.put(clazz, iface);
+        } else {
+            iface = interfaces.get(clazz);
+        }
+        return clazz.cast(iface);
+    }
+
+    private boolean hasChanged() {
+        if (interfaces.isEmpty()) {
+            return true;
+        }
+        int previousModCount = currentModCount;
+        currentModCount = script.getModCount();
+        return previousModCount != currentModCount;
+    }
+
+    private ExtensionScript getExtScript() {
+        if (extScript == null) {
+            extScript =
+                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        }
+        return extScript;
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScript.java
@@ -26,8 +26,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 public interface PassiveScript {
 
-    void scan(ScriptsPassiveScanner scriptsPassiveScanner, HttpMessage msg, Source source)
-            throws ScriptException;
+    void scan(PassiveScriptHelper helper, HttpMessage msg, Source source) throws ScriptException;
 
     /**
      * Tells whether the scanner applies to the given history type.

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptHelper.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptHelper.java
@@ -1,0 +1,117 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public abstract class PassiveScriptHelper extends PluginPassiveScanner {
+
+    @Override
+    public AlertBuilder newAlert() {
+        return super.newAlert();
+    }
+
+    @Override
+    public void addHistoryTag(String tag) {
+        super.addHistoryTag(tag);
+    }
+
+    /**
+     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
+    public void raiseAlert(
+            int risk,
+            int confidence,
+            String name,
+            String description,
+            String uri,
+            String param,
+            String attack,
+            String otherInfo,
+            String solution,
+            String evidence,
+            int cweId,
+            int wascId,
+            HttpMessage msg) {
+
+        raiseAlert(
+                risk,
+                confidence,
+                name,
+                description,
+                uri,
+                param,
+                attack,
+                otherInfo,
+                solution,
+                evidence,
+                null,
+                cweId,
+                wascId,
+                msg);
+    }
+
+    /**
+     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
+    public void raiseAlert(
+            int risk,
+            int confidence,
+            String name,
+            String description,
+            String uri,
+            String param,
+            String attack,
+            String otherInfo,
+            String solution,
+            String evidence,
+            String reference,
+            int cweId,
+            int wascId,
+            HttpMessage msg) {
+
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(name)
+                .setDescription(description)
+                .setParam(param)
+                .setOtherInfo(otherInfo)
+                .setSolution(solution)
+                .setReference(reference)
+                .setEvidence(evidence)
+                .setCweId(cweId)
+                .setWascId(wascId)
+                .setMessage(msg)
+                .raise();
+    }
+
+    /**
+     * @deprecated Replaced by {@link #addHistoryTag(String)}
+     */
+    @Override
+    @Deprecated
+    public void addTag(String tag) {
+        super.addHistoryTag(tag);
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRule.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRule.java
@@ -1,0 +1,143 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.util.List;
+import java.util.Map;
+import net.htmlparser.jericho.Source;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.zap.control.AddOn;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+public class PassiveScriptScanRule extends PassiveScriptHelper {
+
+    private static final Logger LOGGER = LogManager.getLogger(PassiveScriptScanRule.class);
+    private ExtensionScript extScript;
+    private ScriptWrapper script;
+    private CachedScriptInterfaces cachedScriptInterfaces;
+    private ScanRuleMetadata metadata;
+
+    public PassiveScriptScanRule(ScriptWrapper script, ScanRuleMetadata metadata) {
+        this.script = script;
+        cachedScriptInterfaces = new CachedScriptInterfaces(script);
+        this.metadata = metadata;
+    }
+
+    @Override
+    public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        try {
+            var s = cachedScriptInterfaces.getInterface(script, PassiveScript.class);
+            if (s != null) {
+                s.scan(this, msg, source);
+            }
+        } catch (Exception e) {
+            getExtScript().handleScriptException(script, e);
+        }
+    }
+
+    @Override
+    public boolean appliesToHistoryType(int historyType) {
+        try {
+            var s = cachedScriptInterfaces.getInterface(script, PassiveScript.class);
+            if (s != null) {
+                return s.appliesToHistoryType(historyType);
+            }
+        } catch (Exception e) {
+            getExtScript().handleScriptException(script, e);
+        }
+        return false;
+    }
+
+    @Override
+    public PluginPassiveScanner copy() {
+        return new PassiveScriptScanRule(script, metadata);
+    }
+
+    @Override
+    public AlertBuilder newAlert() {
+        return super.newAlert()
+                .setRisk(metadata.getRisk().getValue())
+                .setConfidence(metadata.getConfidence().getValue())
+                .setDescription(metadata.getDescription())
+                .setSolution(metadata.getSolution())
+                .setCweId(metadata.getCweId())
+                .setWascId(metadata.getWascId())
+                .setReference(String.join("\n", metadata.getReferences()))
+                .setOtherInfo(metadata.getOtherInfo());
+    }
+
+    @Override
+    public String getName() {
+        return metadata.getName();
+    }
+
+    @Override
+    public int getPluginId() {
+        return metadata.getId();
+    }
+
+    @Override
+    public AddOn.Status getStatus() {
+        return metadata.getStatus();
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return metadata.getAlertTags();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        script.setEnabled(enabled);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return script.isEnabled();
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(newAlert().build());
+    }
+
+    final ScriptWrapper getScript() {
+        return script;
+    }
+
+    void setMetadata(ScanRuleMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    private ExtensionScript getExtScript() {
+        if (extScript == null) {
+            extScript =
+                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        }
+        return extScript;
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptSynchronizer.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptSynchronizer.java
@@ -1,0 +1,121 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.control.Control;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+public class PassiveScriptSynchronizer {
+
+    private static final Logger LOGGER = LogManager.getLogger(PassiveScriptSynchronizer.class);
+
+    private ExtensionScript extScript;
+    private ExtensionPassiveScan extPscan;
+
+    private final Map<ScriptWrapper, PassiveScriptScanRule> scriptToScanRuleMap = new HashMap<>();
+
+    public void scriptAdded(ScriptWrapper script) {
+        try {
+            PassiveScriptScanRule scanRule = scriptToScanRuleMap.get(script);
+
+            var metadata = ScriptSynchronizerUtils.getMetadataForScript(script);
+            if (metadata == null) {
+                if (scanRule != null) {
+                    // The metadata function was removed from the script
+                    scriptRemoved(script);
+                }
+                return;
+            }
+
+            if (scanRule != null) {
+                if (scanRule.getPluginId() == metadata.getId()) {
+                    scanRule.setMetadata(metadata);
+                    return;
+                }
+                if (unloadScanRule(scanRule)) {
+                    scriptToScanRuleMap.remove(script);
+                }
+            }
+
+            if (ScriptSynchronizerUtils.hasClashingId(metadata.getId(), script)) {
+                return;
+            }
+
+            scanRule = new PassiveScriptScanRule(script, metadata);
+            if (!getExtPscan().addPluginPassiveScanner(scanRule)) {
+                LOGGER.error("Failed to install script scan rule: {}", script.getName());
+                return;
+            }
+            scriptToScanRuleMap.put(script, scanRule);
+        } catch (Exception e) {
+            getExtScript().handleScriptException(script, e);
+        }
+    }
+
+    public void scriptRemoved(ScriptWrapper script) {
+        try {
+            PassiveScriptScanRule scanRule = scriptToScanRuleMap.get(script);
+            if (scanRule == null) {
+                return;
+            }
+            if (unloadScanRule(scanRule)) {
+                scriptToScanRuleMap.remove(script);
+            }
+        } catch (Exception e) {
+            extScript.handleScriptException(script, e);
+        }
+    }
+
+    public void unload() {
+        scriptToScanRuleMap.values().forEach(this::unloadScanRule);
+    }
+
+    private boolean unloadScanRule(PassiveScriptScanRule scanRule) {
+        if (!getExtPscan().removePluginPassiveScanner(scanRule)) {
+            LOGGER.error("Failed to uninstall script scan rule: {}", scanRule.getName());
+            return false;
+        }
+        return true;
+    }
+
+    private ExtensionScript getExtScript() {
+        if (extScript == null) {
+            extScript =
+                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        }
+        return extScript;
+    }
+
+    private ExtensionPassiveScan getExtPscan() {
+        if (extPscan == null) {
+            extPscan =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionPassiveScan.class);
+        }
+        return extPscan;
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptSynchronizerUtils.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptSynchronizerUtils.java
@@ -1,0 +1,106 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.PluginFactory;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+class ScriptSynchronizerUtils {
+
+    private static final Logger LOGGER = LogManager.getLogger(ScriptSynchronizerUtils.class);
+
+    static ScanRuleMetadata getMetadataForScript(ScriptWrapper script) throws Exception {
+        var metadataProvider = getExtScript().getInterface(script, ScanRuleMetadataProvider.class);
+        if (metadataProvider != null) {
+            try {
+                return metadataProvider.getMetadata();
+            } catch (UndeclaredThrowableException ignored) {
+                // Python and Kotlin scripts throw this exception when the method is not implemented
+                return null;
+            } catch (Exception e) {
+                if ("groovy.lang.MissingMethodException"
+                        .equals(e.getCause().getClass().getCanonicalName())) {
+                    // Groovy scripts throw this exception when the method is not implemented
+                    return null;
+                }
+                throw e;
+            }
+        }
+        return null;
+    }
+
+    static boolean providesMetadata(ScriptWrapper script) {
+        try {
+            var metadataProvider =
+                    getExtScript().getInterface(script, ScanRuleMetadataProvider.class);
+            if (metadataProvider != null) {
+                metadataProvider.getMetadata();
+                return true;
+            }
+        } catch (Exception ignored) {
+        }
+        return false;
+    }
+
+    static boolean hasClashingId(int id, ScriptWrapper script) {
+        boolean hasClashingId = false;
+        String existingRuleName = null;
+        var loadedPlugin = PluginFactory.getLoadedPlugin(id);
+        if (loadedPlugin != null) {
+            hasClashingId = true;
+            existingRuleName = loadedPlugin.getName();
+        } else {
+            var pluginPassiveScanner = getExtPscan().getPluginPassiveScanner(id);
+            if (pluginPassiveScanner != null) {
+                hasClashingId = true;
+                existingRuleName = pluginPassiveScanner.getName();
+            }
+        }
+        if (hasClashingId) {
+            String message =
+                    Constant.messages.getString(
+                            "scripts.scanRules.duplicateId",
+                            String.valueOf(id),
+                            existingRuleName,
+                            script.getName());
+            LOGGER.error(message);
+            getExtScript().setError(script, message);
+            getExtScript().setEnabled(script, false);
+        }
+        return hasClashingId;
+    }
+
+    private static ExtensionScript getExtScript() {
+        return Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+    }
+
+    private static ExtensionPassiveScan getExtPscan() {
+        return Control.getSingleton().getExtensionLoader().getExtension(ExtensionPassiveScan.class);
+    }
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScanner.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScanner.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.scripts.scanrules;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -28,10 +27,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
@@ -40,7 +39,7 @@ import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
 import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
 import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceProvider;
 
-public class ScriptsActiveScanner extends AbstractAppParamPlugin {
+public class ScriptsActiveScanner extends ActiveScriptHelper {
 
     private ExtensionScript extension = null;
     private ScriptsCache<ActiveScript> cachedScripts;
@@ -157,6 +156,11 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
             ScriptWrapper script = it.next();
             try {
                 if (script.isEnabled()) {
+
+                    if (ScriptSynchronizerUtils.providesMetadata(script)) {
+                        continue;
+                    }
+
                     ActiveScript2 s = extension.getInterface(script, ActiveScript2.class);
 
                     if (s != null) {
@@ -179,6 +183,10 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
         if (!isStop()) {
             InterfaceProvider<ActiveScript> interfaceProvider =
                     (scriptWrapper, targetInterface) -> {
+                        if (extension.getInterface(scriptWrapper, ScanRuleMetadataProvider.class)
+                                != null) {
+                            return null;
+                        }
                         ActiveScript s = extension.getInterface(scriptWrapper, targetInterface);
                         if (s != null) {
                             return s;
@@ -231,106 +239,6 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
     }
 
     @Override
-    public boolean isStop() {
-        return super.isStop();
-    }
-
-    public String setParam(HttpMessage msg, String param, String value) {
-        return super.setParameter(msg, param, value);
-    }
-
-    @Override
-    public void sendAndReceive(HttpMessage msg) throws IOException {
-        super.sendAndReceive(msg);
-    }
-
-    @Override
-    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect) throws IOException {
-        super.sendAndReceive(msg, isFollowRedirect);
-    }
-
-    @Override
-    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect, boolean handleAntiCSRF)
-            throws IOException {
-        super.sendAndReceive(msg, isFollowRedirect, handleAntiCSRF);
-    }
-
-    @Override
-    public AlertBuilder newAlert() {
-        return super.newAlert();
-    }
-
-    /**
-     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
-     */
-    @Deprecated
-    public void raiseAlert(
-            int risk,
-            int confidence,
-            String name,
-            String description,
-            String uri,
-            String param,
-            String attack,
-            String otherInfo,
-            String solution,
-            String evidence,
-            int cweId,
-            int wascId,
-            HttpMessage msg) {
-        super.bingo(
-                risk,
-                confidence,
-                name,
-                description,
-                uri,
-                param,
-                attack,
-                otherInfo,
-                solution,
-                evidence,
-                cweId,
-                wascId,
-                msg);
-    }
-
-    /**
-     * @deprecated Use {@link #newAlert()} to build and {@link AlertBuilder#raise() raise} alerts.
-     */
-    @Deprecated
-    public void raiseAlert(
-            int risk,
-            int confidence,
-            String name,
-            String description,
-            String uri,
-            String param,
-            String attack,
-            String otherInfo,
-            String solution,
-            String evidence,
-            String reference,
-            int cweId,
-            int wascId,
-            HttpMessage msg) {
-        super.bingo(
-                risk,
-                confidence,
-                name,
-                description,
-                uri,
-                param,
-                attack,
-                otherInfo,
-                solution,
-                evidence,
-                reference,
-                cweId,
-                wascId,
-                msg);
-    }
-
-    @Override
     public int getRisk() {
         return Alert.RISK_INFO;
     }
@@ -343,25 +251,5 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
     @Override
     public int getWascId() {
         return 0;
-    }
-
-    @Override
-    public boolean isPage200(HttpMessage msg) {
-        return super.isPage200(msg);
-    }
-
-    @Override
-    public boolean isPage404(HttpMessage msg) {
-        return super.isPage404(msg);
-    }
-
-    @Override
-    public boolean isPage500(HttpMessage msg) {
-        return super.isPage500(msg);
-    }
-
-    @Override
-    public boolean isPageOther(HttpMessage msg) {
-        return super.isPageOther(msg);
     }
 }

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/scanrules.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/scanrules.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Script Scan Rules</title>
+</head>
+<body>
+<h1>Script Scan Rules</h1>
+
+Active and Passive Scripts that implement the `getMetadata` function are treated as first-class scan rules by ZAP.
+
+Example implementation of this function in a script would look like:
+
+<pre><code>
+function getMetadata() {
+	return ScanRuleMetadata.fromYaml(`
+id: 12345
+name: Active Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+category: INJECTION  # info_gather, browser, server, misc, injection
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other Info
+status: alpha
+`);
+}
+</code></pre>
+
+The <code>category</code> field is only used for Active Scan Scripts.
+
+Any additional fields in the metadata are ignored.
+
+The metadata function is evaluated upon saving the script, which is exposed as a scan rule if the metadata is valid.
+
+</body>
+</html>

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/index.xml
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/index.xml
@@ -8,5 +8,6 @@
 	<indexitem text="script console" target="addon.scripts.scripts" />
 	<indexitem text="script console tab" target="addon.scripts.console" />
 	<indexitem text="script console options" target="addon.scripts.options" />
+	<indexitem text="script scan rules" target="addon.scripts.scanrules" />
 	<indexitem text="scripts tree tab" target="addon.scripts.tree" />
 </index>

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/map.jhm
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/map.jhm
@@ -10,5 +10,6 @@
 	<mapID target="addon.scripts.automation" url="contents/automation.html" />
 	<mapID target="addon.scripts.console" url="contents/console.html" />
 	<mapID target="addon.scripts.options" url="contents/options.html" />
+	<mapID target="addon.scripts.scanrules" url="contents/scanrules.html" />
 	<mapID target="addon.scripts.tree" url="contents/tree.html" />
 </map>

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/toc.xml
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/toc.xml
@@ -10,6 +10,7 @@
 				<tocitem text="Automation" target="addon.scripts.automation" />
 				<tocitem text="Console" target="addon.scripts.console" />
 				<tocitem text="Options" target="addon.scripts.options" />
+				<tocitem text="Scan Rules" target="addon.scripts.scanrules" />
 				<tocitem text="Tree" target="addon.scripts.tree" />
 			</tocitem>
 		</tocitem>

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -121,10 +121,12 @@ scripts.popup.scriptBasedAuth = {0} : Script-Based Authentication Script
 scripts.popup.useForContextAs = Use for Context as...
 
 scripts.runscript.popup = Invoke with Script...
+scripts.scanRules.ascan.disabledSkipReason = the associated script was disabled while the scan was running
 
 scripts.scanRules.ascan.interfaceError = The provided Active Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
 scripts.scanRules.ascan.name = Script Active Scan Rules
 scripts.scanRules.ascan.skipReason = no scripts enabled
+scripts.scanRules.duplicateId = A scan rule with the ID "{0}" already exists ("{1}"). Please use a unique ID for the script "{2}". The script will not be loaded as a scan rule.
 scripts.scanRules.pscan.interfaceError = The provided Passive Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
 scripts.scanRules.pscan.name = Script Passive Scan Rules
 

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/active/Active default template.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/active/Active default template.js
@@ -1,13 +1,37 @@
 // Note that new active scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+var ScanRuleMetadata = Java.type("org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata")
+
+function getMetadata() {
+	return ScanRuleMetadata.fromYaml(`
+id: 12345
+name: Active Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+category: INJECTION  # info_gather, browser, server, misc, injection
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other Info
+status: alpha
+`);
+}
+
 /**
  * Scans a "node", i.e. an individual entry in the Sites Tree.
  * The scanNode function will typically be called once for every page. 
  * 
  * @param as - the ActiveScan parent object that will do all the core interface tasks 
  *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
- *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ *     raising alerts, etc.). This is an ActiveScriptHelper object.
  * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
  */
 function scanNode(as, msg) {
@@ -47,7 +71,7 @@ function scanNode(as, msg) {
  * 
  * @param as - the ActiveScan parent object that will do all the core interface tasks 
  *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
- *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ *     raising alerts, etc.). This is an ActiveScriptHelper object.
  * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
  * @param {string} param - the name of the parameter being manipulated for this test/scan.
  * @param {string} value - the original parameter value.
@@ -68,21 +92,10 @@ function scan(as, msg, param, value) {
 	
 	// Test the response here, and make other requests as required
 	if (true) {	// Change to a test which detects the vulnerability
-		// risk: 0: info, 1: low, 2: medium, 3: high
-		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
 		as.newAlert()
-			.setRisk(1)
-			.setConfidence(1)
-			.setName('Active Vulnerability title')
-			.setDescription('Full description')
 			.setParam(param)
 			.setAttack('Your attack')
 			.setEvidence('Evidence')
-			.setOtherInfo('Any other info')
-			.setSolution('The solution')
-			.setReference('References')
-			.setCweId(0)
-			.setWascId(0)
 			.setMessage(msg)
 			.raise();
 	}

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.js
@@ -4,6 +4,28 @@
 // Right click the script in the Scripts tree and select "enable"  
 
 var PluginPassiveScanner = Java.type("org.zaproxy.zap.extension.pscan.PluginPassiveScanner");
+var ScanRuleMetadata = Java.type("org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata");
+
+function getMetadata() {
+	return ScanRuleMetadata.fromYaml(`
+id: 12345
+name: Passive Vulnerability Title
+description: Full description
+solution: The solution
+references:
+  - Reference 1
+  - Reference 2
+risk: INFO  # info, low, medium, high
+confidence: LOW  # false_positive, low, medium, high, user_confirmed
+cweId: 0
+wascId: 0
+alertTags:
+  name1: value1
+  name2: value2
+otherInfo: Any other info
+status: alpha
+`);
+}
 
 /**
  * Passively scans an HTTP message. The scan function will be called for 
@@ -12,31 +34,20 @@ var PluginPassiveScanner = Java.type("org.zaproxy.zap.extension.pscan.PluginPass
  * 
  * @param ps - the PassiveScan parent object that will do all the core interface tasks 
  *     (i.e.: providing access to Threshold settings, raising alerts, etc.). 
- *     This is an ScriptsPassiveScanner object.
+ *     This is a PassiveScriptHelper object.
  * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
  * @param src - the Jericho Source representation of the message being scanned.
  */
 function scan(ps, msg, src) {
 	// Test the request and/or response here
 	if (true) {	// Change to a test which detects the vulnerability
-		// risk: 0: info, 1: low, 2: medium, 3: high
-		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
 		ps.newAlert()
-			.setRisk(1)
-			.setConfidence(1)
-			.setName('Passive Vulnerability title')
-			.setDescription('Full description')
 			.setParam('The param')
 			.setEvidence('Evidence')
-			.setOtherInfo('Any other info')
-			.setSolution('The solution')
-			.setReference('References')
-			.setCweId(0)
-			.setWascId(0)
 			.raise();
 		
-		//addTag(String tag)
-		ps.addTag('tag')			
+		//addHistoryTag(String tag)
+		ps.addHistoryTag('tag')
 	}
 	
 	// Raise less reliable alert (that is, prone to false positives) when in LOW alert threshold

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRuleUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRuleUnitTest.java
@@ -1,0 +1,163 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.HostProcess;
+import org.parosproxy.paros.core.scanner.NameValuePair;
+import org.parosproxy.paros.core.scanner.ScannerParam;
+import org.parosproxy.paros.core.scanner.Variant;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
+import org.zaproxy.zap.extension.ascan.VariantFactory;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.testutils.TestUtils;
+
+public class ActiveScriptScanRuleUnitTest extends TestUtils {
+
+    private ExtensionScript extensionScript;
+    private ExtensionLoader extensionLoader;
+    private Model model;
+    private HostProcess parent;
+    private HttpMessage message;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        setUpZap();
+        extensionScript = mock(ExtensionScript.class);
+        extensionLoader = mock(ExtensionLoader.class);
+        parent = mock(HostProcess.class);
+        message = new HttpMessage(new HttpRequestHeader("GET / HTTP/1.1"));
+        model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        Control.initSingletonForTesting(model, extensionLoader);
+    }
+
+    @Test
+    void shouldScanNodesWithActiveScript2() throws Exception {
+        // Given
+        ActiveScript2 scriptActiveInterface = mock(ActiveScript2.class);
+        ScriptWrapper script = createScriptWrapper(scriptActiveInterface, ActiveScript2.class);
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(List.of(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var scanRule = new ActiveScriptScanRule(script, metadata);
+        scanRule.init(message, parent);
+        // When
+        scanRule.scan();
+        // Then
+        verify(scriptActiveInterface, times(1)).scanNode(scanRule, message);
+    }
+
+    @Test
+    void shouldScanParamsWithActiveScript() throws Exception {
+        // Given
+        ActiveScript scriptActiveInterface = mock(ActiveScript.class);
+        ScriptWrapper script = createScriptWrapper(scriptActiveInterface, ActiveScript.class);
+        given(parent.getScannerParam()).willReturn(mock(ScannerParam.class));
+        String name1 = "Name1";
+        String value1 = "Value1";
+        NameValuePair param1 = param(name1, value1);
+        String name2 = "Name2";
+        String value2 = "Value2";
+        NameValuePair param2 = param(name2, value2);
+        Variant variant = mock(Variant.class);
+        given(variant.getParamList()).willReturn(List.of(param1, param2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(List.of(variant));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var scanRule = new ActiveScriptScanRule(script, metadata);
+        scanRule.init(message, parent);
+        // When
+        scanRule.scan();
+        // Then
+        verify(scriptActiveInterface, times(1)).scan(scanRule, message, name1, value1);
+        verify(scriptActiveInterface, times(1)).scan(scanRule, message, name2, value2);
+    }
+
+    @Test
+    void shouldScanWithCopyCreatedWithReflectionAndConfig() throws Exception {
+        // Given
+        ActiveScript2 scriptActiveInterface = mock(ActiveScript2.class);
+        var script = mock(ScriptWrapper.class);
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        return metadata;
+                    }
+                };
+        String scriptName = "testScript.js";
+        given(script.getName()).willReturn("testScript.js");
+        given(script.isEnabled()).willReturn(true);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getInterface(script, ActiveScript2.class))
+                .willReturn(scriptActiveInterface);
+        given(extensionScript.getInterface(script, ScanRuleMetadataProvider.class))
+                .willReturn(metadataProvider);
+        given(extensionScript.getScript(scriptName)).willReturn(script);
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(List.of(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        var scanRule = new ActiveScriptScanRule(script, metadata);
+        scanRule.setConfig(new BaseConfiguration());
+        var scanRuleCopy = scanRule.getClass().getDeclaredConstructor().newInstance();
+        scanRuleCopy.setConfig(scanRule.getConfig());
+        scanRuleCopy.init(message, parent);
+        // When
+        scanRuleCopy.scan();
+        // Then
+        verify(scriptActiveInterface, times(1)).scanNode(scanRule, message);
+    }
+
+    private <T> ScriptWrapper createScriptWrapper(T scriptInterface, Class<T> scriptClass)
+            throws Exception {
+        var script = mock(ScriptWrapper.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getInterface(script, scriptClass)).willReturn(scriptInterface);
+        given(script.isEnabled()).willReturn(true);
+        return script;
+    }
+
+    private static NameValuePair param(String name, String value) {
+        NameValuePair nvp = mock(NameValuePair.class);
+        given(nvp.getName()).willReturn(name);
+        given(nvp.getValue()).willReturn(value);
+        return nvp;
+    }
+}

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptSynchronizerUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptSynchronizerUnitTest.java
@@ -1,0 +1,183 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.PluginFactory;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class ActiveScriptSynchronizerUnitTest extends TestUtils {
+
+    private ExtensionPassiveScan extensionPassiveScan;
+    private ExtensionScript extensionScript;
+    private ExtensionLoader extensionLoader;
+    private Model model;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        setUpZap();
+        extensionPassiveScan = mock(ExtensionPassiveScan.class);
+        extensionScript = mock(ExtensionScript.class);
+        extensionLoader = mock(ExtensionLoader.class);
+        model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        Control.initSingletonForTesting(model, extensionLoader);
+    }
+
+    @Test
+    void shouldLoadActiveScanRuleForScript() throws Exception {
+        // Given
+        var synchronizer = new ActiveScriptSynchronizer();
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        return metadata;
+                    }
+                };
+        ScriptWrapper script =
+                createScriptWrapper(metadataProvider, ScanRuleMetadataProvider.class);
+        var scanRuleCaptor = ArgumentCaptor.forClass(ActiveScriptScanRule.class);
+        // When
+        try (var pluginFactory = mockStatic(PluginFactory.class)) {
+            synchronizer.scriptAdded(script);
+            pluginFactory.verify(() -> PluginFactory.loadedPlugin(scanRuleCaptor.capture()));
+        }
+        // Then
+        ActiveScriptScanRule scanRule = scanRuleCaptor.getValue();
+        assertThat(scanRule, is(notNullValue()));
+        assertThat(scanRule.getId(), is(equalTo(metadata.getId())));
+        assertThat(scanRule.getName(), is(equalTo(metadata.getName())));
+    }
+
+    @Test
+    void shouldNotLoadSameScriptTwice() throws Exception {
+        // Given
+        var synchronizer = new ActiveScriptSynchronizer();
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        return metadata;
+                    }
+                };
+        ScriptWrapper script =
+                createScriptWrapper(metadataProvider, ScanRuleMetadataProvider.class);
+        var scanRuleCaptor = ArgumentCaptor.forClass(ActiveScriptScanRule.class);
+        // When
+        try (var pluginFactory = mockStatic(PluginFactory.class)) {
+            pluginFactory.when(() -> PluginFactory.isPluginLoaded(any())).thenReturn(true);
+            synchronizer.scriptAdded(script);
+            synchronizer.scriptAdded(script);
+            pluginFactory.verify(
+                    () -> PluginFactory.loadedPlugin(scanRuleCaptor.capture()), times(1));
+        }
+        // Then
+        ActiveScriptScanRule scanRule = scanRuleCaptor.getValue();
+        assertThat(scanRule, is(notNullValue()));
+        assertThat(scanRule.getId(), is(equalTo(metadata.getId())));
+        assertThat(scanRule.getName(), is(equalTo(metadata.getName())));
+    }
+
+    @Test
+    void shouldUnloadActiveScanRuleForScript() throws Exception {
+        // Given
+        var synchronizer = new ActiveScriptSynchronizer();
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        return metadata;
+                    }
+                };
+        ScriptWrapper script =
+                createScriptWrapper(metadataProvider, ScanRuleMetadataProvider.class);
+        var scanRuleCaptor = ArgumentCaptor.forClass(ActiveScriptScanRule.class);
+        // When
+        try (var pluginFactory = mockStatic(PluginFactory.class)) {
+            pluginFactory.when(() -> PluginFactory.isPluginLoaded(any())).thenReturn(true, false);
+            synchronizer.scriptAdded(script);
+            synchronizer.scriptRemoved(script);
+            pluginFactory.verify(() -> PluginFactory.unloadedPlugin(scanRuleCaptor.capture()));
+        }
+        // Then
+        ActiveScriptScanRule scanRule = scanRuleCaptor.getValue();
+        assertThat(scanRule, is(notNullValue()));
+        assertThat(scanRule.getId(), is(equalTo(metadata.getId())));
+        assertThat(scanRule.getName(), is(equalTo(metadata.getName())));
+    }
+
+    @Test
+    void shouldNotLogErrorOnUndeclaredMethodInPythonScripts() throws Exception {
+        // Given
+        var synchronizer = new ActiveScriptSynchronizer();
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        throw new UndeclaredThrowableException(null, "getMetadata");
+                    }
+                };
+        var script = mock(ScriptWrapper.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getInterface(script, ScanRuleMetadataProvider.class))
+                .willReturn(metadataProvider);
+        // When
+        synchronizer.scriptAdded(script);
+        // Then
+        verify(extensionScript, times(0)).handleScriptException(eq(script), any());
+    }
+
+    private <T> ScriptWrapper createScriptWrapper(T scriptInterface, Class<T> scriptClass)
+            throws Exception {
+        var script = mock(ScriptWrapper.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionLoader.getExtension(ExtensionPassiveScan.class))
+                .willReturn(extensionPassiveScan);
+        given(extensionScript.getInterface(script, scriptClass)).willReturn(scriptInterface);
+        return script;
+    }
+}

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRuleUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRuleUnitTest.java
@@ -1,0 +1,94 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import net.htmlparser.jericho.Source;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.testutils.TestUtils;
+
+public class PassiveScriptScanRuleUnitTest extends TestUtils {
+
+    private ExtensionScript extensionScript;
+    private ExtensionLoader extensionLoader;
+    private HttpMessage message;
+    private int id;
+    private Source source;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        setUpZap();
+        extensionScript = mock(ExtensionScript.class);
+        extensionLoader = mock(ExtensionLoader.class);
+        message = new HttpMessage(new HttpRequestHeader("GET / HTTP/1.1"));
+        id = 1;
+        source = new Source("");
+        var model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        Control.initSingletonForTesting(model, extensionLoader);
+    }
+
+    @Test
+    void shouldScan() throws Exception {
+        // Given
+        PassiveScript scriptInterface = mock(PassiveScript.class);
+        ScriptWrapper script = createScriptWrapper(scriptInterface, PassiveScript.class);
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var scanRule = new PassiveScriptScanRule(script, metadata);
+        // When
+        scanRule.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(scriptInterface, times(1)).scan(scanRule, message, source);
+    }
+
+    @Test
+    void shouldScanWithCopy() throws Exception {
+        // Given
+        PassiveScript scriptInterface = mock(PassiveScript.class);
+        ScriptWrapper script = createScriptWrapper(scriptInterface, PassiveScript.class);
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var scanRule = new PassiveScriptScanRule(script, metadata);
+        // When
+        scanRule.copy().scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(scriptInterface, times(1)).scan(scanRule, message, source);
+    }
+
+    private <T> ScriptWrapper createScriptWrapper(T scriptInterface, Class<T> scriptClass)
+            throws Exception {
+        var script = mock(ScriptWrapper.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getInterface(script, scriptClass)).willReturn(scriptInterface);
+        return script;
+    }
+}

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptSynchronizerUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptSynchronizerUnitTest.java
@@ -1,0 +1,186 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.scanrules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.PluginFactory;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.testutils.TestUtils;
+
+public class PassiveScriptSynchronizerUnitTest extends TestUtils {
+
+    private ExtensionPassiveScan extensionPassiveScan;
+    private ExtensionScript extensionScript;
+    private ExtensionLoader extensionLoader;
+    private Model model;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        setUpZap();
+        extensionPassiveScan = mock(ExtensionPassiveScan.class);
+        extensionScript = mock(ExtensionScript.class);
+        extensionLoader = mock(ExtensionLoader.class);
+        model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        Control.initSingletonForTesting(model, extensionLoader);
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void shouldLoadPassiveScanRuleForScript() throws Exception {
+        // Given
+        var synchronizer = new PassiveScriptSynchronizer();
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        return metadata;
+                    }
+                };
+        ScriptWrapper script =
+                createScriptWrapper(metadataProvider, ScanRuleMetadataProvider.class);
+        var scanRuleCaptor = ArgumentCaptor.forClass(PassiveScriptScanRule.class);
+        given(extensionPassiveScan.addPluginPassiveScanner(any())).willReturn(true);
+        // When
+        try (var ignored = mockStatic(PluginFactory.class)) {
+            synchronizer.scriptAdded(script);
+        }
+        // Then
+        verify(extensionPassiveScan, times(1)).addPluginPassiveScanner(scanRuleCaptor.capture());
+        PassiveScriptScanRule scanRule = scanRuleCaptor.getValue();
+        assertThat(scanRule, is(notNullValue()));
+        assertThat(scanRule.getPluginId(), is(equalTo(metadata.getId())));
+        assertThat(scanRule.getName(), is(equalTo(metadata.getName())));
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void shouldNotLoadSameScriptTwice() throws Exception {
+        // Given
+        var synchronizer = new PassiveScriptSynchronizer();
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        return metadata;
+                    }
+                };
+        ScriptWrapper script =
+                createScriptWrapper(metadataProvider, ScanRuleMetadataProvider.class);
+        given(extensionPassiveScan.addPluginPassiveScanner(any())).willReturn(true);
+        // When
+        try (var ignored = mockStatic(PluginFactory.class)) {
+            synchronizer.scriptAdded(script);
+            synchronizer.scriptAdded(script);
+        }
+        // Then
+        var scanRuleCaptor = ArgumentCaptor.forClass(PassiveScriptScanRule.class);
+        verify(extensionPassiveScan, times(1)).addPluginPassiveScanner(scanRuleCaptor.capture());
+        PassiveScriptScanRule scanRule = scanRuleCaptor.getValue();
+        assertThat(scanRule, is(notNullValue()));
+        assertThat(scanRule.getPluginId(), is(equalTo(metadata.getId())));
+        assertThat(scanRule.getName(), is(equalTo(metadata.getName())));
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void shouldUnloadPassiveScanRuleForScript() throws Exception {
+        // Given
+        var synchronizer = new PassiveScriptSynchronizer();
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        return metadata;
+                    }
+                };
+        given(extensionPassiveScan.addPluginPassiveScanner(any())).willReturn(true);
+        ScriptWrapper script =
+                createScriptWrapper(metadataProvider, ScanRuleMetadataProvider.class);
+        // When
+        try (var ignored = mockStatic(PluginFactory.class)) {
+            synchronizer.scriptAdded(script);
+            synchronizer.scriptRemoved(script);
+        }
+        // Then
+        var scanRuleCaptor = ArgumentCaptor.forClass(PassiveScriptScanRule.class);
+        verify(extensionPassiveScan, times(1)).removePluginPassiveScanner(scanRuleCaptor.capture());
+        PassiveScriptScanRule scanRule = scanRuleCaptor.getValue();
+        assertThat(scanRule, is(notNullValue()));
+        assertThat(scanRule.getPluginId(), is(equalTo(metadata.getId())));
+        assertThat(scanRule.getName(), is(equalTo(metadata.getName())));
+    }
+
+    @Test
+    void shouldNotLogErrorOnUndeclaredMethodInPythonScripts() throws Exception {
+        // Given
+        var synchronizer = new PassiveScriptSynchronizer();
+        var metadataProvider =
+                new ScanRuleMetadataProvider() {
+                    @Override
+                    public ScanRuleMetadata getMetadata() {
+                        throw new UndeclaredThrowableException(null, "getMetadata");
+                    }
+                };
+        var script = mock(ScriptWrapper.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionScript.getInterface(script, ScanRuleMetadataProvider.class))
+                .willReturn(metadataProvider);
+        // When
+        synchronizer.scriptAdded(script);
+        // Then
+        verify(extensionScript, times(0)).handleScriptException(eq(script), any());
+    }
+
+    private <T> ScriptWrapper createScriptWrapper(T scriptInterface, Class<T> scriptClass)
+            throws Exception {
+        var script = mock(ScriptWrapper.class);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+        given(extensionLoader.getExtension(ExtensionPassiveScan.class))
+                .willReturn(extensionPassiveScan);
+        given(extensionScript.getInterface(script, scriptClass)).willReturn(scriptInterface);
+        return script;
+    }
+}

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScannerUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScannerUnitTest.java
@@ -49,6 +49,7 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.VariantFactory;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -435,6 +436,8 @@ class ScriptsActiveScannerUnitTest extends TestUtils {
         given(scriptWrapper.isEnabled()).willReturn(true);
         given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
         given(extensionScript.getInterface(scriptWrapper, scriptClass)).willReturn(script);
+        given(extensionScript.getInterface(scriptWrapper, ScanRuleMetadataProvider.class))
+                .willReturn(null);
         return scriptWrapper;
     }
 

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsPassiveScannerUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsPassiveScannerUnitTest.java
@@ -55,11 +55,9 @@ import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.pscan.PassiveScanData;
 import org.zaproxy.zap.extension.pscan.PassiveScanTaskHelper;
 import org.zaproxy.zap.extension.script.ExtensionScript;
-import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.script.ScriptsCache;
 import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
 import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
-import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceErrorMessageProvider;
 import org.zaproxy.zap.extension.script.ScriptsCache.ScriptWrapperAction;
 import org.zaproxy.zap.extension.scripts.ExtensionScriptsUI;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -176,12 +174,8 @@ class ScriptsPassiveScannerUnitTest extends TestUtils {
         Configuration<PassiveScript> configuration = argumentCaptor.getValue();
         assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
         assertThat(configuration.getTargetInterface(), is(equalTo(TARGET_INTERFACE)));
-        InterfaceErrorMessageProvider errorMessageProvider =
-                configuration.getInterfaceErrorMessageProvider();
-        assertThat(errorMessageProvider, is(not(nullValue())));
-        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
-        given(scriptWrapper.getName()).willReturn("Name");
-        assertThat(errorMessageProvider.getErrorMessage(scriptWrapper), is(not(nullValue())));
+        assertThat(configuration.getInterfaceProvider(), is(not(nullValue())));
+        assertThat(configuration.getInterfaceErrorMessageProvider(), is(nullValue()));
     }
 
     @Test

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for menu weights (Issue 8369)
 
 ### Changed
-- Update minimum Scripts add-on version to 45.
+- Update minimum `scripts` add-on version to 45.1.0.
 - Maintenance changes.
 
 ## [43] - 2023-12-19

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
@@ -27,14 +27,14 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.scripts.scanrules.ActiveScript;
-import org.zaproxy.zap.extension.scripts.scanrules.ScriptsActiveScanner;
+import org.zaproxy.zap.extension.scripts.scanrules.ActiveScriptHelper;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestResponse;
 
 public class ZestActiveRunner extends ZestZapRunner implements ActiveScript {
 
     private ZestScriptWrapper script = null;
-    private ScriptsActiveScanner sas = null;
+    private ActiveScriptHelper scriptHelper = null;
     private HttpMessage msg = null;
     private String param = null;
     private ExtensionZest extension = null;
@@ -49,15 +49,15 @@ public class ZestActiveRunner extends ZestZapRunner implements ActiveScript {
     }
 
     @Override
-    public void scan(ScriptsActiveScanner sas, HttpMessage msg, String param, String value)
+    public void scan(ActiveScriptHelper helper, HttpMessage msg, String param, String value)
             throws ScriptException {
         LOGGER.debug("Zest ActiveScan script: {}", this.script.getName());
-        this.sas = sas;
+        this.scriptHelper = helper;
         this.msg = msg;
         this.param = param;
 
         try {
-            sas.setParam(msg, param, "{{target}}");
+            helper.setParam(msg, param, "{{target}}");
             this.run(
                     script.getZestScript(),
                     ZestZapUtils.toZestRequest(msg, false, true, extension.getParam()),
@@ -71,7 +71,7 @@ public class ZestActiveRunner extends ZestZapRunner implements ActiveScript {
     public ZestResponse send(ZestRequest request) throws IOException {
         HttpMessage msg = ZestZapUtils.toHttpMessage(request, null /*response*/);
 
-        this.sas.sendAndReceive(msg, false /*isFollowRedirect*/);
+        scriptHelper.sendAndReceive(msg, false /*isFollowRedirect*/);
 
         ZestResponse response = ZestZapUtils.toZestResponse(msg);
         return response;
@@ -80,7 +80,8 @@ public class ZestActiveRunner extends ZestZapRunner implements ActiveScript {
     @Override
     public void alertFound(Alert alert) {
         // Override this as we can put in more info from the script and message
-        sas.newAlert()
+        scriptHelper
+                .newAlert()
                 .setRisk(alert.getRisk())
                 .setConfidence(alert.getConfidence())
                 .setName(alert.getName())

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -23,13 +23,13 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">=1.23.0")
+                    version.set(">=1.24.0")
                 }
                 register("network") {
                     version.set(">=0.2.0")
                 }
                 register("scripts") {
-                    version.set(">=45.0.0")
+                    version.set(">=45.2.0")
                 }
                 register("selenium") {
                     version.set(">= 15.13.0")


### PR DESCRIPTION
## Overview
Active and Passive scripts that (correctly) implement a `getMetadata()` function will be treated as first-class scan rules by ZAP.

This is done by wrapping the scripts in respective scan rule classes and loading them dynamically at runtime.

## Related Issues
- Closes zaproxy/zaproxy#7105.

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
- [x] Address minor TODOs in the code
- [x] Update Active and Passive script templates in Python, Ruby, and Groovy. Kotlin doesn't have existing active or passive templates and Zest may need more work out of scope of this PR.
