### PR TITLE
scripts: propagate script errors to AF

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Propagate script errors to the Automation Framework when running them.
 
 ## [45.0.0] - 2024-02-12
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
@@ -208,16 +208,28 @@ public class RunScriptAction extends ScriptAction {
                 extScript.invokeScript(script);
             }
             scriptJobOutputListener.flush();
+
+            if (script.getLastException() != null) {
+                reportScriptError(progress, jobName, parameters, script.getLastException());
+            }
         } catch (Exception e) {
             LOGGER.error(e);
-            progress.error(
-                    Constant.messages.getString(
-                            "scripts.automation.error.scriptError",
-                            jobName,
-                            parameters.getName(),
-                            e.getMessage()));
+            reportScriptError(progress, jobName, parameters, e);
         } finally {
             extScript.removeScriptOutputListener(scriptJobOutputListener);
         }
+    }
+
+    private static void reportScriptError(
+            AutomationProgress progress,
+            String jobName,
+            ScriptJobParameters parameters,
+            Exception e) {
+        progress.error(
+                Constant.messages.getString(
+                        "scripts.automation.error.scriptError",
+                        jobName,
+                        parameters.getName(),
+                        e.getMessage()));
     }
 }


### PR DESCRIPTION
Check if the script run caused an exception in which case propagate it as an AF error.

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/Bogc-vpH8fc