### PR TITLE
ascanrulesBeta: Add more example alerts

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated reference for scan rule: Possible Username Enumeration (Issue 8262)
 - Cookie Slack Detector scan rule now has a more specific CWE.
 - Possible Username Enumeration scan rule now includes CWE-204 as a reference link.
+- The following scan rules now include example alert functionality for documentation generation purposes (Issue 6119):
+    - Relative Path Confusion
+    - Integer Overflow Error
+
+### Removed 
+- Removed HTTP only reference for scan rule: Integer Overflow Error (Issue 8262)
 
 ## [51] - 2024-02-16
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -617,13 +617,8 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
                                                 MESSAGE_PREFIX + "extrainfo.nocontenttype");
                 }
 
-                // alert it..
-                newAlert()
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                buildAlert(hackedUri.toString(), extraInfo, relativeReferenceEvidence)
                         .setUri(getBaseMsg().getRequestHeader().getURI().toString())
-                        .setAttack(hackedUri.toString())
-                        .setOtherInfo(extraInfo)
-                        .setEvidence(relativeReferenceEvidence)
                         .setMessage(hackedMessage)
                         .raise();
 
@@ -640,6 +635,14 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
             LOGGER.error(
                     "Error scanning a request for Relative Path confusion: {}", e.getMessage(), e);
         }
+    }
+
+    private AlertBuilder buildAlert(String attack, String otherInfo, String evidence) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setAttack(attack)
+                .setOtherInfo(otherInfo)
+                .setEvidence(evidence);
     }
 
     @Override
@@ -660,5 +663,16 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildAlert(
+                                "https://example.com/profile/ybpsv/bqmmn/?foo=bar",
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "extrainfo.nocontenttype"),
+                                "background: url(image.png)")
+                        .build());
     }
 }

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -114,7 +114,7 @@ ascanbeta.integeroverflow.error2 = Potential Integer Overflow.  Status code chan
 ascanbeta.integeroverflow.error3 = Potential Integer Overflow.  Status code changed on the input of a long string of ones.
 ascanbeta.integeroverflow.error4 = Potential Integer Overflow.  Status code changed on the input of a long string of nines.
 ascanbeta.integeroverflow.name = Integer Overflow Error
-ascanbeta.integeroverflow.refs = https://en.wikipedia.org/wiki/Integer_overflow\nhttps://cwe.mitre.org/data/definitions/190.html\nhttp://projects.webappsec.org/w/page/13246946/Integer%20Overflows
+ascanbeta.integeroverflow.refs = https://en.wikipedia.org/wiki/Integer_overflow\nhttps://cwe.mitre.org/data/definitions/190.html
 ascanbeta.integeroverflow.soln = In order to prevent overflows and divide by 0 (zero) errors in the application, please rewrite the backend program, checking if the values of integers being processed are within the application's allowed range. This will require a recompilation of the backend executable.
 
 ascanbeta.name = Active Scan Rules - beta

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRuleUnitTest.java
@@ -27,8 +27,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import fi.iki.elonen.NanoHTTPD;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.model.Tech;
@@ -156,5 +158,19 @@ class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOverflowS
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A01_INJECTION.getValue())));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRuleUnitTest.java
@@ -23,8 +23,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 
 class RelativePathConfusionScanRuleUnitTest
@@ -57,5 +59,19 @@ class RelativePathConfusionScanRuleUnitTest
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getValue())));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 }


### PR DESCRIPTION
## Overview
- CHANGELOG > Add notes.
- Scan rules > Add example alert functionality (6119).
- Unit tests > Assert the new example alerts.
- Messages.properties > Updated some http references (8262).

## Related Issues
- zaproxy/zaproxy#6119
- zaproxy/zaproxy#8262

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title