### PR TITLE
ascanrules: Add more example alerts

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The following scan rules now include example alert functionality for documentation generation purposes (Issue 6119):
+    - Source Code Disclosure - CVE-2012-1823
+    - Remote Code Execution - CVE-2012-1823
+    - Server Side Include
+    - Cross Site Scripting (Reflected)
+- The Alerts from the Remote Code Execution - CVE-2012-1823 scan rule no longer have evidence duplicated in the Other Info field.
 
 ## [63] - 2024-02-12
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -1018,6 +1018,18 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin
         return 8;
     }
 
+    @Override
+    public List<Alert> getExampleAlerts() {
+        String attack = "</p><scrIpt>alert`1`;</scRipt><p>";
+        return List.of(
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam("name")
+                        .setAttack(attack)
+                        .setEvidence(attack)
+                        .build());
+    }
+
     private static class Mutation {
         private char original;
         private char mutation;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRule.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -168,20 +169,7 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin
                     && responseBody.startsWith(RANDOM_STRING)) {
                 LOGGER.debug("Remote Code Execution alert for: {}", originalURI);
 
-                // bingo.
-                newAlert()
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setDescription(
-                                Constant.messages.getString(
-                                        "ascanrules.remotecodeexecution.cve-2012-1823.desc"))
-                        .setAttack(payload)
-                        .setOtherInfo(responseBody)
-                        .setSolution(
-                                Constant.messages.getString(
-                                        "ascanrules.remotecodeexecution.cve-2012-1823.soln"))
-                        .setEvidence(responseBody)
-                        .setMessage(attackmsg)
-                        .raise();
+                buildAlert(payload, responseBody).setMessage(attackmsg).raise();
                 return true;
             }
         } catch (Exception e) {
@@ -191,6 +179,19 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin
                     e);
         }
         return false;
+    }
+
+    private AlertBuilder buildAlert(String payload, String evidence) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setDescription(
+                        Constant.messages.getString(
+                                "ascanrules.remotecodeexecution.cve-2012-1823.desc"))
+                .setAttack(payload)
+                .setSolution(
+                        Constant.messages.getString(
+                                "ascanrules.remotecodeexecution.cve-2012-1823.soln"))
+                .setEvidence(evidence);
     }
 
     private static URI createAttackUri(URI originalURI, String attackParam) {
@@ -229,5 +230,14 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildAlert(
+                                "<?php exec('cmd.exe /C echo mt9slj64g5yyp4yzkyqr',$colm);echo join(\"\n\",$colm);die();?>",
+                                "mt9slj64g5yyp4yzkyqr<html><body>X Y Z</body></html>")
+                        .build());
     }
 }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
@@ -30,6 +30,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
@@ -161,13 +162,7 @@ public class ServerSideIncludeScanRule extends AbstractAppParamPlugin
 
             StringBuilder evidence = new StringBuilder();
             if (matchBodyPattern(message, testEvidence, evidence)) {
-                newAlert()
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setParam(parameter)
-                        .setAttack(value)
-                        .setEvidence(evidence.toString())
-                        .setMessage(message)
-                        .raise();
+                buildAlert(parameter, value, evidence.toString()).setMessage(message).raise();
                 return true;
             }
         } catch (IOException e) {
@@ -182,6 +177,14 @@ public class ServerSideIncludeScanRule extends AbstractAppParamPlugin
                     e);
         }
         return false;
+    }
+
+    private AlertBuilder buildAlert(String param, String attack, String evidence) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setParam(param)
+                .setAttack(attack)
+                .setEvidence(evidence);
     }
 
     @Override
@@ -202,5 +205,10 @@ public class ServerSideIncludeScanRule extends AbstractAppParamPlugin
     @Override
     public int getWascId() {
         return 31;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(buildAlert("profile", SSI_UNIX, "/root /sbin /temp /usr").build());
     }
 }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRule.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -169,18 +170,7 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin
                         sourceCode = matcher2.group(1);
                     }
 
-                    // bingo.
-                    newAlert()
-                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setDescription(
-                                    Constant.messages.getString(
-                                            "ascanrules.sourcecodedisclosurecve-2012-1823.desc"))
-                            .setOtherInfo(sourceCode)
-                            .setSolution(
-                                    Constant.messages.getString(
-                                            "ascanrules.sourcecodedisclosurecve-2012-1823.soln"))
-                            .setMessage(attackmsg)
-                            .raise();
+                    buildAlert(sourceCode).setMessage(attackmsg).raise();
                 }
             }
         } catch (Exception e) {
@@ -189,6 +179,18 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin
                     e.getMessage(),
                     e);
         }
+    }
+
+    private AlertBuilder buildAlert(String otherInfo) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setDescription(
+                        Constant.messages.getString(
+                                "ascanrules.sourcecodedisclosurecve-2012-1823.desc"))
+                .setOtherInfo(otherInfo)
+                .setSolution(
+                        Constant.messages.getString(
+                                "ascanrules.sourcecodedisclosurecve-2012-1823.soln"));
     }
 
     private static URI createAttackUri(URI originalURI, String attackParam) {
@@ -227,5 +229,10 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(buildAlert("<?php $x=0; echo '<h1>Welcome!</h1>'; ?>").build());
     }
 }

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 import org.apache.commons.lang3.StringUtils;
@@ -91,6 +92,20 @@ class CrossSiteScriptingScanRuleUnitTest extends ActiveScannerTest<CrossSiteScri
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_INPV_01_REFLECTED_XSS.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_INPV_01_REFLECTED_XSS.getValue())));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 
     @Test

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/RemoteCodeExecutionCve20121823ScanRuleUnitTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.is;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -181,7 +182,6 @@ class RemoteCodeExecutionCve20121823ScanRuleUnitTest
                                         + "',$colm);echo join(\"\n\",$colm);die();?>")));
         assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo(body)));
     }
 
     @Test
@@ -227,7 +227,6 @@ class RemoteCodeExecutionCve20121823ScanRuleUnitTest
                                         + "',$colm);echo join(\"\n\",$colm);die();?>")));
         assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo(body)));
     }
 
     @Test
@@ -278,6 +277,20 @@ class RemoteCodeExecutionCve20121823ScanRuleUnitTest
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_INPV_12_COMMAND_INJ.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_INPV_12_COMMAND_INJ.getValue())));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 
     private abstract static class RceResponse extends NanoServerHandler {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRuleUnitTest.java
@@ -23,8 +23,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
@@ -105,5 +107,19 @@ class ServerSideIncludeScanRuleUnitTest extends ActiveScannerTest<ServerSideIncl
         boolean targets = rule.targets(techSet);
         // Then
         assertThat(targets, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureCve20121823ScanRuleUnitTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.is;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.Test;
@@ -388,6 +389,20 @@ class SourceCodeDisclosureCve20121823ScanRuleUnitTest
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A09_VULN_COMP.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A09_VULN_COMP.getValue())));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 
     private HttpMessage httpMessage404NotFound() throws Exception {


### PR DESCRIPTION
## Overview
- CHANGELOG > Add notes.
- Scan rules > Add example alert functionality (6119).
- Unit tests > Assert the new example alerts.

## Related Issues
- zaproxy/zaproxy#6119

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
