### PR TITLE
retire: Address False Positives

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,13 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Version matching was improved to address some false positives (Issue 8384 & 8398).
 
 ## [0.32.0] - 2024-03-04
 ### Changed
 - Updated with upstream retire.js pattern changes.
-
-
 
 ## [0.31.0] - 2024-02-12
 ### Changed

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
@@ -29,6 +29,7 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -254,6 +255,9 @@ public class Repo {
      */
     private static Map<String, Set<String>> isVersionVulnerable(
             List<Vulnerability> vulnerabilities, String versionString) {
+        if (!isGoodCandidate(versionString)) {
+            return Map.of();
+        }
         // Do a match for each of the above vulnerabilities
         Map<String, Set<String>> results = new HashMap<>();
         ListIterator<Vulnerability> viterator = vulnerabilities.listIterator();
@@ -286,5 +290,21 @@ public class Repo {
             }
         }
         return results;
+    }
+
+    private static boolean isGoodCandidate(String version) {
+        String[] v1 = version.split("[._-]");
+        if (v1.length == 1) {
+            // There were no separators in the "version" being checked
+            // Likely a cache buster string, ex: 7a06f256
+            return false;
+        }
+        int isAllZeros = 9; // Placeholder
+        try {
+            isAllZeros = Arrays.stream(v1).mapToInt(Integer::parseInt).sum();
+        } catch (NumberFormatException nfe) {
+            // Nothing to do, it might happen
+        }
+        return isAllZeros != 0; // Not a good value if all zero
     }
 }

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -110,6 +110,19 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
                 alertsRaised.get(0).getReference());
     }
 
+    @Test
+    void shouldNotRaiseAlertOnUrlWithNonVersionIdentifier() {
+        // Given
+        HttpMessage msg =
+                createMessage("http://example.com/ajax/libs/000-000-0000-00/lodash.min.js", null);
+        msg.getResponseHeader().setHeader(HttpFieldsNames.CONTENT_TYPE, "text/javascript");
+        given(passiveScanData.isPage200(any())).willReturn(true);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(0, alertsRaised.size());
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"jquery-3.1.1.min.js", "jquery-3_1_1.min.js", "jquery-3-1-1.min.js"})
     void shouldRaiseAlertOnVulnerableFilename(String fileName) {
@@ -125,6 +138,19 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         assertEquals(
                 "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/\n",
                 alertsRaised.get(0).getReference());
+    }
+
+    @Test
+    void shouldNotRaiseAlertOnFilenameWithNonVersionIdentifier() {
+        // Given
+        String fileName = "npm.moment.7a06f256.js";
+        HttpMessage msg = createMessage("http://example.com/CommonElements/js/" + fileName, null);
+        msg.getResponseHeader().setHeader(HttpFieldsNames.CONTENT_TYPE, "text/javascript");
+        given(passiveScanData.isPage200(any())).willReturn(true);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(0, alertsRaised.size());
     }
 
     @Test

--- a/addOns/retire/src/test/resources/org/zaproxy/addon/retire/testrepository.json
+++ b/addOns/retire/src/test/resources/org/zaproxy/addon/retire/testrepository.json
@@ -55,7 +55,7 @@
 			{
 				"below" : "3.5.0",
 				"identifiers": {
-					"summary": "Regex in its jQuery.htmlPrefilter  sometimes may introduce XSS"
+					"summary": "Regex in its jQuery.htmlPrefilter sometimes may introduce XSS"
 				},
 				"severity" : "medium",
 				"info" : [ "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/" ]
@@ -130,7 +130,72 @@
 			"hashes"		: {}
 		}
 	},
+	"moment.js": {
+		"bowername": [
+			"moment",
+			"momentjs"
+		],
+		"npmname": "moment",
+		"basePurl": "pkg:npm/moment",
+		"vulnerabilities": [
+			{
+				"below": "2.29.2",
+				"severity": "high",
+				"cwe": [
+					"CWE-22",
+					"CWE-27"
+				],
+				"identifiers": {
+					"summary": "This vulnerability impacts npm (server) users of moment.js, especially if user provided locale string, eg fr is directly used to switch moment locale.",
+					"CVE": [
+						"CVE-2022-24785"
+					],
+					"githubID": "GHSA-8hfj-j24r-96c4"
+				},
+				"info": [
+					"https://github.com/moment/moment/security/advisories/GHSA-8hfj-j24r-96c4"
+				]
+			}
+		],
+		"extractors": {
+			"filename": [
+				"moment(?:-|\\.)(§§version§§)(?:-min)?\\.js"
+			]
+		}
+	},
 
+	"lodash": {
+		"vulnerabilities": [
+			{
+				"below": "4.17.5",
+				"cwe": [
+					"CWE-471"
+				],
+				"severity": "low",
+				"identifiers": {
+					"summary": "Prototype Pollution in lodash",
+					"CVE": [
+						"CVE-2018-3721"
+					],
+					"githubID": "GHSA-fvqr-27wr-82fm"
+				},
+				"info": [
+					"https://github.com/advisories/GHSA-fvqr-27wr-82fm",
+					"https://nvd.nist.gov/vuln/detail/CVE-2018-3721",
+					"https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a",
+					"https://hackerone.com/reports/310443",
+					"https://github.com/advisories/GHSA-fvqr-27wr-82fm",
+					"https://security.netapp.com/advisory/ntap-20190919-0004/",
+					"https://www.npmjs.com/advisories/577"
+				]
+			}
+		],
+		"extractors": {
+			"uri": [
+				"/(§§version§§)/lodash(\\.min)?\\.js"
+			]
+		}
+	},
 
 
 


### PR DESCRIPTION
## Overview
- CHANGELOG > Add fix note.
- Repo > Add pre-check for good version candidates when checking version vulnerability.
- RetireScanRuleUnitTest > Add methods to assert the fixed behavior.
- testrepository.json > Add relevant entries to support tests.

## Related Issues
- Fixes zaproxy/zaproxy#8384
- Fixes zaproxy/zaproxy#8398

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
