### PR TITLE
scripts: error on unsupported script type in AF

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Error when trying to run an unsupported script type through the Automation Framework.
 
 ## [45.1.0] - 2024-03-25
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
@@ -189,6 +189,18 @@ public class RunScriptAction extends ScriptAction {
                                 parameters.getName()));
                 return;
             }
+
+            if (!getSupportedScriptTypes().contains(script.getTypeName())) {
+                progress.error(
+                        Constant.messages.getString(
+                                "scripts.automation.error.scriptTypeNotSupported",
+                                jobName,
+                                script.getTypeName(),
+                                getName(),
+                                String.join(", ", getSupportedScriptTypes())));
+                return;
+            }
+
             if (parameters.getType().equals(ExtensionScript.TYPE_TARGETED)) {
                 URI targetUri = new URI(parameters.getTarget(), true);
                 SiteNode siteNode =


### PR DESCRIPTION
Report an error instead of trying to run an unsupported script type through the Automation Framework.

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/LoWFDfhIzh8/m/8gHOHN0SAQAJ