### PR TITLE
reports: handle alerts without HTTP message

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Handle alerts without HTTP message gracefully (Issue 6880).
 
 ## [0.30.0] - 2024-03-13
 ### Changed

--- a/addOns/reports/src/main/zapHomeFiles/reports/modern/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/modern/report.html
@@ -459,7 +459,7 @@
 											class="indent2">Evidence</td>
 										<td th:text="${instance.userObject.evidence}" width="80%">Evidence</td>
 									</tr>
-									<tr>
+									<tr data-th-if="${instance.userObject.message}">
 										<td width="20%" class="indent2">
 											<div th:id="${'alert-' + instance.userObject.alertId}">
 												<a
@@ -470,7 +470,7 @@
 										</td>
 										<td width="80%"></td>
 									</tr>
-									<tr>
+									<tr data-th-if="${instance.userObject.message}">
 										<td width="20%" class="indent2"><th:block
 												th:text="#{report.alerts.detail.request.header}">Request Header</th:block>
 											<th:block
@@ -488,7 +488,7 @@
 											</div>
 										</td>
 									</tr>
-									<tr>
+									<tr data-th-if="${instance.userObject.message}">
 										<td width="20%" class="indent2"><th:block
 												th:text="#{report.alerts.detail.request.body}">Request Body</th:block>
 											<th:block
@@ -506,7 +506,7 @@
 											</div>
 										</td>
 									</tr>
-									<tr>
+									<tr data-th-if="${instance.userObject.message}">
 										<td width="20%" class="indent2"><th:block
 												th:text="#{report.alerts.detail.response.header}">Response Header</th:block>
 											<th:block
@@ -524,7 +524,7 @@
 											</div>
 										</td>
 									</tr>
-									<tr>
+									<tr data-th-if="${instance.userObject.message}">
 										<td width="20%" class="indent2"><th:block
 												th:text="#{report.alerts.detail.response.body}">Response Body</th:block>
 											<th:block

--- a/addOns/reports/src/main/zapHomeFiles/reports/risk-confidence-html/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/risk-confidence-html/report.html
@@ -34,7 +34,7 @@
 	</header>
 
 	<main
-		data-th-with="MAX_CONFIDENCE_CODE=4, MAX_RISK_CODE=3, alerts=${helper.getDepthFirstChildren(alertTree, false)}, includedConfidenceCodes=${#reportData=reportData, #numbers.sequence(MAX_CONFIDENCE_CODE, 0, -1).{? #code=#this, #reportData.isIncludeConfidence(#code)}}, includedRiskCodes=${#reportData=reportData, #numbers.sequence(MAX_RISK_CODE, 0, -1).{? #code=#this, #reportData.isIncludeRisk(#code)}}, includedConfidenceCodesSize=${includedConfidenceCodes.size()}, includedRiskCodesSize=${includedRiskCodes.size()}, sitesWithAlerts=${#alerts=alerts, #helper=helper, reportData.sites.{? #site=#this, !#alerts.{^ #userObject=#this.userObject, #msgUri=#userObject.msgUri, #helper.getHostForSite(#site) == #msgUri.host &amp;&amp; #helper.getPortForSite(#site) == #userObject.message.requestHeader.hostPort &amp;&amp; #helper.isSslSite(#site) == #msgUri.scheme.equals('https')}.isEmpty()}}">
+		data-th-with="MAX_CONFIDENCE_CODE=4, MAX_RISK_CODE=3, alerts=${helper.getDepthFirstChildren(alertTree, false)}, includedConfidenceCodes=${#reportData=reportData, #numbers.sequence(MAX_CONFIDENCE_CODE, 0, -1).{? #code=#this, #reportData.isIncludeConfidence(#code)}}, includedRiskCodes=${#reportData=reportData, #numbers.sequence(MAX_RISK_CODE, 0, -1).{? #code=#this, #reportData.isIncludeRisk(#code)}}, includedConfidenceCodesSize=${includedConfidenceCodes.size()}, includedRiskCodesSize=${includedRiskCodes.size()}, sitesWithAlerts=${#alerts=alerts, #helper=helper, reportData.sites.{? #site=#this, !#alerts.{^ #userObject=#this.userObject, #msgUri=#userObject.msgUri, #helper.getHostForSite(#site) == #msgUri.host &amp;&amp; #helper.getPortForSite(#site) == #helper.getPortForSite(#msgUri.toString()) &amp;&amp; #helper.isSslSite(#site) == #msgUri.scheme.equals('https')}.isEmpty()}}">
 
 		<section data-th-if="${reportData.isIncludeSection('contents')}"
 			id="contents" class="contents">
@@ -358,7 +358,7 @@
 								data-th-text="#{report.template.site}">Site</th>
 							<th scope="row" data-th-text="${site}">Site</th>
 							<th-block
-								data-th-with="countsForRow=${#site=site, #helper=helper, #alerts=alerts, includedRiskCodes.{#riskCode=#this, #alerts.{? #userObject=#this.userObject, #msgUri=#userObject.msgUri, #userObject.confidence != 0 &amp;&amp; #userObject.risk == #riskCode &amp;&amp; #helper.getHostForSite(#site) == #msgUri.host &amp;&amp; #helper.getPortForSite(#site) == #userObject.message.requestHeader.hostPort &amp;&amp; #helper.isSslSite(#site) == #msgUri.scheme.equals('https')}.size()}}">
+								data-th-with="countsForRow=${#site=site, #helper=helper, #alerts=alerts, includedRiskCodes.{#riskCode=#this, #alerts.{? #userObject=#this.userObject, #msgUri=#userObject.msgUri, #userObject.confidence != 0 &amp;&amp; #userObject.risk == #riskCode &amp;&amp; #helper.getHostForSite(#site) == #msgUri.host &amp;&amp; #helper.getPortForSite(#site) ==  #helper.getPortForSite(#msgUri.toString()) &amp;&amp; #helper.isSslSite(#site) == #msgUri.scheme.equals('https')}.size()}}">
 							<td data-th-each="count, iterStat: ${countsForRow}"><span
 								data-th-text="${count}">count</span><br> <span
 								class="additional-info-percentages"
@@ -446,7 +446,7 @@
 					</h3>
 					<ol>
 						<th-block data-th-each="site: ${sitesWithAlerts}"
-							data-th-with="filteredAlerts=${#helper=helper, #site=site, filteredAlerts.{? #userObject=#this.userObject, #msgUri=#userObject.msgUri, #helper.getHostForSite(#site) == #msgUri.host &amp;&amp; #helper.getPortForSite(#site) == #userObject.message.requestHeader.hostPort &amp;&amp; #helper.isSslSite(#site) == #msgUri.scheme.equals('https')}}">
+							data-th-with="filteredAlerts=${#helper=helper, #site=site, filteredAlerts.{? #userObject=#this.userObject, #msgUri=#userObject.msgUri, #helper.getHostForSite(#site) == #msgUri.host &amp;&amp; #helper.getPortForSite(#site) == #helper.getPortForSite(#msgUri.toString()) &amp;&amp; #helper.isSslSite(#site) == #msgUri.scheme.equals('https')}}">
 						<li data-th-unless="${filteredAlerts.isEmpty()}"
 							class="alerts--site-li">
 							<h4>
@@ -618,7 +618,7 @@
 				data-th-replace="~{::nl2p(text=${userObject.otherInfo})}">Other
 			info</th-block></td>
 	</tr>
-	<tr>
+	<tr data-th-if="${userObject.message}">
 		<th scope="row" data-th-text="#{report.template.alertsTable.request}">Request</th>
 		<td><details
 				data-th-with="requestHeader=${userObject.message.requestHeader}, headerLength=${requestHeader.toString().length}"
@@ -648,7 +648,7 @@
 				</th-block>
 			</details></td>
 	</tr>
-	<tr>
+	<tr data-th-if="${userObject.message}">
 		<th scope="row" data-th-text="#{report.template.alertsTable.response}">Response</th>
 		<td><details
 				data-th-with="responseHeader=${userObject.message.responseHeader}, headerLength=${responseHeader.toString().length}"

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
@@ -370,7 +370,7 @@
 						<td th:text="${instance.userObject.otherinfo}" width="80%">Other
 							Info</td>
 					</tr>
-					<tr>
+					<tr data-th-if="${instance.userObject.message}">
 						<td width="20%" class="indent2">
 							<div th:id="${'alert-' + instance.userObject.alertId}">
 								<a
@@ -381,7 +381,7 @@
 						</td>
 						<td width="80%"></td>
 					</tr>
-					<tr>
+					<tr data-th-if="${instance.userObject.message}">
 						<td width="20%" class="indent2"><th:block
 								th:text="#{report.alerts.detail.request.header}">Request Header</th:block>
 							<th:block
@@ -398,7 +398,7 @@
 							</div>
 						</td>
 					</tr>
-					<tr>
+					<tr data-th-if="${instance.userObject.message}">
 						<td width="20%" class="indent2"><th:block
 								th:text="#{report.alerts.detail.request.body}">Request Body</th:block>
 							<th:block
@@ -415,7 +415,7 @@
 							</div>
 						</td>
 					</tr>
-					<tr>
+					<tr data-th-if="${instance.userObject.message}">
 						<td width="20%" class="indent2"><th:block
 								th:text="#{report.alerts.detail.response.header}">Response Header</th:block>
 							<th:block
@@ -432,7 +432,7 @@
 							</div>
 						</td>
 					</tr>
-					<tr>
+					<tr data-th-if="${instance.userObject.message}">
 						<td width="20%" class="indent2"><th:block
 								th:text="#{report.alerts.detail.response.body}">Response Body</th:block>
 							<th:block

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
@@ -25,11 +25,11 @@
                             "param": "[(${helper.legacyEscapeTextAlertParam(instance, true)})]",
                             "attack": "[(${helper.legacyEscapeText(instance.attack, true)})]",
                             "evidence": "[(${helper.legacyEscapeText(instance.evidence, true)})]",
-                            "otherinfo": "[(${helper.legacyEscapeText(instance.otherinfo, true)})]",
+                            "otherinfo": "[(${helper.legacyEscapeText(instance.otherinfo, true)})]"[#th:block th:if="${instance.message}"],
                             "request-header": "[(${helper.legacyEscapeText(instance.message.requestHeader, true)})]",
                             "request-body": "[(${helper.legacyEscapeText(instance.message.requestBody, true)})]",
                             "response-header": "[(${helper.legacyEscapeText(instance.message.responseHeader, true)})]",
-                            "response-body": "[(${helper.legacyEscapeText(instance.message.responseBody, true)})]"
+                            "response-body": "[(${helper.legacyEscapeText(instance.message.responseBody, true)})]"[/th:block]
                         }[/th:block]
                     ],
                     "count": "[(${instances.size})]",

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -220,7 +220,7 @@ class ExtensionReportsUnitTest extends TestUtils {
         assertThat(counts.get(2), is(equalTo(4)));
     }
 
-    private HttpMessage newMsg(String uri) {
+    private static HttpMessage newMsg(String uri) {
         try {
             HttpMessage msg = new HttpMessage(new URI(uri + ILLEGAL_XML_CHRS, true));
             msg.getRequestHeader().setHeader("Test", "Foo-Header" + ILLEGAL_XML_CHRS);
@@ -233,9 +233,25 @@ class ExtensionReportsUnitTest extends TestUtils {
         }
     }
 
-    private AlertNode newAlertNode(
+    private static AlertNode newAlertNode(
             int pluginId, int level, String name, String uri, int childCount) {
         Alert alert = new Alert(pluginId);
+        setAlertData(uri, alert);
+        AlertNode alertNode = new AlertNode(level, name + ILLEGAL_XML_CHRS);
+        alertNode.setUserObject(alert);
+        for (int i = 0; i < childCount; i++) {
+            AlertNode childNode = new AlertNode(level, name + ILLEGAL_XML_CHRS);
+            Alert childAlert = new Alert(pluginId);
+            // TODO uncomment for illegal chars in PDF (and remove the following line)
+            // setAlertData(uri, childAlert);
+            childAlert.setMessage(newMsg(uri));
+            childNode.setUserObject(childAlert);
+            alertNode.add(childNode);
+        }
+        return alertNode;
+    }
+
+    private static void setAlertData(String uri, Alert alert) {
         alert.setUri(uri + ILLEGAL_XML_CHRS);
         alert.setName("Foo-name" + ILLEGAL_XML_CHRS);
         alert.setDescription("Foo-Desc" + ILLEGAL_XML_CHRS);
@@ -248,16 +264,6 @@ class ExtensionReportsUnitTest extends TestUtils {
 
         alert.setParam("Foo-param" + ILLEGAL_XML_CHRS);
         alert.setMessage(newMsg(uri));
-        AlertNode alertNode = new AlertNode(level, name + ILLEGAL_XML_CHRS);
-        alertNode.setUserObject(alert);
-        for (int i = 0; i < childCount; i++) {
-            AlertNode childNode = new AlertNode(level, name + ILLEGAL_XML_CHRS);
-            Alert childAlert = new Alert(pluginId);
-            childAlert.setMessage(newMsg(uri));
-            childNode.setUserObject(childAlert);
-            alertNode.add(childNode);
-        }
-        return alertNode;
     }
 
     @Test
@@ -544,7 +550,7 @@ class ExtensionReportsUnitTest extends TestUtils {
         assertThat(ExtensionReports.isIncluded(reportData, alertNode3), is(equalTo(false)));
     }
 
-    private ReportData getTestReportData() {
+    private static ReportData getTestReportData() {
         ReportData reportData = new ReportData();
         AlertNode root = new AlertNode(0, "Test");
         reportData.setAlertTreeRootNode(root);
@@ -1226,7 +1232,7 @@ class ExtensionReportsUnitTest extends TestUtils {
         assertThat(logEvents, not(hasItem(startsWith("ERROR"))));
     }
 
-    private ReportData setupReportData() {
+    private static ReportData setupReportData() {
         ReportData reportData = getTestReportData();
         AlertNode root = new AlertNode(0, "Alerts");
         root.add(newAlertNode(1, Alert.RISK_HIGH, "Alert High 1", "https://www.example.com", 1));
@@ -1238,6 +1244,14 @@ class ExtensionReportsUnitTest extends TestUtils {
                         "Alert Low 2",
                         "https://www.example.com",
                         8));
+        // Cover cases where the HTTP message is missing.
+        AlertNode noMsgAlertNode =
+                newAlertNode(
+                        4, Alert.RISK_HIGH, "Alert No HTTP Message", "https://www.example.com", 2);
+        noMsgAlertNode.getUserObject().setMessage(null);
+        noMsgAlertNode.getChildAt(0).getUserObject().setMessage(null);
+        root.add(noMsgAlertNode);
+
         reportData.setAlertTreeRootNode(root);
         String site1 = "https://www.example.com";
         reportData.setSites(List.of(site1 + NOT_ILLEGAL_XML_CHRS));


### PR DESCRIPTION
Do not try to use the HTTP message if it's not present in the alert.

Part of zaproxy/zaproxy#6880.