### PR TITLE
Fix more issues with illegal chrs in pdf reports

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Handle alerts without HTTP message gracefully (Issue 6880).
+- More issues with illegal XML characters in pdf reports (Issue 8330).
 
 ## [0.30.0] - 2024-03-13
 ### Changed

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-pdf/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-pdf/report.html
@@ -220,8 +220,10 @@ td {
 					<tr>
 						<td th:text="#{report.alerts.detail.url}" width="20%"
 							class="indent1">URL</td>
-						<td width="80%"><a th:href="${instance.userObject.uri}"
-							th:text="${instance.userObject.uri}" href="url.html">URL</a></td>
+						<td width="80%"><a
+							th:href="${helper.escapeXml(instance.userObject.uri)}"
+							th:text="${helper.escapeXml(instance.userObject.uri)}"
+							href="url.html">URL</a></td>
 					</tr>
 					<tr>
 						<td th:text="#{report.alerts.detail.method}" width="20%"
@@ -231,18 +233,20 @@ td {
 					<tr>
 						<td th:text="#{report.alerts.detail.attack}" width="20%"
 							class="indent2">Attack</td>
-						<td th:text="${instance.userObject.attack}" width="80%">Attack</td>
+						<td th:text="${helper.escapeXml(instance.userObject.attack)}"
+							width="80%">Attack</td>
 					</tr>
 					<tr>
 						<td th:text="#{report.alerts.detail.evidence}" width="20%"
 							class="indent2">Evidence</td>
-						<td th:text="${instance.userObject.evidence}" width="80%">Evidence</td>
+						<td th:text="${helper.escapeXml(instance.userObject.evidence)}"
+							width="80%">Evidence</td>
 					</tr>
 					<tr>
 						<td th:text="#{report.alerts.detail.otherinfo}" width="20%"
 							class="indent2">Other Info</td>
-						<td th:text="${instance.userObject.otherinfo}" width="80%">Other
-							Info</td>
+						<td th:text="${helper.escapeXml(instance.userObject.otherinfo)}"
+							width="80%">Other Info</td>
 					</tr>
 				</th:block>
 				<tr>

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -242,9 +242,7 @@ class ExtensionReportsUnitTest extends TestUtils {
         for (int i = 0; i < childCount; i++) {
             AlertNode childNode = new AlertNode(level, name + ILLEGAL_XML_CHRS);
             Alert childAlert = new Alert(pluginId);
-            // TODO uncomment for illegal chars in PDF (and remove the following line)
-            // setAlertData(uri, childAlert);
-            childAlert.setMessage(newMsg(uri));
+            setAlertData(uri, childAlert);
             childNode.setUserObject(childAlert);
             alertNode.add(childNode);
         }


### PR DESCRIPTION
## Overview
As per title.

## Related Issues
Fixes https://github.com/zaproxy/zaproxy/issues/8330

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
