### PR TITLE
automation: replace vars recursively

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Allow to use variables composed of multiple variables.
 
 ## [0.36.0] - 2024-03-25
 ### Added

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -284,6 +284,7 @@ automation.error.env.badcontexts = Invalid contexts in environment: {0}
 automation.error.env.badsessionmgmt = Invalid sessionManagement in context: {0}
 automation.error.env.badvars = Invalid vars in environment: {0}
 automation.error.env.badverification = Invalid verification in context: {0}
+automation.error.env.loopvar = Variable {0} has self reference
 automation.error.env.missing = Missing environment: {0}
 automation.error.env.nocontexts = Missing contexts in environment: {0}
 automation.error.env.novar = Variable {0} used but not specified


### PR DESCRIPTION
Replace the vars until there are no vars in the string, to allow to use vars composed with other vars.

---
From zaproxy IRC channel.