### PR TITLE
selenium: update HtmlUnit to 3.x

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [45] - 2024-03-25
 ### Changed

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ZapItScan.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ZapItScan.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart;
 
-import com.gargoylesoftware.htmlunit.HttpHeader;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -42,6 +41,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update Selenium to version 4.19.0.
+- Update HtmlUnit to major version 3.
 
 ### Fixed
 - A typo on the intro page in the add-on's help.

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -38,7 +38,7 @@ zapAddOn {
 dependencies {
     var seleniumVersion = "4.19.0"
     selenium("org.seleniumhq.selenium:selenium-java:$seleniumVersion")
-    selenium("org.seleniumhq.selenium:htmlunit-driver:4.13.0")
+    selenium("org.seleniumhq.selenium:htmlunit3-driver:4.18.1")
     implementation(libs.log4j.slf4j) {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")


### PR DESCRIPTION
Use latest major version of HtmlUnit and the driver.
Change quickstart to use core constants instead of HtmlUnit ones.