### PR TITLE
postman: correct deserialization of item groups

### DIFF
--- a/addOns/postman/CHANGELOG.md
+++ b/addOns/postman/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Automation support.
 
+### Fixed
+- Correct deserialization of item groups (Issue 8400).
+
 ## [0.2.0] - 2023-10-12
 ### Changed
 - Update minimum ZAP version to 2.14.0.

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
@@ -119,6 +119,9 @@ public class PostmanParser {
 
         extractHttpMessages(
                 postmanCollection.getItem(), httpMessages, errors, postmanCollection.getVariable());
+        if (httpMessages.isEmpty()) {
+            errors.add(Constant.messages.getString("postman.import.error.noItem"));
+        }
         return httpMessages;
     }
 
@@ -239,9 +242,6 @@ public class PostmanParser {
                             getCombinedVarList(itemGroup.getVariable(), parentVariables));
                 }
             }
-        }
-        if (httpMessages.isEmpty()) {
-            errors.add(Constant.messages.getString("postman.import.error.noItem"));
         }
     }
 

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/deserializers/ListItemDeserializer.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/deserializers/ListItemDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.postman.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.zaproxy.addon.postman.models.AbstractItem;
+import org.zaproxy.addon.postman.models.Item;
+import org.zaproxy.addon.postman.models.ItemGroup;
+
+public class ListItemDeserializer extends JsonDeserializer<List<AbstractItem>> {
+
+    @Override
+    public List<AbstractItem> deserialize(JsonParser jsonParser, DeserializationContext ctxt)
+            throws IOException {
+        JsonNode itemsNode = jsonParser.getCodec().readTree(jsonParser);
+
+        if (itemsNode.isArray()) {
+            return deserializeArray(jsonParser, itemsNode);
+        } else if (itemsNode.isObject()) {
+            return deserializeObject(jsonParser, itemsNode);
+        }
+
+        return List.of();
+    }
+
+    private static List<AbstractItem> deserializeArray(JsonParser jsonParser, JsonNode itemsNode) {
+        List<AbstractItem> items = new ArrayList<>();
+        for (JsonNode itemNode : itemsNode) {
+            AbstractItem item = deserializeItem(jsonParser, itemNode);
+            if (item != null) {
+                items.add(item);
+            }
+        }
+        return Collections.unmodifiableList(items);
+    }
+
+    private static List<AbstractItem> deserializeObject(JsonParser jsonParser, JsonNode itemNode) {
+        AbstractItem item = deserializeItem(jsonParser, itemNode);
+        return (item != null) ? List.of(item) : List.of();
+    }
+
+    private static AbstractItem deserializeItem(JsonParser jsonParser, JsonNode itemNode) {
+        try {
+
+            Class<? extends AbstractItem> clazz =
+                    itemNode.get("item") != null ? ItemGroup.class : Item.class;
+            return jsonParser.getCodec().treeToValue(itemNode, clazz);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/AbstractItem.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/AbstractItem.java
@@ -20,10 +20,6 @@
 package org.zaproxy.addon.postman.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-@JsonSubTypes({@JsonSubTypes.Type(Item.class), @JsonSubTypes.Type(ItemGroup.class)})
-public abstract class AbstractItem extends AbstractListElement {}
+public abstract class AbstractItem {}

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/ItemGroup.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/ItemGroup.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import org.zaproxy.addon.postman.deserializers.ListDeserializer;
+import org.zaproxy.addon.postman.deserializers.ListItemDeserializer;
 
 /**
  * Represents an item-group in the Postman format which can contain both item and item-group
@@ -32,7 +33,7 @@ import org.zaproxy.addon.postman.deserializers.ListDeserializer;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ItemGroup extends AbstractItem {
-    @JsonDeserialize(using = ListDeserializer.class)
+    @JsonDeserialize(using = ListItemDeserializer.class)
     private List<AbstractItem> item;
 
     @JsonDeserialize(using = ListDeserializer.class)

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/PostmanCollection.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/models/PostmanCollection.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import org.zaproxy.addon.postman.deserializers.ListDeserializer;
+import org.zaproxy.addon.postman.deserializers.ListItemDeserializer;
 
 /**
  * Represents a collection in the Postman format.
@@ -32,7 +33,7 @@ import org.zaproxy.addon.postman.deserializers.ListDeserializer;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PostmanCollection {
 
-    @JsonDeserialize(using = ListDeserializer.class)
+    @JsonDeserialize(using = ListItemDeserializer.class)
     private List<AbstractItem> item;
 
     @JsonDeserialize(using = ListDeserializer.class)

--- a/addOns/postman/src/test/java/org/zaproxy/addon/postman/ListDeserializerUnitTest.java
+++ b/addOns/postman/src/test/java/org/zaproxy/addon/postman/ListDeserializerUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.addon.postman;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +65,9 @@ class ListDeserializerUnitTest extends TestUtils {
         String collectionJson = "{\"item\":[true,{\"randomKey\":\"randomValue\"}]}";
 
         PostmanCollection collection = assertDoesNotThrow(() -> parser.parse(collectionJson));
-        assertEquals(0, collection.getItem().size());
+        assertEquals(1, collection.getItem().size());
+        var item = collection.getItem().get(0);
+        assertTrue(Item.class.isInstance(item));
+        assertNull(((Item) item).getRequest());
     }
 }


### PR DESCRIPTION
Deserialize taking into account the presence of the item field, which indicates an item group rather than an item.
Move the check for no items imported to after the import is concluded, to ensure it's only reported once.

Fix zaproxy/zaproxy#8400.