### PR TITLE
alertFilters: use pscan extension to gather data

### DIFF
--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -46,8 +46,6 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.Session.OnContextsChangedListener;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
-import org.zaproxy.zap.control.CoreFunctionality;
-import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.alert.AlertEventPublisher;
@@ -55,6 +53,7 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.alert.PopupMenuItemAlert;
 import org.zaproxy.zap.extension.alertFilters.internal.ScanRulesInfo;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.model.SessionStructure;
@@ -141,8 +140,9 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
             scanRulesInfo =
                     new ScanRulesInfo(
                             getExtAscan(),
-                            CoreFunctionality.getBuiltInPassiveScanRules(),
-                            ExtensionFactory.getAddOnLoader().getPassiveScanRules());
+                            Control.getSingleton()
+                                    .getExtensionLoader()
+                                    .getExtension(ExtensionPassiveScan.class));
         }
         return scanRulesInfo;
     }

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.pscan.PassiveScanData;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -48,20 +49,17 @@ public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
     private Map<String, Entry> entriesById;
 
     public ScanRulesInfo(
-            ExtensionActiveScan extensionActiveScan,
-            List<PluginPassiveScanner> builtInPassiveScanRules,
-            List<PluginPassiveScanner> passiveScanRules) {
+            ExtensionActiveScan extensionActiveScan, ExtensionPassiveScan extensionPassiveScan) {
         entries = new ArrayList<>();
         entriesById = new HashMap<>();
         ScanPolicy sp = extensionActiveScan.getPolicyManager().getDefaultScanPolicy();
         for (Plugin scanRule : sp.getPluginFactory().getAllPlugin()) {
             addEntry(scanRule, scanRule.getId(), scanRule.getName());
         }
-        for (PluginPassiveScanner scanRule : builtInPassiveScanRules) {
-            addEntry(scanRule, scanRule.getPluginId(), scanRule.getName());
-        }
-        for (PluginPassiveScanner scanRule : passiveScanRules) {
-            addEntry(scanRule, scanRule.getPluginId(), scanRule.getName());
+        if (extensionPassiveScan != null) {
+            for (PluginPassiveScanner scanRule : extensionPassiveScan.getPluginPassiveScanners()) {
+                addEntry(scanRule, scanRule.getPluginId(), scanRule.getName());
+            }
         }
         Collections.sort(entries);
     }


### PR DESCRIPTION
Use the extension instead of other core classes, which should be considered internal and thus subject to changes.