### PR TITLE
scripts: Fix removal of passive scan rules

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Error when trying to run an unsupported script type through the Automation Framework.
+- The "Scripts Passive Scanner" scan rule was being loaded twice.
 
 ## [45.1.0] - 2024-03-25
 ### Added

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -59,5 +59,7 @@ dependencies {
     zapAddOn("automation")
     zapAddOn("commonlib")
 
+    implementation("net.bytebuddy:byte-buddy:1.14.13")
+
     testImplementation(project(":testutils"))
 }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -62,7 +62,6 @@ import org.zaproxy.zap.extension.script.ScriptUI;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.scripts.scanrules.ActiveScriptSynchronizer;
 import org.zaproxy.zap.extension.scripts.scanrules.PassiveScriptSynchronizer;
-import org.zaproxy.zap.extension.scripts.scanrules.ScriptsPassiveScanner;
 import org.zaproxy.zap.extension.stdmenus.PopupContextMenuItemFactory;
 import org.zaproxy.zap.model.Context;
 
@@ -265,7 +264,6 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
                 if (installedPscanRule != null
                         && installedPscanRule.getClass().getName().equals(corePscanRuleName)) {
                     extensionPscan.removePluginPassiveScanner(installedPscanRule);
-                    extensionPscan.addPluginPassiveScanner(new ScriptsPassiveScanner());
                 }
             }
         }


### PR DESCRIPTION
Passive scripts exposed as scan rules were not being removed reliably (e.g. commenting out the metadata function in one passive script ended up removing another).

This was happening because `ExtensionPassiveScan` in core relies on the class name of the passive scan rule to remove it, and all passive scripts exposed as scan rules have the same class name.

This PR uses [Byte Buddy](https://bytebuddy.net), a library that allows creating Java classes at runtime, to expose scripts as passive scan rules with classes that have unique names.

This is temporary until we update `ExtensionPassiveScan` to not use the scan rule name (and maybe use the ID like in
`PluginFactory#unloadedPlugin`?) to remove passive scan rules.