### PR TITLE
replacer: Add a default rule to disable CSP (etc) Reporting

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Video link in help for Automation Framework job.
+- A rule to disable CSP reporting (Issue 740).
 
 ## [16] - 2023-11-30
 ### Changed

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamUnitTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamUnitTest.java
@@ -1,0 +1,184 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.replacer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ReplacerParam}. */
+class ReplacerParamUnitTest {
+
+    private static final int EXPECTED_V1_RULE_COUNT = 4;
+
+    private ReplacerParam param;
+    private ZapXmlConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        param = new ReplacerParam();
+        configuration = new ZapXmlConfiguration();
+    }
+
+    @Test
+    void shouldHaveConfigVersionKey() {
+        // Given / When
+        param.load(configuration);
+        // Then
+        assertThat(param.getConfigVersionKey(), is(equalTo("replacer[@version]")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void shouldLoadConfirmRemoveFromConfig(boolean state) {
+        // Given
+        configuration.setProperty("replacer.confirmRemoveToken", state);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.isConfirmRemoveToken(), is(equalTo(state)));
+    }
+
+    @Test
+    void shouldDefaultConfirmRemoveTrue() {
+        // Given / When
+        param.load(configuration);
+        // Then
+        assertThat(param.isConfirmRemoveToken(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldHaveExpectedVersionInDefaultConfig() {
+        // Given / When
+        param.load(configuration);
+        // Then
+        assertThat(param.getCurrentVersion(), is(equalTo(1)));
+    }
+
+    @Test
+    void shouldHaveExpectedRulesOnUpdateFromUnversioned() {
+        // Given
+        List<String> expectedDescs =
+                List.of(
+                        "Remove CSP",
+                        "Remove HSTS",
+                        "Replace User-Agent with shellshock attack",
+                        ReplacerParam.REPORT_TO_DESC);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getRules().size(), is(equalTo(EXPECTED_V1_RULE_COUNT)));
+
+        List<String> ruleDescs = new ArrayList<>();
+        param.getRules().forEach(x -> ruleDescs.add(x.getDescription()));
+
+        assertTrue(ruleDescs.containsAll(expectedDescs));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(ints = {2, 999})
+    void shouldNotOverwriteExistingRulesOnUpdate(Object version) {
+        // Given / When
+        param.load(configuration);
+        configuration = new ZapXmlConfiguration();
+        configuration.setProperty(param.getConfigVersionKey(), version);
+        createConfigWithReportToRule(configuration);
+        param.load(configuration);
+        ReplacerParamRule enabledReportTo = getReportToRule(true);
+        param.addRule(enabledReportTo);
+        // Then
+        assertThat(param.getRules().size(), is(equalTo(2)));
+        // getRule returns first match (0th)
+        ReplacerParamRule originalRule = param.getRule(ReplacerParam.REPORT_TO_DESC);
+        assertNotNull(originalRule);
+        assertThat(originalRule.getDescription(), is(equalTo(ReplacerParam.REPORT_TO_DESC)));
+        assertThat(originalRule.isEnabled(), is(equalTo(false)));
+        // Added rule (1st) should be enabled
+        assertThat(param.getRules().get(1).isEnabled(), is(equalTo(true)));
+    }
+
+    private void createConfigWithReportToRule(ZapXmlConfiguration config) {
+        ((HierarchicalConfiguration) config).clearTree(ReplacerParam.ALL_RULES_KEY);
+        List<ReplacerParamRule> rules = List.of(getReportToRule(false));
+        ArrayList<String> enabledTokens = new ArrayList<>(rules.size());
+        for (int i = 0, size = rules.size(); i < size; ++i) {
+            String elementBaseKey = ReplacerParam.ALL_RULES_KEY + "(" + i + ").";
+            ReplacerParamRule rule = rules.get(i);
+
+            config.setProperty(
+                    elementBaseKey + ReplacerParam.RULE_DESCRIPTION_KEY, rule.getDescription());
+            config.setProperty(elementBaseKey + ReplacerParam.RULE_URL_KEY, rule.getUrl());
+            config.setProperty(
+                    elementBaseKey + ReplacerParam.RULE_ENABLED_KEY,
+                    Boolean.valueOf(rule.isEnabled()));
+            config.setProperty(
+                    elementBaseKey + ReplacerParam.RULE_MATCH_TYPE_KEY, rule.getMatchType().name());
+            config.setProperty(
+                    elementBaseKey + ReplacerParam.RULE_MATCH_STRING_KEY, rule.getMatchString());
+            config.setProperty(
+                    elementBaseKey + ReplacerParam.RULE_REGEX_KEY,
+                    Boolean.valueOf(rule.isMatchRegex()));
+            config.setProperty(
+                    elementBaseKey + ReplacerParam.RULE_REPLACEMENT_KEY, rule.getReplacement());
+            config.setProperty(
+                    elementBaseKey + ReplacerParam.RULE_EXTRA_PROCESSING_KEY,
+                    Boolean.valueOf(rule.isTokenProcessingEnabled()));
+
+            List<Integer> initiators = rule.getInitiators();
+            if (initiators == null || initiators.isEmpty()) {
+                config.setProperty(elementBaseKey + ReplacerParam.RULE_INITIATORS_KEY, "");
+            } else {
+                config.setProperty(
+                        elementBaseKey + ReplacerParam.RULE_INITIATORS_KEY, initiators.toString());
+            }
+
+            if (rule.isEnabled()) {
+                enabledTokens.add(rule.getDescription());
+            }
+        }
+
+        enabledTokens.trimToSize();
+    }
+
+    private ReplacerParamRule getReportToRule(boolean enabled) {
+        return new ReplacerParamRule(
+                ReplacerParam.REPORT_TO_DESC,
+                MatchType.RESP_HEADER_STR,
+                ReplacerParam.REPORT_TO_REGEX,
+                true,
+                ReplacerParam.REPORT_TO_REPLACEMENT,
+                null,
+                enabled);
+    }
+}


### PR DESCRIPTION
## Overview
- CHANGELOG > Added note.
- ReplacerParam > Added new pattern. Change to VersionedAbstractParam, add handling for unversioned to versioned upgrade, etc.
- ExtensionReplacerTest > Add test for new replacer rule.
- ReplacerParamUnitTest > New tests.

## Related Issues
Fixes zaproxy/zaproxy#740

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

---

This will replace all occurrences of `report-to` or `report-uri` in the response. Ex: CSP, CORS, Report-To header itself:
```http
Content-Security-Policy-Report-Only: require-trusted-types-for 'script'; report-disabled https://csp.withgoogle.com/csp/apps-themes
Cross-Origin-Resource-Policy: cross-origin
Cross-Origin-Opener-Policy: same-origin; report-disabled="apps-themes"
report-disabled: {"group":"apps-themes","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-disabled/apps-themes"}]}
```