### PR TITLE
sse: Graceful handling of empty "id"-field in sse add-on

### DIFF
--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.14.0.
 - Maintenance changes.
 
+### Fixed
+- More gracefully handle missing value for "id" field (Issue 8320)
+
 ## [12] - 2022-10-28
 ### Changed
 - Update minimum ZAP version to 2.12.0.

--- a/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/EventStreamProxy.java
+++ b/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/EventStreamProxy.java
@@ -150,7 +150,7 @@ public class EventStreamProxy {
                 field = line.substring(0, colonIndex);
 
                 int dataIndex = colonIndex + 1;
-                if (line.charAt(dataIndex) == ' ') {
+                if (dataIndex < line.length() && line.charAt(dataIndex) == ' ') {
                     // do not include first whitespace
                     dataIndex++;
                 }

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
@@ -177,6 +177,24 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
+    void shouldProcessEmptyLastEventIdWithEventData() throws IOException {
+        // Given
+        final String eventStream = "data: blub\nid:\nevent: welcome";
+
+        BufferedWriter writer = mock(BufferedWriter.class);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
+
+        // When
+        ServerSentEvent event = proxy.processEvent(eventStream);
+
+        // Then
+        assertThat(event.getData(), is("blub"));
+        assertThat(event.getEventType(), is("welcome"));
+        assertThat(event.getLastEventId(), is(""));
+        assertThat(event.getRawEvent(), is(eventStream));
+    }
+
+    @Test
     void shouldRemoveFirstWhitespaceFromLineAfterColon() throws IOException {
         // Given
         final String eventStream = "data:  third event";


### PR DESCRIPTION
When an SSE packet has an empty "id" field, the addon stops processing.

## Overview
Handles the case where an SSE packet has an empty "id" followed by "event" field. Enables addOn to further process packets instead of stopping with an exception.

## Related Issues
https://github.com/zaproxy/zaproxy/issues/8320

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
