### PR TITLE
QuickStart: support AJAX "if modern" option

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- AJAX spider selection to include "if modern" option.
 
 ### Fixed
 - Help content typos.

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -375,6 +375,16 @@ public class AttackPanel extends QuickStartSubPanel {
             this.getUrlField().requestFocusInWindow();
             return false;
         }
+        if (plugableSpider != null
+                && plugableSpider.requireStdSpider()
+                && (traditionalSpider == null || !traditionalSpider.isSelected())) {
+            getExtensionQuickStart()
+                    .getView()
+                    .showWarningDialog(
+                            Constant.messages.getString("quickstart.url.warning.needspider"));
+            return false;
+        }
+
         String urlStr = item.toString();
         URL url;
         try {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -96,6 +96,9 @@ public class AttackThread extends Thread {
             }
             Target target = new Target(startNode);
             target.setRecurse(true);
+            if (plugableSpider != null) {
+                plugableSpider.init();
+            }
             if (this.useStdSpider) {
 
                 if (traditionalSpider == null) {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/PlugableSpider.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/PlugableSpider.java
@@ -25,6 +25,8 @@ import javax.swing.JPanel;
 /** Interface to allow the Ajax Spider to be plugged into the Quick Start panels */
 public interface PlugableSpider {
 
+    void init();
+
     void startScan(URI uri);
 
     void stopScan();
@@ -38,4 +40,6 @@ public interface PlugableSpider {
     boolean isRunning();
 
     void setEnabled(boolean val);
+
+    boolean requireStdSpider();
 }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
@@ -20,16 +20,23 @@
 package org.zaproxy.zap.extension.quickstart.ajaxspider;
 
 import java.net.URI;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.swing.Box;
 import javax.swing.ComboBoxModel;
-import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.ZAP;
+import org.zaproxy.zap.eventBus.Event;
+import org.zaproxy.zap.eventBus.EventConsumer;
+import org.zaproxy.zap.extension.alert.AlertEventPublisher;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.quickstart.PlugableSpider;
 import org.zaproxy.zap.extension.quickstart.QuickStartBackgroundPanel;
 import org.zaproxy.zap.extension.quickstart.QuickStartParam;
@@ -44,21 +51,96 @@ import org.zaproxy.zap.view.LayoutHelper;
 
 public class AjaxSpiderExplorer implements PlugableSpider {
 
+    public enum Select {
+        NEVER(0),
+        MODERN(1),
+        ALWAYS(2);
+
+        private int index;
+
+        private Select(int idx) {
+            index = idx;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        @Override
+        public String toString() {
+            return Constant.messages.getString(
+                    "quickstart.select." + name().toLowerCase(Locale.ROOT));
+        }
+    }
+
+    private static final String MODERN_APP_PLUGIN_ID = "10109";
+    private static final String MODERN_APP_I18N_KEY = "pscanrules.modernapp.name";
+
     private ExtensionQuickStartAjaxSpider extension;
-    private JCheckBox selectCheckBox;
     private JComboBox<ProvidedBrowserUI> browserComboBox;
+    private JComboBox<Select> selectComboBox;
+    private EventConsumerImpl eventConsumer;
+    private boolean isModern;
+    private String modernAppAlertName = "Modern Web Application";
+
     private JPanel panel;
 
     public AjaxSpiderExplorer(ExtensionQuickStartAjaxSpider extension) {
         this.extension = extension;
     }
 
+    @Override
+    public void init() {
+        isModern = false;
+        eventConsumer = new EventConsumerImpl();
+        ZAP.getEventBus()
+                .registerConsumer(
+                        eventConsumer,
+                        AlertEventPublisher.getPublisher().getPublisherName(),
+                        AlertEventPublisher.ALERT_ADDED_EVENT);
+
+        if (Constant.messages.containsKey(MODERN_APP_I18N_KEY)) {
+            // Handle the case where this has been i18n'ed, or changed in the alert..
+            modernAppAlertName = Constant.messages.getString(MODERN_APP_I18N_KEY);
+        }
+    }
+
     public ExtensionAjax getExtAjax() {
         return Control.getSingleton().getExtensionLoader().getExtension(ExtensionAjax.class);
     }
 
+    public ExtensionPassiveScan getExtPscan() {
+        return Control.getSingleton().getExtensionLoader().getExtension(ExtensionPassiveScan.class);
+    }
+
     @Override
     public void startScan(URI uri) {
+        int selInd = this.getSelectComboBox().getSelectedIndex();
+        if (selInd == Select.NEVER.getIndex()) {
+            ZAP.getEventBus().unregisterConsumer(eventConsumer);
+            return;
+        }
+        if (selInd == Select.MODERN.getIndex()) {
+            // Only run if modern - keep monitoring for the relevant alert until the passive scan
+            // queue empties
+            ExtensionPassiveScan extPscan = this.getExtPscan();
+            while (extPscan.getRecordsToScan() > 0) {
+                if (isModern) {
+                    break;
+                }
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    // Ignore
+                }
+            }
+            if (!isModern) {
+                ZAP.getEventBus().unregisterConsumer(eventConsumer);
+                return;
+            }
+        }
+        ZAP.getEventBus().unregisterConsumer(eventConsumer);
+
         ExtensionAjax extAjax = this.getExtAjax();
         AjaxSpiderParam options =
                 Model.getSingleton().getOptionsParam().getParamSet(AjaxSpiderParam.class).clone();
@@ -73,6 +155,27 @@ public class AjaxSpiderExplorer implements PlugableSpider {
         extAjax.startScan(builder.build());
     }
 
+    /**
+     * Monitors the alert added events for the Modern App Detection rule: 10109 In 2.14.0 the
+     * pluginId is not present, so we have to rely on the i18n'ed name.
+     */
+    private class EventConsumerImpl implements EventConsumer {
+        @Override
+        public void eventReceived(Event event) {
+            if (isModern) {
+                // No need to check anything
+                return;
+            } else if (event.getEventType().equals(AlertEventPublisher.ALERT_ADDED_EVENT)) {
+                Map<String, String> params = event.getParameters();
+                // FIXME Use the PLUGIN_ID constant and remove the name check post 2.15
+                if (MODERN_APP_PLUGIN_ID.equals(params.get("pluginId"))
+                        || params.get(AlertEventPublisher.NAME).equals(modernAppAlertName)) {
+                    isModern = true;
+                }
+            }
+        }
+    }
+
     @Override
     public void stopScan() {
         this.getExtAjax().stopScan();
@@ -83,19 +186,19 @@ public class AjaxSpiderExplorer implements PlugableSpider {
         return Constant.messages.getString("quickstart.label.ajaxspider");
     }
 
-    private JCheckBox getSelectCheckBox() {
-        if (selectCheckBox == null) {
-            selectCheckBox = new JCheckBox();
-            selectCheckBox.addActionListener(
-                    e -> {
-                        getBrowserComboBox().setEnabled(selectCheckBox.isSelected());
-                        extension
-                                .getExtQuickStart()
-                                .getQuickStartParam()
-                                .setAjaxSpiderEnabled(selectCheckBox.isSelected());
-                    });
+    private JComboBox<Select> getSelectComboBox() {
+        if (selectComboBox == null) {
+            selectComboBox = new JComboBox<>();
+            Stream.of(Select.values()).forEach(s -> selectComboBox.addItem(s));
+            selectComboBox.addActionListener(
+                    e ->
+                            extension
+                                    .getExtQuickStart()
+                                    .getQuickStartParam()
+                                    .setAjaxSpiderSelection(
+                                            ((Select) selectComboBox.getSelectedItem()).name()));
         }
-        return selectCheckBox;
+        return selectComboBox;
     }
 
     private JComboBox<ProvidedBrowserUI> getBrowserComboBox() {
@@ -130,7 +233,7 @@ public class AjaxSpiderExplorer implements PlugableSpider {
         if (panel == null) {
             panel = new QuickStartBackgroundPanel();
             panel.add(
-                    getSelectCheckBox(),
+                    getSelectComboBox(),
                     LayoutHelper.getGBC(0, 0, 1, 0.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));
             panel.add(
                     new JLabel(Constant.messages.getString("quickstart.label.withbrowser")),
@@ -148,7 +251,8 @@ public class AjaxSpiderExplorer implements PlugableSpider {
 
     @Override
     public boolean isSelected() {
-        return getSelectCheckBox().isSelected();
+        // Always 'enabled', as this class decides if it runs or not
+        return true;
     }
 
     @Override
@@ -158,11 +262,17 @@ public class AjaxSpiderExplorer implements PlugableSpider {
 
     @Override
     public void setEnabled(boolean val) {
-        getSelectCheckBox().setEnabled(val);
+        // Nothing to do
     }
 
     public void optionsLoaded(QuickStartParam quickStartParam) {
-        getSelectCheckBox().setSelected(quickStartParam.isAjaxSpiderEnabled());
+        Select select = Select.MODERN;
+        try {
+            select = Select.valueOf(quickStartParam.getAjaxSpiderSelection());
+        } catch (Exception e) {
+            // Ignore
+        }
+        getSelectComboBox().setSelectedItem(select);
         String def = quickStartParam.getAjaxSpiderDefaultBrowser();
         if (def == null || def.length() == 0) {
             // no default
@@ -176,5 +286,10 @@ public class AjaxSpiderExplorer implements PlugableSpider {
                 break;
             }
         }
+    }
+
+    @Override
+    public boolean requireStdSpider() {
+        return this.getSelectComboBox().getSelectedIndex() != Select.ALWAYS.getIndex();
     }
 }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/ExtensionQuickStartAjaxSpider.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/ExtensionQuickStartAjaxSpider.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.quickstart.ExtensionQuickStart;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.spiderAjax.ExtensionAjax;
@@ -39,7 +40,7 @@ public class ExtensionQuickStartAjaxSpider extends ExtensionAdaptor {
     public static final String NAME = "ExtensionQuickStartAjaxSpider";
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            List.of(ExtensionAjax.class, ExtensionSelenium.class);
+            List.of(ExtensionAjax.class, ExtensionSelenium.class, ExtensionPassiveScan.class);
 
     private AjaxSpiderExplorer ase;
 

--- a/addOns/quickstart/src/main/javahelp/org/zaproxy/zap/extension/quickstart/resources/help/contents/quickstart.html
+++ b/addOns/quickstart/src/main/javahelp/org/zaproxy/zap/extension/quickstart/resources/help/contents/quickstart.html
@@ -36,6 +36,13 @@ The ajax spider explores the application by launching the browser you have chose
 It is slower than the traditional spider but handles JavaScript well.<br>
 This option is only shown if the ajax spider add-on is installed. 
 If it is not available then you can download and install it for free from the ZAP Marketplace.
+<br><br>
+The options available are:
+<ul>
+<li>Never: you will then need to use the traditional spider
+<li>If Modern: will run if ZAP identifies the target as a modern app - for this you need to use the traditional spider
+<li>Always: if you choose this option then you do not need to run the traditional spider
+</ul>
 
 <H2>Manual Explore</H2>
 

--- a/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
+++ b/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
@@ -146,6 +146,10 @@ quickstart.progress.spider = Using traditional spider to discover the content
 quickstart.progress.started = Accessing URL
 quickstart.progress.stopped = Manually stopped
 
+quickstart.select.always = Always
+quickstart.select.modern = If Modern
+quickstart.select.never = Never
+
 quickstart.spider.desc = Adds the option to use the traditional Spider in the Quick Start scan.
 quickstart.spider.name = Quick Start Spider Integration
 
@@ -176,4 +180,5 @@ quickstart.top.panel.message3 = ZAP is sponsored by the Crash Override Open Sour
 quickstart.top.panel.title = Welcome to ZAP
 
 quickstart.url.warning.invalid = You need to enter a valid URL.
+quickstart.url.warning.needspider = The options chosen mean that you need to select the traditional spider.
 quickstart.url.warning.nospider = You need to select one of the spiders.


### PR DESCRIPTION
## Overview
Add an option to the Quick Start panel to only run the AJAX Spider if the app is modern - this is the new default, as its probably the most useful option.

## Related Issues
Related PR: https://github.com/zaproxy/zaproxy/pull/8454 (but not a dependency)

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
