### PR TITLE
replacer: Add cache prevention rules

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Video link in help for Automation Framework job.
 - A rule to disable CSP reporting (Issue 740).
+- Rules to disable Caching (Issue 8437).
 
 ## [16] - 2023-11-30
 ### Changed


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note
- ReplacerParam > Added new default rules (disabled by default).
- ReplacerParamUnitTest > Tweaked to accommodate these additional changes.

## Related Issues
zaproxy/zaproxy#8437

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
