### PR TITLE
graaljs: suppress interpreter warn globally

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Disable warns about the engine being executed in interpreter mode, that's the expected mode of execution.
 
 ## [0.6.0] - 2024-04-11
 ### Changed

--- a/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/ExtensionGraalJs.java
+++ b/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/ExtensionGraalJs.java
@@ -37,6 +37,10 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 
 public class ExtensionGraalJs extends ExtensionAdaptor {
 
+    static {
+        System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");
+    }
+
     public static final String NAME = "ExtensionGraalJs";
 
     private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =


### PR DESCRIPTION
Globally suppress interpreter only warn as that's expected and the engine can be executed directly (e.g. Zest, which does not set the desired flags to suppress it).