### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update Zest library to 0.21.0:
+  - Update Selenium to version 4.20.0.
+  - Update HtmlUnit to major version 3.
 
 ## [44] - 2024-04-11
 ### Added

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     zapAddOn("scripts")
     zapAddOn("selenium")
 
-    implementation("org.zaproxy:zest:0.20.0") {
+    implementation("org.zaproxy:zest:0.21.0") {
         // Provided by commonlib add-on.
         exclude(group = "com.fasterxml.jackson")
         // Provided by Selenium add-on.


### PR DESCRIPTION
Update Zest library to 0.21.0:
 - Update Selenium to version 4.20.0.
 - Update HtmlUnit to major version 3.