### PR TITLE
graphql, openapi: Update dependencies

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [0.23.0] - 2024-02-22
 ### Added

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -62,11 +62,7 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("spider")
 
-    implementation("com.graphql-java:graphql-java:21.3")
-    implementation(libs.log4j.slf4j2) {
-        // Provided by ZAP.
-        exclude(group = "org.apache.logging.log4j")
-    }
+    implementation("com.graphql-java:graphql-java:22.0")
 
     testImplementation(project(":testutils"))
     testImplementation(libs.log4j.core)

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Dependency updates.
 
 ## [39] - 2024-01-26
 ### Added

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -62,8 +62,8 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("spider")
 
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.20")
-    implementation("io.swagger:swagger-compat-spec-parser:1.0.69") {
+    implementation("io.swagger.parser.v3:swagger-parser:2.1.22")
+    implementation("io.swagger:swagger-compat-spec-parser:1.0.70") {
         // Not needed:
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")


### PR DESCRIPTION
- Upgrade `graphql-java` to `22.0`.
- Upgrade `swagger-parser` to `2.1.22`.
- Upgrade `swagger-compat-spec-parser` to `1.0.70`.
