### PR TITLE
wappalyzer: Address class contention issue

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- Implemented a change to address a resource contention issue when loading Tech Detection details (Issue 8464).
 
+### Changed
+- Suppress further un-helpful messages from the jsvg library logger.
 
 ## [21.35.0] - 2024-04-23
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -110,6 +110,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
                         "com.github.weisj.jsvg.util.ResourceUtil",
                         "com.github.weisj.jsvg.parser.css.impl.SimpleCssParser",
                         "com.github.weisj.jsvg.parser.css.impl.Lexer",
+                        "com.github.weisj.jsvg.parser.SVGLoader",
                         "com.github.weisj.jsvg.nodes.Image",
                         "com.github.weisj.jsvg.nodes.container.BaseContainerNode"),
                 Level.OFF);

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.wappalyzer;
 
 import com.github.weisj.jsvg.SVGDocument;
+import com.github.weisj.jsvg.attributes.paint.SVGPaint;
 import com.github.weisj.jsvg.parser.SVGLoader;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
@@ -75,6 +76,11 @@ public class WappalyzerJsonParser {
 
     WappalyzerData parse(String categories, List<String> technologies, boolean createIcons) {
         LOGGER.info("Starting to parse Tech Detecction technologies.");
+        if (createIcons) {
+            // Access the SVGPaint class to hopefully address class contention when parallel loading
+            // below. Issue 8464
+            SVGPaint.DEFAULT_PAINT.paint();
+        }
         Instant start = Instant.now();
         WappalyzerData wappalyzerData = new WappalyzerData();
         parseCategories(wappalyzerData, getStringResource(categories));


### PR DESCRIPTION
## Overview
- CHANGELOG > Add fix note.
- WappalyzerJsonParser > Access SVGPaint prior to parallel loading of the patterns/icons, to hopefully address class contention.
- ExtensionWappalyzer > Suppress further unhelpful logging from jsvg.

## Related Issues
Fixes zaproxy/zaproxy#8464

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [NA] Write tests
- [NA] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
