### PR TITLE
scripts: allow to set raw value from Active Rules

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Allow to set raw parameter values from Active Rules, by calling `as.setEscapedParam(HttpMessage msg, String param, String value)`.
 
 ## [45.2.0] - 2024-04-11
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptHelper.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptHelper.java
@@ -34,6 +34,10 @@ public abstract class ActiveScriptHelper extends AbstractAppParamPlugin {
         return super.setParameter(msg, param, value);
     }
 
+    public String setEscapedParam(HttpMessage msg, String param, String value) {
+        return super.setEscapedParameter(msg, param, value);
+    }
+
     @Override
     public void sendAndReceive(HttpMessage msg) throws IOException {
         super.sendAndReceive(msg);


### PR DESCRIPTION
Expose the method `setEscapedParameter(...)` to the scripts so it's possible to set raw values, like it's possible from Java active scan rules.