### PR TITLE
Update codebase to ZAP 2.15

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [10] - 2024-03-25
 ### Changed

--- a/addOns/accessControl/src/test/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessorUnitTest.java
+++ b/addOns/accessControl/src/test/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessorUnitTest.java
@@ -69,10 +69,12 @@ class AccessControlAlertsProcessorUnitTest {
         assertThat(alert.getCweId(), is(equalTo(cweId)));
         assertThat(alert.getWascId(), is(equalTo(wascId)));
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags,
                 allOf(
+                        hasEntry(
+                                "CWE-" + cweId,
+                                "https://cwe.mitre.org/data/definitions/" + cweId + ".html"),
                         hasEntry(
                                 CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag(),
                                 CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getValue()),

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -148,7 +148,7 @@ subprojects {
         }
     }
 
-    val zapGav = "org.zaproxy:zap:2.14.0"
+    val zapGav = "org.zaproxy:zap:2.15.0-SNAPSHOT"
     dependencies {
         "zap"(zapGav)
     }
@@ -159,7 +159,7 @@ subprojects {
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })
 
         manifest {
-            zapVersion.set("2.14.0")
+            zapVersion.set("2.15.0")
 
             changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
             repo.set("https://github.com/zaproxy/zap-extensions/")

--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [20] - 2024-04-02
 ### Added

--- a/addOns/allinonenotes/CHANGELOG.md
+++ b/addOns/allinonenotes/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [65] - 2024-03-28
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CloudMetadataScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CloudMetadataScanRule.java
@@ -30,10 +30,7 @@ import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.extension.custompages.CustomPage;
-import org.zaproxy.zap.model.Context;
 
 /**
  * Attempts to retrieve cloud metadata by forging the host header and requesting a specific URL. See
@@ -102,22 +99,6 @@ public class CloudMetadataScanRule extends AbstractHostPlugin implements CommonA
                 .setAttack(host)
                 .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "otherinfo"))
                 .setMessage(newRequest);
-    }
-
-    /** FIXME Remove this call after 2.15.0 to call the fixed version in the parent. */
-    @Override
-    public boolean isSuccess(HttpMessage msg) {
-        Context context = getParent().getContext();
-        if (context != null) {
-            if (context.isCustomPage(msg, CustomPage.Type.NOTFOUND_404)
-                    || context.isCustomPage(msg, CustomPage.Type.ERROR_500)) {
-                return false;
-            }
-            if (context.isCustomPage(msg, CustomPage.Type.OK_200)) {
-                return true;
-            }
-        }
-        return HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode());
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRule.java
@@ -47,8 +47,6 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
-import org.zaproxy.zap.extension.custompages.CustomPage;
-import org.zaproxy.zap.model.Context;
 
 /**
  * Active scan rule which checks whether various URL paths are exposed.
@@ -141,22 +139,6 @@ public class HiddenFilesScanRule extends AbstractHostPlugin implements CommonAct
                 raiseAlert(testMsg, Alert.CONFIDENCE_LOW, Alert.RISK_INFO, file);
             }
         }
-    }
-
-    /** FIXME Remove this call after 2.15.0 to call the fixed version in the parent. */
-    @Override
-    protected boolean isPage200(HttpMessage msg) {
-        Context context = getParent().getContext();
-        if (context != null) {
-            if (context.isCustomPage(msg, CustomPage.Type.NOTFOUND_404)
-                    || context.isCustomPage(msg, CustomPage.Type.ERROR_500)) {
-                return false;
-            }
-            if (context.isCustomPage(msg, CustomPage.Type.OK_200)) {
-                return true;
-            }
-        }
-        return HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode());
     }
 
     private static String generatePath(String baseUriPath, String hiddenFile) {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRuleUnitTest.java
@@ -76,7 +76,8 @@ class DirectoryBrowsingScanRuleUnitTest extends ActiveScannerTest<DirectoryBrows
         assertThat(alerts.size(), is(equalTo(1)));
         Alert alert = alerts.get(0);
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags.size(), is(equalTo(3)));
+        assertThat(tags, hasKey("CWE-548"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A05_BROKEN_AC.getTag()));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRuleUnitTest.java
@@ -91,7 +91,8 @@ class FormatStringScanRuleUnitTest extends ActiveScannerTest<FormatStringScanRul
         assertThat(alerts.size(), is(equalTo(1)));
         Alert alert = alerts.get(0);
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags.size(), is(equalTo(3)));
+        assertThat(tags, hasKey("CWE-134"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
@@ -742,7 +742,8 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         Map<String, String> tags = alert.getTags();
         // Then
         assertThat(alerts.size(), is(equalTo(1)));
-        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(tags.size(), is(equalTo(5)));
+        assertThat(tags, hasKey("CWE-538"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getTag()));

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/Log4ShellScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/Log4ShellScanRuleUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.ascanrules;
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -133,12 +134,14 @@ class Log4ShellScanRuleUnitTest extends ActiveScannerTest<Log4ShellScanRule> {
         // Then
         assertThat(alerts.size(), is(equalTo(2)));
         assertThat(alert1.getAlertRef(), is(equalTo("40043-1")));
-        assertThat(alert1.getTags().size(), is(equalTo(5)));
+        assertThat(alert1.getTags().size(), is(equalTo(6)));
+        assertThat(alert1.getTags(), hasKey("CWE-117"));
         assertThat(alert1.getTags().containsKey("CVE-2021-44228"), is(equalTo(true)));
         assertThat(alert1.getName(), is(equalTo("Log4Shell (CVE-2021-44228)")));
         assertThat(alert2.getAlertRef(), is(equalTo("40043-2")));
         assertThat(alert2.getTags().containsKey("CVE-2021-45046"), is(equalTo(true)));
-        assertThat(alert2.getTags().size(), is(equalTo(5)));
+        assertThat(alert2.getTags().size(), is(equalTo(6)));
+        assertThat(alert2.getTags(), hasKey("CWE-117"));
         assertThat(alert2.getName(), is(equalTo("Log4Shell (CVE-2021-45046)")));
     }
 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRuleUnitTest.java
@@ -23,6 +23,7 @@ import static fi.iki.elonen.SimpleWebServer.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -259,8 +260,9 @@ class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<ParameterTamperS
 
         Alert alert = alerts.get(0);
         Map<String, String> tags1 = alert.getTags();
-        assertThat(tags1.size(), is(equalTo(2)));
+        assertThat(tags1.size(), is(equalTo(3)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(tags1, hasKey("CWE-472"));
         assertThat(
                 tags1.containsKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
                 is(equalTo(true)));

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [47] - 2024-03-28
 ### Changed

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [53] - 2024-03-28

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySiteScanRuleUnitTest.java
@@ -160,7 +160,8 @@ class HttpOnlySiteScanRuleUnitTest extends ActiveScannerTest<HttpOnlySiteScanRul
         Alert alert = alerts.get(0);
 
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(3)));
+        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(tags, hasKey("CWE-311"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_SESS_02_COOKIE_ATTRS.getTag()));

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
@@ -75,7 +75,8 @@ class SourceCodeDisclosureFileInclusionScanRuleUnitTest
         Alert alert = alerts.get(0);
 
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags.size(), is(equalTo(3)));
+        assertThat(tags, hasKey("CWE-541"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
 

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRuleUnitTest.java
@@ -70,7 +70,8 @@ class SourceCodeDisclosureGitScanRuleUnitTest
         assertThat(alerts.size(), is(equalTo(1)));
         Alert alert = alerts.get(0);
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags.size(), is(equalTo(3)));
+        assertThat(tags, hasKey("CWE-541"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));

--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [0.12.0] - 2024-02-06

--- a/addOns/authstats/CHANGELOG.md
+++ b/addOns/authstats/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [2] - 2021-10-07

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.39.0] - 2024-04-23
 ### Added

--- a/addOns/automation/src/test/java/org/parosproxy/paros/core/scanner/PluginFactoryTestHelper.java
+++ b/addOns/automation/src/test/java/org/parosproxy/paros/core/scanner/PluginFactoryTestHelper.java
@@ -1,0 +1,29 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.scanner;
+
+public final class PluginFactoryTestHelper extends PluginFactory {
+
+    private PluginFactoryTestHelper() {}
+
+    public static void init() {
+        PluginFactory.init(false);
+    }
+}

--- a/addOns/automation/src/test/java/org/parosproxy/paros/core/scanner/PluginTestHelper.java
+++ b/addOns/automation/src/test/java/org/parosproxy/paros/core/scanner/PluginTestHelper.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.scanner;
+
+public class PluginTestHelper extends AbstractPlugin {
+
+    @Override
+    public int getId() {
+        return 50000;
+    }
+
+    @Override
+    public String getName() {
+        return "PluginTestHelper";
+    }
+
+    @Override
+    public String getDescription() {
+        return "";
+    }
+
+    @Override
+    public void scan() {}
+
+    @Override
+    public int getCategory() {
+        return 0;
+    }
+
+    @Override
+    public String getSolution() {
+        return "";
+    }
+
+    @Override
+    public String getReference() {
+        return "";
+    }
+
+    @Override
+    public void notifyPluginCompleted(HostProcess parent) {}
+}

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -56,8 +56,12 @@ import org.mockito.quality.Strictness;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.parosproxy.paros.core.scanner.PluginFactory;
+import org.parosproxy.paros.core.scanner.PluginFactoryTestHelper;
+import org.parosproxy.paros.core.scanner.PluginTestHelper;
 import org.parosproxy.paros.core.scanner.ScannerParam;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
@@ -79,6 +83,7 @@ class ActiveScanJobUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
     private ExtensionActiveScan extAScan;
+    private static AbstractPlugin plugin;
 
     @TempDir static Path tempDir;
 
@@ -88,11 +93,19 @@ class ActiveScanJobUnitTest {
 
         Constant.setZapHome(
                 Files.createDirectory(tempDir.resolve("home")).toAbsolutePath().toString());
+
+        PluginFactoryTestHelper.init();
+        plugin = new PluginTestHelper();
+        PluginFactory.loadedPlugin(plugin);
     }
 
     @AfterAll
     static void close() {
         mockedCmdLine.close();
+
+        if (plugin != null) {
+            PluginFactory.unloadedPlugin(plugin);
+        }
     }
 
     @BeforeEach
@@ -196,8 +209,9 @@ class ActiveScanJobUnitTest {
                 job.getConfigParameters(new ScannerParamWrapper(), job.getParamMethodName());
 
         // Then
-        assertThat(params.size(), is(equalTo(11)));
+        assertThat(params.size(), is(equalTo(12)));
 
+        assertThat(params.containsKey("encodeCookieValues"), is(equalTo(true)));
         assertThat(params.containsKey("addQueryParam"), is(equalTo(true)));
         assertThat(params.containsKey("defaultPolicy"), is(equalTo(true)));
         assertThat(params.containsKey("delayInMs"), is(equalTo(true)));
@@ -477,8 +491,6 @@ class ActiveScanJobUnitTest {
 
     @Test
     void shouldDisableAllRulesWithString() throws MalformedURLException {
-        // There is one built in rule, and mocking more is tricky outside of the package :/
-
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -505,8 +517,6 @@ class ActiveScanJobUnitTest {
 
     @Test
     void shouldSetSpecifiedRuleConfigs() throws MalformedURLException {
-        // There is one built in rule, and mocking more is tricky outside of the package :/
-
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -550,8 +560,6 @@ class ActiveScanJobUnitTest {
 
     @Test
     void shouldTurnOffSpecifiedRule() throws MalformedURLException {
-        // There is one built in rule, and mocking more is tricky outside of the package :/
-
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();

--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Dependency updates.
 
 ## [7] - 2021-10-07

--- a/addOns/browserView/CHANGELOG.md
+++ b/addOns/browserView/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [6] - 2023-03-13
 ### Added

--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for menu weights (Issue 8369).
 
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/PopupMenuBruteForceSite.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/PopupMenuBruteForceSite.java
@@ -54,10 +54,6 @@ public class PopupMenuBruteForceSite extends PopupMenuItemSiteNodeContainer {
     }
 
     @Override
-    public int getParentMenuIndex() {
-        return ATTACK_MENU_INDEX;
-    }
-
     public int getParentWeight() {
         return MenuWeights.MENU_ATTACK_WEIGHT;
     }

--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/callgraph/CHANGELOG.md
+++ b/addOns/callgraph/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [5] - 2021-10-07
 ### Added

--- a/addOns/callgraph/src/main/java/org/zaproxy/zap/extension/callgraph/PopupMenuCallGraph.java
+++ b/addOns/callgraph/src/main/java/org/zaproxy/zap/extension/callgraph/PopupMenuCallGraph.java
@@ -74,11 +74,6 @@ class PopupMenuCallGraph extends PopupMenuHttpMessageContainer {
         }
     }
 
-    @Override
-    public boolean precedeWithSeparator() {
-        return true;
-    }
-
     private static class CallGraphPopupMenuItem extends PopupMenuItemHttpMessageContainer {
 
         private static final long serialVersionUID = -4108212857830575776L;

--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.11.0] - 2024-03-13
 ### Changed

--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.15.0.
+
 ### Added
 - Support for menu weights (Issue 8369)
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/PopupMenuSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/PopupMenuSpider.java
@@ -49,14 +49,11 @@ public class PopupMenuSpider extends PopupMenuItemSiteNodeContainer {
     }
 
     @Override
-    public int getParentMenuIndex() {
-        return ATTACK_MENU_INDEX;
-    }
-
     public int getParentWeight() {
         return MenuWeights.MENU_ATTACK_WEIGHT;
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_ATTACK_CLIENT_WEIGHT;
     }

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for code and help links for script scan rules.
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [1.24.0] - 2024-04-11

--- a/addOns/coreLang/CHANGELOG.md
+++ b/addOns/coreLang/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [15] - 2022-02-14
 ### Changed

--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [0.13.0] - 2023-11-10

--- a/addOns/database/CHANGELOG.md
+++ b/addOns/database/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.3.0] - 2023-10-12
 ### Changed

--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.5.0] - 2024-01-10
 ### Added

--- a/addOns/diff/CHANGELOG.md
+++ b/addOns/diff/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for menu weights (Issue 8369).
 
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [14] - 2023-10-12

--- a/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/PopupMenuDiff.java
+++ b/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/PopupMenuDiff.java
@@ -86,10 +86,12 @@ public class PopupMenuDiff extends PopupMenuItemHistoryReferenceContainer {
         return true;
     }
 
+    @Override
     public int getWeight() {
         return weight;
     }
 
+    @Override
     public void setWeight(int weight) {
         this.weight = weight;
     }

--- a/addOns/directorylistv1/CHANGELOG.md
+++ b/addOns/directorylistv1/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [7] - 2023-10-12
 ### Changed

--- a/addOns/directorylistv2_3/CHANGELOG.md
+++ b/addOns/directorylistv2_3/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/directorylistv2_3_lc/CHANGELOG.md
+++ b/addOns/directorylistv2_3_lc/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [18] - 2023-10-12

--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for menu weights (Issue 8369)
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [1.4.0] - 2023-10-12

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
@@ -73,6 +73,7 @@ public class PopupEncoderMenu extends ExtensionPopupMenuItem {
                 || invoker.getName().equals(EncodeDecodeDialog.ENCODE_DECODE_RESULTFIELD);
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_ENCODE_WEIGHT;
     }

--- a/addOns/evalvillain/CHANGELOG.md
+++ b/addOns/evalvillain/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.3.0] - 2023-09-26
 ### Changed

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for menu weights (Issue 8369)
 
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [0.8.0] - 2023-11-10

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/AbstractPopupMenuSaveMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/AbstractPopupMenuSaveMessage.java
@@ -95,11 +95,6 @@ abstract class AbstractPopupMenuSaveMessage extends PopupMenuHttpMessageContaine
     }
 
     @Override
-    public boolean precedeWithSeparator() {
-        return true;
-    }
-
-    @Override
     public boolean isSafe() {
         return true;
     }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuCopyUrls.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuCopyUrls.java
@@ -73,6 +73,7 @@ public class PopupMenuCopyUrls extends PopupMenuItemHistoryReferenceContainer
         // Ignore
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_COPY_URLS_WEIGHT;
     }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuExportUrls.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuExportUrls.java
@@ -188,6 +188,7 @@ public class PopupMenuExportUrls extends ExtensionPopupMenuItem {
         return null;
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_SAVE_ALL_URLS_WEIGHT;
     }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveRawMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveRawMessage.java
@@ -109,6 +109,7 @@ public class PopupMenuSaveRawMessage extends AbstractPopupMenuSaveMessage {
         }
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_SAVE_RAW_WEIGHT;
     }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveXmlMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveXmlMessage.java
@@ -139,6 +139,7 @@ public class PopupMenuSaveXmlMessage extends AbstractPopupMenuSaveMessage {
         }
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_SAVE_XML_WEIGHT;
     }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/PopupMenuItemSaveHarMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/PopupMenuItemSaveHarMessage.java
@@ -62,11 +62,6 @@ public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContain
     }
 
     @Override
-    public boolean precedeWithSeparator() {
-        return true;
-    }
-
-    @Override
     public boolean isSafe() {
         return true;
     }
@@ -123,6 +118,7 @@ public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContain
         return null;
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_SAVE_HAR_WEIGHT;
     }

--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [6.5.0] - 2023-10-12
 ### Changed

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Support for menu weights (Issue 8369)
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [13.12.0] - 2023-10-12

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzMessageWithLocationPopupMenuItem.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzMessageWithLocationPopupMenuItem.java
@@ -66,11 +66,6 @@ public class FuzzMessageWithLocationPopupMenuItem extends ExtensionPopupMenuItem
         return false;
     }
 
-    @Override
-    public int getMenuIndex() {
-        return 3;
-    }
-
     private <M extends Message, F extends Fuzzer<M>> boolean isEnableForMessageContainerHelper(
             SelectableContentMessageContainer<M> invoker) {
         if (SwingUtilities.getAncestorOfClass(FuzzerDialog.class, invoker.getComponent()) != null

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzAttackPopupMenuItem.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzAttackPopupMenuItem.java
@@ -57,14 +57,11 @@ public class HttpFuzzAttackPopupMenuItem extends PopupMenuItemHttpMessageContain
     }
 
     @Override
-    public int getParentMenuIndex() {
-        return ATTACK_MENU_INDEX;
-    }
-
     public int getParentWeight() {
         return MenuWeights.MENU_ATTACK_WEIGHT;
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_ATTACK_FUZZ_WEIGHT;
     }

--- a/addOns/fuzzdb/CHANGELOG.md
+++ b/addOns/fuzzdb/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [9] - 2022-09-23
 ### Changed

--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Disable warns about the engine being executed in interpreter mode, that's the expected mode of execution.
 
 ## [0.6.0] - 2024-04-11

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Dependency updates.
 
 ## [0.23.0] - 2024-02-22

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [3.2.0] - 2024-04-11
 ### Changed

--- a/addOns/highlighter/CHANGELOG.md
+++ b/addOns/highlighter/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [8] - 2021-10-07
 ### Added

--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [5] - 2024-04-11
 ### Changed

--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.15.0.
+
 ### Added
 - Support for menu weights (Issue 8369)
 

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/PopupMenuInvokers.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/PopupMenuInvokers.java
@@ -38,11 +38,6 @@ public class PopupMenuInvokers extends PopupMenuHttpMessageContainer {
     }
 
     @Override
-    public int getMenuIndex() {
-        return 3;
-    }
-
-    @Override
     protected boolean isButtonEnabledForNumberOfSelectedMessages(int numberOfSelectedMessages) {
         return true;
     }
@@ -64,6 +59,7 @@ public class PopupMenuInvokers extends PopupMenuHttpMessageContainer {
         add(confPopup);
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_RUN_APP_WEIGHT;
     }

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 - This add-on now depends on the Scripts add-on for providing scanning related functionality.
 - The active and passive scan rule templates were updated to import classes from the scripts add-on.

--- a/addOns/jsonview/CHANGELOG.md
+++ b/addOns/jsonview/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [3] - 2023-09-07
 ### Changed

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [15] - 2024-04-11
 ### Changed

--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ### Added

--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Update default user-agents.
 
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ContentEncodingsHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ContentEncodingsHandler.java
@@ -22,12 +22,14 @@ package org.zaproxy.addon.network.internal;
 import java.util.List;
 import org.parosproxy.paros.network.HttpBody;
 import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage.HttpEncodingsHandler;
 import org.zaproxy.zap.network.HttpEncoding;
 import org.zaproxy.zap.network.HttpEncodingDeflate;
 import org.zaproxy.zap.network.HttpEncodingGzip;
 
-public class ContentEncodingsHandler /* TODO implements HttpEncodingsHandler */ {
+public class ContentEncodingsHandler implements HttpEncodingsHandler {
 
+    @Override
     public void handle(HttpHeader header, HttpBody body) {
         String encoding = header.getHeader(HttpHeader.CONTENT_ENCODING);
         if (encoding == null || encoding.isEmpty()) {

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [0.17.0] - 2023-10-12

--- a/addOns/onlineMenu/CHANGELOG.md
+++ b/addOns/onlineMenu/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [12] - 2023-10-12
 ### Changed

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 - Dependency updates.
 

--- a/addOns/packpentester/CHANGELOG.md
+++ b/addOns/packpentester/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.1.0] - 2022-05-12
 

--- a/addOns/packscanrules/CHANGELOG.md
+++ b/addOns/packscanrules/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.0.1] - 2022-05-13
 

--- a/addOns/paramdigger/CHANGELOG.md
+++ b/addOns/paramdigger/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.2.0] - 2023-06-06
 ### Fixed

--- a/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/gui/PopupMenuParamDigger.java
+++ b/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/gui/PopupMenuParamDigger.java
@@ -48,14 +48,11 @@ public class PopupMenuParamDigger extends PopupMenuItemHttpMessageContainer {
     }
 
     @Override
-    public int getParentMenuIndex() {
-        return ATTACK_MENU_INDEX;
-    }
-
     public int getParentWeight() {
         return MenuWeights.MENU_ATTACK_WEIGHT;
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_ATTACK_DIGGER_WEIGHT;
     }

--- a/addOns/plugnhack/CHANGELOG.md
+++ b/addOns/plugnhack/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prevent exception if no display (Issue 3978).
 
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [13] - 2022-10-27

--- a/addOns/portscan/CHANGELOG.md
+++ b/addOns/portscan/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for menu weights (Issue 8369)
 
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 - Default number of threads to 2 * processor count.
 

--- a/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/PopupMenuPortScan.java
+++ b/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/PopupMenuPortScan.java
@@ -52,10 +52,6 @@ public class PopupMenuPortScan extends PopupMenuItemSiteNodeContainer {
     }
 
     @Override
-    public int getParentMenuIndex() {
-        return ATTACK_MENU_INDEX;
-    }
-
     public int getParentWeight() {
         return MenuWeights.MENU_ATTACK_WEIGHT;
     }

--- a/addOns/postman/CHANGELOG.md
+++ b/addOns/postman/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [0.3.0] - 2024-04-02
 ### Added

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - The library (htmlunit-csp) used by the Content Security Policy scan rule was updated to v4.0.0, which includes support for the wasm-unsafe-eval source expression.
 
 ### Fixed

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
@@ -120,7 +120,8 @@ class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<ApplicationErr
         Map<String, String> tags = alert.getTags();
         // Then
         assertThat(alerts.size(), is(equalTo(1)));
-        assertThat(alert.getTags().size(), is(equalTo(5)));
+        assertThat(tags.size(), is(equalTo(6)));
+        assertThat(tags, hasKey("CWE-200"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_ERRH_01_ERR.getTag()));

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRuleUnitTest.java
@@ -429,7 +429,7 @@ class CrossDomainScriptInclusionScanRuleUnitTest
         assertThat(alerts.size(), is(equalTo(1)));
         Alert alert = alerts.get(0);
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(1)));
+        assertThat(tags.size(), is(equalTo(2)));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_LOW)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRuleUnitTest.java
@@ -80,7 +80,7 @@ class InfoPrivateAddressDisclosureScanRuleUnitTest
         assertThat(alerts.size(), is(equalTo(1)));
         Alert alert = alerts.get(0);
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags.size(), is(equalTo(3)));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_LOW)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
@@ -355,7 +355,8 @@ class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
                                         "<!-- FixMe: cookie: root=true; Secure -->"))));
         assertThat(alert.getEvidence(), is(equalTo("FixMe")));
         Map<String, String> tags = alert.getTags();
-        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(tags.size(), is(equalTo(5)));
+        assertThat(tags, hasKey("CWE-200"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getTag()));

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRuleUnitTest.java
@@ -106,7 +106,8 @@ class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdorScanRu
         Alert alert = alerts.get(0);
         Map<String, String> tags = alert.getTags();
         // Then
-        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(tags.size(), is(equalTo(5)));
+        assertThat(tags, hasKey("CWE-284"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A05_BROKEN_AC.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_ATHZ_04_IDOR.getTag()));

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
@@ -163,8 +164,9 @@ class XChromeLoggerDataInfoLeakScanRuleUnitTest
 
         Alert alert = alerts.get(0);
         Map<String, String> tags1 = alert.getTags();
-        assertThat(tags1.size(), is(equalTo(3)));
+        assertThat(tags1.size(), is(equalTo(4)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_HIGH)));
+        assertThat(tags1, hasKey("CWE-200"));
         assertThat(
                 tags1.containsKey(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()),
                 is(equalTo(true)));

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [42] - 2024-01-16
 ### Changed

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [37] - 2024-02-12
 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRuleUnitTest.java
@@ -245,7 +245,8 @@ class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionScanRule> 
         Map<String, String> tags = alert.getTags();
         // Then
         assertThat(alerts.size(), is(equalTo(1)));
-        assertThat(tags.size(), is(equalTo(3)));
+        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(tags, hasKey("CWE-749"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A04_INSECURE_DESIGN.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_CLNT_02_JS_EXEC.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.15.0.
+
 ### Fixed
 - Sub panel names.
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
@@ -74,14 +74,12 @@ public class AjaxSpiderExplorer implements PlugableSpider {
     }
 
     private static final String MODERN_APP_PLUGIN_ID = "10109";
-    private static final String MODERN_APP_I18N_KEY = "pscanrules.modernapp.name";
 
     private ExtensionQuickStartAjaxSpider extension;
     private JComboBox<ProvidedBrowserUI> browserComboBox;
     private JComboBox<Select> selectComboBox;
     private EventConsumerImpl eventConsumer;
     private boolean isModern;
-    private String modernAppAlertName = "Modern Web Application";
 
     private JPanel panel;
 
@@ -98,11 +96,6 @@ public class AjaxSpiderExplorer implements PlugableSpider {
                         eventConsumer,
                         AlertEventPublisher.getPublisher().getPublisherName(),
                         AlertEventPublisher.ALERT_ADDED_EVENT);
-
-        if (Constant.messages.containsKey(MODERN_APP_I18N_KEY)) {
-            // Handle the case where this has been i18n'ed, or changed in the alert..
-            modernAppAlertName = Constant.messages.getString(MODERN_APP_I18N_KEY);
-        }
     }
 
     public ExtensionAjax getExtAjax() {
@@ -155,10 +148,7 @@ public class AjaxSpiderExplorer implements PlugableSpider {
         extAjax.startScan(builder.build());
     }
 
-    /**
-     * Monitors the alert added events for the Modern App Detection rule: 10109 In 2.14.0 the
-     * pluginId is not present, so we have to rely on the i18n'ed name.
-     */
+    /** Monitors the alert added events for the Modern App Detection rule: 10109. */
     private class EventConsumerImpl implements EventConsumer {
         @Override
         public void eventReceived(Event event) {
@@ -167,9 +157,7 @@ public class AjaxSpiderExplorer implements PlugableSpider {
                 return;
             } else if (event.getEventType().equals(AlertEventPublisher.ALERT_ADDED_EVENT)) {
                 Map<String, String> params = event.getParameters();
-                // FIXME Use the PLUGIN_ID constant and remove the name check post 2.15
-                if (MODERN_APP_PLUGIN_ID.equals(params.get("pluginId"))
-                        || params.get(AlertEventPublisher.NAME).equals(modernAppAlertName)) {
+                if (MODERN_APP_PLUGIN_ID.equals(params.get(AlertEventPublisher.PLUGIN_ID))) {
                     isModern = true;
                 }
             }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -33,8 +33,8 @@ import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
+import org.zaproxy.zap.extension.AddOnInstallationStatusListener.StatusUpdate;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.quickstart.ExtensionQuickStart;
 import org.zaproxy.zap.extension.quickstart.QuickStartParam;
@@ -266,16 +266,10 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
     }
 
     @Override
-    public void addOnInstalled(AddOn addOn) {
-        // Not currently supported
-    }
-
-    @Override
-    public void addOnSoftUninstalled(AddOn addOn, boolean successfully) {}
-
-    @Override
-    public void addOnUninstalled(AddOn addOn, boolean successfully) {
-        if (hasView() && addOn.getId().equals("hud")) {
+    public void update(StatusUpdate statusUpdate) {
+        if (statusUpdate.getStatus() == StatusUpdate.Status.UNINSTALLED
+                && hasView()
+                && statusUpdate.getAddOn().getId().equals("hud")) {
             this.launchPanel.hudAddOnUninstalled();
         }
     }

--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegExTesterPopupMenuItem.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegExTesterPopupMenuItem.java
@@ -118,11 +118,6 @@ public class RegExTesterPopupMenuItem extends PopupMenuHttpMessageContainer {
     }
 
     @Override
-    public boolean precedeWithSeparator() {
-        return true;
-    }
-
-    @Override
     public boolean isSafe() {
         return true;
     }

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.15.0.
+
 ### Added
 - Video link in help for Automation Framework job.
 - A rule to disable CSP reporting (Issue 740).

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - The following reports now include the number of Sites tree nodes actively scanned:
   - Traditional HTML with Requests and Responses
 

--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [7.5.0] - 2024-03-25
 ### Added 

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/PopupMenuResendMessage.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/PopupMenuResendMessage.java
@@ -39,7 +39,6 @@ public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
 
         this.showResendDialogue = Objects.requireNonNull(showResendDialogue);
         setIcon(icon);
-        setMenuIndex(5);
     }
 
     @Override
@@ -47,6 +46,7 @@ public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
         showResendDialogue.accept(message.cloneRequest());
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_OPEN_REQUEST_WEIGHT;
     }

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/RightClickMsgMenuRequester.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/RightClickMsgMenuRequester.java
@@ -61,6 +61,7 @@ public class RightClickMsgMenuRequester extends PopupMenuItemHttpMessageContaine
         return true;
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_OPEN_REQUESTER_WEIGHT;
     }

--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [0.8.0] - 2023-10-12

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Updated with upstream retire.js pattern changes.
 
 

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -173,8 +173,8 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         assertEquals(
                 "https://github.com/twbs/bootstrap/issues/20184\n",
                 alertsRaised.get(0).getReference());
-        // Two Constant OWASP tags plus one CVE
-        assertEquals(3, alertsRaised.get(0).getTags().size());
+        // Two Constant OWASP tags plus one CVE and CWE
+        assertEquals(4, alertsRaised.get(0).getTags().size());
     }
 
     @Test

--- a/addOns/reveal/CHANGELOG.md
+++ b/addOns/reveal/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [7] - 2023-10-12
 ### Changed

--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [5] - 2023-10-23

--- a/addOns/saml/CHANGELOG.md
+++ b/addOns/saml/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [10] - 2022-10-28

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for code and help links for script scan rules.
 
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Allow to set raw parameter values from Active Rules, by calling `as.setEscapedParam(HttpMessage msg, String param, String value)`.
 
 ## [45.2.0] - 2024-04-11

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -105,9 +105,6 @@ public class ConsolePanel extends AbstractPanel {
                 Constant.messages.getString("scripts.changed.replace")
             };
 
-    // TODO: Remove after this add-on depends on ZAP 2.15.0
-    private final Object scriptLock = new Object();
-
     private Map<ScriptWrapper, Integer> scriptWrapperToOffset = new HashMap<>();
 
     private static final Logger LOGGER = LogManager.getLogger(ConsolePanel.class);
@@ -153,9 +150,7 @@ public class ConsolePanel extends AbstractPanel {
         if (script == null) {
             return false;
         }
-        synchronized (scriptLock) {
-            return script.hasChangedOnDisk();
-        }
+        return script.hasChangedOnDisk();
     }
 
     private void startPollingForChanges() {
@@ -214,9 +209,7 @@ public class ConsolePanel extends AbstractPanel {
                     () -> {
                         if (getSaveOrReplaceScriptChoice() == JOptionPane.YES_OPTION) {
                             try {
-                                synchronized (scriptLock) {
-                                    extension.getExtScript().saveScript(script);
-                                }
+                                extension.getExtScript().saveScript(script);
                             } catch (IOException e) {
                                 LOGGER.error(e.getMessage(), e);
                             }
@@ -650,10 +643,6 @@ public class ConsolePanel extends AbstractPanel {
         if (!isTabVisible()) {
             setTabFocus();
         }
-    }
-
-    Object getScriptLock() {
-        return scriptLock;
     }
 
     /**

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -36,8 +36,6 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
-import org.parosproxy.paros.core.scanner.AbstractPlugin;
-import org.parosproxy.paros.core.scanner.PluginFactory;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -243,33 +241,6 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     }
 
     @Override
-    public void postInit() {
-        if (org.zaproxy.zap.extension.ascan.ScriptsActiveScanner.class.getAnnotation(
-                        Deprecated.class)
-                == null) {
-            PluginFactory.unloadedPlugin((AbstractPlugin) PluginFactory.getLoadedPlugin(50000));
-        }
-        if (org.zaproxy.zap.extension.pscan.scanner.ScriptsPassiveScanner.class.getAnnotation(
-                        Deprecated.class)
-                == null) {
-            var extensionPscan =
-                    Control.getSingleton()
-                            .getExtensionLoader()
-                            .getExtension(ExtensionPassiveScan.class);
-            if (extensionPscan != null) {
-                var installedPscanRule = extensionPscan.getPluginPassiveScanner(50001);
-                var corePscanRuleName =
-                        org.zaproxy.zap.extension.pscan.scanner.ScriptsPassiveScanner.class
-                                .getName();
-                if (installedPscanRule != null
-                        && installedPscanRule.getClass().getName().equals(corePscanRuleName)) {
-                    extensionPscan.removePluginPassiveScanner(installedPscanRule);
-                }
-            }
-        }
-    }
-
-    @Override
     public void postInstall() {
         // Install and enable the 'built in' scripts
         for (ScriptWrapper template : this.getExtScript().getTemplates(extScriptType)) {
@@ -436,11 +407,6 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
                                 Context context, String parentMenu) {
                             return new PopupUseScriptAsAuthenticationScript(
                                     ExtensionScriptsUI.this, context);
-                        }
-
-                        @Override
-                        public int getMenuIndex() {
-                            return 1000;
                         }
                     };
         }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessagePopupMenu.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessagePopupMenu.java
@@ -84,7 +84,6 @@ public class InvokeScriptWithHttpMessagePopupMenu extends PopupMenuItemHttpMessa
         for (ScriptWrapper script :
                 extension.getExtScript().getScripts(ExtensionScript.TYPE_TARGETED)) {
             ExtensionPopupMenuItem piicm = createPopupAddToScriptMenu(script);
-            piicm.setMenuIndex(this.getMenuIndex());
             mainPopupMenuItems.add(piicm);
         }
     }
@@ -98,6 +97,7 @@ public class InvokeScriptWithHttpMessagePopupMenu extends PopupMenuItemHttpMessa
         return true;
     }
 
+    @Override
     public int getParentWeight() {
         return MenuWeights.MENU_SCRIPT_INVOKE_WEIGHT;
     }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -308,9 +308,7 @@ public class ScriptsListPanel extends AbstractPanel {
     protected void saveScript(ScriptWrapper script) {
         if (script.getFile() != null) {
             try {
-                synchronized (extension.getConsolePanel().getScriptLock()) {
-                    extension.getExtScript().saveScript(script);
-                }
+                extension.getExtScript().saveScript(script);
                 ((ScriptTreeModel) this.getTree().getModel())
                         .nodeChanged(this.getSelectedScriptNode());
             } catch (IOException e1) {
@@ -352,9 +350,7 @@ public class ScriptsListPanel extends AbstractPanel {
                 script.setFile(file);
 
                 try {
-                    synchronized (extension.getConsolePanel().getScriptLock()) {
-                        extension.getExtScript().saveScript(script);
-                    }
+                    extension.getExtScript().saveScript(script);
                     ((ScriptTreeModel) this.getTree().getModel())
                             .nodeChanged(this.getSelectedScriptNode());
                 } catch (IOException e1) {

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
@@ -148,38 +148,23 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
             syntaxMenu = new SyntaxMenu();
             viewMenu = new ViewMenu();
 
-            undoAction =
-                    new TextAreaMenuItem(
-                            RTextArea.UNDO_ACTION, true, false, MenuWeights.MENU_UNDO_WEIGHT);
-            redoAction =
-                    new TextAreaMenuItem(
-                            RTextArea.REDO_ACTION, false, true, MenuWeights.MENU_REDO_WEIGHT);
+            undoAction = new TextAreaMenuItem(RTextArea.UNDO_ACTION, MenuWeights.MENU_UNDO_WEIGHT);
+            redoAction = new TextAreaMenuItem(RTextArea.REDO_ACTION, MenuWeights.MENU_REDO_WEIGHT);
 
             cutAction =
-                    new TextAreaMenuItem(
-                            RTextArea.CUT_ACTION, false, false, MenuWeights.MENU_EDIT_CUT_WEIGHT);
+                    new TextAreaMenuItem(RTextArea.CUT_ACTION, MenuWeights.MENU_EDIT_CUT_WEIGHT);
             copyAction =
-                    new TextAreaMenuItem(
-                            RTextArea.COPY_ACTION, false, false, MenuWeights.MENU_EDIT_COPY_WEIGHT);
+                    new TextAreaMenuItem(RTextArea.COPY_ACTION, MenuWeights.MENU_EDIT_COPY_WEIGHT);
             pasteAction =
                     new TextAreaMenuItem(
-                            RTextArea.PASTE_ACTION,
-                            false,
-                            false,
-                            MenuWeights.MENU_EDIT_PASTE_WEIGHT);
+                            RTextArea.PASTE_ACTION, MenuWeights.MENU_EDIT_PASTE_WEIGHT);
             deleteAction =
                     new TextAreaMenuItem(
-                            RTextArea.DELETE_ACTION,
-                            false,
-                            true,
-                            MenuWeights.MENU_EDIT_DELETE_WEIGHT);
+                            RTextArea.DELETE_ACTION, MenuWeights.MENU_EDIT_DELETE_WEIGHT);
 
             selectAllAction =
                     new TextAreaMenuItem(
-                            RTextArea.SELECT_ALL_ACTION,
-                            false,
-                            false,
-                            MenuWeights.MENU_SECECT_ALL_WEIGHT);
+                            RTextArea.SELECT_ALL_ACTION, MenuWeights.MENU_SECECT_ALL_WEIGHT);
             final List<JMenuItem> mainPopupMenuItems = View.getSingleton().getPopupList();
 
             mainPopupMenuItems.add(syntaxMenu);
@@ -271,19 +256,10 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
         private static final long serialVersionUID = -8369459846515841057L;
 
         private int actionId;
-        private boolean precedeWithSeparator;
-        private boolean succeedWithSeparator;
         private int weight;
 
-        public TextAreaMenuItem(
-                int actionId,
-                boolean precedeWithSeparator,
-                boolean succeedWithSeparator,
-                int weight)
-                throws IllegalArgumentException {
+        public TextAreaMenuItem(int actionId, int weight) throws IllegalArgumentException {
             this.actionId = actionId;
-            this.precedeWithSeparator = precedeWithSeparator;
-            this.succeedWithSeparator = succeedWithSeparator;
             this.weight = weight;
             Action action = RTextArea.getAction(actionId);
             if (action == null) {
@@ -318,20 +294,11 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
         }
 
         @Override
-        public boolean precedeWithSeparator() {
-            return precedeWithSeparator;
-        }
-
-        @Override
-        public boolean succeedWithSeparator() {
-            return succeedWithSeparator;
-        }
-
-        @Override
         public boolean isSafe() {
             return true;
         }
 
+        @Override
         public int getWeight() {
             return weight;
         }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxMenu.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxMenu.java
@@ -73,11 +73,6 @@ public class SyntaxMenu extends ExtensionPopupMenu {
         return false;
     }
 
-    @Override
-    public boolean precedeWithSeparator() {
-        return true;
-    }
-
     public void updateState(SyntaxHighlightTextArea httpPanelTextArea) {
 
         Vector<SyntaxStyle> styles = httpPanelTextArea.getSyntaxStyles();

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [15.22.0] - 2024-04-26
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/PopupMenuOpenInBrowser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/PopupMenuOpenInBrowser.java
@@ -36,12 +36,6 @@ public class PopupMenuOpenInBrowser extends PopupMenuHttpMessageContainer {
     }
 
     @Override
-    public int getMenuIndex() {
-        // This currently puts the menu just above the 'Open URL in System Browser' item
-        return 7;
-    }
-
-    @Override
     protected boolean isButtonEnabledForNumberOfSelectedMessages(int numberOfSelectedMessages) {
         return true;
     }
@@ -63,6 +57,7 @@ public class PopupMenuOpenInBrowser extends PopupMenuHttpMessageContainer {
         return super.isEnableForMessageContainer(invoker);
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_OPEN_BROWSER_WEIGHT;
     }

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [7] - 2023-10-23

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [22] - 2024-03-25
 ### Added

--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.15.0.
+
 ### Added
 - Support for menu weights (Issue 8369)
 ### Fixed

--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
 
 val japicmp by tasks.existing(JapicmpTask::class) {
     packageExcludes = listOf("org.zaproxy.addon.spider.automation")
+    methodExcludes = listOf("org.zaproxy.addon.spider.PopupMenuItemSpiderDialog#getParentMenuIndex()")
 }
 
 spotless {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/PopupMenuItemSpiderDialog.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/PopupMenuItemSpiderDialog.java
@@ -56,11 +56,6 @@ public class PopupMenuItemSpiderDialog extends PopupMenuItemSiteNodeContainer {
     }
 
     @Override
-    public int getParentMenuIndex() {
-        return ATTACK_MENU_INDEX;
-    }
-
-    @Override
     public void performAction(SiteNode node) {
         extension.showSpiderDialog(node);
     }
@@ -82,10 +77,12 @@ public class PopupMenuItemSpiderDialog extends PopupMenuItemSiteNodeContainer {
         }
     }
 
+    @Override
     public int getParentWeight() {
         return MenuWeights.MENU_ATTACK_WEIGHT;
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_ATTACK_SPIDER_WEIGHT;
     }

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/PopupMenuItemSpiderDialogWithContext.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/PopupMenuItemSpiderDialogWithContext.java
@@ -48,6 +48,7 @@ public class PopupMenuItemSpiderDialogWithContext extends PopupContextTreeMenu {
                 });
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_CONTEXT_SPIDER_WEIGHT;
     }

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for menu weights (Issue 8369)
 
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
@@ -49,16 +49,12 @@ public class PopupMenuAjaxSite extends PopupMenuItemSiteNodeContainer {
         return Constant.messages.getString("attack.site.popup");
     }
 
-    /** */
     @Override
-    public int getParentMenuIndex() {
-        return ATTACK_MENU_INDEX;
-    }
-
     public int getParentWeight() {
         return MenuWeights.MENU_ATTACK_WEIGHT;
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_ATTACK_AJAX_WEIGHT;
     }

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/internal/PopupMenuItemSpiderDialogWithContext.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/internal/PopupMenuItemSpiderDialogWithContext.java
@@ -46,6 +46,7 @@ public class PopupMenuItemSpiderDialogWithContext extends PopupContextTreeMenu {
                 });
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_CONTEXT_AJAX_WEIGHT;
     }

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [15] - 2021-10-20

--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ### Fixed

--- a/addOns/svndigger/CHANGELOG.md
+++ b/addOns/svndigger/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/tips/CHANGELOG.md
+++ b/addOns/tips/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [12] - 2023-10-12
 ### Changed

--- a/addOns/tokengen/CHANGELOG.md
+++ b/addOns/tokengen/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [15] - 2021-10-07
 ### Changed

--- a/addOns/treetools/CHANGELOG.md
+++ b/addOns/treetools/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [8] - 2021-10-07
 ### Added

--- a/addOns/treetools/src/main/java/org/zaproxy/zap/extension/treetools/PopupMenuTreeTools.java
+++ b/addOns/treetools/src/main/java/org/zaproxy/zap/extension/treetools/PopupMenuTreeTools.java
@@ -81,11 +81,6 @@ public class PopupMenuTreeTools extends ExtensionPopupMenuItem {
     }
 
     @Override
-    public boolean precedeWithSeparator() {
-        return true;
-    }
-
-    @Override
     public boolean isSafe() {
         return true;
     }

--- a/addOns/viewstate/CHANGELOG.md
+++ b/addOns/viewstate/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
-- Update minimum ZAP version to 2.14.0.
+- Update minimum ZAP version to 2.15.0.
 
 ## [3] - 2021-10-07
 ### Changed

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Updated with enthec upstream icon and pattern changes.
 - Maintenance changes (standardize on "Technology Detection" naming).
 

--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [81] - 2024-04-26
 ### Changed

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [81] - 2024-04-26
 ### Changed

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.15.0.
 
 ## [81] - 2024-04-26
 ### Changed

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Support for menu weights (Issue 8369)
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
 
 ## [30] - 2023-10-12

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ui/WebSocketFuzzAttackPopupMenuItem.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ui/WebSocketFuzzAttackPopupMenuItem.java
@@ -68,11 +68,6 @@ public class WebSocketFuzzAttackPopupMenuItem extends ExtensionPopupMenuItemMess
     }
 
     @Override
-    public int getParentMenuIndex() {
-        return ATTACK_MENU_INDEX;
-    }
-
-    @Override
     public boolean isEnableForMessageContainer(MessageContainer<?> messageContainer) {
         resetState();
         setEnabled(false);

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupExcludeWebSocketContextMenu.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupExcludeWebSocketContextMenu.java
@@ -38,6 +38,7 @@ public class PopupExcludeWebSocketContextMenu extends PopupMenuItemContextExclud
         return MENU_NAME;
     }
 
+    @Override
     public int getParentWeight() {
         return MenuWeights.MENU_EXC_CHANNEL_CONTEXT_WEIGHT;
     }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketContextMenu.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketContextMenu.java
@@ -38,6 +38,7 @@ public class PopupIncludeWebSocketContextMenu extends PopupMenuItemContextInclud
         return MENU_NAME;
     }
 
+    @Override
     public int getParentWeight() {
         return MenuWeights.MENU_INC_CHANNEL_CONTEXT_WEIGHT;
     }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketInContextMenu.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketInContextMenu.java
@@ -56,7 +56,6 @@ public class PopupIncludeWebSocketInContextMenu extends ExtensionPopupMenuItem {
     public PopupIncludeWebSocketInContextMenu() {
         super(Constant.messages.getString("context.new.title"));
         this.context = null;
-        this.setPrecedeWithSeparator(true);
 
         initialize();
     }

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.15.0.
 - Update Zest library to 0.21.0:
   - Update Selenium to version 4.20.0.
   - Update HtmlUnit to major version 3.

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestPassiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestPassiveRunner.java
@@ -26,14 +26,14 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.network.ExtensionNetwork;
-import org.zaproxy.zap.extension.pscan.PassiveScript;
-import org.zaproxy.zap.extension.pscan.scanner.ScriptsPassiveScanner;
+import org.zaproxy.zap.extension.scripts.scanrules.PassiveScript;
+import org.zaproxy.zap.extension.scripts.scanrules.PassiveScriptHelper;
 import org.zaproxy.zest.core.v1.ZestRequest;
 
 public class ZestPassiveRunner extends ZestZapRunner implements PassiveScript {
 
     private ZestScriptWrapper script = null;
-    private ScriptsPassiveScanner sps = null;
+    private PassiveScriptHelper helper;
     private HttpMessage msg = null;
     private ExtensionZest extension = null;
 
@@ -48,10 +48,10 @@ public class ZestPassiveRunner extends ZestZapRunner implements PassiveScript {
     }
 
     @Override
-    public void scan(ScriptsPassiveScanner scriptsPassiveScanner, HttpMessage msg, Source source)
+    public void scan(PassiveScriptHelper helper, HttpMessage msg, Source source)
             throws ScriptException {
         LOGGER.debug("Zest PassiveScan script: {}", this.script.getName());
-        this.sps = scriptsPassiveScanner;
+        this.helper = helper;
         this.msg = msg;
 
         try {
@@ -69,7 +69,7 @@ public class ZestPassiveRunner extends ZestZapRunner implements PassiveScript {
     @Override
     public void alertFound(Alert alert) {
         // Override this as we can put in more info from the script and message
-        sps.newAlert()
+        helper.newAlert()
                 .setRisk(alert.getRisk())
                 .setConfidence(alert.getConfidence())
                 .setName(alert.getName())

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddActionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddActionPopupMenu.java
@@ -177,7 +177,6 @@ public class ZestAddActionPopupMenu extends ExtensionPopupMenuItem {
                                 .showZestActionDialog(parent, child, stmt, za, true);
                     }
                 });
-        menu.setMenuIndex(this.getMenuIndex());
         View.getSingleton().getPopupList().add(menu);
     }
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddAssertionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddAssertionPopupMenu.java
@@ -129,7 +129,6 @@ public class ZestAddAssertionPopupMenu extends ExtensionPopupMenuItem {
                         ZestZapUtils.toUiString(za2, false));
         menu.addActionListener(
                 e -> extension.getDialogManager().showZestAssertionDialog(req, null, za2, true));
-        menu.setMenuIndex(this.getMenuIndex());
         View.getSingleton().getPopupList().add(menu);
     }
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddAssignPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddAssignPopupMenu.java
@@ -149,7 +149,6 @@ public class ZestAddAssignPopupMenu extends ExtensionPopupMenuItem {
                         extension
                                 .getDialogManager()
                                 .showZestAssignDialog(parent, child, stmt, za, true));
-        menu.setMenuIndex(this.getMenuIndex());
         View.getSingleton().getPopupList().add(menu);
     }
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddConditionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddConditionPopupMenu.java
@@ -280,7 +280,6 @@ public class ZestAddConditionPopupMenu extends ExtensionPopupMenuItem {
                     }
                 });
         final List<JMenuItem> mainPopupMenuItems = View.getSingleton().getPopupList();
-        menu.setMenuIndex(this.getMenuIndex());
         mainPopupMenuItems.add(menu);
         if (menu2 != null) {
             menu2.addActionListener(
@@ -303,7 +302,6 @@ public class ZestAddConditionPopupMenu extends ExtensionPopupMenuItem {
                                     new ZestConditional(new ZestExpressionOr()));
                         }
                     });
-            menu2.setMenuIndex(this.getMenuIndex());
             mainPopupMenuItems.add(menu2);
         }
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddControlPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddControlPopupMenu.java
@@ -142,7 +142,6 @@ public class ZestAddControlPopupMenu extends ExtensionPopupMenuItem {
                         extension.addToParent(parent, za);
                     }
                 });
-        menu.setMenuIndex(this.getMenuIndex());
         View.getSingleton().getPopupList().add(menu);
     }
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddExpressionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddExpressionPopupMenu.java
@@ -136,7 +136,6 @@ public class ZestAddExpressionPopupMenu extends ExtensionPopupMenuItem {
                     e ->
                             // add a new empty structures expression node (no dialog needed)
                             extension.addToParent(extension.getSelectedZestNode(), exp));
-            menu.setMenuIndex(this.getMenuIndex());
             View.getSingleton().getPopupList().add(menu);
         }
     }
@@ -166,7 +165,6 @@ public class ZestAddExpressionPopupMenu extends ExtensionPopupMenuItem {
                                 .getDialogManager()
                                 .showZestExpressionDialog(
                                         parent, nodes, stmt, ze, true, false, false));
-        menu.setMenuIndex(this.getMenuIndex());
         View.getSingleton().getPopupList().add(menu);
     }
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddLoopPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddLoopPopupMenu.java
@@ -123,7 +123,6 @@ public class ZestAddLoopPopupMenu extends ExtensionPopupMenuItem {
                         extension
                                 .getDialogManager()
                                 .showZestLoopDialog(parent, children, stmt, za, true, false));
-        menu.setMenuIndex(this.getMenuIndex());
         View.getSingleton().getPopupList().add(menu);
     }
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptMenu.java
@@ -43,7 +43,6 @@ public class ZestAddToScriptMenu extends PopupMenuItemHttpMessageContainer {
         super(Constant.messages.getString("zest.addto.new.title"), true);
         this.extension = extension;
         this.parent = null;
-        this.setPrecedeWithSeparator(true);
     }
 
     public ZestAddToScriptMenu(ExtensionZest extension, ScriptNode parent) {
@@ -57,6 +56,7 @@ public class ZestAddToScriptMenu extends PopupMenuItemHttpMessageContainer {
         return Constant.messages.getString("zest.addto.popup");
     }
 
+    @Override
     public int getParentWeight() {
         return MenuWeights.MENU_SCRIPT_ZEST_ADD_WEIGHT;
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptPopupMenu.java
@@ -53,6 +53,7 @@ public class ZestAddToScriptPopupMenu extends PopupMenuItemHistoryReferenceConta
         return Constant.messages.getString("zest.addto.popup", true);
     }
 
+    @Override
     public int getParentWeight() {
         return MenuWeights.MENU_SCRIPT_ZEST_ADD_WEIGHT;
     }
@@ -84,7 +85,6 @@ public class ZestAddToScriptPopupMenu extends PopupMenuItemHistoryReferenceConta
         if (ze != null) {
             if (ze instanceof ZestConditional) {
                 ExtensionPopupMenuItem piicm = createPopupAddToScriptMenu(selNode);
-                piicm.setMenuIndex(this.getMenuIndex());
                 mainPopupMenuItems.add(piicm);
             }
         }
@@ -93,7 +93,6 @@ public class ZestAddToScriptPopupMenu extends PopupMenuItemHistoryReferenceConta
             if (st.hasCapability(ScriptType.CAPABILITY_APPEND)) {
                 for (ScriptNode node : extension.getZestScriptNodes(st.getName())) {
                     ExtensionPopupMenuItem piicm = createPopupAddToScriptMenu(node);
-                    piicm.setMenuIndex(this.getMenuIndex());
                     mainPopupMenuItems.add(piicm);
                 }
             }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPasteVariablePopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPasteVariablePopupMenu.java
@@ -103,7 +103,6 @@ public class ZestPasteVariablePopupMenu extends ExtensionPopupMenuItem {
             TreeSet<String> sortedSet = new TreeSet<>(script.getZestScript().getVariableNames());
             for (String var : sortedSet) {
                 ExtensionPopupMenuItem piicm = new ZestPasteVariableMenu(script, lastInvoker, var);
-                piicm.setMenuIndex(this.getMenuIndex());
                 mainPopupMenuItems.add(piicm);
                 this.subMenus.add(piicm);
             }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRecordFromNodePopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRecordFromNodePopupMenu.java
@@ -48,6 +48,7 @@ public class ZestRecordFromNodePopupMenu extends PopupMenuItemSiteNodeContainer 
         extension.getDialogManager().showZestRecordScriptDialog(node);
     }
 
+    @Override
     public int getWeight() {
         return MenuWeights.MENU_SCRIPT_ZEST_RECORD_WEIGHT;
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestSurroundWithPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestSurroundWithPopupMenu.java
@@ -220,7 +220,6 @@ public class ZestSurroundWithPopupMenu extends ExtensionPopupMenuItem {
                         extension.pasteToNode(orNode);
                     });
         }
-        menu.setMenuIndex(this.getMenuIndex());
         View.getSingleton().getPopupList().add(menu);
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,9 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 
     spotless {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -15,7 +15,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.14.0")
+    compileOnly("org.zaproxy:zap:2.15.0-SNAPSHOT")
     implementation(project(":addOns:network"))
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 


### PR DESCRIPTION
Change all add-ons and `testutils` to use 2.15 (SNAPSHOT).
Update code accordingly (e.g. address deprecations).
