### PR TITLE
wappalyzer: Maint - Standardize on naming

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated with enthec upstream icon and pattern changes.
-
-
+- Maintenance changes (standardize on "Technology Detection" naming).
 
 ## [21.36.0] - 2024-05-02
 ### Fixed

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/api.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/api.html
@@ -2,16 +2,16 @@
 <HTML>
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
-<TITLE>Wappalyzer API</TITLE>
+<TITLE>Technology Detection API</TITLE>
 </HEAD>
 <BODY>
-	<H1>Wappalyzer API</H1>
+	<H1>Technology Detection API</H1>
 	The following views are available via the API:
 
 	<h3>Views</h3>
 
 	<ul>
-		<li>listSites: Lists all the sites recognized by the wappalyzer addon.</li>
+		<li>listSites: Lists all the sites recognized by the Technology Detection add-on.</li>
 		<li>listAll: Lists all sites and their associated applications (technologies).</li>
 		<li>listSite (site*): Lists all the applications (technologies) associated with the specified site.</li>
 	</ul>

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -1,9 +1,9 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-description = "Technology detection using Wappalyzer: wappalyzer.com"
+description = "Technology detection using various fingerprints and identifiers."
 
 zapAddOn {
-    addOnName.set("Wappalyzer - Technology Detection")
+    addOnName.set("Technology Detection")
     addOnStatus.set(AddOnStatus.RELEASE)
 
     manifest {


### PR DESCRIPTION
As discussed via email.

## Overview
- api.html > Tweak naming.
- CHANGELOG > Add note.
- wappalyzer.gradle.kts > Tweak nameing.

## Related Issues
N/A

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [NA] Write tests
- [NA] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
