### PR TITLE
Remove usage of ZAP snapshot

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -148,7 +148,7 @@ subprojects {
         }
     }
 
-    val zapGav = "org.zaproxy:zap:2.15.0-SNAPSHOT"
+    val zapGav = "org.zaproxy:zap:2.15.0"
     dependencies {
         "zap"(zapGav)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
     }
 
     spotless {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -15,7 +15,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.15.0-SNAPSHOT")
+    compileOnly("org.zaproxy:zap:2.15.0")
     implementation(project(":addOns:network"))
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 


### PR DESCRIPTION
Use the main release which is already available.