### PR TITLE
openapi: rely on commonlib for Jackson library

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Include the Jackson Datatype: JSR310 library for other add-ons to use.
 
 ## [1.25.0] - 2024-05-07
 ### Added

--- a/addOns/commonlib/commonlib.gradle.kts
+++ b/addOns/commonlib/commonlib.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     implementation("commons-io:commons-io:2.16.1")
     implementation("org.apache.commons:commons-csv:1.10.0")

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Rely on Common Library add-on for use of Jackson library.
 
 ## [40] - 2024-05-07
 ### Changed

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -38,7 +38,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.17.0 & < 2.0.0")
+                    version.set(">= 1.26.0 & < 2.0.0")
                 }
             }
         }
@@ -62,8 +62,19 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("spider")
 
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.22")
+    implementation("io.swagger.parser.v3:swagger-parser:2.1.22") {
+        // Provided by commonlib add-on:
+        exclude(group = "com.fasterxml.jackson")
+        exclude(group = "com.fasterxml.jackson.core")
+        exclude(group = "com.fasterxml.jackson.dataformat")
+        exclude(group = "com.fasterxml.jackson.datatype")
+    }
     implementation("io.swagger:swagger-compat-spec-parser:1.0.70") {
+        // Provided by commonlib add-on:
+        exclude(group = "com.fasterxml.jackson")
+        exclude(group = "com.fasterxml.jackson.core")
+        exclude(group = "com.fasterxml.jackson.dataformat")
+        exclude(group = "com.fasterxml.jackson.datatype")
         // Not needed:
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")


### PR DESCRIPTION
Exclude Jackson from openapi and rely on commonlib to prevent class loading issues.
Add Jackson Datatype: JSR310 to commonlib for openapi to use.