### PR TITLE
grpc: remove ZAP version override

### DIFF
--- a/addOns/grpc/grpc.gradle.kts
+++ b/addOns/grpc/grpc.gradle.kts
@@ -2,7 +2,6 @@ description = "Inspect, attack gRPC endpoints, and decode protobuf messages."
 
 zapAddOn {
     addOnName.set("gRPC Support")
-    zapVersion.set("2.14.0")
 
     manifest {
         author.set("ZAP Dev Team")


### PR DESCRIPTION
Let it use the default defined by the build.