### PR TITLE
database: update deps and suppress Flyway warn

### DIFF
--- a/addOns/database/CHANGELOG.md
+++ b/addOns/database/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
+- Maintenance changes.
 
 ## [0.4.0] - 2024-05-07
 ### Changed

--- a/addOns/database/database.gradle.kts
+++ b/addOns/database/database.gradle.kts
@@ -31,7 +31,7 @@ zapAddOn {
 
 crowdin {
     configuration {
-        file.set(file("$rootDir/gradle/crowdin-help-only.yml"))
+        tokens.put("%messagesPath%", "org/zaproxy/addon/${zapAddOn.addOnId.get()}/resources/")
         tokens.put("%helpPath%", "")
     }
 }
@@ -48,10 +48,13 @@ spotless {
 }
 
 dependencies {
-    datanucleus("org.datanucleus:datanucleus-accessplatform-jdo-rdbms:6.0.4")
-    sqlite("org.xerial:sqlite-jdbc:3.42.0.0")
+    compileOnly(libs.log4j.core)
 
-    implementation("org.flywaydb:flyway-core:9.20.0")
+    datanucleus("org.datanucleus:datanucleus-accessplatform-jdo-rdbms:6.0.7")
+    sqlite("org.xerial:sqlite-jdbc:3.45.3.0")
 
+    implementation("org.flywaydb:flyway-core:9.22.3")
+
+    testImplementation(libs.log4j.core)
     testImplementation(project(":testutils"))
 }

--- a/addOns/database/src/main/java/org/zaproxy/addon/database/ExtensionDatabase.java
+++ b/addOns/database/src/main/java/org/zaproxy/addon/database/ExtensionDatabase.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.database;
+
+import java.util.List;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+
+public class ExtensionDatabase extends ExtensionAdaptor {
+
+    public ExtensionDatabase() {
+        super(ExtensionDatabase.class.getSimpleName());
+
+        setI18nPrefix("database");
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("database.ext.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("database.ext.desc");
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void init() {
+        super.init();
+
+        // Suppress warn that HSQLDB is not official supported yet.
+        setLogLevel(List.of("org.flywaydb.core.internal.database.base.Database"), Level.ERROR);
+    }
+
+    private static void setLogLevel(List<String> classnames, Level level) {
+        boolean updateLoggers = false;
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = ctx.getConfiguration();
+        for (String classname : classnames) {
+            LoggerConfig loggerConfig = configuration.getLoggerConfig(classname);
+            if (!classname.equals(loggerConfig.getName())) {
+                configuration.addLogger(
+                        classname,
+                        LoggerConfig.newBuilder()
+                                .withLoggerName(classname)
+                                .withLevel(level)
+                                .withConfig(configuration)
+                                .build());
+                updateLoggers = true;
+            }
+        }
+
+        if (updateLoggers) {
+            ctx.updateLoggers();
+        }
+    }
+}

--- a/addOns/database/src/main/resources/org/zaproxy/addon/database/resources/Messages.properties
+++ b/addOns/database/src/main/resources/org/zaproxy/addon/database/resources/Messages.properties
@@ -1,0 +1,2 @@
+database.ext.desc = Provides databases and persistence capabilities.
+database.ext.name = Database Extension

--- a/addOns/database/src/test/java/org/zaproxy/addon/database/ExtensionDatabaseUnitTest.java
+++ b/addOns/database/src/test/java/org/zaproxy/addon/database/ExtensionDatabaseUnitTest.java
@@ -1,0 +1,69 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.database;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link ExtensionDatabase}. */
+class ExtensionDatabaseUnitTest extends TestUtils {
+
+    private ExtensionDatabase extension;
+
+    @BeforeEach
+    void setUp() {
+        extension = new ExtensionDatabase();
+        mockMessages(extension);
+    }
+
+    @AfterEach
+    void cleanUp() throws Exception {
+        Configurator.reconfigure(getClass().getResource("/log4j2-test.properties").toURI());
+    }
+
+    @Test
+    void shouldHaveName() {
+        assertThat(extension.getName(), is(equalTo("ExtensionDatabase")));
+    }
+
+    @Test
+    void shouldHaveUiName() {
+        assertThat(extension.getUIName(), is(not(emptyString())));
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(extension.getDescription(), is(not(emptyString())));
+    }
+
+    @Test
+    void shouldBeUnloadable() {
+        assertThat(extension.canUnload(), is(true));
+    }
+}


### PR DESCRIPTION
Update dependencies to latest versions (that still are Java 11 compatible).
Suppress Flyway warning that HSQLDB is not yet officially supported, there's nothing that can be done.