### PR TITLE
automation: do not use null auth realm

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Address HTTP authentication failure when the realm is not configured.
 
 ## [0.40.0] - 2024-05-07
 ### Changed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AuthenticationData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AuthenticationData.java
@@ -223,8 +223,12 @@ public class AuthenticationData extends AutomationData {
                     httpAuthMethod.setHostname(
                             env.replaceVars(
                                     getParameters().get(AuthenticationData.PARAM_HOSTNAME)));
-                    httpAuthMethod.setRealm(
-                            env.replaceVars(getParameters().get(AuthenticationData.PARAM_REALM)));
+                    var realm =
+                            env.replaceVars(getParameters().get(AuthenticationData.PARAM_REALM));
+                    if (realm == null) {
+                        realm = "";
+                    }
+                    httpAuthMethod.setRealm(realm);
                     try {
                         httpAuthMethod.setPort(
                                 Integer.parseInt(

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AuthenticationDataUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AuthenticationDataUnitTest.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.automation.jobs.JobUtils;
@@ -198,8 +199,9 @@ class AuthenticationDataUnitTest {
         assertThat(params.get("field2"), is(equalTo("value2")));
     }
 
-    @Test
-    void shouldInitContextWithHttpAuth() {
+    @ParameterizedTest
+    @CsvSource({"realm,realm", ",''", "'',''"})
+    void shouldInitContextWithHttpAuth(String realm, String expectedRealm) {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         Context context = new Context(null, -1);
@@ -207,7 +209,7 @@ class AuthenticationDataUnitTest {
         AuthenticationData data = new AuthenticationData();
         data.setMethod("http");
         data.getParameters().put(AuthenticationData.PARAM_HOSTNAME, "https://www.example.com");
-        data.getParameters().put(AuthenticationData.PARAM_REALM, "realm");
+        data.getParameters().put(AuthenticationData.PARAM_REALM, realm);
         data.getParameters().put(AuthenticationData.PARAM_PORT, 123);
 
         AutomationProgress progress = new AutomationProgress();
@@ -226,7 +228,7 @@ class AuthenticationDataUnitTest {
                 is(equalTo("https://www.example.com")));
         assertThat(
                 JobUtils.getPrivateField(method, AuthenticationData.PARAM_REALM),
-                is(equalTo("realm")));
+                is(equalTo(expectedRealm)));
         assertThat(
                 JobUtils.getPrivateField(method, AuthenticationData.PARAM_PORT), is(equalTo(123)));
     }


### PR DESCRIPTION
Set an empty realm instead, as null is not allowed and would break the authentication.

Related to zaproxy/zaproxy#8498.