### PR TITLE
network: guard against user without auth state

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Guard against user without authentication state.
+
 ## [0.16.0] - 2024-05-07
 ### Changed
 - Update minimum ZAP version to 2.15.0.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpStateCredentialsProvider.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpStateCredentialsProvider.java
@@ -41,6 +41,9 @@ public class HttpStateCredentialsProvider implements CredentialsProvider {
 
     @Override
     public Credentials getCredentials(AuthScope authScope, HttpContext context) {
+        if (state == null) {
+            return null;
+        }
         return convertCredentials(authScope, state.getCredentials(convertAuthScope(authScope)));
     }
 


### PR DESCRIPTION
Check that the user actually has an auth state before trying to use it, which could happen if the auth attempt lead to an error.

Related to zaproxy/zaproxy#8498.