### PR TITLE
selenium: ensure WebDriver is executable always

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Ensure the specified WebDriver is executable always.
 
 ## [15.24.0] - 2024-05-21
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
@@ -223,7 +223,7 @@ public class SeleniumOptions extends VersionedAbstractParam {
                 saveAndSetSystemProperty(optionKey, systemProperty, bundledPath);
                 return bundledPath;
             }
-        } else if (Browser.isBundledWebDriverPath(path)) {
+        } else {
             Path driver = Paths.get(path);
             if (!Files.exists(driver) || !Browser.ensureExecutable(driver)) {
                 saveAndSetSystemProperty(optionKey, systemProperty, "");


### PR DESCRIPTION
Do not check if the WebDriver is a bundled one to ensure all specified WebDriver are executable.