### PR TITLE
network: fix NPE after root CA cert regen

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Guard against user without authentication state.
+- Fix exception after regenerating the root CA cert during ZAP startup (Issue 8499).
 
 ## [0.16.0] - 2024-05-07
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -1119,7 +1119,7 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
      * @param serverConfigs the server configurations to filter.
      */
     void removeStartedLocalServers(Set<LocalServerConfig> serverConfigs) {
-        if (mainProxyServer.isStarted()) {
+        if (mainProxyServer != null && mainProxyServer.isStarted()) {
             serverConfigs.remove(mainProxyServer.getConfig());
         }
         localServers.values().stream()


### PR DESCRIPTION
Check that the main proxy was already initialised before checking if it is started as it might not have been, e.g. when starting ZAP with the root CA cert expired the options might be shown before initialising the proxies.

Fix zaproxy/zaproxy#8499.