### PR TITLE
Document script engine names in the help pages

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Document the engine name in the help page.
 
 ## [0.7.0] - 2024-05-07
 ### Changed

--- a/addOns/graaljs/src/main/javahelp/help/contents/graaljs.html
+++ b/addOns/graaljs/src/main/javahelp/help/contents/graaljs.html
@@ -10,5 +10,8 @@ GraalVM JavaScript
 <H1>GraalVM JavaScript</H1>
 Allows to use <a href="https://www.graalvm.org/">GraalVM</a> JavaScript engine for ZAP scripting.
 
+<h2>Engine Name</h2>
+The engine is named <code>Graal.js</code>, which should be used when manually/programmatically configuring ZAP.
+
 </BODY>
 </HTML>

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Document the engine name in the help page.
+
 ### Changed
 - Update minimum ZAP version to 2.15.0.
 

--- a/addOns/groovy/src/main/javahelp/org/zaproxy/zap/extension/groovy/resources/help/contents/intro.html
+++ b/addOns/groovy/src/main/javahelp/org/zaproxy/zap/extension/groovy/resources/help/contents/intro.html
@@ -20,6 +20,8 @@ Groovy Support
 <p>
     It's recommended to depend on this add-on when creating Groovy add-ons, to reduce the overall size of the add-ons and memory used at runtime.
 
+<h2>Engine Name</h2>
+The engine is named <code>Groovy Scripting Engine</code>, which should be used when manually/programmatically configuring ZAP.
 
 </BODY>
 </HTML>

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Document the engine name in the help page.
+
 ### Changed
 - Update minimum ZAP version to 2.15.0.
 - Maintenance changes.

--- a/addOns/jruby/src/main/javahelp/org/zaproxy/zap/extension/jruby/resources/help/contents/jruby.html
+++ b/addOns/jruby/src/main/javahelp/org/zaproxy/zap/extension/jruby/resources/help/contents/jruby.html
@@ -16,5 +16,8 @@ Ruby Scripting
 	When you create a new script you will be given the option to use Ruby, as well as the option to choose from various Ruby templates.
 </p>
 
+<h2>Engine Name</h2>
+The engine is named <code>JSR 223 JRuby Engine</code>, which should be used when manually/programmatically configuring ZAP.
+
 </BODY>
 </HTML>

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Document the engine name in the help page.
+
 ### Changed
 - Update minimum ZAP version to 2.15.0.
 

--- a/addOns/jython/src/main/javahelp/org/zaproxy/zap/extension/jython/resources/help/contents/jython.html
+++ b/addOns/jython/src/main/javahelp/org/zaproxy/zap/extension/jython/resources/help/contents/jython.html
@@ -17,5 +17,8 @@ Python Scripting
 <p>
 	Python Scripting is configured using the <a href="options.html">Options Jython screen</a>.<br />
 
+<h2>Engine Name</h2>
+The engine is named <code>jython</code>, which should be used when manually/programmatically configuring ZAP.
+
 </BODY>
 </HTML>

--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Script template: encode-decode-template.kts, for the Encoder (encode/decode/hash) add-on (Issue 5996).
+- Document the engine name in the help page.
 
 ## [1.1.0] - 2021-10-07
 ### Changed

--- a/addOns/kotlin/src/main/javahelp/org/zaproxy/addon/kotlin/resources/help/contents/kotlin.html
+++ b/addOns/kotlin/src/main/javahelp/org/zaproxy/addon/kotlin/resources/help/contents/kotlin.html
@@ -15,5 +15,8 @@ Kotlin Support
 	When you create a new script you will be given the option to use Kotlin, as well as the option to choose from Kotlin templates.
 </p>
 
+<h2>Engine Name</h2>
+The engine is named <code>kotlin</code>, which should be used when manually/programmatically configuring ZAP.
+
 </BODY>
 </HTML>

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Document the engine name in the help page.
 
 ## [45] - 2024-05-07
 ### Changed

--- a/addOns/zest/src/main/javahelp/org/zaproxy/zap/extension/zest/resources/help/contents/zest.html
+++ b/addOns/zest/src/main/javahelp/org/zaproxy/zap/extension/zest/resources/help/contents/zest.html
@@ -12,6 +12,9 @@ originally developed by the Mozilla security team and is intended to be used in 
 <p>
 It is included by default with ZAP.<br>
 
+<h2>Engine Name</h2>
+The engine is named <code>Mozilla Zest</code>, which should be used when manually/programmatically configuring ZAP.
+
 <H2>Creating Zest scripts</H2>
 
 There are a variety of ways to create Zest scripts:


### PR DESCRIPTION
Mention the name of the engines so the user can easily know them when manually/programmatically configuring ZAP.