### PR TITLE
ascanrulesBeta: Fixed regex for relative path confusion, which detected absolute url as relative

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
+
+### Fixed
 - Fixed regex for Relative Path Confusion, which detected absolute url as relative
 
 ## [53] - 2024-03-28

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
+- Fixed regex for Relative Path Confusion, which detected absolute url as relative
 
 ## [53] - 2024-03-28
 ### Changed
@@ -21,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Relative Path Confusion
     - Integer Overflow Error
 
-### Removed 
+### Removed
 - Removed HTTP only reference for scan rule: Integer Overflow Error (Issue 8262)
 
 ## [51] - 2024-02-16
@@ -31,11 +32,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Httpoxy - Proxy Header Misuse
     - Anti-CSRF Tokens Check
     - HTTP Parameter Pollution
-    - Cross-Domain Misconfiguration 
+    - Cross-Domain Misconfiguration
 - Alerts from the HTTP Parameter Pollution scan rule are now raised with Low confidence.
 - Updated reference for scan rules (Issue 8262):
     - Session Fixation
-    - Cross-Domain Misconfiguration 
+    - Cross-Domain Misconfiguration
 - Add website alert links to the help page (Issue 8189).
 
 ## [50] - 2024-01-26
@@ -371,7 +372,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correct HTTP message usage in Insecure HTTP Method scanner.
 - Fix missing resource messages with Cross-Domain Misconfiguration scanner.
 - Remove Source Code Disclosure WEB-INF Scanner (promoted to release Issue 4448).
-- Report source code disclosure alerts at Medium instead of High 
+- Report source code disclosure alerts at Medium instead of High
 - Bundle Diff Utils library instead of relying on core.
 
 ## 24 - 2018-07-31

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -327,7 +327,9 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
                             // attribute)
                             if (tag.toUpperCase().equals("STYLE")) {
                                 // for the style tag, look at the entire body, not an attribute..
-                                String styleBody = tagInstance.data();
+                                // remove all " and ' for proper matching url('somefile.png')
+                                String styleBody =
+                                        tagInstance.data().replaceAll("'", "").replaceAll("\"", "");
                                 LOGGER.debug("Got <style> data: {}", styleBody);
                                 Matcher matcher = STYLE_URL_LOAD.matcher(styleBody);
                                 if (matcher.find()) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -327,11 +327,8 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
                             // attribute)
                             if (tag.toUpperCase().equals("STYLE")) {
                                 // for the style tag, look at the entire body, not an attribute..
-                                // remove all " and ' for proper matching url('somefile.png')
-                                String styleBody =
-                                        tagInstance.data().replaceAll("['\"]", "");
-                                LOGGER.debug("Got <style> data: {}", styleBody);
-                                Matcher matcher = STYLE_URL_LOAD.matcher(styleBody);
+                                LOGGER.debug("Got <style> data: {}", tagInstance.data());
+                                Matcher matcher = matchStyles(tagInstance.data());
                                 if (matcher.find()) {
                                     relativeReferenceFound = true;
                                     relativeReferenceEvidence = matcher.group();
@@ -379,7 +376,7 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
                                 } else {
                                     // for the style attribute (on various tags), look for a pattern
                                     // like "background: url(image.png)"
-                                    Matcher matcher = STYLE_URL_LOAD.matcher(attributeUpper);
+                                    Matcher matcher = matchStyles(attributeUpper);
                                     if (matcher.find()) {
                                         relativeReferenceFound = true;
                                         relativeReferenceEvidence =
@@ -645,6 +642,12 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
                 .setAttack(attack)
                 .setOtherInfo(otherInfo)
                 .setEvidence(evidence);
+    }
+
+    private Matcher matchStyles(String body) {
+        // remove all " and ' for proper matching url('somefile.png')
+        String styleBody = body.replaceAll("['\"]", "");
+        return STYLE_URL_LOAD.matcher(styleBody);
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -329,7 +329,7 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
                                 // for the style tag, look at the entire body, not an attribute..
                                 // remove all " and ' for proper matching url('somefile.png')
                                 String styleBody =
-                                        tagInstance.data().replaceAll("'", "").replaceAll("\"", "");
+                                        tagInstance.data().replaceAll("['\"]", "");
                                 LOGGER.debug("Got <style> data: {}", styleBody);
                                 Matcher matcher = STYLE_URL_LOAD.matcher(styleBody);
                                 if (matcher.find()) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -148,7 +148,7 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
     //										     background: url(image.png)
     static final Pattern STYLE_URL_LOAD =
             Pattern.compile(
-                    "[a-zA-Z_-]*\\s*:\\s*url\\s*\\([^/)]+[^)]*\\)",
+                    "[a-zA-Z_-]*\\s*:\\s*url\\s*\\((?!https?:)[^/][^)]*\\)",
                     Pattern.MULTILINE | Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     // Note: important here to *NOT* include any characters that could cause the resulting file

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -327,8 +327,9 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
                             // attribute)
                             if (tag.toUpperCase().equals("STYLE")) {
                                 // for the style tag, look at the entire body, not an attribute..
-                                LOGGER.debug("Got <style> data: {}", tagInstance.data());
-                                Matcher matcher = matchStyles(tagInstance.data());
+                                String styleBody = tagInstance.data();
+                                LOGGER.debug("Got <style> data: {}", styleBody);
+                                Matcher matcher = matchStyles(styleBody);
                                 if (matcher.find()) {
                                     relativeReferenceFound = true;
                                     relativeReferenceEvidence = matcher.group();

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRuleUnitTest.java
@@ -19,15 +19,25 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
+import org.zaproxy.zap.testutils.NanoServerHandler;
 
 class RelativePathConfusionScanRuleUnitTest
         extends ActiveScannerTest<RelativePathConfusionScanRule> {
@@ -70,8 +80,52 @@ class RelativePathConfusionScanRuleUnitTest
     }
 
     @Test
+    void shouldNotAlertIfAbsolutePathIsDetected() throws Exception {
+        // Given
+        String path = "/index.html";
+        String body =
+                "<html><head><style>body {background: url(http://google.com/abc.png);}</style></head><html>";
+        this.nano.addHandler(createHandler(path, Response.Status.OK, body, ""));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"abc.png", "../abc.png", "'abc.png'", "\"../xxx/abc.png\"", "./abc.png"})
+    void shouldAlertIfRelativePathIsDetected(String relativePath) throws Exception {
+        // Given
+        String path = "/index.html";
+        String body = "<head><style>body {background: url(" + relativePath + ");}</style></head>";
+        this.nano.addHandler(createHandler(path, Response.Status.OK, body, ""));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
     @Override
     public void shouldHaveValidReferences() {
         super.shouldHaveValidReferences();
+    }
+
+    private static NanoServerHandler createHandler(
+            String path, Response.Status status, String body, String host) {
+        return new NanoServerHandler(path) {
+            @Override
+            protected Response serve(IHTTPSession session) {
+                if (session.getHeaders().get(HttpFieldsNames.HOST).equals(host) || host.isEmpty()) {
+                    return newFixedLengthResponse(status, NanoHTTPD.MIME_HTML, body);
+                }
+                return newFixedLengthResponse(Response.Status.NOT_FOUND, NanoHTTPD.MIME_HTML, "");
+            }
+        };
     }
 }

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRuleUnitTest.java
@@ -84,10 +84,10 @@ class RelativePathConfusionScanRuleUnitTest
         // Given
         String path = "/index.html";
         String body =
-               "<html><head><style>"
-                         + "body {background: url(http://google.com/abc.png);}"
-                         + "div {background: url('http://google.com/abc.png');}"
-                         + "</style></head><html>";
+                "<html><head><style>"
+                        + "body {background: url(http://google.com/abc.png);}"
+                        + "div {background: url('http://google.com/abc.png');}"
+                        + "</style></head><html>";
         this.nano.addHandler(createHandler(path, Response.Status.OK, body, ""));
         HttpMessage msg = this.getHttpMessage(path);
         rule.init(msg, this.parent);

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRuleUnitTest.java
@@ -84,7 +84,10 @@ class RelativePathConfusionScanRuleUnitTest
         // Given
         String path = "/index.html";
         String body =
-                "<html><head><style>body {background: url(http://google.com/abc.png);}</style></head><html>";
+               "<html><head><style>"
+                         + "body {background: url(http://google.com/abc.png);}"
+                         + "div {background: url('http://google.com/abc.png');}"
+                         + "</style></head><html>";
         this.nano.addHandler(createHandler(path, Response.Status.OK, body, ""));
         HttpMessage msg = this.getHttpMessage(path);
         rule.init(msg, this.parent);


### PR DESCRIPTION
## Overview
Fixed wrong regex which detected absolute URLs as relative.
Current implementation detects styles like `background: url(https://abc.com/abc.png)` as relative url and vulnerable.

MR tested on regex101.com:
![image](https://github.com/zaproxy/zap-extensions/assets/1748665/d34f0a03-aa6c-43a1-83f6-d40b1e6e2caf)


## Related Issues
none

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
