### PR TITLE
ascanrules: Various alert text fixes (periods and whitespace(s))

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - False positives in the Path Traversal rule.
+- Alert text for various rules has been updated to more consistently use periods and spaces in a uniform manner.
 
 ## [66] - 2024-05-07
 ### Changed

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -1,9 +1,9 @@
 
-ascanrules.bufferoverflow.desc = Buffer overflow errors are characterized by the overwriting of memory spaces of the background web process, which should have never been modified intentionally or unintentionally. Overwriting values of the IP (Instruction Pointer), BP (Base Pointer) and other registers causes exceptions, segmentation faults, and other process errors to occur. Usually these errors end execution of the application in an unexpected way. 
+ascanrules.bufferoverflow.desc = Buffer overflow errors are characterized by the overwriting of memory spaces of the background web process, which should have never been modified intentionally or unintentionally. Overwriting values of the IP (Instruction Pointer), BP (Base Pointer) and other registers causes exceptions, segmentation faults, and other process errors to occur. Usually these errors end execution of the application in an unexpected way.
 ascanrules.bufferoverflow.name = Buffer Overflow
-ascanrules.bufferoverflow.other = Potential Buffer Overflow.  The script closed the connection and threw a 500 Internal Server Error
+ascanrules.bufferoverflow.other = Potential Buffer Overflow. The script closed the connection and threw a 500 Internal Server Error.
 ascanrules.bufferoverflow.refs = https://owasp.org/www-community/attacks/Buffer_overflow_attack
-ascanrules.bufferoverflow.soln = Rewrite the background program using proper return length checking.  This will require a recompile of the background executable.
+ascanrules.bufferoverflow.soln = Rewrite the background program using proper return length checking. This will require a recompile of the background executable.
 
 ascanrules.cloudmetadata.desc = The Cloud Metadata Attack attempts to abuse a misconfigured NGINX server in order to access the instance metadata maintained by cloud service providers such as AWS, GCP and Azure.\nAll of these providers provide metadata via an internal unroutable IP address '169.254.169.254' - this can be exposed by incorrectly configured NGINX servers and accessed by using this IP address in the Host header field.
 ascanrules.cloudmetadata.name = Cloud Metadata Potentially Exposed
@@ -11,20 +11,20 @@ ascanrules.cloudmetadata.otherinfo = Based on the successful response status cod
 ascanrules.cloudmetadata.refs = https://www.nginx.com/blog/trust-no-one-perils-of-trusting-user-input/
 ascanrules.cloudmetadata.soln = Do not trust any user data in NGINX configs. In this case it is probably the use of the $host variable which is set from the 'Host' header and can be controlled by an attacker.
 
-ascanrules.codeinjection.desc = A code injection may be possible including custom code that will be evaluated by the scripting engine
+ascanrules.codeinjection.desc = A code injection may be possible including custom code that will be evaluated by the scripting engine.
 ascanrules.codeinjection.name = Server Side Code Injection
 ascanrules.codeinjection.name.asp = Server Side Code Injection - ASP Code Injection
 ascanrules.codeinjection.name.php = Server Side Code Injection - PHP Code Injection
 ascanrules.codeinjection.refs = https://cwe.mitre.org/data/definitions/94.html\nhttps://owasp.org/www-community/attacks/Direct_Dynamic_Code_Evaluation_Eval%20Injection
-ascanrules.codeinjection.soln = Do not trust client side input, even if there is client side validation in place.\nIn general, type check all data on the server side and escape all data received from the client.\n Avoid the use of eval() functions combined with user input data.
+ascanrules.codeinjection.soln = Do not trust client side input, even if there is client side validation in place.\nIn general, type check all data on the server side and escape all data received from the client.\nAvoid the use of eval() functions combined with user input data.
 
 ascanrules.commandinjection.desc = Attack technique used for unauthorized execution of operating system commands. This attack is possible when an application accepts untrusted input to build operating system commands in an insecure manner involving improper data sanitization, and/or improper calling of external programs.
 ascanrules.commandinjection.name = Remote OS Command Injection
-ascanrules.commandinjection.otherinfo.feedback-based = The scan rule was able to retrieve the content of a file or command by sending [{0}] to the operating system running this application
-ascanrules.commandinjection.otherinfo.time-based = The scan rule was able to control the timing of the application response by sending [{0}] to the operating system running this application
+ascanrules.commandinjection.otherinfo.feedback-based = The scan rule was able to retrieve the content of a file or command by sending [{0}] to the operating system running this application.
+ascanrules.commandinjection.otherinfo.time-based = The scan rule was able to control the timing of the application response by sending [{0}] to the operating system running this application.
 ascanrules.commandinjection.refs = https://cwe.mitre.org/data/definitions/78.html\nhttps://owasp.org/www-community/attacks/Command_Injection
 
-ascanrules.crlfinjection.desc = Cookie can be set via CRLF injection.  It may also be possible to set arbitrary HTTP response headers. In addition, by carefully crafting the injected response using cross-site script, cache poisoning vulnerability may also exist.
+ascanrules.crlfinjection.desc = Cookie can be set via CRLF injection. It may also be possible to set arbitrary HTTP response headers. In addition, by carefully crafting the injected response using cross-site script, cache poisoning vulnerability may also exist.
 ascanrules.crlfinjection.name = CRLF Injection
 ascanrules.crlfinjection.refs = https://owasp.org/www-community/vulnerabilities/CRLF_Injection\nhttps://cwe.mitre.org/data/definitions/113.html
 ascanrules.crlfinjection.soln = Type check the submitted parameter carefully. Do not allow CRLF to be injected by filtering CRLF.
@@ -33,22 +33,22 @@ ascanrules.crosssitescripting.json.desc = A XSS attack was reflected in a JSON r
 ascanrules.crosssitescripting.json.name = Cross Site Scripting Weakness (Reflected in JSON Response)
 ascanrules.crosssitescripting.name = Cross Site Scripting (Reflected)
 ascanrules.crosssitescripting.otherinfo.accesskey = The accesskey attribute specifies a shortcut key to activate/focus an element. This attribute can trigger payloads for non-conventional or custom tags.
-ascanrules.crosssitescripting.otherinfo.nothtml = Raised with LOW confidence as the Content-Type is not HTML
+ascanrules.crosssitescripting.otherinfo.nothtml = Raised with LOW confidence as the Content-Type is not HTML.
 
 ascanrules.desc = Release status active scan rules
 
-ascanrules.directorybrowsing.desc = It is possible to view the directory listing.  Directory listing may reveal hidden scripts, include files, backup source files, etc. which can be accessed to read sensitive information.
+ascanrules.directorybrowsing.desc = It is possible to view the directory listing. Directory listing may reveal hidden scripts, include files, backup source files, etc. which can be accessed to read sensitive information.
 ascanrules.directorybrowsing.name = Directory Browsing
 ascanrules.directorybrowsing.refs = https://httpd.apache.org/docs/mod/core.html#options
-ascanrules.directorybrowsing.soln = Disable directory browsing.  If this is required, make sure the listed files does not induce risks.
+ascanrules.directorybrowsing.soln = Disable directory browsing. If this is required, make sure the listed files does not induce risks.
 
 ascanrules.elmah.desc = The Error Logging Modules and Handlers (ELMAH [elmah.axd]) HTTP Module was found to be available. This module can leak a significant amount of valuable information.
 ascanrules.elmah.name = ELMAH Information Leak
-ascanrules.elmah.otherinfo = Based on response status code ELMAH may be protected by an authentication or authorization mechanism.  
+ascanrules.elmah.otherinfo = Based on response status code ELMAH may be protected by an authentication or authorization mechanism.
 ascanrules.elmah.refs = https://www.troyhunt.com/aspnet-session-hijacking-with-google/\nhttps://www.nuget.org/packages/elmah\nhttps://elmah.github.io/
 ascanrules.elmah.soln = Consider whether or not ELMAH is actually required in production, if it isn't then disable it. If it is then ensure access to it requires authentication and authorization. See also: https://elmah.github.io/a/securing-error-log-pages/
 
-ascanrules.envfiles.desc = One or more .env files seems to have been located on the server. These files often expose infrastructure or administrative account credentials, API or APP keys, or other sensitive configuration information. 
+ascanrules.envfiles.desc = One or more .env files seems to have been located on the server. These files often expose infrastructure or administrative account credentials, API or APP keys, or other sensitive configuration information.
 ascanrules.envfiles.name = .env Information Leak
 ascanrules.envfiles.otherinfo = Based on response status code the .env file may be protected by an authentication or authorization mechanism.
 ascanrules.envfiles.refs = https://www.google.com/search?q=db_password+filetype%3Aenv\nhttps://mobile.twitter.com/svblxyz/status/1045013939904532482
@@ -62,13 +62,13 @@ ascanrules.externalredirect.reason.notfound = No reason found for it...
 ascanrules.externalredirect.reason.refresh.header = The response contains a redirect in its Refresh header which allows an external Url to be set.
 ascanrules.externalredirect.reason.refresh.meta = The response contains a redirect in its meta http-equiv tag for 'Refresh' which allows an external Url to be set.
 
-ascanrules.formatstring.desc = A Format String error occurs when the submitted data of an input string is evaluated as a command by the application. 
-ascanrules.formatstring.error1 = Potential Format String Error.  The script closed the connection on a /%s
-ascanrules.formatstring.error2 = Potential Format String Error.  The script closed the connection on a /%s and /%x
-ascanrules.formatstring.error3 = Potential Format String Error.  The script closed the connection on a microsoft format string error
+ascanrules.formatstring.desc = A Format String error occurs when the submitted data of an input string is evaluated as a command by the application.
+ascanrules.formatstring.error1 = Potential Format String Error. The script closed the connection on a /%s.
+ascanrules.formatstring.error2 = Potential Format String Error. The script closed the connection on a /%s and /%x.
+ascanrules.formatstring.error3 = Potential Format String Error. The script closed the connection on a Microsoft format string error.
 ascanrules.formatstring.name = Format String Error
 ascanrules.formatstring.refs = https://owasp.org/www-community/attacks/Format_string_attack
-ascanrules.formatstring.soln = Rewrite the background program using proper deletion of bad character strings.  This will require a recompile of the background executable.
+ascanrules.formatstring.soln = Rewrite the background program using proper deletion of bad character strings. This will require a recompile of the background executable.
 
 ascanrules.getforpost.desc = A request that was originally observed as a POST was also accepted as a GET. This issue does not represent a security weakness unto itself, however, it may facilitate simplification of other attacks. For example if the original POST is subject to Cross-Site Scripting (XSS), then this finding may indicate that a simplified (GET based) XSS may also be possible.
 ascanrules.getforpost.name = GET for POST
@@ -86,7 +86,7 @@ ascanrules.hidden.files.name = Hidden File Finder
 ascanrules.hidden.files.refs = https://blog.hboeck.de/archives/892-Introducing-Snallygaster-a-Tool-to-Scan-for-Secrets-on-Web-Servers.html
 ascanrules.hidden.files.soln = Consider whether or not the component is actually required in production, if it isn't then disable it. If it is then ensure access to it requires appropriate authentication and authorization, or limit exposure to internal systems or specific source IPs, etc.
 
-ascanrules.htaccess.desc = htaccess files can be used to alter the configuration of the Apache Web Server software to enable/disable additional functionality and features that the Apache Web Server software has to offer. 
+ascanrules.htaccess.desc = htaccess files can be used to alter the configuration of the Apache Web Server software to enable/disable additional functionality and features that the Apache Web Server software has to offer.
 ascanrules.htaccess.name = .htaccess Information Leak
 ascanrules.htaccess.otherinfo = Based on response status code htaccess file may be protected by an authentication or authorization mechanism.
 ascanrules.htaccess.refs = https://developer.mozilla.org/en-US/docs/Learn/Server-side/Apache_Configuration_htaccess\nhttps://httpd.apache.org/docs/2.4/howto/htaccess.html
@@ -110,9 +110,9 @@ ascanrules.paddingoracle.name = Generic Padding Oracle
 ascanrules.paddingoracle.refs = https://learn.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-070\nhttps://www.mono-project.com/docs/about-mono/vulnerabilities/\nhttps://bugzilla.redhat.com/show_bug.cgi?id=623799
 ascanrules.paddingoracle.soln = Update the affected server software, or modify the scripts so that they properly validate encrypted data before attempting decryption.
 
-ascanrules.parametertamper.desc = Parameter manipulation caused an error page or Java stack trace to be displayed.  This indicated lack of exception handling and potential areas for further exploit.
+ascanrules.parametertamper.desc = Parameter manipulation caused an error page or Java stack trace to be displayed. This indicated lack of exception handling and potential areas for further exploit.
 ascanrules.parametertamper.name = Parameter Tampering
-ascanrules.parametertamper.soln = Identify the cause of the error and fix it.  Do not trust client side input and enforce a tight check in the server side.  Besides, catch the exception properly.  Use a generic 500 error page for internal server error.
+ascanrules.parametertamper.soln = Identify the cause of the error and fix it. Do not trust client side input and enforce a tight check in the server side. Besides, catch the exception properly. Use a generic 500 error page for internal server error.
 
 ascanrules.pathtraversal.name = Path Traversal
 
@@ -123,33 +123,33 @@ ascanrules.persistentxssattack.json.desc = A XSS attack was found in a JSON resp
 ascanrules.persistentxssattack.json.name = Cross Site Scripting Weakness (Persistent in JSON Response)
 ascanrules.persistentxssattack.name = Cross Site Scripting (Persistent)
 ascanrules.persistentxssattack.otherinfo = Source URL: {0}
-ascanrules.persistentxssattack.otherinfo.nothtml = Raised with LOW confidence as the Content-Type is not HTML 
+ascanrules.persistentxssattack.otherinfo.nothtml = Raised with LOW confidence as the Content-Type is not HTML.
 
 ascanrules.persistentxssprime.name = Cross Site Scripting (Persistent) - Prime
 
 ascanrules.persistentxssspider.name = Cross Site Scripting (Persistent) - Spider
 
-ascanrules.remotecodeexecution.cve-2012-1823.desc = Some PHP versions, when configured to run using CGI, do not correctly handle query strings that lack an unescaped "=" character, enabling arbitrary code execution. In this case, an operating system command was caused to be executed on the web server, and the results were returned to the web browser. 
+ascanrules.remotecodeexecution.cve-2012-1823.desc = Some PHP versions, when configured to run using CGI, do not correctly handle query strings that lack an unescaped "=" character, enabling arbitrary code execution. In this case, an operating system command was caused to be executed on the web server, and the results were returned to the web browser.
 ascanrules.remotecodeexecution.cve-2012-1823.name = Remote Code Execution - CVE-2012-1823
 ascanrules.remotecodeexecution.cve-2012-1823.soln = Upgrade to the latest stable version of PHP, or use the Apache web server and the mod_rewrite module to filter out malicious requests using the "RewriteCond" and "RewriteRule" directives.
 
 ascanrules.remotefileinclude.name = Remote File Inclusion
 
-ascanrules.serversideinclude.desc = Certain parameters may cause Server Side Include commands to be executed.  This may allow database connection or arbitrary code to be executed.
+ascanrules.serversideinclude.desc = Certain parameters may cause Server Side Include commands to be executed. This may allow database connection or arbitrary code to be executed.
 ascanrules.serversideinclude.name = Server Side Include
 ascanrules.serversideinclude.refs = https://httpd.apache.org/docs/current/howto/ssi.html
-ascanrules.serversideinclude.soln = Do not trust client side input and enforce a tight check in the server side. Disable server side includes.\nRefer to manual to disable Sever Side Include.\nUse least privilege to run your web server or application server.\nFor Apache, disable the following:\nOptions Indexes FollowSymLinks Includes\nAddType application/x-httpd-cgi .cgi\nAddType text/x-server-parsed-html .html
+ascanrules.serversideinclude.soln = Do not trust client side input and enforce a tight check in the server side. Disable server side includes.\nRefer to manual to disable Sever Side Include.\nUse least privilege to run your web server or application server.\nFor Apache, disable the following:\nOptions Indexes FollowSymLinks Includes\nAddType application/x-httpd-cgi .cgi\nAddType text/x-server-parsed-html .html.
 
 ascanrules.sourcecodedisclosurecve-2012-1823.desc = Some PHP versions, when configured to run using CGI, do not correctly handle query strings that lack an unescaped "=" character, enabling PHP source code disclosure, and arbitrary code execution. In this case, the contents of the PHP file were served directly to the web browser. This output will typically contain PHP, although it may also contain straight HTML.
 ascanrules.sourcecodedisclosurecve-2012-1823.name = Source Code Disclosure - CVE-2012-1823
 ascanrules.sourcecodedisclosurecve-2012-1823.soln = Upgrade to the latest stable version of PHP, or use the Apache web server and the mod_rewrite module to filter out malicious requests using the "RewriteCond" and "RewriteRule" directives.
 
-ascanrules.sourcecodedisclosurewebinf.desc = Java source code was disclosed by the web server in Java class files in the WEB-INF folder. The class files can be dis-assembled to produce source code which very closely matches the original source code.  
+ascanrules.sourcecodedisclosurewebinf.desc = Java source code was disclosed by the web server in Java class files in the WEB-INF folder. The class files can be dis-assembled to produce source code which very closely matches the original source code.
 ascanrules.sourcecodedisclosurewebinf.name = Source Code Disclosure - /WEB-INF Folder
-ascanrules.sourcecodedisclosurewebinf.propertiesfile.desc = A Java class in the /WEB-INF folder disclosed the presence of the properties file. Properties file are not intended to be publicly accessible, and typically contain configuration information, application credentials, or cryptographic keys.   
+ascanrules.sourcecodedisclosurewebinf.propertiesfile.desc = A Java class in the /WEB-INF folder disclosed the presence of the properties file. Properties file are not intended to be publicly accessible, and typically contain configuration information, application credentials, or cryptographic keys.
 ascanrules.sourcecodedisclosurewebinf.propertiesfile.extrainfo = The reference to the properties file was found in the dis-assembled Java source code for Java class [{0}].
 ascanrules.sourcecodedisclosurewebinf.propertiesfile.name = Properties File Disclosure - /WEB-INF folder
-ascanrules.sourcecodedisclosurewebinf.propertiesfile.soln = The web server should be configured to not serve the /WEB-INF folder or its contents to web browsers.  It may also be possible to remove the /WEB-INF folder.  
+ascanrules.sourcecodedisclosurewebinf.propertiesfile.soln = The web server should be configured to not serve the /WEB-INF folder or its contents to web browsers. It may also be possible to remove the /WEB-INF folder.
 ascanrules.sourcecodedisclosurewebinf.soln = The web server should be configured to not serve the /WEB-INF folder or its contents to web browsers, since it contains sensitive information such as compiled Java source code and properties files which may contain credentials. Java classes deployed with the application should be obfuscated, as an additional layer of defence in a "defence-in-depth" approach.
 
 ascanrules.spring4shell.desc = The application appears to be vulnerable to CVE-2022-22965 (otherwise known as Spring4Shell) - remote code execution (RCE) via data binding.
@@ -164,19 +164,19 @@ ascanrules.springactuator.soln = Disable the Health Actuators and other actuator
 
 #ascanrules.sqlinjection.alert.errorbased.attack={1}
 ascanrules.sqlinjection.alert.booleanbased.attack = field: [{0}], value [{1}]
-ascanrules.sqlinjection.alert.booleanbased.extrainfo = The page results were successfully manipulated using the boolean conditions [{0}] and [{1}]\nThe parameter value being modified was {2}stripped from the HTML output for the purposes of the comparison
-ascanrules.sqlinjection.alert.booleanbased.extrainfo.dataexists = Data was returned for the original parameter.\nThe vulnerability was detected by successfully restricting the data originally returned, by manipulating the parameter
-ascanrules.sqlinjection.alert.booleanbased.extrainfo.datanotexists = Data was NOT returned for the original parameter.\nThe vulnerability was detected by successfully retrieving more data than originally returned, by manipulating the parameter
+ascanrules.sqlinjection.alert.booleanbased.extrainfo = The page results were successfully manipulated using the boolean conditions [{0}] and [{1}]\nThe parameter value being modified was {2}stripped from the HTML output for the purposes of the comparison.
+ascanrules.sqlinjection.alert.booleanbased.extrainfo.dataexists = Data was returned for the original parameter.\nThe vulnerability was detected by successfully restricting the data originally returned, by manipulating the parameter.
+ascanrules.sqlinjection.alert.booleanbased.extrainfo.datanotexists = Data was NOT returned for the original parameter.\nThe vulnerability was detected by successfully retrieving more data than originally returned, by manipulating the parameter.
 ascanrules.sqlinjection.alert.errorbased.attack = [{0}] field: [{1}], value [{2}]
 ascanrules.sqlinjection.alert.errorbased.differentiation.attack = Original Value: [{0}]. Modified Value: [{1}]. Control Value: [{2}]
-ascanrules.sqlinjection.alert.errorbased.differentiation.extrainfo = Unmodified message gave HTTP status [{0}], body of length [{1}], modified message gave HTTP status [{2}], body of length [{3}]. A third (non-SQL injection inducing value) gave HTTP status [{4}], body of length [{5}]
-ascanrules.sqlinjection.alert.errorbased.extrainfo = RDBMS [{0}] likely, given error message regular expression [{1}] matched by the HTML results.\nThe vulnerability was detected by manipulating the parameter to cause a database error message to be returned and recognised
-ascanrules.sqlinjection.alert.errorbased.httpstatuscode.extrainfo = Unmodified message gave HTTP status [{0}], modified message gave HTTP status [{1}]
-ascanrules.sqlinjection.alert.expressionbased.extrainfo = The original page results were successfully replicated using the expression [{0}] as the parameter value\nThe parameter value being modified was {1}stripped from the HTML output for the purposes of the comparison
-ascanrules.sqlinjection.alert.orderbybased.extrainfo = The original page results were successfully replicated using the "ORDER BY" expression [{0}] as the parameter value\nThe parameter value being modified was {1}stripped from the HTML output for the purposes of the comparison
-ascanrules.sqlinjection.alert.timebased.extrainfo = The query time is controllable using parameter value [{0}], which caused the request to take [{1}] milliseconds, when the original unmodified query with value [{2}] took [{3}] milliseconds 
+ascanrules.sqlinjection.alert.errorbased.differentiation.extrainfo = Unmodified message gave HTTP status [{0}], body of length [{1}], modified message gave HTTP status [{2}], body of length [{3}]. A third (non-SQL injection inducing value) gave HTTP status [{4}], body of length [{5}].
+ascanrules.sqlinjection.alert.errorbased.extrainfo = RDBMS [{0}] likely, given error message regular expression [{1}] matched by the HTML results.\nThe vulnerability was detected by manipulating the parameter to cause a database error message to be returned and recognised.
+ascanrules.sqlinjection.alert.errorbased.httpstatuscode.extrainfo = Unmodified message gave HTTP status [{0}], modified message gave HTTP status [{1}].
+ascanrules.sqlinjection.alert.expressionbased.extrainfo = The original page results were successfully replicated using the expression [{0}] as the parameter value\nThe parameter value being modified was {1}stripped from the HTML output for the purposes of the comparison.
+ascanrules.sqlinjection.alert.orderbybased.extrainfo = The original page results were successfully replicated using the "ORDER BY" expression [{0}] as the parameter value\nThe parameter value being modified was {1}stripped from the HTML output for the purposes of the comparison.
+ascanrules.sqlinjection.alert.timebased.extrainfo = The query time is controllable using parameter value [{0}], which caused the request to take [{1}] milliseconds, when the original unmodified query with value [{2}] took [{3}] milliseconds.
 ascanrules.sqlinjection.alert.unionbased.attack = [{0}] field: [{1}], value [{2}]
-ascanrules.sqlinjection.alert.unionbased.extrainfo = RDBMS [{0}] likely, given UNION-specific error message regular expression [{1}] matched by the HTML results\nThe vulnerability was detected by manipulating the parameter with an SQL 'UNION' clause to cause a database error message to be returned and recognised
+ascanrules.sqlinjection.alert.unionbased.extrainfo = RDBMS [{0}] likely, given UNION-specific error message regular expression [{1}] matched by the HTML results\nThe vulnerability was detected by manipulating the parameter with an SQL 'UNION' clause to cause a database error message to be returned and recognised.
 ascanrules.sqlinjection.authbypass.desc = SQL injection may be possible on a login page, potentially allowing the application's authentication mechanism to be bypassed
 ascanrules.sqlinjection.authbypass.name = SQL Injection - Authentication Bypass
 ascanrules.sqlinjection.desc = SQL injection may be possible.
@@ -194,7 +194,7 @@ ascanrules.sqlinjection.sqlite.alert.timebased.extrainfo = The query time is con
 ascanrules.sqlinjection.sqlite.alert.versionnumber.extrainfo = Using a UNION based SQL Injection attack, and by exploiting SQLite's dynamic typing mechanism, the SQLite version was determined to be [{0}].\nWith string-based injection points, full SQLite version information can be extracted, but with numeric injection points, only partial SQLite version information can be extracted.\nMore information on SQLite version [{0}] is available at https://www.sqlite.org/changes.html
 ascanrules.sqlinjection.sqlite.name = SQL Injection - SQLite
 
-ascanrules.ssti.alert.otherinfo = Proof found at [{0}] \ncontent:\n[{1}]
+ascanrules.ssti.alert.otherinfo = Proof found at [{0}]\ncontent:\n[{1}]
 ascanrules.ssti.desc = When the user input is inserted in the template instead of being used as argument in rendering is evaluated by the template engine. Depending on the template engine it can lead to remote code execution.
 ascanrules.ssti.name = Server Side Template Injection
 ascanrules.ssti.refs = https://portswigger.net/blog/server-side-template-injection
@@ -208,7 +208,7 @@ ascanrules.sstiblind.soln = Instead of inserting the user input in the template,
 
 ascanrules.traceaxd.desc = The ASP.NET Trace Viewer (trace.axd) was found to be available. This component can leak a significant amount of valuable information.
 ascanrules.traceaxd.name = Trace.axd Information Leak
-ascanrules.traceaxd.otherinfo = Based on response status code Trace Viewer may be protected by an authentication or authorization mechanism.  
+ascanrules.traceaxd.otherinfo = Based on response status code Trace Viewer may be protected by an authentication or authorization mechanism.
 ascanrules.traceaxd.refs = https://msdn.microsoft.com/en-us/library/bb386420.aspx\nhttps://msdn.microsoft.com/en-us/library/wwh16c6c.aspx\nhttps://www.dotnetperls.com/trace
 ascanrules.traceaxd.soln = Consider whether or not Trace Viewer is actually required in production, if it isn't then disable it. If it is then ensure access to it requires authentication and authorization.
 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRuleUnitTest.java
@@ -369,7 +369,7 @@ class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandInjectio
                         equalTo(
                                 "The scan rule was able to retrieve the content of a file or "
                                         + "command by sending [a;cat /etc/passwd ] to the operating "
-                                        + "system running this application")));
+                                        + "system running this application.")));
     }
 
     private static class PayloadCollectorHandler extends NanoServerHandler {


### PR DESCRIPTION
## Overview
- CHANGELOG  > Added fix note.
- Messages.properties > Updated various resource messages.
- CommandInjectionScanRuleUnitTest - Updated to match the new content.

---

* Removed use of period space space (should always be period space between sentences now).
* Removed trailing spaces.
* Added periods.

## Related Issues
Reported via Slack.

## Checklist
- [NA] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title