### PR TITLE
webuipoc: use `ci` instead of `install`

### DIFF
--- a/addOns/webuipoc/webuipoc.gradle.kts
+++ b/addOns/webuipoc/webuipoc.gradle.kts
@@ -25,7 +25,7 @@ for (dir in pocsSrcDir.listFiles()!!) {
             tasks.register<NpmTask>("installPoc${normalizedPocName}Dependencies") {
                 group = pocBuildTasksGroup
                 workingDir = dir
-                args.set(arrayListOf("install"))
+                args.set(arrayListOf("ci"))
             }
         pocBuildTasks.add(
             tasks.register<NpmTask>("assemblePoc$normalizedPocName") {


### PR DESCRIPTION
Ensure automated changes (e.g. #5524) do no lead to unwanted changes in the lock file and that it's kept in sync.