### PR TITLE
scripts: Handle null references in metadata

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Provide the `script` API on newer ZAP versions.
 
+### Fixed
+- Handle missing "references" field in the script metadata correctly.
+
 ## [45.4.0] - 2024-05-16
 ### Added
 - Support for Automation Framework loaddir action, which loads all of the scripts under the specified directory.

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRule.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRule.java
@@ -193,7 +193,10 @@ public class ActiveScriptScanRule extends ActiveScriptHelper {
 
     @Override
     public String getReference() {
-        return String.join("\n", metadata.getReferences());
+        if (metadata.getReferences() != null && !metadata.getReferences().isEmpty()) {
+            return String.join("\n", metadata.getReferences());
+        }
+        return "";
     }
 
     @Override

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRule.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRule.java
@@ -79,15 +79,19 @@ public class PassiveScriptScanRule extends PassiveScriptHelper {
 
     @Override
     public AlertBuilder newAlert() {
-        return super.newAlert()
-                .setRisk(metadata.getRisk().getValue())
-                .setConfidence(metadata.getConfidence().getValue())
-                .setDescription(metadata.getDescription())
-                .setSolution(metadata.getSolution())
-                .setCweId(metadata.getCweId())
-                .setWascId(metadata.getWascId())
-                .setReference(String.join("\n", metadata.getReferences()))
-                .setOtherInfo(metadata.getOtherInfo());
+        var alertBuilder =
+                super.newAlert()
+                        .setRisk(metadata.getRisk().getValue())
+                        .setConfidence(metadata.getConfidence().getValue())
+                        .setDescription(metadata.getDescription())
+                        .setSolution(metadata.getSolution())
+                        .setCweId(metadata.getCweId())
+                        .setWascId(metadata.getWascId())
+                        .setOtherInfo(metadata.getOtherInfo());
+        if (metadata.getReferences() != null && !metadata.getReferences().isEmpty()) {
+            alertBuilder.setReference(String.join("\n", metadata.getReferences()));
+        }
+        return alertBuilder;
     }
 
     @Override

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRuleUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRuleUnitTest.java
@@ -19,6 +19,9 @@
  */
 package org.zaproxy.zap.extension.scripts.scanrules;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -30,6 +33,7 @@ import org.apache.commons.configuration.BaseConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.HostProcess;
 import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.core.scanner.ScannerParam;
@@ -38,6 +42,8 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.scanrules.Confidence;
+import org.zaproxy.addon.commonlib.scanrules.Risk;
 import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
 import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
 import org.zaproxy.zap.extension.ascan.VariantFactory;
@@ -143,6 +149,21 @@ public class ActiveScriptScanRuleUnitTest extends TestUtils {
         scanRuleCopy.scan();
         // Then
         verify(scriptActiveInterface, times(1)).scanNode(scanRule, message);
+    }
+
+    @Test
+    void shouldHandleNullReferences() throws Exception {
+        // Given
+        ScriptWrapper script = mock(ScriptWrapper.class);
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        metadata.setRisk(Risk.HIGH);
+        metadata.setConfidence(Confidence.HIGH);
+        metadata.setReferences(null);
+        var scanRule = new ActiveScriptScanRule(script, metadata);
+        // When
+        Alert alert = scanRule.newAlert().build();
+        // Then
+        assertThat(alert.getReference(), is(equalTo("")));
     }
 
     private <T> ScriptWrapper createScriptWrapper(T scriptInterface, Class<T> scriptClass)

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRuleUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRuleUnitTest.java
@@ -19,6 +19,9 @@
  */
 package org.zaproxy.zap.extension.scripts.scanrules;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -28,11 +31,15 @@ import net.htmlparser.jericho.Source;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.scanrules.Confidence;
+import org.zaproxy.addon.commonlib.scanrules.Risk;
 import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.zap.extension.pscan.PassiveScanData;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -82,6 +89,22 @@ public class PassiveScriptScanRuleUnitTest extends TestUtils {
         scanRule.copy().scanHttpResponseReceive(message, id, source);
         // Then
         verify(scriptInterface, times(1)).scan(scanRule, message, source);
+    }
+
+    @Test
+    void shouldHandleNullReferences() throws Exception {
+        // Given
+        ScriptWrapper script = mock(ScriptWrapper.class);
+        var metadata = new ScanRuleMetadata(12345, "Test Scan Rule");
+        metadata.setRisk(Risk.HIGH);
+        metadata.setConfidence(Confidence.HIGH);
+        metadata.setReferences(null);
+        var scanRule = new PassiveScriptScanRule(script, metadata);
+        scanRule.setHelper(mock(PassiveScanData.class));
+        // When
+        Alert alert = scanRule.newAlert().build();
+        // Then
+        assertThat(alert.getReference(), is(equalTo("")));
     }
 
     private <T> ScriptWrapper createScriptWrapper(T scriptInterface, Class<T> scriptClass)


### PR DESCRIPTION
Scripts without `references` in their metadata were failing with NPEs.