### PR TITLE
spider: update JavaDoc

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.11.0] - 2024-05-07
 ### Changed

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderParam.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderParam.java
@@ -1014,9 +1014,7 @@ public class SpiderParam extends VersionedAbstractParam {
      * <ul>
      *   <li>This option has low priority, the Spider will respect other (global) options related to
      *       the HTTP state. This option is ignored if, for example, a {@link
-     *       org.zaproxy.zap.users.User User} was set or the option {@link
-     *       org.parosproxy.paros.network.ConnectionParam#isHttpStateEnabled() Session Tracking
-     *       (Cookie)} is enabled.
+     *       org.zaproxy.zap.users.User User} was set or the option Global HTTP State is enabled.
      *   <li>The cookies are not shared between spider processes, each process has its own cookie
      *       jar.
      * </ul>


### PR DESCRIPTION
Update to mention the newer option instead of the older option and linking to deprecated class.