### PR TITLE
scan rules: Clean code tweaks

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
@@ -169,7 +169,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin
         return 7;
     }
 
-    private String randomCharacterString(int length) {
+    private static String randomCharacterString(int length) {
         StringBuilder sb1 = new StringBuilder(length + 1);
         int counter = 0;
         int character = 0;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
@@ -366,7 +366,7 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin
         return Alert.RISK_HIGH;
     }
 
-    private String getOtherInfo(TestType testType, String testValue) {
+    private static String getOtherInfo(TestType testType, String testValue) {
         return Constant.messages.getString(
                 MESSAGE_PREFIX + "otherinfo." + testType.getNameKey(), testValue);
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
@@ -95,7 +95,7 @@ public class DirectoryBrowsingScanRule extends AbstractAppPlugin
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
-    private void checkIfDirectory(HttpMessage msg) throws URIException {
+    private static void checkIfDirectory(HttpMessage msg) throws URIException {
 
         URI uri = msg.getRequestHeader().getURI();
         uri.setQuery(null);

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
@@ -342,7 +342,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin
      * @param msg the current message where reflected redirection should be check into
      * @return get back the redirection type if exists
      */
-    private int isRedirected(String payload, HttpMessage msg) {
+    private static int isRedirected(String payload, HttpMessage msg) {
 
         // (1) Check if redirection by "Location" header
         // http://en.wikipedia.org/wiki/HTTP_location
@@ -471,7 +471,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin
      * @param type the redirection type
      * @return a string representing the reason of this redirection
      */
-    private String getRedirectionReason(int type) {
+    private static String getRedirectionReason(int type) {
         switch (type) {
             case REDIRECT_LOCATION_HEADER:
                 return Constant.messages.getString(MESSAGE_PREFIX + "reason.location.header");

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
@@ -105,7 +105,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
-    private String getError(char c) {
+    private static String getError(char c) {
         return Constant.messages.getString(MESSAGE_PREFIX + "error" + c);
     }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PaddingOracleScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PaddingOracleScanRule.java
@@ -267,7 +267,7 @@ public class PaddingOracleScanRule extends AbstractAppParamPlugin
      * @param value the value that need to be checked
      * @return true if it seems to be encrypted
      */
-    private boolean isEncrypted(byte[] value) {
+    private static boolean isEncrypted(byte[] value) {
 
         // Make sure we have a reasonable sized string
         // (encrypted strings tend to be long, and short strings tend to break our numbers)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -608,7 +608,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin
         return false;
     }
 
-    private String getContentsToMatch(HttpMessage message) {
+    private static String getContentsToMatch(HttpMessage message) {
         return message.getResponseHeader().isHtml()
                 ? StringEscapeUtils.unescapeHtml4(message.getResponseBody().toString())
                 : message.getResponseHeader().toString() + message.getResponseBody().toString();
@@ -700,7 +700,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin
             return matchWinDirectories(contents);
         }
 
-        private String matchNixDirectories(String contents) {
+        private static String matchNixDirectories(String contents) {
             Pattern procPattern =
                     Pattern.compile("(?:^|\\W)proc(?:\\W|$)", Pattern.CASE_INSENSITIVE);
             Pattern etcPattern = Pattern.compile("(?:^|\\W)etc(?:\\W|$)", Pattern.CASE_INSENSITIVE);
@@ -727,7 +727,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin
             return null;
         }
 
-        private String matchWinDirectories(String contents) {
+        private static String matchWinDirectories(String contents) {
             if (contents.contains("Windows")
                     && Pattern.compile("Program\\sFiles").matcher(contents).find()) {
                 return "Windows";

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -277,7 +277,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin
      * @return
      * @throws URIException
      */
-    private URI getClassURI(URI hostURI, String classname) throws URIException {
+    private static URI getClassURI(URI hostURI, String classname) throws URIException {
         return new URI(
                 hostURI.getScheme()
                         + "://"
@@ -288,7 +288,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin
                 false);
     }
 
-    private URI getPropsFileURI(URI hostURI, String propsfilename) throws URIException {
+    private static URI getPropsFileURI(URI hostURI, String propsfilename) throws URIException {
         return new URI(
                 hostURI.getScheme()
                         + "://"

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/Spring4ShellScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/Spring4ShellScanRule.java
@@ -76,11 +76,11 @@ public class Spring4ShellScanRule extends AbstractAppPlugin implements CommonAct
         return Constant.messages.getString("ascanrules.spring4shell.desc");
     }
 
-    private boolean is400Response(HttpMessage msg) {
+    private static boolean is400Response(HttpMessage msg) {
         return !msg.getResponseHeader().isEmpty() && msg.getResponseHeader().getStatusCode() == 400;
     }
 
-    private void setGetPayload(HttpMessage msg, String payload) throws URIException {
+    private static void setGetPayload(HttpMessage msg, String payload) throws URIException {
         msg.getRequestHeader().setMethod("GET");
         URI uri = msg.getRequestHeader().getURI();
         String query = uri.getEscapedQuery();
@@ -92,7 +92,7 @@ public class Spring4ShellScanRule extends AbstractAppPlugin implements CommonAct
         uri.setEscapedQuery(query);
     }
 
-    private void setPostPayload(HttpMessage msg, String payload) {
+    private static void setPostPayload(HttpMessage msg, String payload) {
         msg.getRequestHeader().setMethod("POST");
         String body = msg.getRequestBody().toString();
         if (body.isEmpty()

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRuleUnitTest.java
@@ -80,11 +80,11 @@ class ExternalRedirectScanRuleUnitTest extends ActiveScannerTest<ExternalRedirec
         CONCAT_PATH
     };
 
-    private NanoServerHandler createHttpRedirectHandler(String path, String header) {
+    private static NanoServerHandler createHttpRedirectHandler(String path, String header) {
         return createHttpRedirectHandler(path, header, PayloadHandling.NEITHER);
     }
 
-    private NanoServerHandler createHttpRedirectHandler(
+    private static NanoServerHandler createHttpRedirectHandler(
             String path, String header, PayloadHandling payloadHandling) {
         return new NanoServerHandler(path) {
             @Override

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
@@ -110,7 +110,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         }
     }
 
-    private void assertNoLeadingSlash(String message, String path) {
+    private static void assertNoLeadingSlash(String message, String path) {
         assertThat(message.replace(REPLACE_TOKEN, path), !path.startsWith("/"), is(true));
     }
 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/XxeScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/XxeScanRuleUnitTest.java
@@ -314,7 +314,7 @@ class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
         assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
     }
 
-    private NanoServerHandler createNanoHandler(
+    private static NanoServerHandler createNanoHandler(
             String path, NanoHTTPD.Response.IStatus status, String responseBody) {
         return new NanoServerHandler(path) {
             @Override

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [48] - 2024-09-02
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanRule.java
@@ -43,7 +43,8 @@ import org.zaproxy.zap.model.TechSet;
  *
  * @author psiinon
  */
-public class ExampleFileActiveScanRule extends AbstractAppParamPlugin {
+public class ExampleFileActiveScanRule extends AbstractAppParamPlugin
+        implements CommonActiveScanRuleInfo {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanalpha.examplefile.";
@@ -80,7 +81,7 @@ public class ExampleFileActiveScanRule extends AbstractAppParamPlugin {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
 
-    private String getOtherInfo() {
+    private static String getOtherInfo() {
         return Constant.messages.getString(MESSAGE_PREFIX + "other");
     }
 
@@ -155,14 +156,7 @@ public class ExampleFileActiveScanRule extends AbstractAppParamPlugin {
                 String evidence;
                 if ((evidence = doesResponseContainString(msg.getResponseBody(), attack)) != null) {
                     // Raise an alert
-                    newAlert()
-                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setParam(param)
-                            .setAttack(attack)
-                            .setOtherInfo(getOtherInfo())
-                            .setEvidence(evidence)
-                            .setMessage(testMsg)
-                            .raise();
+                    createAlert(param, attack, evidence).setMessage(testMsg).raise();
                     return;
                 }
             }
@@ -194,7 +188,16 @@ public class ExampleFileActiveScanRule extends AbstractAppParamPlugin {
         return null;
     }
 
-    private List<String> loadFile(String file) {
+    private AlertBuilder createAlert(String param, String attack, String evidence) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setParam(param)
+                .setAttack(attack)
+                .setOtherInfo(getOtherInfo())
+                .setEvidence(evidence);
+    }
+
+    private static List<String> loadFile(String file) {
         /*
          * ZAP will have already extracted the file from the add-on and put it underneath the 'ZAP home' directory
          */
@@ -243,5 +246,10 @@ public class ExampleFileActiveScanRule extends AbstractAppParamPlugin {
     public int getWascId() {
         // The WASC ID
         return 0;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(createAlert("foo", "<SCRIPT>a=/XSS/", "<SCRIPT>a=/XSS/").build());
     }
 }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanRule.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.ascanrulesAlpha;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,7 +40,8 @@ import org.zaproxy.zap.model.TechSet;
  *
  * @author psiinon
  */
-public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin {
+public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin
+        implements CommonActiveScanRuleInfo {
 
     // wasc_10 is Denial of Service - well, its just an example ;)
     private static final Vulnerability VULN = Vulnerabilities.getDefault().get("wasc_10");
@@ -59,8 +61,7 @@ public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin {
 
     @Override
     public String getName() {
-        // Strip off the "Example Active Scan Rule: " part if implementing a real one ;)
-        return "Example Active Scan Rule: " + VULN.getName();
+        return Constant.messages.getString("ascanalpha.examplesimple.name");
     }
 
     @Override
@@ -118,18 +119,17 @@ public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin {
             // For this example we're just going to raise the alert at random!
 
             if (rnd.nextInt(10) == 0) {
-                newAlert()
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setParam(param)
-                        .setAttack(value)
-                        .setMessage(testMsg)
-                        .raise();
+                createAlert(param, attack).setMessage(testMsg).raise();
                 return;
             }
 
         } catch (IOException e) {
             LOGGER.error(e.getMessage(), e);
         }
+    }
+
+    private AlertBuilder createAlert(String param, String attack) {
+        return newAlert().setConfidence(Alert.CONFIDENCE_MEDIUM).setParam(param).setAttack(attack);
     }
 
     @Override
@@ -147,5 +147,10 @@ public class ExampleSimpleActiveScanRule extends AbstractAppParamPlugin {
     public int getWascId() {
         // The WASC ID
         return 0;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(createAlert("foo", "attack").build());
     }
 }

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -9,14 +9,14 @@ Active Scan Rules - Alpha
 <H1>Active Scan Rules - Alpha</H1>
 The following alpha status active scan rules are included in this add-on:
 
-<H2>An example active scan rule which loads data from a file</H2>
+<H2 id="id-60101">An example active scan rule which loads data from a file</H2>
 This implements an example active scan rule that loads strings from a file that the user can edit.<br>
 For more details see: 
 <a href="https://www.zaproxy.org/blog/2014-04-30-hacking-zap-4-active-scan-rules/">Hacking ZAP Part 4: Active Scan Rules</a>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanRule.java">ExampleFileActiveScanRule.java</a>
 
-<H2>Example Active Scan Rule: Denial of Service</H2>
+<H2 id="id-60100">Example Active Scan Rule: Denial of Service</H2>
 This implements a very simple example active scan rule.<br>
 For more details see: 
 <a href="https://www.zaproxy.org/blog/2014-04-30-hacking-zap-4-active-scan-rules/">Hacking ZAP Part 4: Active Scan Rules</a>.

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -6,6 +6,8 @@ ascanalpha.examplefile.other = This is for information that doesnt fit in any of
 ascanalpha.examplefile.refs = https://www.zaproxy.org/blog/2014-04-30-hacking-zap-4-active-scan-rules/
 ascanalpha.examplefile.soln = A general description of how to solve the problem.
 
+ascanalpha.examplesimple.name = Example Active Scan Rule: Denial of Service
+
 #ascanalpha.ldapinjection.alert.attack=[{0}] field [{1}] set to [{2}]
 ascanalpha.ldapinjection.alert.attack = parameter [{0}] set to [{1}]
 #ascanalpha.ldapinjection.alert.extrainfo=[{0}] field [{1}] on [{2}] [{3}] may be vulnerable to LDAP injection, using an attack with LDAP meta-characters [{4}], yielding known [{5}] error message [{6}], which was not present in the original response.

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanRuleUnitTest.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+
+class ExampleFileActiveScanRuleUnitTest extends ActiveScannerTest<ExampleFileActiveScanRule> {
+
+    @Override
+    protected ExampleFileActiveScanRule createScanner() {
+        return new ExampleFileActiveScanRule();
+    }
+
+    @Test
+    void shouldHaveExpectedExample() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts, hasSize(1));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getParam(), is(equalTo("foo")));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
+    }
+}

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanRuleUnitTest.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+
+class ExampleSimpleActiveScanRuleUnitTest extends ActiveScannerTest<ExampleSimpleActiveScanRule> {
+
+    @Override
+    protected ExampleSimpleActiveScanRule createScanner() {
+        return new ExampleSimpleActiveScanRule();
+    }
+
+    @Test
+    void shouldHaveExpectedExample() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts, hasSize(1));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getParam(), is(equalTo("foo")));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
+    }
+}

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Log exception details in Out of Band XSS scan rule.
+- Maintenance changes.
 
 ## [55] - 2024-09-02
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
@@ -426,7 +426,7 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin
                         .build());
     }
 
-    private boolean isEmptyResponse(byte[] response) {
+    private static boolean isEmptyResponse(byte[] response) {
         return response.length == 0;
     }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
@@ -242,7 +242,7 @@ public class HttpParameterPollutionScanRule extends AbstractAppPlugin
      * @param url found in the body of the targeted page
      * @return a hashmap of the query string
      */
-    private Map<String, List<String>> getUrlParameters(String url) {
+    private static Map<String, List<String>> getUrlParameters(String url) {
         Map<String, List<String>> params = new HashMap<>();
 
         if (url != null) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
@@ -85,7 +85,7 @@ public class IntegerOverflowScanRule extends AbstractAppParamPlugin
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
-    private String getError(char c) {
+    private static String getError(char c) {
         return Constant.messages.getString(MESSAGE_PREFIX + "error" + c);
     }
 
@@ -145,7 +145,7 @@ public class IntegerOverflowScanRule extends AbstractAppParamPlugin
         return ALERT_TAGS;
     }
 
-    private String randomIntegerString(int length) {
+    private static String randomIntegerString(int length) {
 
         int numbercounter = 0;
         int character = 0;
@@ -169,7 +169,7 @@ public class IntegerOverflowScanRule extends AbstractAppParamPlugin
         return sb1.toString();
     }
 
-    private String singleString(int length, char c) // Single Character String
+    private static String singleString(int length, char c) // Single Character String
             {
 
         int numbercounter = 0;
@@ -241,7 +241,7 @@ public class IntegerOverflowScanRule extends AbstractAppParamPlugin
                 .setUri(url)
                 .setParam(param)
                 .setAttack(attack)
-                .setOtherInfo(this.getError(type))
+                .setOtherInfo(getError(type))
                 .setEvidence(evidence);
     }
 }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
@@ -765,7 +765,7 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin implements Common
         }
     }
 
-    private String getPath(URI uri) {
+    private static String getPath(URI uri) {
         String path = uri.getEscapedPath();
         if (path != null) {
             return path;

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -645,7 +645,7 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin
                 .setEvidence(evidence);
     }
 
-    private Matcher matchStyles(String body) {
+    private static Matcher matchStyles(String body) {
         // remove all " and ' for proper matching url('somefile.png')
         String styleBody = body.replaceAll("['\"]", "");
         return STYLE_URL_LOAD.matcher(styleBody);

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
@@ -1317,7 +1317,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin implements Common
      * @param cookieName
      * @return the HtmlParameter representing the cookie, or null if no matching cookie was found
      */
-    private HtmlParameter getResponseCookie(HttpMessage message, String cookieName) {
+    private static HtmlParameter getResponseCookie(HttpMessage message, String cookieName) {
         TreeSet<HtmlParameter> cookieBackParams = message.getResponseHeader().getCookieParams();
         if (cookieBackParams.isEmpty()) {
             // no cookies

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieScanRule.java
@@ -212,7 +212,7 @@ public class SlackerCookieScanRule extends AbstractAppPlugin implements CommonAc
         return newAlert().setRisk(risk).setConfidence(Alert.CONFIDENCE_LOW).setOtherInfo(otherInfo);
     }
 
-    private StringBuilder createOtherInfoText(
+    private static StringBuilder createOtherInfoText(
             Set<String> cookiesThatMakeADifference, Set<String> cookiesThatDoNOTMakeADifference) {
 
         StringBuilder otherInfoBuff =
@@ -228,7 +228,7 @@ public class SlackerCookieScanRule extends AbstractAppPlugin implements CommonAc
         return otherInfoBuff;
     }
 
-    private void listCookies(Set<String> cookieSet, StringBuilder otherInfoBuff) {
+    private static void listCookies(Set<String> cookieSet, StringBuilder otherInfoBuff) {
         Iterator<String> itYes = cookieSet.iterator();
         while (itYes.hasNext()) {
             formatCookiesList(otherInfoBuff, itYes);
@@ -236,7 +236,7 @@ public class SlackerCookieScanRule extends AbstractAppPlugin implements CommonAc
         otherInfoBuff.append(getEOL());
     }
 
-    private int calculateRisk(
+    private static int calculateRisk(
             Set<String> cookiesThatDoNOTMakeADifference, StringBuilder otherInfoBuff) {
         int riskLevel = Alert.RISK_INFO;
         for (String cookie : cookiesThatDoNOTMakeADifference) {
@@ -252,27 +252,28 @@ public class SlackerCookieScanRule extends AbstractAppPlugin implements CommonAc
         return riskLevel;
     }
 
-    private String getSessionDestroyedText(String cookie) {
+    private static String getSessionDestroyedText(String cookie) {
         return Constant.messages.getString("ascanbeta.cookieslack.session.destroyed", cookie);
     }
 
-    private String getAffectResponseYes() {
+    private static String getAffectResponseYes() {
         return Constant.messages.getString("ascanbeta.cookieslack.affect.response.yes");
     }
 
-    private String getAffectResponseNo() {
+    private static String getAffectResponseNo() {
         return Constant.messages.getString("ascanbeta.cookieslack.affect.response.no");
     }
 
-    private String getSeparator() {
+    private static String getSeparator() {
         return Constant.messages.getString("ascanbeta.cookieslack.separator");
     }
 
-    private String getEOL() {
+    private static String getEOL() {
         return Constant.messages.getString("ascanbeta.cookieslack.endline");
     }
 
-    private void formatCookiesList(StringBuilder otherInfoBuff, Iterator<String> cookieIterator) {
+    private static void formatCookiesList(
+            StringBuilder otherInfoBuff, Iterator<String> cookieIterator) {
 
         otherInfoBuff.append(cookieIterator.next());
         if (cookieIterator.hasNext()) {
@@ -280,7 +281,7 @@ public class SlackerCookieScanRule extends AbstractAppPlugin implements CommonAc
         }
     }
 
-    private String getSessionCookieWarning(String cookie) {
+    private static String getSessionCookieWarning(String cookie) {
         return Constant.messages.getString("ascanbeta.cookieslack.session.warning", cookie);
     }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -448,7 +448,7 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
      * @param fileExtension
      * @return
      */
-    private boolean dataMatchesExtension(byte[] data, String fileExtension) {
+    private static boolean dataMatchesExtension(byte[] data, String fileExtension) {
         if (fileExtension != null) {
             if (fileExtension.equals("JSP")) {
                 if (PATTERN_JSP.matcher(new String(data)).find()) return true;
@@ -502,7 +502,7 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
      * @param b
      * @return
      */
-    private int calcLengthMatchPercentage(int a, int b) {
+    private static int calcLengthMatchPercentage(int a, int b) {
         if (a == 0 && b == 0) return 100;
         if (a == 0 || b == 0) return 0;
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
@@ -107,7 +107,7 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin
         return VULN.getReferencesAsString();
     }
 
-    private String getEvidence(String filename, String gitURIs) {
+    private static String getEvidence(String filename, String gitURIs) {
         return Constant.messages.getString(
                 "ascanbeta.sourcecodedisclosure.gitbased.evidence", filename, gitURIs);
     }
@@ -158,7 +158,7 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin
      * @param fileExtension
      * @return
      */
-    private boolean dataMatchesExtension(byte[] data, String fileExtension) {
+    private static boolean dataMatchesExtension(byte[] data, String fileExtension) {
         if (fileExtension != null) {
             if (fileExtension.equals("JSP")) {
                 if (PATTERN_JSP.matcher(new String(data)).find()) return true;

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
@@ -730,7 +730,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin
         return hirshberg.getLCS(a, b);
     }
 
-    private boolean shouldContinue(List<Context> contextList) {
+    private static boolean shouldContinue(List<Context> contextList) {
         boolean hasAuth = false;
         for (Context context : contextList) {
             if (context.getAuthenticationMethod() instanceof FormBasedAuthenticationMethod) {

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRuleUnitTest.java
@@ -370,7 +370,7 @@ class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRule> {
         return msg;
     }
 
-    private void setUpHttpSessionsParam() {
+    private static void setUpHttpSessionsParam() {
         HttpSessionsParam sessionOptions = new HttpSessionsParam();
         sessionOptions.load(new ZapXmlConfiguration());
         Model.getSingleton().getOptionsParam().addParamSet(sessionOptions);
@@ -385,7 +385,7 @@ class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRule> {
                         + "></input></form></html>");
     }
 
-    private HtmlParameter getCookieAs(String cookieName) {
+    private static HtmlParameter getCookieAs(String cookieName) {
         return new HtmlParameter(
                 HtmlParameter.Type.cookie, cookieName, "FF4F838FDA9E1974DEEB4020AB6127FD");
     }

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Rename Mac OSX salted SHA-1 in the Hash Disclosure scan rule to "Salted SHA-1", reduce the associated alerts to Low risk and Low confidence, to align with other SHA related patterns it will only be evaluated a Low Threshold. (Note such matches may indicate leaks related but not limited to: MacOS X, Oracle, Tiger-192, Haval-192) (Issue 8624).
 - The Insecure JSF ViewState now includes example alert functionality for documentation generation purposes (Issue 6119).
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRule.java
@@ -144,8 +144,8 @@ public class AntiClickjackingScanRule extends PluginPassiveScanner
                 .setSolution(getAlertElement(currentVT, "soln"))
                 .setReference(getAlertElement(currentVT, "refs"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId())
+                .setCweId(1021) // CWE-1021: Improper Restriction of Rendered UI Layers or Frames
+                .setWascId(15) // WASC-15: Application Misconfiguration
                 .setAlertRef(PLUGIN_ID + "-" + currentVT.getRef());
     }
 
@@ -164,15 +164,7 @@ public class AntiClickjackingScanRule extends PluginPassiveScanner
         return ALERT_TAGS;
     }
 
-    public int getCweId() {
-        return 1021; //  CWE-1021: Improper Restriction of Rendered UI Layers or Frames
-    }
-
-    public int getWascId() {
-        return 15; // WASC-15: Application Misconfiguration
-    }
-
-    private String getAlertElement(VulnType currentVT, String element) {
+    private static String getAlertElement(VulnType currentVT, String element) {
         switch (currentVT) {
             case XFO_MISSING:
                 return Constant.messages.getString(MESSAGE_PREFIX + "missing." + element);
@@ -197,7 +189,7 @@ public class AntiClickjackingScanRule extends PluginPassiveScanner
      *     {@code null}.
      * @see <a href="https://tools.ietf.org/html/rfc7034#section-4">RFC 7034 Section 4</a>
      */
-    private String getMetaXFOEvidence(Source source) {
+    private static String getMetaXFOEvidence(Source source) {
         List<Element> metaElements = source.getAllElements(HTMLElementName.META);
         String httpEquiv;
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/BigRedirectsScanRule.java
@@ -100,7 +100,7 @@ public class BigRedirectsScanRule extends PluginPassiveScanner
      * @param redirectURILength the length of the URI in the redirect response Location header
      * @return predictedResponseSize
      */
-    private int getPredictedResponseSize(int redirectURILength) {
+    private static int getPredictedResponseSize(int redirectURILength) {
         int predictedResponseSize = redirectURILength + 300;
         LOGGER.debug("Original Response Location Header URI Length: {}", redirectURILength);
         LOGGER.debug("Predicted Response Size: {}", predictedResponseSize);
@@ -111,7 +111,7 @@ public class BigRedirectsScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setSolution(getSolution())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setCweId(201)
                 .setWascId(13)
                 .setAlertRef(String.valueOf(PLUGIN_ID) + ref);
@@ -153,10 +153,6 @@ public class BigRedirectsScanRule extends PluginPassiveScanner
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
@@ -84,15 +84,15 @@ public class CacheControlScanRule extends PluginPassiveScanner
             evidence = evidence.substring(1, evidence.length() - 1);
         }
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(CACHE_CONTROL_HEADER)
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(525)
+                .setWascId(13);
     }
 
     @Override
@@ -108,30 +108,6 @@ public class CacheControlScanRule extends PluginPassiveScanner
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getRisk() {
-        return Alert.RISK_INFO;
-    }
-
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    public int getCweId() {
-        return 525;
-    }
-
-    public int getWascId() {
-        return 13;
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
@@ -213,7 +213,7 @@ public class CharsetMismatchScanRule extends PluginPassiveScanner
     // FIX: This will match Atom and RSS feeds now, which set text/html but
     // use &lt;?xml&gt; in content
 
-    private boolean isResponseHTML(HttpMessage message, Source source) {
+    private static boolean isResponseHTML(HttpMessage message, Source source) {
         String contentType = message.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
         if (contentType == null) {
             return false;
@@ -224,12 +224,12 @@ public class CharsetMismatchScanRule extends PluginPassiveScanner
                 || contentType.indexOf("application/xhtml") != -1;
     }
 
-    private boolean isResponseXML(HttpMessage message, Source source) {
+    private static boolean isResponseXML(HttpMessage message, Source source) {
         // Return true if source or response is identified as XML
         return source.isXML() || message.getResponseHeader().isXml();
     }
 
-    private String getBodyContentCharset(String bodyContentType) {
+    private static String getBodyContentCharset(String bodyContentType) {
         // preconditions
         assert bodyContentType != null;
 
@@ -303,7 +303,7 @@ public class CharsetMismatchScanRule extends PluginPassiveScanner
         return 15; // WASC-15: Application Misconfiguration
     }
 
-    private String getExtraInfo(
+    private static String getExtraInfo(
             String firstCharset, String secondCharset, MismatchType mismatchType) {
 
         String extraInfo = "";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRule.java
@@ -87,7 +87,7 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner
         return getAlertAttribute("name");
     }
 
-    private String getAlertAttribute(String key) {
+    private static String getAlertAttribute(String key) {
         return Constant.messages.getString(MESSAGE_PREFIX + key);
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -376,7 +376,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         return false;
     }
 
-    private String getCspNoticesString(List<PolicyError> notices) {
+    private static String getCspNoticesString(List<PolicyError> notices) {
         if (notices.isEmpty()) {
             return "";
         }
@@ -431,7 +431,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
      * @param header The header field(s) to be found
      * @return list of the matched headers
      */
-    private List<String> getHeaderField(HttpMessage msg, String header) {
+    private static List<String> getHeaderField(HttpMessage msg, String header) {
         List<String> matchedHeaders = new ArrayList<>();
         String headers = msg.getResponseHeader().toString();
         String[] headerElements = headers.split("\\r\\n");
@@ -446,7 +446,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         return matchedHeaders;
     }
 
-    private List<String> getAllowedWildcardSources(String policyText) {
+    private static List<String> getAllowedWildcardSources(String policyText) {
 
         List<String> allowedSources = new ArrayList<>();
         Policy pol = Policy.parseSerializedCSP(policyText, PolicyErrorConsumer.ignored);
@@ -550,25 +550,9 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 693; // CWE-693: Protection Mechanism Failure
-    }
-
-    public int getWascId() {
-        return 15; // WASC-15: Application Misconfiguration
     }
 
     private AlertBuilder getBuilder(String name, String alertRef) {
@@ -577,10 +561,10 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                 .setName(alertName)
                 .setConfidence(Alert.CONFIDENCE_HIGH)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
-                .setSolution(getSolution())
-                .setReference(getReference())
-                .setCweId(getCweId())
-                .setWascId(getWascId())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
+                .setCweId(693) // CWE-693: Protection Mechanism Failure
+                .setWascId(15) // WASC-15: Application Misconfiguration
                 .setAlertRef(PLUGIN_ID + "-" + alertRef);
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
@@ -69,14 +69,14 @@ public class ContentTypeMissingScanRule extends PluginPassiveScanner
 
         return newAlert()
                 .setName(issue)
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(HttpHeader.CONTENT_TYPE)
-                .setSolution(getSolution())
-                .setReference(getReference())
-                .setCweId(getCweId())
-                .setWascId(getWascId())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
+                .setCweId(345) // CWE Id 345 - Insufficient Verification of Data Authenticity
+                .setWascId(12) // WASC Id 12 - Content Spoofing)
                 .setAlertRef(alertRef);
     }
 
@@ -85,33 +85,9 @@ public class ContentTypeMissingScanRule extends PluginPassiveScanner
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 345; // CWE Id 345 - Insufficient Verification of Data Authenticity
-    }
-
-    public int getWascId() {
-        return 12; // WASC Id 12 - Content Spoofing
-    }
-
-    public int getRisk() {
-        return Alert.RISK_INFO;
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -84,17 +84,17 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner
 
     private AlertBuilder buildAlert(HttpMessage msg, String headerValue) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(CookieUtils.getCookieName(headerValue))
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(
                         CookieUtils.getSetCookiePlusName(
                                 msg.getResponseHeader().toString(), headerValue))
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(1004) // CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag
+                .setWascId(13); // WASC-13: Info leakage
     }
 
     @Override
@@ -107,33 +107,9 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 1004; // CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag
-    }
-
-    public int getWascId() {
-        return 13; // WASC-13: Info leakage
-    }
-
-    public int getRisk() {
-        return Alert.RISK_LOW;
     }
 
     private Model getModel() {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -86,7 +86,7 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner
      * Determines whether the specified cookie is loosely scoped by
      * checking it's Domain attribute value against the host
      */
-    private boolean isLooselyScopedCookie(HttpCookie cookie, String host) {
+    private static boolean isLooselyScopedCookie(HttpCookie cookie, String host) {
         // preconditions
         assert cookie != null;
         assert host != null;
@@ -138,7 +138,8 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner
         return true;
     }
 
-    private boolean isCookieAndHostHaveTheSameDomain(String[] cookieDomains, String[] hostDomains) {
+    private static boolean isCookieAndHostHaveTheSameDomain(
+            String[] cookieDomains, String[] hostDomains) {
         if (cookieDomains == null
                 || hostDomains == null
                 || cookieDomains[0].equalsIgnoreCase("null")
@@ -168,15 +169,15 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner
         }
 
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(
                         Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", host, sbCookies))
-                .setSolution(getSolution())
-                .setReference(getReference())
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
+                .setCweId(565) // CWE-565: Reliance on Cookies without Validation and Integrity)
+                .setWascId(15); // WASC-15: Application Misconfiguration)
     }
 
     @Override
@@ -193,37 +194,9 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner
         return 90033;
     }
 
-    public int getRisk() {
-        return Alert.RISK_INFO;
-    }
-
-    /*
-     * Rule-associated messages
-     */
-
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 565; // CWE-565: Reliance on Cookies without Validation and Integrity
-    }
-
-    public int getWascId() {
-        return 15; // WASC-15: Application Misconfiguration)
     }
 
     private Model getModel() {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
@@ -92,20 +92,20 @@ public class CookieSameSiteScanRule extends PluginPassiveScanner
 
     private AlertBuilder buildAlert(String responseHeader, String cookieHeaderValue) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setParam(CookieUtils.getCookieName(cookieHeaderValue))
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(CookieUtils.getSetCookiePlusName(responseHeader, cookieHeaderValue))
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(1275) // CWE-1275: Sensitive Cookie with Improper SameSite Attribute
+                .setWascId(13); // WASC Id - Info leakage
     }
 
     private AlertBuilder buildMissingAlert(String responseHeader, String cookieHeaderValue) {
         return buildAlert(responseHeader, cookieHeaderValue)
                 .setName(getName())
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setAlertRef(PLUGIN_ID + "-1");
     }
 
@@ -128,38 +128,14 @@ public class CookieSameSiteScanRule extends PluginPassiveScanner
         return PLUGIN_ID;
     }
 
-    public int getRisk() {
-        return Alert.RISK_LOW;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 1275; // CWE-1275: Sensitive Cookie with Improper SameSite Attribute
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
@@ -89,17 +89,18 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner
 
     private AlertBuilder buildAlert(HttpMessage msg, String headerValue) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(CookieUtils.getCookieName(headerValue))
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(
                         CookieUtils.getSetCookiePlusName(
                                 msg.getResponseHeader().toString(), headerValue))
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(614) // CWE-614: Sensitive Cookie in HTTPS Session Without 'Secure'
+                // Attribute
+                .setWascId(13); // WASC-13: Info leakage;
     }
 
     @Override
@@ -107,38 +108,14 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner
         return PLUGIN_ID;
     }
 
-    public int getRisk() {
-        return Alert.RISK_LOW;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 614; // CWE-614: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-    }
-
-    public int getWascId() {
-        return 13; // WASC-13: Info leakage
     }
 
     private Model getModel() {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
@@ -139,15 +139,15 @@ public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner
 
     private AlertBuilder buildAlert(String evidence) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "extrainfo"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(264) // CWE 264: Permissions, Privileges, and Access Controls
+                .setWascId(14); // WASC-14: Server Misconfiguration
     }
 
     private static String extractEvidence(String header, String headerName) {
@@ -155,21 +155,9 @@ public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner
         return header.substring(start, header.indexOf("\r", start));
     }
 
-    public int getRisk() {
-        return Alert.RISK_MEDIUM;
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 264; // CWE 264: Permissions, Privileges, and Access Controls
-    }
-
-    public int getWascId() {
-        return 14; // WASC-14: Server Misconfiguration
     }
 
     /**
@@ -180,15 +168,6 @@ public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner
     @Override
     public int getPluginId() {
         return 10098;
-    }
-
-    /**
-     * get the description of the alert
-     *
-     * @return
-     */
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
@@ -87,14 +87,15 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner
 
     private AlertBuilder createAlert(String crossDomainScript, String evidence) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(crossDomainScript)
-                .setSolution(getSolution())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(829) // CWE Id 829 - Inclusion of Functionality from Untrusted Control
+                // Sphere
+                .setWascId(15); // WASC-15: Application Misconfiguration
     }
 
     private void raiseAlert(HttpMessage msg, int id, String crossDomainScript, String evidence) {
@@ -115,34 +116,14 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner
         return PLUGIN_ID;
     }
 
-    public int getRisk() {
-        return Alert.RISK_LOW;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 829; // CWE Id 829 - Inclusion of Functionality from Untrusted Control Sphere
-    }
-
-    public int getWascId() {
-        return 15; // WASC-15: Application Misconfiguration)
     }
 
     private Model getModel() {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -208,12 +208,12 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner
         LOGGER.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
     }
 
-    private String getExtraInfo(String tokenNamesFlattened, String formDetails) {
+    private static String getExtraInfo(String tokenNamesFlattened, String formDetails) {
         return Constant.messages.getString(
                 "pscanrules.noanticsrftokens.alert.extrainfo", tokenNamesFlattened, formDetails);
     }
 
-    private boolean formOnIgnoreList(Element formElement, List<String> ignoreList) {
+    private static boolean formOnIgnoreList(Element formElement, List<String> ignoreList) {
         String id = formElement.getAttributeValue("id");
         String name = formElement.getAttributeValue("name");
         for (String ignore : ignoreList) {
@@ -235,42 +235,22 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner
         return Constant.messages.getString("pscanrules.noanticsrftokens.name");
     }
 
-    public String getDescription() {
-        return VULN.getDescription();
-    }
-
-    public String getSolution() {
-        return VULN.getSolution();
-    }
-
-    public String getReference() {
-        return VULN.getReferencesAsString();
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 352; // CWE-352: Cross-Site Request Forgery (CSRF)
-    }
-
-    public int getWascId() {
-        return 9;
     }
 
     private AlertBuilder buildAlert(int risk, String desc, String extraInfo, String evidence) {
         return newAlert()
                 .setRisk(risk)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(desc + "\n" + getDescription())
+                .setDescription(desc + "\n" + VULN.getDescription())
                 .setOtherInfo(extraInfo)
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(VULN.getSolution())
+                .setReference(VULN.getReferencesAsString())
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(352) // CWE-352: Cross-Site Request Forgery (CSRF)
+                .setWascId(9);
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRule.java
@@ -116,10 +116,10 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner
                 .setName(getName())
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
-                .setOtherInfo(getExtraInfo(server))
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", server))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
                 .setCweId(548) // Information Exposure Through Directory Listing
                 .setWascId(16); // Directory Indexing
@@ -138,37 +138,6 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner
     @Override
     public int getPluginId() {
         return 10033;
-    }
-
-    /**
-     * get the description of the alert
-     *
-     * @return
-     */
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    /**
-     * get the solution for the alert
-     *
-     * @return
-     */
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    /**
-     * gets references for the alert
-     *
-     * @return
-     */
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private static String getExtraInfo(String server) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", server);
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
@@ -265,9 +265,12 @@ public class HashDisclosureScanRule extends PluginPassiveScanner
                 .setName(getName() + " - " + hashAlert.getDescription())
                 .setRisk(hashAlert.getRisk())
                 .setConfidence(hashAlert.getConfidence())
-                .setDescription(getDescription() + " - " + hashAlert.getDescription())
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(
+                        Constant.messages.getString(MESSAGE_PREFIX + "desc")
+                                + " - "
+                                + hashAlert.getDescription())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
                 .setCweId(200) // Information Exposure,
                 .setWascId(13); // Information Leakage
@@ -276,18 +279,6 @@ public class HashDisclosureScanRule extends PluginPassiveScanner
     @Override
     public int getPluginId() {
         return 10097;
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeartBleedScanRule.java
@@ -116,10 +116,12 @@ public class HeartBleedScanRule extends PluginPassiveScanner implements CommonPa
         return newAlert()
                 .setRisk(Alert.RISK_HIGH)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescription())
-                .setOtherInfo(getExtraInfo(fullVersionString))
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                MESSAGE_PREFIX + "extrainfo", fullVersionString))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(fullVersionString)
                 .setCweId(119) // CWE 119: Failure to Constrain Operations within the Bounds of a
                 // Memory Buffer
@@ -129,22 +131,6 @@ public class HeartBleedScanRule extends PluginPassiveScanner implements CommonPa
     @Override
     public int getPluginId() {
         return 10034;
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getExtraInfo(String opensslVersion) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", opensslVersion);
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
@@ -134,29 +134,9 @@ public class InfoPrivateAddressDisclosureScanRule extends PluginPassiveScanner
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
     }
 
     @Override
@@ -195,18 +175,14 @@ public class InfoPrivateAddressDisclosureScanRule extends PluginPassiveScanner
 
     private AlertBuilder createAlert(String otherInfo, String evidence) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(otherInfo)
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
-    }
-
-    public int getRisk() {
-        return Alert.RISK_LOW;
+                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setWascId(13); // WASC Id - Info leakage
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
@@ -105,33 +105,17 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
+    private static String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
 
-    public String getSolution() {
+    private static String getSolution() {
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    public int getRisk() {
-        return Alert.RISK_MEDIUM;
     }
 
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
     }
 
     private static final Pattern PATHSESSIONIDPATTERN =
@@ -177,7 +161,6 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
                                         getName(),
                                         getDescription(),
                                         getSolution(),
-                                        getRisk(),
                                         Alert.CONFIDENCE_HIGH,
                                         param.getValue(),
                                         param.getName(),
@@ -206,7 +189,6 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
                                 getName(),
                                 getDescription(),
                                 getSolution(),
-                                getRisk(),
                                 Alert.CONFIDENCE_HIGH,
                                 jsessMatcher.group(),
                                 "",
@@ -248,17 +230,17 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
     };
 
     // The name of this sub-alert
-    private String getRefererAlert() {
+    private static String getRefererAlert() {
         return Constant.messages.getString(MESSAGE_PREFIX + "referrer.alert");
     }
 
     // The description of this sub-alert
-    private String getRefererDescription() {
+    private static String getRefererDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "referrer.desc");
     }
 
     // The solution of this sub-alert
-    private String getRefererSolution() {
+    private static String getRefererSolution() {
         return Constant.messages.getString(MESSAGE_PREFIX + "referrer.soln");
     }
 
@@ -274,7 +256,6 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
      */
     private void checkSessionIDExposureTo3rdParty(HttpMessage msg, int id) throws URIException {
 
-        int risk = (msg.getRequestHeader().isSecure()) ? Alert.RISK_MEDIUM : Alert.RISK_LOW;
         String body = msg.getResponseBody().toString();
         String host = msg.getRequestHeader().getURI().getHost();
         String linkHostName;
@@ -290,11 +271,14 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
                                     getRefererAlert(),
                                     getRefererDescription(),
                                     getRefererSolution(),
-                                    risk,
                                     Alert.CONFIDENCE_MEDIUM,
                                     linkHostName,
                                     "",
                                     "-3")
+                            .setRisk(
+                                    msg.getRequestHeader().isSecure()
+                                            ? Alert.RISK_MEDIUM
+                                            : Alert.RISK_LOW)
                             .raise();
 
                     break; // Only need one
@@ -311,7 +295,6 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
                                 getName(),
                                 getDescription(),
                                 getSolution(),
-                                getRisk(),
                                 Alert.CONFIDENCE_HIGH,
                                 "1A530637289A03B07199A44E8D531427",
                                 "jsessionid",
@@ -322,7 +305,6 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
                                 getName(),
                                 getDescription(),
                                 getSolution(),
-                                getRisk(),
                                 Alert.CONFIDENCE_HIGH,
                                 "jsessionid=1A530637289A03B07199A44E8D531427",
                                 "",
@@ -333,7 +315,6 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
                                 getRefererAlert(),
                                 getRefererDescription(),
                                 getRefererSolution(),
-                                Alert.RISK_MEDIUM,
                                 Alert.CONFIDENCE_MEDIUM,
                                 "www.example.org",
                                 "",
@@ -346,22 +327,21 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
             String name,
             String desc,
             String soln,
-            int risk,
             int confidence,
             String evidence,
             String param,
             String alertRef) {
         return newAlert()
                 .setName(name)
-                .setRisk(risk)
+                .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(confidence)
                 .setDescription(desc)
                 .setSolution(soln)
-                .setReference(getReference())
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setParam(param)
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId())
+                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setWascId(13) // WASC Id - Info leakage
                 .setAlertRef(getPluginId() + alertRef);
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
@@ -75,13 +75,13 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
 
     private AlertBuilder buildAlert(String evidence) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
-                .setSolution(getSolution())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setWascId(13); // WASC Id - Info leakage
     }
 
     private String doesResponseContainsDebugErrorMessage(HttpBody body) {
@@ -99,7 +99,7 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
         return null;
     }
 
-    private List<String> loadFile(Path path) {
+    private static List<String> loadFile(Path path) {
         List<String> strings = new ArrayList<>();
         BufferedReader reader = null;
         File f = path.toFile();
@@ -133,34 +133,14 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
         this.errors = loadFile(path);
     }
 
-    public int getRisk() {
-        return Alert.RISK_LOW;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
@@ -99,21 +99,21 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner
         }
     }
 
-    private String getSsnOtherInfo() {
+    private static String getSsnOtherInfo() {
         return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo.ssn");
     }
 
     private AlertBuilder buildAlert(String param, String evidence, String other) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(param)
                 .setOtherInfo(other)
-                .setSolution(getSolution())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(200) // CWE Id 200 - Information Exposure)
+                .setWascId(13); // WASC Id - Info leakage
     }
 
     private static List<String> loadFile(String file) {
@@ -155,21 +155,9 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner
         return null;
     }
 
-    public int getRisk() {
-        return Alert.RISK_INFO;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
     @Override
@@ -177,30 +165,22 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner
         return ALERT_TAGS;
     }
 
-    public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
-    }
-
     @Override
     public int getPluginId() {
         return PLUGIN_ID;
     }
 
-    private boolean isEmailAddress(String emailAddress) {
+    private static boolean isEmailAddress(String emailAddress) {
         Matcher matcher = emailAddressPattern.matcher(emailAddress);
         return matcher.find();
     }
 
-    private boolean isCreditCard(String creditCard) {
+    private static boolean isCreditCard(String creditCard) {
         Matcher matcher = creditCardPattern.matcher(creditCard);
         return matcher.find();
     }
 
-    private boolean isUsSSN(String usSSN) {
+    private static boolean isUsSSN(String usSSN) {
         Matcher matcher = usSSNPattern.matcher(usSSN);
         return matcher.find();
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
@@ -102,11 +102,11 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
         }
     }
 
-    private String getSsnOtherInfo() {
+    private static String getSsnOtherInfo() {
         return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo.ssn");
     }
 
-    private boolean isRequestedURLSameDomainAsHTTPReferrer(String host, String referrerURL) {
+    private static boolean isRequestedURLSameDomainAsHTTPReferrer(String host, String referrerURL) {
         boolean result = false;
         if (referrerURL.startsWith("/")) {
             result = true;
@@ -126,32 +126,25 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
 
     private AlertBuilder buildAlert(String evidence, String other) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_INFO)
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setWascId(13) // WASC Id - Info leakage
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
                 .setOtherInfo(other)
-                .setSolution(getSolution())
-                .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setEvidence(evidence);
     }
 
     private AlertBuilder buildCcAlert(String evidence, String other, BinRecord binRec) {
         if (binRec != null) {
             other = other + '\n' + getBinRecString(binRec);
         }
-        return newAlert()
-                .setRisk(getRisk())
-                .setConfidence(binRec != null ? Alert.CONFIDENCE_HIGH : Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
-                .setOtherInfo(other)
-                .setSolution(getSolution())
-                .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+        return buildAlert(evidence, other)
+                .setConfidence(binRec != null ? Alert.CONFIDENCE_HIGH : Alert.CONFIDENCE_MEDIUM);
     }
 
-    private String getBinRecString(BinRecord binRec) {
+    private static String getBinRecString(BinRecord binRec) {
         StringBuilder recString = new StringBuilder(75);
         recString
                 .append(Constant.messages.getString(MESSAGE_PREFIX + "bin.field"))
@@ -175,7 +168,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
         return recString.toString();
     }
 
-    private List<String> loadFile(String file) {
+    private static List<String> loadFile(String file) {
         List<String> strings = new ArrayList<>();
         File f = new File(Constant.getZapHome() + File.separator + file);
         if (!f.exists()) {
@@ -221,21 +214,9 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
         return PLUGIN_ID;
     }
 
-    public int getRisk() {
-        return Alert.RISK_INFO;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
     @Override
@@ -243,15 +224,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
         return ALERT_TAGS;
     }
 
-    public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
-    }
-
-    private String doesContainEmailAddress(String emailAddress) {
+    private static String doesContainEmailAddress(String emailAddress) {
         Matcher matcher = emailAddressPattern.matcher(emailAddress);
         if (matcher.find()) {
             return matcher.group();
@@ -259,7 +232,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
         return null;
     }
 
-    private String doesContainCreditCard(String creditCard) {
+    private static String doesContainCreditCard(String creditCard) {
         Matcher matcher = creditCardPattern.matcher(creditCard);
         if (matcher.find()) {
             String candidate = matcher.group();
@@ -270,7 +243,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
         return null;
     }
 
-    private String doesContainUsSSN(String usSSN) {
+    private static String doesContainUsSSN(String usSSN) {
         Matcher matcher = usSSNPattern.matcher(usSSN);
         if (matcher.find()) {
             return matcher.group();

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
@@ -179,7 +179,7 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
         alertMap.computeIfAbsent(summary.getPattern(), k -> new ArrayList<>()).add(summary);
     }
 
-    private String truncateString(String str) {
+    private static String truncateString(String str) {
         if (str.length() > MAX_ELEMENT_CHRS_TO_REPORT) {
             return str.substring(0, MAX_ELEMENT_CHRS_TO_REPORT);
         }
@@ -188,13 +188,13 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
 
     private AlertBuilder createAlert(String detail, int confidence, String evidence) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_INFO)
                 .setConfidence(confidence)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(detail)
-                .setSolution(getSolution())
-                .setCweId(getCweId())
-                .setWascId(getWascId())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setCweId(200) // CWE Id 200 - Information Exposure)
+                .setWascId(13) // WASC Id - Info leakage)
                 .setEvidence(evidence);
     }
 
@@ -205,7 +205,7 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
         return patterns;
     }
 
-    private List<Pattern> initPatterns() {
+    private static List<Pattern> initPatterns() {
         List<Pattern> targetPatterns = new ArrayList<>();
         for (String payload : payloadProvider.get()) {
             targetPatterns.add(compilePayload(payload));
@@ -213,7 +213,7 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
         return targetPatterns;
     }
 
-    private Pattern compilePayload(String payload) {
+    private static Pattern compilePayload(String payload) {
         return Pattern.compile("\\b" + payload + "\\b", Pattern.CASE_INSENSITIVE);
     }
 
@@ -221,34 +221,14 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
         payloadProvider = provider == null ? DEFAULT_PAYLOAD_PROVIDER : provider;
     }
 
-    public int getRisk() {
-        return Alert.RISK_INFO;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
@@ -214,29 +214,9 @@ public class InsecureAuthenticationScanRule extends PluginPassiveScanner
         return Constant.messages.getString("pscanrules.insecureauthentication.name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString("pscanrules.insecureauthentication.desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString("pscanrules.insecureauthentication.soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString("pscanrules.insecureauthentication.refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 326; // CWE Id - Inadequate Encryption Strength
-    }
-
-    public int getWascId() {
-        return 4; // WASC Id - Insufficient Transport Layer Protection
     }
 
     @Override
@@ -283,12 +263,13 @@ public class InsecureAuthenticationScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(
+                        Constant.messages.getString("pscanrules.insecureauthentication.desc"))
+                .setSolution(Constant.messages.getString("pscanrules.insecureauthentication.soln"))
+                .setReference(Constant.messages.getString("pscanrules.insecureauthentication.refs"))
                 .setEvidence(HttpHeader.WWW_AUTHENTICATE + ": " + auth)
-                .setCweId(getCweId())
-                .setWascId(getWascId())
+                .setCweId(326) // CWE Id - Inadequate Encryption Strength
+                .setWascId(4) // WASC Id - Insufficient Transport Layer Protection
                 .setAlertRef(getPluginId() + "-2");
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRule.java
@@ -71,7 +71,7 @@ public class InsecureFormLoadScanRule extends PluginPassiveScanner
         }
     }
 
-    private boolean isHttps(HttpMessage msg) {
+    private static boolean isHttps(HttpMessage msg) {
         return HttpHeader.HTTPS.equals(msg.getRequestHeader().getURI().getScheme());
     }
 
@@ -81,7 +81,7 @@ public class InsecureFormLoadScanRule extends PluginPassiveScanner
 
     // TODO: these methods have been extracted from CharsetMismatchScanner
     // I think we should create helper methods for them
-    private boolean isResponseHTML(HttpMessage message, Source source) {
+    private static boolean isResponseHTML(HttpMessage message, Source source) {
         String contentType = message.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
         if (contentType == null) {
             return false;
@@ -96,9 +96,9 @@ public class InsecureFormLoadScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescriptionMessage())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(getExtraInfoMessage(url, formElement))
-                .setSolution(getSolutionMessage())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
                 .setCweId(319) // CWE-319: Cleartext Transmission of Sensitive Information
                 .setWascId(15); // WASC-15: Application Misconfiguration
@@ -107,14 +107,6 @@ public class InsecureFormLoadScanRule extends PluginPassiveScanner
     @Override
     public int getPluginId() {
         return 10041;
-    }
-
-    private String getDescriptionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolutionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
     private static String getExtraInfoMessage(String url, String formElement) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRule.java
@@ -71,7 +71,7 @@ public class InsecureFormPostScanRule extends PluginPassiveScanner
         }
     }
 
-    private boolean isHttps(HttpMessage msg) {
+    private static boolean isHttps(HttpMessage msg) {
         String scheme = msg.getRequestHeader().getURI().getScheme();
         if ("https".equals(scheme)) {
             return true;
@@ -86,7 +86,7 @@ public class InsecureFormPostScanRule extends PluginPassiveScanner
 
     // TODO: these methods have been extracted from CharsetMismatchScanner
     // I think we should create helper methods for them
-    private boolean isResponseHTML(HttpMessage message, Source source) {
+    private static boolean isResponseHTML(HttpMessage message, Source source) {
         String contentType = message.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
         if (contentType == null) {
             return false;
@@ -101,9 +101,9 @@ public class InsecureFormPostScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescriptionMessage())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(getExtraInfoMessage(url, formElement))
-                .setSolution(getSolutionMessage())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
                 .setCweId(319) // CWE-319: Cleartext Transmission of Sensitive Information
                 .setWascId(15); // WASC-15: Application Misconfiguration
@@ -112,14 +112,6 @@ public class InsecureFormPostScanRule extends PluginPassiveScanner
     @Override
     public int getPluginId() {
         return 10042;
-    }
-
-    private String getDescriptionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolutionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
     private static String getExtraInfoMessage(String url, String formElement) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
@@ -132,7 +132,7 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner
      * @return {@code true} if {@code viewState} is cryptographically secure, and {@code false}
      *     otherwise (there might be false positives and false negatives)
      */
-    private boolean isViewStateSecure(String viewState, String charset) {
+    private static boolean isViewStateSecure(String viewState, String charset) {
         if (viewState == null || viewState.equals("")) {
             return true;
         }
@@ -185,7 +185,7 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner
         return output.toByteArray();
     }
 
-    private boolean isRawViewStateSecure(String viewState) {
+    private static boolean isRawViewStateSecure(String viewState) {
         if (viewState == null || viewState.equals("")) {
             return true;
         }
@@ -216,7 +216,7 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner
 
     // jsf server side implementation in com.sun.faces.renderkit.ServerSideStateHelper
     // two id's separated by :
-    private boolean isViewStateStoredOnServer(String val) {
+    private static boolean isViewStateStoredOnServer(String val) {
         return val != null && val.contains(":");
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRule.java
@@ -141,9 +141,9 @@ public class LinkTargetScanRule extends PluginPassiveScanner implements CommonPa
         return newAlert()
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence);
     }
 
@@ -175,18 +175,6 @@ public class LinkTargetScanRule extends PluginPassiveScanner implements CommonPa
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
@@ -124,13 +124,13 @@ public class MixedContentScanRule extends PluginPassiveScanner
                 .setName(name)
                 .setRisk(risk)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(all)
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(first)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(311) // CWE Id 311 - Missing Encryption of Sensitive Data
+                .setWascId(4); // WASC Id 4 - Insufficient Transport Layer Protection
     }
 
     @Override
@@ -143,29 +143,9 @@ public class MixedContentScanRule extends PluginPassiveScanner
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 311; // CWE Id 311 - Missing Encryption of Sensitive Data
-    }
-
-    public int getWascId() {
-        return 4; // WASC Id 4 - Insufficient Transport Layer Protection
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java
@@ -93,23 +93,15 @@ public class ModernAppDetectionScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(otherInfo)
-                .setSolution(getSolution())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence);
     }
 
     @Override
     public int getPluginId() {
         return 10109;
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java
@@ -180,7 +180,7 @@ public class PiiScanRule extends PluginPassiveScanner implements CommonPassiveSc
                 .setWascId(13); // WASC-13: Information Leakage
     }
 
-    private String getBinRecString(BinRecord binRec) {
+    private static String getBinRecString(BinRecord binRec) {
         StringBuilder recString = new StringBuilder(75);
         recString
                 .append(Constant.messages.getString(MESSAGE_PREFIX + "bin.field"))

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PolyfillCdnScriptScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PolyfillCdnScriptScanRule.java
@@ -167,7 +167,7 @@ public class PolyfillCdnScriptScanRule extends PluginPassiveScanner
     private AlertBuilder createAlert(
             int confidence, String description, String param, String evidence, int alertRef) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_HIGH)
                 .setConfidence(confidence)
                 .setDescription(description)
                 .setParam(param)
@@ -196,10 +196,6 @@ public class PolyfillCdnScriptScanRule extends PluginPassiveScanner
     @Override
     public int getPluginId() {
         return PLUGIN_ID;
-    }
-
-    public int getRisk() {
-        return Alert.RISK_HIGH;
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRule.java
@@ -137,9 +137,9 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
                 // If compliant Other Info: "Age" header implies a HTTP/1.1 compliant cache server.
                 .setOtherInfo(
@@ -158,18 +158,6 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRule.java
@@ -193,7 +193,7 @@ public class StrictTransportSecurityScanRule extends PluginPassiveScanner
         return ALERT_TAGS;
     }
 
-    private String getAlertElement(VulnType currentVT, String element) {
+    private static String getAlertElement(VulnType currentVT, String element) {
         String elementValue = "";
         switch (currentVT) {
             case HSTS_MISSING:
@@ -234,7 +234,7 @@ public class StrictTransportSecurityScanRule extends PluginPassiveScanner
         return elementValue;
     }
 
-    private int getRisk(VulnType currentVT) {
+    private static int getRisk(VulnType currentVT) {
         switch (currentVT) {
             case HSTS_MISSING:
             case HSTS_MAX_AGE_DISABLED:
@@ -259,7 +259,7 @@ public class StrictTransportSecurityScanRule extends PluginPassiveScanner
      *     return {@code null}.
      * @see <a href="https://tools.ietf.org/html/rfc6797#section-8.5">RFC 6797 Section 8.5</a>
      */
-    private String getMetaHSTSEvidence(Source source) {
+    private static String getMetaHSTSEvidence(Source source) {
         List<Element> metaElements = source.getAllElements(HTMLElementName.META);
         String httpEquiv;
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -187,37 +187,24 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
             String timestampType, String evidence, String param, Date timestamp) {
         return newAlert()
                 .setName(getName() + " - " + timestampType)
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescription() + " - " + timestampType)
+                .setDescription(
+                        Constant.messages.getString(MESSAGE_PREFIX + "desc")
+                                + " - "
+                                + timestampType)
                 .setParam(param)
                 .setOtherInfo(getExtraInfo(evidence, timestamp))
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setWascId(13); // WASC Id - Info leakage
     }
 
     @Override
     public int getPluginId() {
         return 10096;
-    }
-
-    public int getRisk() {
-        return Alert.RISK_LOW;
-    }
-
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
     private static String getExtraInfo(String evidence, Date timestamp) {
@@ -228,14 +215,6 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCharsetScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCharsetScanRule.java
@@ -119,7 +119,7 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner
     }
 
     // TODO: taken from CharsetMismatchScanner. Extract into helper method
-    private String getBodyContentCharset(String bodyContentType) {
+    private static String getBodyContentCharset(String bodyContentType) {
         // preconditions
         assert bodyContentType != null;
 
@@ -176,7 +176,7 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner
 
     // TODO: these methods have been extracted from CharsetMismatchScanner
     // I think we should create helper methods for them
-    private boolean isResponseHTML(HttpMessage message, Source source) {
+    private static boolean isResponseHTML(HttpMessage message, Source source) {
         String contentType = message.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
         if (contentType == null) {
             return false;
@@ -187,7 +187,7 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner
                 || contentType.indexOf("application/xhtml") != -1;
     }
 
-    private boolean isResponseXML(Source source) {
+    private static boolean isResponseXML(Source source) {
         return source.isXML();
     }
 
@@ -195,10 +195,10 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescriptionMessage())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(param.getName())
                 .setOtherInfo(getExtraInfoMessage(tag, attr, param, charset))
-                .setSolution(getSolutionMessage())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setCweId(20) // CWE-20: Improper Input Validation
                 .setWascId(20); // WASC-20: Improper Input Handling
     }
@@ -216,15 +216,6 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner
     /*
      * Rule-associated messages
      */
-
-    private String getDescriptionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolutionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
     private static String getExtraInfoMessage(
             String tag, String attr, HtmlParameter param, String charset) {
         return Constant.messages.getString(

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCookieScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledCookieScanRule.java
@@ -99,7 +99,7 @@ public class UserControlledCookieScanRule extends PluginPassiveScanner
 
     // Cookies are commonly URL encoded, maybe other encodings.
     // TODO: apply other decodings?  htmlDecode, etc.
-    private String decodeCookie(String cookie, String charset) {
+    private static String decodeCookie(String cookie, String charset) {
         if (charset != null) {
             try {
                 return URLDecoder.decode(cookie, charset);
@@ -158,11 +158,11 @@ public class UserControlledCookieScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescriptionMessage())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(param.getName())
                 .setOtherInfo(getExtraInfoMessage(msg, param, cookie))
-                .setSolution(getSolutionMessage())
-                .setReference(getReferenceMessage())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setCweId(565) // CWE-565: Reliance on Cookies without Validation and Integrity
                 // Checking
                 .setWascId(20); // WASC-20: Improper Input Handling
@@ -178,23 +178,7 @@ public class UserControlledCookieScanRule extends PluginPassiveScanner
         return ALERT_TAGS;
     }
 
-    /*
-     * Rule-associated messages
-     */
-
-    private String getDescriptionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolutionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReferenceMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getExtraInfoMessage(HttpMessage msg, HtmlParameter param, String cookie) {
+    private static String getExtraInfoMessage(HttpMessage msg, HtmlParameter param, String cookie) {
         String introMessage = "";
         if ("GET".equalsIgnoreCase(msg.getRequestHeader().getMethod())) {
             introMessage = Constant.messages.getString(MESSAGE_PREFIX + "extrainfo.get");

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledHTMLAttributesScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledHTMLAttributesScanRule.java
@@ -232,7 +232,7 @@ public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner
 
     // TODO: these methods have been extracted from CharsetMismatchScanner
     // I think we should create helper methods for them
-    private boolean isResponseHTML(HttpMessage message, Source source) {
+    private static boolean isResponseHTML(HttpMessage message, Source source) {
         String contentType = message.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
         if (contentType == null) {
             return false;
@@ -252,13 +252,19 @@ public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescriptionMessage())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(param.getName())
                 .setOtherInfo(
-                        getExtraInfoMessage(
-                                url, htmlElement, htmlAttribute, param, userControlledValue))
-                .setSolution(getSolutionMessage())
-                .setReference(getReferenceMessage())
+                        Constant.messages.getString(
+                                MESSAGE_PREFIX + "extrainfo",
+                                url,
+                                htmlElement,
+                                htmlAttribute,
+                                param.getName(),
+                                param.getValue(),
+                                userControlledValue))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setCweId(20) // CWE-20: Improper Input Validation
                 .setWascId(20); // WASC-20: Improper Input Handling
     }
@@ -271,34 +277,6 @@ public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    /*
-     * Rule-associated messages
-     */
-
-    private String getDescriptionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolutionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReferenceMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getExtraInfoMessage(
-            String url, String tag, String attr, HtmlParameter param, String userControlledValue) {
-        return Constant.messages.getString(
-                MESSAGE_PREFIX + "extrainfo",
-                url,
-                tag,
-                attr,
-                param.getName(),
-                param.getValue(),
-                userControlledValue);
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledJavascriptEventScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledJavascriptEventScanRule.java
@@ -161,7 +161,7 @@ public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner
 
     // TODO: these methods have been extracted from CharsetMismatchScanner
     // I think we should create helper methods for them
-    private boolean isResponseHTML(HttpMessage message) {
+    private static boolean isResponseHTML(HttpMessage message) {
         String contentType = message.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
         if (contentType == null) {
             return false;
@@ -177,11 +177,17 @@ public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescriptionMessage())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(param.getName())
-                .setOtherInfo(getExtraInfoMessage(url, attribute, attributeValue, param))
-                .setSolution(getSolutionMessage())
-                .setReference(getReferenceMessage())
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                MESSAGE_PREFIX + "extrainfo",
+                                url,
+                                attribute,
+                                attributeValue,
+                                param.getValue()))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setCweId(20) // CWE-20: Improper Input Validation
                 .setWascId(20); // WASC-20: Improper Input Handling
     }
@@ -194,28 +200,6 @@ public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    /*
-     * Rule-associated messages
-     */
-
-    private String getDescriptionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolutionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReferenceMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getExtraInfoMessage(
-            String url, String attribute, String attributeValue, HtmlParameter param) {
-        return Constant.messages.getString(
-                MESSAGE_PREFIX + "extrainfo", url, attribute, attributeValue, param.getValue());
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledOpenRedirectScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UserControlledOpenRedirectScanRule.java
@@ -138,11 +138,11 @@ public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_HIGH)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescriptionMessage())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(paramName)
                 .setOtherInfo(getExtraInfoMessage(msg, paramName, paramValue, responseLocation))
-                .setSolution(getSolutionMessage())
-                .setReference(getReferenceMessage())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setCweId(601) // CWE-601: URL Redirection to Untrusted Site ('Open Redirect')
                 .setWascId(38); // WASC-38: URL Redirector Abuse
     }
@@ -157,23 +157,7 @@ public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner
         return ALERT_TAGS;
     }
 
-    /*
-     * Rule-associated messages
-     */
-
-    private String getDescriptionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolutionMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReferenceMessage() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getExtraInfoMessage(
+    private static String getExtraInfoMessage(
             HttpMessage msg, String paramName, String paramValue, String responseLocation) {
         StringBuilder extraInfoSB = new StringBuilder();
         if ("GET".equalsIgnoreCase(msg.getRequestHeader().getMethod())) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
@@ -119,15 +119,17 @@ public class UsernameIdorScanRule extends PluginPassiveScanner
     private AlertBuilder buildAlert(
             String username, String evidence, String hashType, int id, HttpMessage msg) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_HIGH)
-                .setDescription(getDescription(username))
-                .setOtherInfo(getOtherinfo(hashType, evidence))
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc", username))
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                MESSAGE_PREFIX + "otherinfo", hashType, evidence))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(284) // CWE-284: Improper Access Control
+                .setWascId(2); // WASC-02: Insufficient Authorization
     }
 
     @Override
@@ -147,42 +149,14 @@ public class UsernameIdorScanRule extends PluginPassiveScanner
         return PLUGIN_ID;
     }
 
-    public int getRisk() {
-        return Alert.RISK_INFO;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription(String username) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc", username);
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getOtherinfo(String hashType, String hashValue) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo", hashType, hashValue);
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 284; // CWE-284: Improper Access Control
-    }
-
-    public int getWascId() {
-        return 2; // WASC-02: Insufficient Authorization
     }
 
     public String match(String contents, Pattern pattern) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
@@ -82,68 +82,64 @@ public class ViewstateScanRule extends PluginPassiveScanner implements CommonPas
         if (v.isSplit()) alertSplitViewstate().raise();
     }
 
-    private AlertBuilder alertViewstateAnalyzerResult(ViewstateAnalyzerResult var) {
+    private AlertBuilder baseAlert() {
         return newAlert()
+                .setCweId(642) // CWE-642: External Control of Critical State Data)
+                .setWascId(14); // WASC-14 - Server Misconfiguration
+    }
+
+    private AlertBuilder alertViewstateAnalyzerResult(ViewstateAnalyzerResult var) {
+        return baseAlert()
                 .setName(var.pattern.getAlertHeader())
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(var.pattern.getAlertDescription())
                 .setOtherInfo(var.getResultExtract().toString())
-                .setSolution(getSolution())
-                .setCweId(getCweId())
-                .setWascId(getWascId())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setAlertRef(PLUGIN_ID + "-" + var.getAlertRef());
     }
 
     private AlertBuilder alertOldAspVersion() {
-        return newAlert()
+        return baseAlert()
                 .setName(Constant.messages.getString(MESSAGE_PREFIX + "oldver.name"))
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "oldver.desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "oldver.soln"))
-                .setCweId(getCweId())
-                .setWascId(getWascId())
                 .setAlertRef(PLUGIN_ID + "-3");
     }
 
     // TODO: see if this alert triggers too often, as the detection rule is far from being robust
     // for the moment
     private AlertBuilder alertNoMACUnsure() {
-        return newAlert()
+        return baseAlert()
                 .setName(Constant.messages.getString(MESSAGE_PREFIX + "nomac.unsure.name"))
                 .setRisk(Alert.RISK_HIGH)
                 .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "nomac.unsure.desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "nomac.unsure.soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "nomac.unsure.refs"))
-                .setCweId(getCweId())
-                .setWascId(getWascId())
                 .setAlertRef(PLUGIN_ID + "-4");
     }
 
     private AlertBuilder alertNoMACforSure() {
-        return newAlert()
+        return baseAlert()
                 .setName(Constant.messages.getString(MESSAGE_PREFIX + "nomac.sure.name"))
                 .setRisk(Alert.RISK_HIGH)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "nomac.sure.desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "nomac.sure.soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "nomac.sure.refs"))
-                .setCweId(getCweId())
-                .setWascId(getWascId())
                 .setAlertRef(PLUGIN_ID + "-5");
     }
 
     private AlertBuilder alertSplitViewstate() {
-        return newAlert()
+        return baseAlert()
                 .setName(Constant.messages.getString(MESSAGE_PREFIX + "split.name"))
                 .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "split.desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "split.soln"))
-                .setCweId(getCweId())
-                .setWascId(getWascId())
                 .setAlertRef(PLUGIN_ID + "-6");
     }
 
@@ -185,24 +181,12 @@ public class ViewstateScanRule extends PluginPassiveScanner implements CommonPas
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }
 
-    public int getCweId() {
-        return 642; // CWE-642: External Control of Critical State Data
-    }
-
-    public int getWascId() {
-        return 14; // WASC-14 - Server Misconfiguration
-    }
-
-    private Map<String, StartTag> getHiddenFields(Source source) {
+    private static Map<String, StartTag> getHiddenFields(Source source) {
         List<StartTag> result = source.getAllStartTags("input");
 
         // Searching for name only tags only makes sense for Asp.Net 1.1 websites

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
@@ -65,24 +65,21 @@ public class XAspNetVersionScanRule extends PluginPassiveScanner
 
     private AlertBuilder createAlert(String evidence) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_HIGH)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "extrainfo"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(
+                        933) // CWE-933: OWASP Top Ten 2013 Category A5 - Security Misconfiguration
+                .setWascId(14); //  WASC-14: Server Misconfiguration);
     }
 
     @Override
     public int getPluginId() {
         return 10061;
-    }
-
-    public int getRisk() {
-        return Alert.RISK_LOW;
     }
 
     @Override
@@ -93,14 +90,6 @@ public class XAspNetVersionScanRule extends PluginPassiveScanner
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 933; // CWE-933: OWASP Top Ten 2013 Category A5 - Security Misconfiguration
-    }
-
-    public int getWascId() {
-        return 14; //  WASC-14: Server Misconfiguration
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRule.java
@@ -67,8 +67,8 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
-                .setSolution(getSolution())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
                 .setCweId(200)
                 .setWascId(13);
@@ -82,14 +82,6 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java
@@ -83,19 +83,7 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getOtherInfo(String headerValue) {
+    private static String getOtherInfo(String headerValue) {
         try {
             byte[] decodedByteArray = Base64.getDecoder().decode(headerValue);
             return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo.msg")
@@ -117,10 +105,10 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner
         return newAlert()
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_HIGH)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(getOtherInfo(xcldField))
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(xcldField)
                 .setCweId(200)
                 .setWascId(13);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
@@ -84,13 +84,13 @@ public class XContentTypeOptionsScanRule extends PluginPassiveScanner
 
     private AlertBuilder buildAlert(String xContentTypeOption) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setParam(HttpHeader.X_CONTENT_TYPE_OPTIONS)
-                .setOtherInfo(getOtherInfo())
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "otherinfo"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(xContentTypeOption)
                 .setCweId(getCweId())
                 .setWascId(getWascId());
@@ -104,26 +104,6 @@ public class XContentTypeOptionsScanRule extends PluginPassiveScanner
     @Override
     public int getPluginId() {
         return PLUGIN_ID;
-    }
-
-    public int getRisk() {
-        return Alert.RISK_LOW;
-    }
-
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getOtherInfo() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
@@ -70,12 +70,12 @@ public class XDebugTokenScanRule extends PluginPassiveScanner implements CommonP
 
     private AlertBuilder buildAlert(String evidence) {
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_HIGH)
-                .setDescription(getDescription())
-                .setOtherInfo(getOtherInfo())
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "otherinfo"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
                 .setCweId(getCweId())
                 .setWascId(getWascId());
@@ -88,7 +88,7 @@ public class XDebugTokenScanRule extends PluginPassiveScanner implements CommonP
      * @param header the name of the header field being looked for
      * @return boolean status of existence
      */
-    private boolean responseHasHeader(HttpMessage msg, String header) {
+    private static boolean responseHasHeader(HttpMessage msg, String header) {
         return !msg.getResponseHeader().getHeaderValues(header).isEmpty();
     }
 
@@ -99,7 +99,7 @@ public class XDebugTokenScanRule extends PluginPassiveScanner implements CommonP
      * @param header the name of the header field(s) to be collected
      * @return list of the matched headers
      */
-    private List<String> getHeaders(HttpMessage msg, String header) {
+    private static List<String> getHeaders(HttpMessage msg, String header) {
         List<String> matchedHeaders = new ArrayList<>();
         String headers = msg.getResponseHeader().toString();
         String[] headerElements = headers.split("\\r\\n");
@@ -119,29 +119,9 @@ public class XDebugTokenScanRule extends PluginPassiveScanner implements CommonP
         return PLUGIN_ID;
     }
 
-    public int getRisk() {
-        return Alert.RISK_LOW;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    public String getOtherInfo() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo");
-    }
-
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
     @Override

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
@@ -69,7 +69,7 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner
      * @param msg Response Http message
      * @return boolean status of existence
      */
-    private boolean isXPoweredByHeaderExist(HttpMessage msg) {
+    private static boolean isXPoweredByHeaderExist(HttpMessage msg) {
         return !msg.getResponseHeader().getHeaderValues(HEADER_NAME).isEmpty();
     }
 
@@ -79,7 +79,7 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner
      * @param msg Response Http message
      * @return list of the matched headers
      */
-    private List<String> getXPoweredByHeaders(HttpMessage msg) {
+    private static List<String> getXPoweredByHeaders(HttpMessage msg) {
         List<String> matchedHeaders = new ArrayList<>();
         String headers = msg.getResponseHeader().toString();
         String[] headerElements = headers.split("\\r\\n");
@@ -107,15 +107,15 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner
             alertOtherInfo = sb.toString();
         }
         return newAlert()
-                .setRisk(getRisk())
+                .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(alertOtherInfo)
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(alertEvidence)
-                .setCweId(getCweId())
-                .setWascId(getWascId());
+                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setWascId(13); // WASC Id - Info leakage
     }
 
     @Override
@@ -123,38 +123,14 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner
         return PLUGIN_ID;
     }
 
-    public int getRisk() {
-        return Alert.RISK_LOW;
-    }
-
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
-    }
-
-    public int getWascId() {
-        return 13; // WASC Id - Info leakage
     }
 
     @Override

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/AntiClickjackingScanRuleUnitTest.java
@@ -51,12 +51,8 @@ class AntiClickjackingScanRuleUnitTest extends PassiveScannerTest<AntiClickjacki
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(1021)));
-        assertThat(wasc, is(equalTo(15)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
@@ -80,12 +80,8 @@ class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<ApplicationErr
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(4)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -61,12 +61,8 @@ class ContentSecurityPolicyScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(693)));
-        assertThat(wasc, is(equalTo(15)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),
@@ -653,15 +649,15 @@ class ContentSecurityPolicyScanRuleUnitTest
                 is(equalTo("Warnings:\nThe prefetch-src directive has been deprecated\n")));
     }
 
-    private HttpMessage createHttpMessageWithReasonableCsp(String cspHeaderName) {
+    private static HttpMessage createHttpMessageWithReasonableCsp(String cspHeaderName) {
         return createHttpMessage(cspHeaderName, REASONABLE_POLICY);
     }
 
-    private HttpMessage createHttpMessage(String cspPolicy) {
+    private static HttpMessage createHttpMessage(String cspPolicy) {
         return createHttpMessage(HttpFieldsNames.CONTENT_SECURITY_POLICY, cspPolicy);
     }
 
-    private HttpMessage createHttpMessage(String cspHeaderName, String cspPolicy) {
+    private static HttpMessage createHttpMessage(String cspHeaderName, String cspPolicy) {
         HttpMessage msg = new HttpMessage();
 
         String header =
@@ -689,7 +685,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         return msg;
     }
 
-    private HttpMessage createHttpMessage() {
+    private static HttpMessage createHttpMessage() {
         HttpMessage msg = new HttpMessage();
         try {
             msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRuleUnitTest.java
@@ -40,7 +40,7 @@ class ContentTypeMissingScanRuleUnitTest extends PassiveScannerTest<ContentTypeM
         return new ContentTypeMissingScanRule();
     }
 
-    private HttpMessage createMessage() throws HttpMalformedHeaderException {
+    private static HttpMessage createMessage() throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
 
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -60,12 +60,8 @@ class ContentTypeMissingScanRuleUnitTest extends PassiveScannerTest<ContentTypeM
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(345)));
-        assertThat(wasc, is(equalTo(12)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
@@ -62,12 +62,8 @@ class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHttpOnlySc
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(1004)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
@@ -62,7 +62,7 @@ class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLoose
         return rule;
     }
 
-    private HttpMessage createBasicMessage() throws HttpMalformedHeaderException {
+    private static HttpMessage createBasicMessage() throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Server: Apache-Coyote/1.1\r\n");
 
@@ -72,12 +72,8 @@ class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLoose
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(565)));
-        assertThat(wasc, is(equalTo(15)));
         assertThat(tags.size(), is(equalTo(3)));
         assertAlertTags(tags);
     }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRuleUnitTest.java
@@ -67,12 +67,8 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(1275)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRuleUnitTest.java
@@ -62,12 +62,8 @@ class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieSecureFl
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(614)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRuleUnitTest.java
@@ -47,12 +47,8 @@ class CrossDomainMisconfigurationScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(264)));
-        assertThat(wasc, is(equalTo(14)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRuleUnitTest.java
@@ -71,12 +71,8 @@ class CrossDomainScriptInclusionScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(829)));
-        assertThat(wasc, is(equalTo(15)));
         assertThat(tags.size(), is(equalTo(1)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A08_INTEGRITY_FAIL.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -98,12 +98,8 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(352)));
-        assertThat(wasc, is(equalTo(9)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),
@@ -461,7 +457,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
                 "<html><head></head><body><form id=\"no_csrf_token\"><input type=\"text\"/><input type=\"submit\"/></form></body></html>");
     }
 
-    private HttpMessage createScopedMessage(boolean isInScope) throws URIException {
+    private static HttpMessage createScopedMessage(boolean isInScope) throws URIException {
         HttpMessage newMsg =
                 new HttpMessage() {
                     @Override

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/DirectoryBrowsingScanRuleUnitTest.java
@@ -37,7 +37,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 
 class DirectoryBrowsingScanRuleUnitTest extends PassiveScannerTest<DirectoryBrowsingScanRule> {
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRuleUnitTest.java
@@ -191,7 +191,7 @@ class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDisclosureSc
         super.shouldHaveValidReferences();
     }
 
-    private HttpMessage createMsg(String hashVal) throws HttpMalformedHeaderException {
+    private static HttpMessage createMsg(String hashVal) throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Server: Apache-Coyote/1.1\r\n");

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRuleUnitTest.java
@@ -52,12 +52,8 @@ class InfoPrivateAddressDisclosureScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),
@@ -420,11 +416,11 @@ class InfoPrivateAddressDisclosureScanRuleUnitTest
         assertThat(alert.getUri(), equalTo(requestUri));
     }
 
-    private HttpMessage createHttpMessage(String body) throws HttpMalformedHeaderException {
+    private static HttpMessage createHttpMessage(String body) throws HttpMalformedHeaderException {
         return createHttpMessage(URI, body);
     }
 
-    private HttpMessage createHttpMessage(String requestUri, String body)
+    private static HttpMessage createHttpMessage(String requestUri, String body)
             throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         requestUri = requestUri.startsWith("http") ? requestUri : "http://" + requestUri;

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRuleUnitTest.java
@@ -78,12 +78,8 @@ class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSessionIdU
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),
@@ -483,7 +479,7 @@ class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSessionIdU
         assertEquals(1, alertsRaised.size());
     }
 
-    private void setUpHttpSessionsParam() {
+    private static void setUpHttpSessionsParam() {
         OptionsParam options = Model.getSingleton().getOptionsParam();
         options.load(new ZapXmlConfiguration());
         HttpSessionsParam httpSessions = new HttpSessionsParam();

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRuleUnitTest.java
@@ -92,12 +92,8 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRuleUnitTest.java
@@ -88,12 +88,8 @@ class InformationDisclosureInUrlScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRuleUnitTest.java
@@ -90,12 +90,8 @@ class InformationDisclosureReferrerScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
@@ -73,12 +73,8 @@ class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRuleUnitTest.java
@@ -59,12 +59,8 @@ class InsecureAuthenticationScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(326)));
-        assertThat(wasc, is(equalTo(4)));
         assertThat(tags.size(), is(equalTo(5)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureFormLoadScanRuleUnitTest.java
@@ -40,7 +40,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 
 class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<InsecureFormLoadScanRule> {
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureFormPostScanRuleUnitTest.java
@@ -40,7 +40,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 
 class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<InsecureFormPostScanRule> {
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("https://example.com", false));
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRuleUnitTest.java
@@ -265,7 +265,8 @@ class InsecureJsfViewStatePassiveScanRuleUnitTest
         return output.toByteArray();
     }
 
-    private void setTextHtmlResponseHeader(HttpMessage msg) throws HttpMalformedHeaderException {
+    private static void setTextHtmlResponseHeader(HttpMessage msg)
+            throws HttpMalformedHeaderException {
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"
                         + "Server: Apache-Coyote/1.1\r\n"

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/LinkTargetScanRuleUnitTest.java
@@ -71,7 +71,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         return rule;
     }
 
-    private String getHeader(String contentType, int bodyLength) {
+    private static String getHeader(String contentType, int bodyLength) {
         return "HTTP/1.1 200 OK\r\n"
                 + "Content-Type: "
                 + contentType

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRuleUnitTest.java
@@ -46,12 +46,8 @@ class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedContentScanRu
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(311)));
-        assertThat(wasc, is(equalTo(4)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PiiScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PiiScanRuleUnitTest.java
@@ -484,7 +484,7 @@ class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
         super.shouldHaveValidReferences();
     }
 
-    private HttpMessage createMsg(String cardNumber) throws HttpMalformedHeaderException {
+    private static HttpMessage createMsg(String cardNumber) throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         msg.setResponseHeader(

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/RetrievedFromCacheScanRuleUnitTest.java
@@ -38,7 +38,7 @@ class RetrievedFromCacheScanRuleUnitTest extends PassiveScannerTest<RetrievedFro
     private static final String X_CACHE = "X-Cache";
     private static final String AGE = "Age";
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRuleUnitTest.java
@@ -40,7 +40,7 @@ class ServerHeaderInfoLeakScanRuleUnitTest
 
     private static final String SERVER = "Server";
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/StrictTransportSecurityScanRuleUnitTest.java
@@ -42,7 +42,7 @@ class StrictTransportSecurityScanRuleUnitTest
     private static final String HEADER_VALUE = "max-age=31536000"; // 1 year
     private static final String SHORT_VALUE = "max-age=86400";
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("https://example.com", false));
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -55,12 +55,8 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRuleUnitTest.java
@@ -75,12 +75,8 @@ class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdorScanRu
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(284)));
-        assertThat(wasc, is(equalTo(2)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ViewStateScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ViewStateScanRuleUnitTest.java
@@ -61,12 +61,8 @@ class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanRule> {
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(642)));
-        assertThat(wasc, is(equalTo(14)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A04_INSECURE_DESIGN.getTag()),
@@ -253,7 +249,7 @@ class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanRule> {
      * @param inject the string to inject
      * @return a base64 encoded string with the inject value injected at byte 40.
      */
-    private String getViewstateWithText(String inject) {
+    private static String getViewstateWithText(String inject) {
         String base =
                 "/wEPDwUJODczNjQ5OTk0D2QWAgIDD2QWAgIFDw8WAh4EVGV4dAUWSSBMb3ZlIERvdG5ldEN1cnJ5LmNvbWRkZMHbBY9JqBTvB5/6kXnY15AUSAwa";
         byte[] decoded;

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRuleUnitTest.java
@@ -42,12 +42,8 @@ class XAspNetVersionScanRuleUnitTest extends PassiveScannerTest<XAspNetVersionSc
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(933)));
-        assertThat(wasc, is(equalTo(14)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),
@@ -127,7 +123,7 @@ class XAspNetVersionScanRuleUnitTest extends PassiveScannerTest<XAspNetVersionSc
         super.shouldHaveValidReferences();
     }
 
-    private HttpMessage createMessage(String header) throws HttpMalformedHeaderException {
+    private static HttpMessage createMessage(String header) throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRuleUnitTest.java
@@ -40,7 +40,7 @@ class XBackendServerInformationLeakScanRuleUnitTest
     private static final String XBS_HEADER = "X-Backend-Server";
     private static final String HEADER_VALUE = "developer1.webapp.scl3.mozilla.com";
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
@@ -53,7 +53,7 @@ class XChromeLoggerDataInfoLeakScanRuleUnitTest
                     + "ZWN1cml0eUNvbnRleHQgd2l0aCBhbiBhbm9ueW1vdXMgVG9rZW4iLCJ1bmtub"
                     + "3duIiwiaW5mbyJdXSwicmVxdWVzdF91cmkiOiJcL2xvZ2luIn0=";
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRuleUnitTest.java
@@ -41,7 +41,7 @@ class XDebugTokenScanRuleUnitTest extends PassiveScannerTest<XDebugTokenScanRule
         return new XDebugTokenScanRule();
     }
 
-    private HttpMessage createMessage() throws HttpMalformedHeaderException {
+    private static HttpMessage createMessage() throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Server: Apache-Coyote/1.1\r\n");

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRuleUnitTest.java
@@ -46,12 +46,8 @@ class XPoweredByHeaderInfoLeakScanRuleUnitTest
     @Test
     void shouldReturnExpectedMappings() {
         // Given / When
-        int cwe = rule.getCweId();
-        int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
-        assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [43] - 2024-09-02
 ### Changed

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanRule.java
@@ -74,10 +74,10 @@ public class ExampleFilePassiveScanRule extends PluginPassiveScanner {
         return newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription())
-                .setOtherInfo(getOtherInfo())
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "other"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
                 .setWascId(13);
     }
@@ -114,7 +114,7 @@ public class ExampleFilePassiveScanRule extends PluginPassiveScanner {
         return null;
     }
 
-    private List<String> loadFile(String file) {
+    private static List<String> loadFile(String file) {
         /*
          * ZAP will have already extracted the file from the add-on and put it underneath the 'ZAP home' directory
          */
@@ -160,21 +160,5 @@ public class ExampleFilePassiveScanRule extends PluginPassiveScanner {
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getOtherInfo() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "other");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRule.java
@@ -82,27 +82,14 @@ public class FullPathDisclosureScanRule extends PluginPassiveScanner
         return ALERT_TAGS;
     }
 
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
     private AlertBuilder buildAlert(String evidence) {
         return newAlert()
                 .setConfidence(Alert.CONFIDENCE_LOW)
                 .setRisk(Alert.RISK_LOW)
                 .setEvidence(evidence)
-                .setDescription(getDescription())
-                .setSolution(getSolution())
-                .setReference(getReference())
-                .setSolution(getSolution())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setWascId(13) // WASC-13 Information Leakage
                 .setCweId(209); // CWE-209: Generation of Error Message Containing Sensitive
         // Information

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRuleTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FetchMetadataRequestHeadersScanRuleTest.java
@@ -229,7 +229,7 @@ class FetchMetadataRequestHeadersScanRuleTest
         return new FetchMetadataRequestHeadersScanRule();
     }
 
-    private String generateRequestForMissingCase(String missingHeader) {
+    private static String generateRequestForMissingCase(String missingHeader) {
         switch (missingHeader) {
             case "Sec-Fetch-Site":
                 return HTTP_METHOD + SFM_VALID_HEADER + SFD_VALID_HEADER + SFU_VALID_HEADER;
@@ -248,7 +248,7 @@ class FetchMetadataRequestHeadersScanRuleTest
         }
     }
 
-    private String generateRequestForInvalidCase(String invalidHeader) {
+    private static String generateRequestForInvalidCase(String invalidHeader) {
         switch (invalidHeader) {
             case "Sec-Fetch-Site":
                 return HTTP_METHOD

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRuleUnitTest.java
@@ -156,7 +156,7 @@ class FullPathDisclosureScanRuleUnitTest extends PassiveScannerTest<FullPathDisc
         return new FullPathDisclosureScanRule();
     }
 
-    private HttpMessage createMessage(String body, Integer status) throws URIException {
+    private static HttpMessage createMessage(String body, Integer status) throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix typo in log message.
 
+### Changed
+- Maintenance changes.
+
 ## [41] - 2024-09-02
 ### Fixed
 - A possible false positive condition with the Dangerous JS Functions scan rule with substrings in certain circumstances (Issue 8553).

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRule.java
@@ -692,7 +692,7 @@ public class CacheableScanRule extends PluginPassiveScanner implements CommonPas
         }
     }
 
-    private Long extractAgeValue(String directiveToken, int tokenLength) {
+    private static Long extractAgeValue(String directiveToken, int tokenLength) {
         int commaLocation = directiveToken.indexOf(",", tokenLength);
         return Long.parseLong(
                 directiveToken.substring(

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRule.java
@@ -149,9 +149,9 @@ public class JsFunctionScanRule extends PluginPassiveScanner implements CommonPa
         return newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_LOW)
-                .setDescription(getDescription())
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
                 .setCweId(749); // CWE-749: Exposed Dangerous Method or Function
     }
@@ -190,18 +190,6 @@ public class JsFunctionScanRule extends PluginPassiveScanner implements CommonPa
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
     @Override

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsoScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/JsoScanRule.java
@@ -125,7 +125,7 @@ public class JsoScanRule extends PluginPassiveScanner implements CommonPassiveSc
                 .setCweId(502); // CWE-502: Deserialization of Untrusted Data
     }
 
-    private boolean hasJsoMagicSequence(String value) {
+    private static boolean hasJsoMagicSequence(String value) {
         return hasJsoBase64MagicSequence(value) || hasUriEncodedMagicSequence(value);
     }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRule.java
@@ -692,9 +692,12 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner
                 .setName(getName() + " - " + programmingLanguage)
                 .setRisk(Alert.RISK_MEDIUM)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(getDescription() + " - " + programmingLanguage)
-                .setSolution(getSolution())
-                .setReference(getReference())
+                .setDescription(
+                        Constant.messages.getString(MESSAGE_PREFIX + "desc")
+                                + " - "
+                                + programmingLanguage)
+                .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
                 .setCweId(540) // Information Exposure Through Source Code
                 .setWascId(13); // WASC-13: Information Leakage
@@ -713,17 +716,5 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    private String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java
@@ -128,7 +128,7 @@ public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner
         }
     }
 
-    private String calculateIntegrityHash(HttpMessage msg, Element element, SiteMap tree) {
+    private static String calculateIntegrityHash(HttpMessage msg, Element element, SiteMap tree) {
         String src = element.getAttributeValue("src");
         if (src == null) {
             return "";
@@ -155,7 +155,7 @@ public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner
         return integrityHash;
     }
 
-    private String getOtherInfo(HttpMessage msg, Element element, SiteMap tree) {
+    private static String getOtherInfo(HttpMessage msg, Element element, SiteMap tree) {
         String integrityHash = calculateIntegrityHash(msg, element, tree);
         if (integrityHash.isEmpty()) {
             return "";

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/CacheableScanRuleUnitTest.java
@@ -45,7 +45,7 @@ import org.zaproxy.addon.commonlib.http.HttpDateUtils;
  */
 class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
 
-    private HttpMessage createMessage() throws URIException {
+    private static HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setMethod("GET");
         requestHeader.setURI(new URI("https://example.com/fred/", false));
@@ -55,7 +55,7 @@ class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
         return msg;
     }
 
-    private HttpMessage createMessageBasicAuthorization() throws URIException {
+    private static HttpMessage createMessageBasicAuthorization() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setMethod("GET");
         requestHeader.setURI(new URI("https://example.com/fred/", false));

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRuleUnitTest.java
@@ -40,7 +40,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 class InPageBannerInfoLeakScanRuleUnitTest
         extends PassiveScannerTest<InPageBannerInfoLeakScanRule> {
 
-    private HttpMessage createMessage(String banner) throws URIException {
+    private static HttpMessage createMessage(String banner) throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/JsFunctionScanRuleUnitTest.java
@@ -267,7 +267,8 @@ class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionScanRule> 
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));
     }
 
-    private HttpMessage createHttpMessageWithRespBody(String responseBody, String contentType)
+    private static HttpMessage createHttpMessageWithRespBody(
+            String responseBody, String contentType)
             throws HttpMalformedHeaderException, URIException {
 
         HttpRequestHeader requestHeader = new HttpRequestHeader();

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRuleUnitTest.java
@@ -222,7 +222,8 @@ class ServletParameterPollutionScanRuleUnitTest
         assertEquals(expected, alertsRaised.size());
     }
 
-    private HttpMessage createHttpMessageFromHtml(String html) throws HttpMalformedHeaderException {
+    private static HttpMessage createHttpMessageFromHtml(String html)
+            throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET " + URI + " HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 200\r\n");

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SourceCodeDisclosureScanRuleUnitTest.java
@@ -243,11 +243,11 @@ class SourceCodeDisclosureScanRuleUnitTest
         assertThat(example.getName(), is(equalTo("Source Code Disclosure - PHP")));
     }
 
-    private String wrapWithHTML(String code) {
+    private static String wrapWithHTML(String code) {
         return CODE_HTML + code + CODE_HTML;
     }
 
-    private void assertAlertAttributes(Alert alert, String evidence, final String language) {
+    private static void assertAlertAttributes(Alert alert, String evidence, final String language) {
         assertThat(alert.getRisk(), is(Alert.RISK_MEDIUM));
         assertThat(alert.getConfidence(), is(Alert.CONFIDENCE_MEDIUM));
         assertThat(alert.getName(), is(getLocalisedString("name") + " - " + language));
@@ -261,7 +261,7 @@ class SourceCodeDisclosureScanRuleUnitTest
         assertThat(alert.getWascId(), is(13));
     }
 
-    private String getLocalisedString(String key, Object... params) {
+    private static String getLocalisedString(String key, Object... params) {
         return Constant.messages.getString("pscanbeta.sourcecodedisclosure." + key, params);
     }
 }


### PR DESCRIPTION
## Overview

### scan rules: Clean code tweaks

- Add static modifier where applicable.
- CHANGELOG > Add maintenance note (if there wasn't already one present).
- pscanrules > Made resource message methods private again where example alerts have been implemented, or removed them where there was only a single usage (inlining the Constant resource message usage).

### ascanrulesAlpha: Add example alerts to example rules

- CHANGELOG > Added change note.
- Scan Rules > Added example alert handling, updated to conform to the common active scan rule tests.
- Scan Rule Unit Tests > Added to assert the example alert and references, as well as common tests.

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [na] Write tests
- [na] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

