### PR TITLE
requester: allow to display a msg in the editor

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Allow to display a message in the editor dialogue.
 
 ## [7.6.0] - 2024-05-07
 ### Changed

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/ExtensionRequester.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/ExtensionRequester.java
@@ -186,6 +186,22 @@ public class ExtensionRequester extends ExtensionAdaptor {
         return requesterPanel;
     }
 
+    /**
+     * Displays the given {@code message} in the "Manual Editor" dialogue and sets it visible.
+     *
+     * <p>Currently supports only HTTP messages.
+     *
+     * @param message the message to display.
+     * @since 7.7.0
+     */
+    public void displayMessage(Message message) {
+        if (!hasView() || !(message instanceof HttpMessage)) {
+            return;
+        }
+
+        sendDialog.displayMessage(message);
+    }
+
     public void newRequesterPane(HttpMessage msg) {
         getRequesterPanel().newRequester(msg);
         if (getOptionsParam().isAutoFocus()) {

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/MessageEditorDialog.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/MessageEditorDialog.java
@@ -82,6 +82,16 @@ public abstract class MessageEditorDialog extends AbstractFrame {
     }
 
     /**
+     * Displays the given {@code message} in the dialogue and sets it visible.
+     *
+     * @param message the message to display.
+     */
+    public void displayMessage(Message message) {
+        panel.setMessage(message);
+        setVisible(true);
+    }
+
+    /**
      * Unloads the dialogue from ZAP.
      *
      * <p>Unloads the panel, hides and disposes the dialogue.

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/SendHttpMessageEditorDialog.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/internal/SendHttpMessageEditorDialog.java
@@ -50,17 +50,7 @@ public class SendHttpMessageEditorDialog extends AbstractHttpMessageEditorDialog
                         "requester.send.toolsmenuitem",
                         View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_M, 0, false));
         menuItem.setIcon(ExtensionRequester.getManualIcon());
-        menuItem.addActionListener(
-                e -> {
-                    Message message = extensionRequester.getSelectedMsg();
-                    if (message instanceof HttpMessage
-                            && !((HttpMessage) message).getRequestHeader().isEmpty()) {
-                        getPanel().setMessage(message);
-                    } else {
-                        getPanel().setDefaultMessage();
-                    }
-                    setVisible(true);
-                });
+        menuItem.addActionListener(e -> displayMessage(extensionRequester.getSelectedMsg()));
         extensionHook.getHookMenu().addToolsMenuItem(menuItem);
 
         PopupMenuResendMessage popupMenuResendMessage =
@@ -72,5 +62,16 @@ public class SendHttpMessageEditorDialog extends AbstractHttpMessageEditorDialog
                             setVisible(true);
                         });
         extensionHook.getHookMenu().addPopupMenuItem(popupMenuResendMessage);
+    }
+
+    @Override
+    public void displayMessage(Message message) {
+        if (message instanceof HttpMessage
+                && !((HttpMessage) message).getRequestHeader().isEmpty()) {
+            getPanel().setMessage(message);
+        } else {
+            getPanel().setDefaultMessage();
+        }
+        setVisible(true);
     }
 }


### PR DESCRIPTION
Add method to the extension to display a message and show the dialogue.

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/p7EcrHg-LxY/m/HQIsF7_RAAAJ