### PR TITLE
zest: use script engines from ZAP

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Document the engine name in the help page.
 
+### Changed
+- Use script engines from ZAP when executing scripts.
+- Update Zest library to 0.22.0:
+  - Update Selenium to version 4.22.0.
+
 ## [45] - 2024-05-07
 ### Changed
 - Update minimum ZAP version to 2.15.0.

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     zapAddOn("scripts")
     zapAddOn("selenium")
 
-    implementation("org.zaproxy:zest:0.21.0") {
+    implementation("org.zaproxy:zest:0.22.0") {
         // Provided by commonlib add-on.
         exclude(group = "com.fasterxml.jackson")
         // Provided by Selenium add-on.


### PR DESCRIPTION
Update Zest library and change the `ZestZapRunner` to provide the script engines that ZAP has so the scripts are executed with same configurations as scripts executed directly from ZAP.