### PR TITLE
grpc: skip non-gRPC responses in the variant

### DIFF
--- a/addOns/grpc/CHANGELOG.md
+++ b/addOns/grpc/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Do not try to decode non-gRPC responses when active scanning, which would lead to unnecessary warnings.
 
 ## [0.1.0] - 2024-06-11
 

--- a/addOns/grpc/grpc.gradle.kts
+++ b/addOns/grpc/grpc.gradle.kts
@@ -20,4 +20,6 @@ crowdin {
 dependencies {
     testImplementation(project(":testutils"))
     implementation("io.grpc:grpc-protobuf:1.61.1")
+
+    testImplementation(libs.log4j.core)
 }


### PR DESCRIPTION
Check that the response is valid gRPC before trying to decode it, otherwise it would lead to unnecessary warns as the response is not gRPC.