### PR TITLE
network: use configured timeout as default

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Guard against user without authentication state.
 - Fix exception after regenerating the root CA cert during ZAP startup (Issue 8499).
+- Use configured timeout as default.
 
 ## [0.16.0] - 2024-05-07
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -74,6 +74,7 @@ import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.io.HttpClientConnection;
+import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.http.message.BasicHttpRequest;
@@ -253,6 +254,9 @@ public class HttpSenderApache
                         .setSocketTimeout(timeout)
                         .build();
         connectionManager.setDefaultConnectionConfig(connConfig);
+
+        connectionManager.setDefaultSocketConfig(
+                SocketConfig.custom().setSoTimeout(timeout).build());
 
         connectionManager.setDefaultTlsConfig(
                 TlsConfig.custom()


### PR DESCRIPTION
Change `HttpSenderApache` to use the configured timeout as default, to ensure the same timeout value is used consistently in all operations.