### PR TITLE
automation: Address warnings/errors when building with java 21

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.40.1] - 2024-05-28
 ### Fixed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -25,7 +25,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -678,7 +677,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
 
     private static URI createUri(String source) {
         try {
-            new URL(source).toURI();
+            new java.net.URI(source).toURL();
             URI uri = new URI(source, true);
             String scheme = uri.getScheme();
             if (HttpHeader.HTTP.equalsIgnoreCase(scheme)

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/UrlPresenceTestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/UrlPresenceTestDialog.java
@@ -20,6 +20,7 @@
 package org.zaproxy.addon.automation.gui;
 
 import java.awt.Component;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.regex.Pattern;
@@ -120,8 +121,7 @@ public class UrlPresenceTestDialog extends StandardFieldsDialog {
 
         URL uri = null;
         try {
-            uri = new URL(url);
-            uri.toURI();
+            uri = new URI(url).toURL();
         } catch (Exception e) {
             return Constant.messages.getString(ERROR_URL_INVALID, url, e.getMessage());
         }


### PR DESCRIPTION
## Overview
- CHANGELOG > Added maint note.
- ExtensionAutomation > Adjust URL/URI handling.
- UrlPresenceTestDialog > Adjust URL/URI handling.

As far as I could see from the related JavaDoc, the same exceptions should still be thrown (if there's an issue) with the updated code.

## Related Issues
```bash
> Task :addOns:automation:compileJava
C:\Users\thorin\Desktop\zap-ws\zap-extensions\addOns\automation\src\main\java\org\zaproxy\addon\automation\ExtensionAutomation.java:681: warning: [deprecation] URL(String) in URL has been deprecated
            new URL(source).toURI();
            ^
error: warnings found and -Werror specified

> Task :addOns:wappalyzer:jhindexer-help_ja_JP

> Task :addOns:automation:compileJava FAILED
C:\Users\thorin\Desktop\zap-ws\zap-extensions\addOns\automation\src\main\java\org\zaproxy\addon\automation\gui\UrlPresenceTestDialog.java:123: warning: [deprecation] URL(String) in URL has been deprecated
            uri = new URL(url);
                  ^
1 error
2 warnings
```

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [na] Write tests (Still run fine)
- [na] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
