### PR TITLE
domxss: include response in raised alerts

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Include the whole HTTP message in the raised alerts.
 
 ## [19] - 2024-05-07
 ### Changed

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -665,7 +665,7 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
     }
 
     public boolean scan(String attackVector, String currUrl) {
-        HttpMessage msg = getNewMsg();
+        HttpMessage msg = getBaseMsg();
 
         DomAlertInfo result = scanHelper(attackVector, currUrl);
         if (result != null) {


### PR DESCRIPTION
Include the whole HTTP message when raising the alerts.