### PR TITLE
exim: Leverage Jackson from common-lib

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Leverage Jackson library from the Common Library add-on.
 
 ## [0.10.0] - 2024-07-22
 ### Changed

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -31,7 +31,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.23.0 & < 2.0.0")
+                    version.set(">= 1.26.0 & < 2.0.0")
                 }
             }
         }
@@ -55,7 +55,10 @@ dependencies {
     zapAddOn("commonlib")
 
     implementation(files("lib/org.jwall.web.audit-0.2.15.jar"))
-    implementation("de.sstoehr:har-reader:2.3.0")
+    implementation("de.sstoehr:har-reader:2.3.0") {
+        // Provided by commonlib add-on:
+        exclude(group = "com.fasterxml.jackson.core")
+    }
 
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(project(":testutils"))


### PR DESCRIPTION
## Overview
- Leverage Jackson library from the Common Library add-on.

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [na] Write tests
- [na] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
