### PR TITLE
Dev: fix folder reqs and add extra protected pages

### DIFF
--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Extra protected pages to simple-json-cookie to ensure spidering really works.
+
+### Fixed
+- Issue where folder level pages without a trailing slash did not link correctly to sub pages.
 
 
 ## [0.6.0] - 2024-07-22

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestDirectory.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestDirectory.java
@@ -75,11 +75,6 @@ public class TestDirectory implements HttpMessageHandler {
         if (name.length() == 0) {
             name = INDEX_PAGE;
         }
-
-        if (name.equals(this.getName())) {
-            // Handle the case where there is no trailing slash, otherwise this will 404
-            name = INDEX_PAGE;
-        }
         int qIndex = name.indexOf('?');
         if (qIndex > 0) {
             name = name.substring(0, qIndex - 1);
@@ -110,6 +105,11 @@ public class TestDirectory implements HttpMessageHandler {
             }
 
             if (body == null) {
+                if (name.equals(this.getName())) {
+                    // Redirect with a trailing slash
+                    getServer().redirect(name + "/", msg);
+                    return;
+                }
                 LOGGER.debug("Failed to find tutorial file {}", name);
                 body = server.getTextFile("404.html");
                 msg.setResponseBody(body);

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestProxyServer.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestProxyServer.java
@@ -79,7 +79,7 @@ public class TestProxyServer {
         authDir.addDirectory(new PasswordAddedJsonDir(this, "password-added-json"));
         authDir.addDirectory(new PasswordHiddenJsonDir(this, "password-hidden-json"));
         authDir.addDirectory(new PasswordNewPageDir(this, "password-new-page"));
-        authDir.addDirectory(new PasswordAddedNoSubmitDir(this, "password-added-json"));
+        authDir.addDirectory(new PasswordAddedNoSubmitDir(this, "password-added-nosubmit"));
         authDir.addDirectory(new JsonMultipleCookiesDir(this, "json-multiple-cookies"));
 
         TestDirectory apiDir = new TestDirectory(this, "api");

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieDir.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieDir.java
@@ -33,6 +33,8 @@ public class SimpleJsonCookieDir extends TestAuthDirectory {
         this.addPage(new SimpleJsonCookieIndexPage(server));
         this.addPage(new SimpleJsonCookieLoginPage(server));
         this.addPage(new SimpleJsonCookieVerificationPage(server));
-        this.addPage(new SimpleJsonCookiePage1(server));
+        this.addPage(new SimpleJsonCookieProtectedPage(server, "page1.html"));
+        this.addPage(new SimpleJsonCookieProtectedPage(server, "page2.html"));
+        this.addPage(new SimpleJsonCookieProtectedPage(server, "page3.html"));
     }
 }

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieIndexPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieIndexPage.java
@@ -51,7 +51,7 @@ public class SimpleJsonCookieIndexPage extends TestPage {
 
         if (cookie != null && user != null) {
             // Already logged in, dont display the login page again
-            getServer().redirect("page1.html", msg);
+            getServer().redirect("home.html", msg);
         } else {
             this.getServer().handleFile(getParent(), this.getName(), msg);
         }

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieProtectedPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieProtectedPage.java
@@ -28,12 +28,12 @@ import org.zaproxy.addon.dev.TestPage;
 import org.zaproxy.addon.dev.TestProxyServer;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 
-public class SimpleJsonCookiePage1 extends TestPage {
+public class SimpleJsonCookieProtectedPage extends TestPage {
 
-    private static final Logger LOGGER = LogManager.getLogger(SimpleJsonCookiePage1.class);
+    private static final Logger LOGGER = LogManager.getLogger(SimpleJsonCookieProtectedPage.class);
 
-    public SimpleJsonCookiePage1(TestProxyServer server) {
-        super(server, "page1.html");
+    public SimpleJsonCookieProtectedPage(TestProxyServer server, String name) {
+        super(server, name);
     }
 
     @Override

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/home.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/home.html
@@ -10,6 +10,7 @@
 	<div id="message"></div>
 	<ul>
     <li><a href="page1.html">Page 1</a>
+    <li><a href="page2.html">Page 2</a>
     </ul>
 
 </div>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/page2.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/page2.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Page 2</H1>
+	Protected by creds so that it can be used to test authenticated spidering.
+	<ul>
+    <li><a href="page3.html">Page 3</a>
+    </ul>
+
+</div>
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/page3.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/page3.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Page 3</H1>
+	Protected by creds so that it can be used to test authenticated spidering.
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Overview
Requests to 'folders' without a trailing slash messed up relate links, so not redirect them to the same URL but with a slash.
Also added a couple more protected pages for testing spiders.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
