### PR TITLE
Authhelper: fix potential timing issue with browser based auth

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Potential timing issue trying to use browser based auth to authenticate before the session management method has been identified.
 
 ## [0.13.0] - 2024-05-07
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -376,8 +376,29 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
 
                 if (authMsg != null) {
                     // Update the session as it may have changed
+                    for (int i = 0; i < AuthUtils.getWaitLoopCount(); i++) {
+                        // The session management method is set via a pscan rule, so make sure it is
+                        // set
+                        LOGGER.debug(
+                                "Update session? {}",
+                                sessionManagementMethod.getClass().getCanonicalName());
+                        if (!(sessionManagementMethod
+                                instanceof
+                                AutoDetectSessionManagementMethodType
+                                        .AutoDetectSessionManagementMethod)) {
+                            break;
+                        }
+                        sessionManagementMethod = user.getContext().getSessionManagementMethod();
+                        AuthUtils.sleep(AuthUtils.TIME_TO_SLEEP_IN_MSECS);
+                    }
                     WebSession session = sessionManagementMethod.extractWebSession(authMsg);
-                    user.setAuthenticatedSession(session);
+                    if (session != null) {
+                        LOGGER.info(
+                                "Updating session management method {} with session {}",
+                                sessionManagementMethod.getClass().getCanonicalName(),
+                                session.getClass().getCanonicalName());
+                        user.setAuthenticatedSession(session);
+                    }
 
                     if (this.isAuthenticated(authMsg, user, true)) {
                         // Let the user know it worked

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
@@ -222,7 +222,7 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
             } else {
                 LOGGER.debug(
                         "processMessageToMatchSession unexpected session type: {}",
-                        session.getClass().getCanonicalName());
+                        session != null ? session.getClass().getCanonicalName() : "null");
             }
         }
 


### PR DESCRIPTION
## Overview
Fix potential timing issue trying to use browser based auth authenticate before the autodetect session management method has been identified.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
