### PR TITLE
automation: let job report alert tests support

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
@@ -493,6 +493,10 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
         tests.forEach(t -> t.logToProgress(progress));
     }
 
+    public boolean supportsAlertTests() {
+        return false;
+    }
+
     public boolean supportsMonitorTests() {
         return false;
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddTestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddTestDialog.java
@@ -25,8 +25,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.automation.AutomationEventPublisher;
 import org.zaproxy.addon.automation.AutomationJob;
-import org.zaproxy.addon.automation.jobs.ActiveScanJob;
-import org.zaproxy.addon.automation.jobs.PassiveScanWaitJob;
 import org.zaproxy.addon.automation.tests.AbstractAutomationTest;
 import org.zaproxy.addon.automation.tests.AutomationAlertTest;
 import org.zaproxy.addon.automation.tests.AutomationMonitorTest;
@@ -60,7 +58,7 @@ public class AddTestDialog extends StandardFieldsDialog {
         }
         testNames.add(Constant.messages.getString(URL_PRESENCE_TEST_NAME));
 
-        if (job instanceof PassiveScanWaitJob || job instanceof ActiveScanJob) {
+        if (job.supportsAlertTests()) {
             testNames.add(Constant.messages.getString(ALERT_TEST_NAME));
         }
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -67,6 +67,11 @@ public class ActiveScanJob extends AutomationJob {
         data = new Data(this, this.parameters, this.policyDefinition);
     }
 
+    @Override
+    public boolean supportsAlertTests() {
+        return true;
+    }
+
     private ExtensionActiveScan getExtAScan() {
         if (extAScan == null) {
             extAScan =

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJob.java
@@ -48,6 +48,11 @@ public class PassiveScanWaitJob extends AutomationJob {
     }
 
     @Override
+    public boolean supportsAlertTests() {
+        return true;
+    }
+
+    @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
         ExtensionPassiveScan extPScan = getExtPassiveScan();
 


### PR DESCRIPTION
Allow the job itself to tell if it supports or not alert tests to remove direct dependencies to jobs in implementations.

Part of zaproxy/zaproxy#7959.