### PR TITLE
tech detection: Allow raising alerts

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The add-on now has an options screen to allow users to select Quick/Exhaustive mode used by the passive scanner (part of Issue 8361).
     - Quick > Return on first match; which may mean missing version information, but should be slightly more performant. (This is the default.)
     - Exhaustive > Keep matching and don't return early; likely slightly less performant.
+- The add-on now also has the ability to optionally raise Alerts for each technology identified. The default setting is enabled. (Issue 8361)
 
 ## [21.39.0] - 2024-07-04
 ### Changed
@@ -17,8 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.38.0] - 2024-06-03
 ### Changed
 - Updated with enthec upstream icon and pattern changes.
-
-
 
 ## [21.37.0] - 2024-05-21
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/AppPattern.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/AppPattern.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.wappalyzer;
 
 import com.google.re2j.Pattern;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 
@@ -82,42 +81,63 @@ public class AppPattern {
         this.type = type;
     }
 
-    public List<String> findInString(String str) {
-        List<String> results = null;
+    public Result findInString(String str) {
+        Result result = new Result();
         if (this.re2jPattern != null) {
             com.google.re2j.Matcher re2jMatcher = this.re2jPattern.matcher(str);
             if (re2jMatcher.find()) {
-                results = createResultsList(re2jMatcher.groupCount());
+                result.setEvidence(re2jMatcher.group());
                 for (int i = 1; i <= re2jMatcher.groupCount(); i++) {
-                    addGroup(re2jMatcher.group(i), results);
+                    addGroup(re2jMatcher.group(i), result);
                 }
             }
         } else {
             Matcher matcher = this.javaPattern.matcher(str);
             if (matcher.find()) {
-                results = createResultsList(matcher.groupCount());
+                result.setEvidence(matcher.group());
                 for (int i = 1; i <= matcher.groupCount(); i++) {
-                    addGroup(matcher.group(i), results);
+                    addGroup(matcher.group(i), result);
                 }
             }
         }
-        return results;
+        return result;
     }
 
-    private List<String> createResultsList(int size) {
-        if (size == 0) {
-            return Collections.emptyList();
-        }
-        return new ArrayList<>(size);
-    }
-
-    private void addGroup(String group, List<String> results) {
+    private static void addGroup(String group, Result result) {
         if (group == null) {
             return;
         }
         String trimmedGroup = group.trim();
         if (!trimmedGroup.isEmpty()) {
-            results.add(trimmedGroup);
+            result.addVersion(trimmedGroup);
+        }
+    }
+
+    public static class Result {
+        private String evidence = "";
+        private List<String> versions;
+
+        Result() {
+            // Nothing to do
+        }
+
+        public String getEvidence() {
+            return evidence;
+        }
+
+        public void setEvidence(String evidence) {
+            this.evidence = evidence;
+        }
+
+        public List<String> getVersions() {
+            if (this.versions == null) {
+                versions = new ArrayList<String>();
+            }
+            return versions;
+        }
+
+        public void addVersion(String version) {
+            getVersions().add(version);
         }
     }
 }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ApplicationMatch.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ApplicationMatch.java
@@ -27,10 +27,12 @@ public class ApplicationMatch {
 
     private Application application;
     private Set<String> versions;
+    private Set<String> evidences;
 
     public ApplicationMatch(Application application) {
         this.application = application;
         this.versions = new HashSet<>();
+        this.evidences = new HashSet<>();
     }
 
     public Application getApplication() {
@@ -47,5 +49,13 @@ public class ApplicationMatch {
 
     public Set<String> getVersions() {
         return versions;
+    }
+
+    public void addEvidence(String evidence) {
+        evidences.add(evidence);
+    }
+
+    public Set<String> getEvidences() {
+        return evidences;
     }
 }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -202,6 +202,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
 
         setWappalyzer(wappalyzerParam.isEnabled());
         passiveScanner.setMode(wappalyzerParam.getMode());
+        passiveScanner.setRaiseAlerts(wappalyzerParam.isRaiseAlerts());
     }
 
     void setWappalyzer(boolean enabled) {
@@ -395,6 +396,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     private void sessionChangedEventHandler(Session session) {
         // Clear all scans
         recreateSiteTreeMap();
+        getPassiveScanner().reset();
         if (hasView()) {
             this.getTechPanel().reset();
             if (session == null) {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechOptionsPanel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechOptionsPanel.java
@@ -22,18 +22,17 @@ package org.zaproxy.zap.extension.wappalyzer;
 import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
-import javax.swing.border.TitledBorder;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.extension.wappalyzer.ExtensionWappalyzer.Mode;
-import org.zaproxy.zap.utils.FontUtils;
 
 @SuppressWarnings("serial")
 public class TechOptionsPanel extends AbstractParamPanel {
@@ -41,11 +40,11 @@ public class TechOptionsPanel extends AbstractParamPanel {
     private static final long serialVersionUID = -4195576861254405033L;
 
     private static final String NAME = Constant.messages.getString("wappalyzer.optionspanel.name");
-    private static final String NAME_MODE =
+    private static final String MODE_LABEL =
             Constant.messages.getString("wappalyzer.optionspanel.mode");
 
     private JComboBox<Mode> modeComboBox;
-    private JPanel modePanel;
+    private JCheckBox raiseAlertsCheckBox;
 
     public TechOptionsPanel() {
         super();
@@ -64,40 +63,16 @@ public class TechOptionsPanel extends AbstractParamPanel {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weighty = 0.0D;
         gbc.weightx = 1.0D;
-        panel.add(getModePanel(), gbc);
+        JLabel modeLabel = new JLabel(MODE_LABEL);
+        modeLabel.setLabelFor(getModeComboBox());
+        panel.add(modeLabel, gbc);
+        gbc.gridx = 1;
+        panel.add(getModeComboBox(), gbc);
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        panel.add(getRaiseAlertsCheckBox(), gbc);
 
         add(panel, BorderLayout.NORTH);
-    }
-
-    private JPanel getModePanel() {
-        if (modePanel == null) {
-            modePanel = new JPanel();
-            modePanel.setLayout(new GridBagLayout());
-
-            GridBagConstraints gbc = new GridBagConstraints();
-
-            modePanel.setBorder(
-                    BorderFactory.createTitledBorder(
-                            null,
-                            NAME_MODE,
-                            TitledBorder.DEFAULT_JUSTIFICATION,
-                            TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard)));
-
-            gbc.gridx = 0;
-            gbc.gridy = 0;
-            gbc.insets = new java.awt.Insets(2, 2, 2, 2);
-            gbc.anchor = GridBagConstraints.WEST;
-            gbc.fill = GridBagConstraints.HORIZONTAL;
-            gbc.weightx = 0.5D;
-            modePanel.add(new JLabel(NAME_MODE), gbc);
-
-            gbc.gridx = 1;
-            gbc.gridy = 0;
-            gbc.ipadx = 50;
-            modePanel.add(getModeComboBox(), gbc);
-        }
-        return modePanel;
     }
 
     private JComboBox<Mode> getModeComboBox() {
@@ -107,12 +82,23 @@ public class TechOptionsPanel extends AbstractParamPanel {
         return modeComboBox;
     }
 
+    private JCheckBox getRaiseAlertsCheckBox() {
+        if (raiseAlertsCheckBox == null) {
+            raiseAlertsCheckBox =
+                    new JCheckBox(
+                            Constant.messages.getString("wappalyzer.optionspanel.raisealerts"));
+            raiseAlertsCheckBox.setHorizontalTextPosition(SwingConstants.LEADING);
+        }
+        return raiseAlertsCheckBox;
+    }
+
     @Override
     public void initParam(Object obj) {
         OptionsParam options = (OptionsParam) obj;
         WappalyzerParam param = options.getParamSet(WappalyzerParam.class);
 
         modeComboBox.setSelectedItem(param.getMode());
+        raiseAlertsCheckBox.setSelected(param.isRaiseAlerts());
     }
 
     @Override
@@ -121,5 +107,11 @@ public class TechOptionsPanel extends AbstractParamPanel {
         WappalyzerParam param = options.getParamSet(WappalyzerParam.class);
 
         param.setMode((Mode) modeComboBox.getSelectedItem());
+        param.setRaiseAlerts(raiseAlertsCheckBox.isSelected());
+    }
+
+    @Override
+    public String getHelpIndex() {
+        return "addon.wappalyzer.options";
     }
 }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerParam.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerParam.java
@@ -41,11 +41,15 @@ public class WappalyzerParam extends VersionedAbstractParam {
     /** The configuration key for the mode of tech detection behavior. */
     private static final String PARAM_WAPPALYZER_MODE = PARAM_BASE_KEY + ".mode";
 
+    private static final String PARAM_WAPPALYZER_ALERTS = PARAM_BASE_KEY + ".alerts";
+
     private static final boolean PARAM_WAPPALYZER_STATE_DEFAULT_VALUE = true;
     private static final Mode PARAM_WAPPALYZER_MODE_DEFAULT_VALUE = Mode.QUICK;
+    private static final boolean PARAM_WAPPALYZER_ALERTS_DEAULT = true;
 
     private boolean enabled;
     private Mode mode;
+    private boolean raiseAlerts;
 
     public boolean isEnabled() {
         return enabled;
@@ -71,10 +75,23 @@ public class WappalyzerParam extends VersionedAbstractParam {
         }
     }
 
+    public void setRaiseAlerts(boolean raiseAlerts) {
+        if (this.raiseAlerts != raiseAlerts) {
+            this.raiseAlerts = raiseAlerts;
+
+            getConfig().setProperty(PARAM_WAPPALYZER_ALERTS, Boolean.valueOf(raiseAlerts));
+        }
+    }
+
+    public boolean isRaiseAlerts() {
+        return raiseAlerts;
+    }
+
     @Override
     protected void parseImpl() {
         enabled = getBoolean(PARAM_WAPPALYZER_STATE, PARAM_WAPPALYZER_STATE_DEFAULT_VALUE);
         mode = getEnum(PARAM_WAPPALYZER_MODE, PARAM_WAPPALYZER_MODE_DEFAULT_VALUE);
+        raiseAlerts = getBoolean(PARAM_WAPPALYZER_ALERTS, PARAM_WAPPALYZER_ALERTS_DEAULT);
     }
 
     @Override

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/options.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/options.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Options Tech Detection screen</TITLE>
+</HEAD>
+<BODY>
+<H1>Options Tech Detection screen</H1>
+<p>
+This screen allows you to configure the <a href="wappalyzer.html">Tech Detection</a> options:
+
+<H3>Mode</H3>
+
+The Mode which controls the behavior of the technology detection passive scan rule. This Mode is persisted between ZAP sessions.
+<ul>
+  <li>Quick > Return on first match; which may mean missing version information, but should be slightly more performant. (This is the default.)</li>
+  <li>Exhaustive > Keep matching and don't return early; likely slightly less performant.</li>
+</ul>
+
+<H3>Alerts</H3>
+Allows the user to select whether or not the technology detection passive scan rule should raise alerts as technologies are identified (Enabled by default).
+
+</BODY>
+</HTML>

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -30,17 +30,6 @@ The toolbar also includes:
   <li>An enable/disable toggle button which controls whether the technology detection passive scan rule is functioning or not. This enabled state is persisted between ZAP sessions.</li>
 <ul>
 
-<H2>Options</H2>>
-
-The add-on also includes an options panel which allows users to control:
-<ul>
-  <li>The Mode which controls the behavior of the technology detection passive scan rule. This Mode is persisted between ZAP sessions.
-  <ul>
-    <li>Quick > Return on first match; which may mean missing version information, but should be slightly more performant. (This is the default.)</li>
-    <li>Exhaustive > Keep matching and don't return early; likely slightly less performant.</li>
-  <ul>
-<ul>
-
 <H2>Reporting</H2>
 
 Technology data is available to reports via the 

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/index.xml
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/index.xml
@@ -6,4 +6,5 @@
 <index version="2.0">
 	<indexitem text="Wappalyzer" target="addon.wappalyzer" />
 	<indexitem text="Wappalyzer API" target="addon.wappalyzer.api" />
+	<indexitem text="Wappalyzer Options" target="addon.wappalyzer.options" />
 </index>

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/map.jhm
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/map.jhm
@@ -8,4 +8,5 @@
 
 	<mapID target="addon.wappalyzer" url="contents/wappalyzer.html" />
 	<mapID target="addon.wappalyzer.api" url="contents/api.html" />
+	<mapID target="addon.wappalyzer.options" url="contents/options.html" />
 </map>

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/toc.xml
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/toc.xml
@@ -8,6 +8,7 @@
 		<tocitem text="Add Ons" tocid="addons">
 			<tocitem text="Technology Detection" image="addon.wappalyzer.icon" target="addon.wappalyzer">
 				<tocitem text="API" target="addon.wappalyzer.api" />
+				<tocitem text="Options" target="addon.wappalyzer.options" />
 			</tocitem>
 		</tocitem>
 	</tocitem>

--- a/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
+++ b/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
@@ -1,3 +1,9 @@
+wappalyzer.alert.desc = The following "{0}" technology was identified: {1}.
+wappalyzer.alert.desc.extended = \nDescribed as:\n{0}
+wappalyzer.alert.name.prefix = Tech Detected - {0}
+wappalyzer.alert.otherinfo.cpe = The following CPE is associated with the identified tech: {0}
+wappalyzer.alert.otherinfo.version = The following version(s) is/are associated with the identified tech: {0}
+
 wappalyzer.api.view.listAll = Lists all sites and their associated applications (technologies).
 wappalyzer.api.view.listSite = Lists all the applications (technologies) associated with a specific site.
 wappalyzer.api.view.listSite.site = The site for which the applications (technologies) should be returned. (See listSites).
@@ -53,9 +59,10 @@ wappalyzer.mode.exhaustive = Exhaustive
 wappalyzer.mode.quick = Quick
 
 wappalyzer.name = Technology Detection
-wappalyzer.optionspanel.mode = Mode
 
+wappalyzer.optionspanel.mode = Mode:
 wappalyzer.optionspanel.name = Tech Detection
+wappalyzer.optionspanel.raisealerts = Raise alerts?
 
 wappalyzer.panel.mnemonic = t
 wappalyzer.panel.title = Technology

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/JsonParserUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/JsonParserUnitTest.java
@@ -45,7 +45,7 @@ class JsonParserUnitTest {
         assertEquals("Test Entry is a test entry for UnitTests", app.getDescription());
         assertEquals("https://www.example.com/testentry", app.getWebsite());
         assertEquals(expectedCategory, app.getCategories());
-        assertEquals(1, app.getHeaders().size());
+        assertEquals(2, app.getHeaders().size());
         assertEquals(1, app.getUrl().size());
         assertEquals(2, app.getHtml().size());
         assertEquals(2, app.getScript().size());

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/PassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/PassiveScannerUnitTest.java
@@ -20,7 +20,10 @@
 package org.zaproxy.zap.extension.wappalyzer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
@@ -30,9 +33,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpHeader;
@@ -205,7 +210,8 @@ class PassiveScannerUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveSc
         scan(msg);
         // Then
         assertFoundAppCount("https://www.example.com", 1);
-        assertFoundApp("https://www.example.com", "Test Entry2");
+        // No evidence on DOM selectors
+        assertFoundApp("https://www.example.com", "Test Entry2", false);
     }
 
     @Test
@@ -248,7 +254,8 @@ class PassiveScannerUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveSc
         // Then
         assertFoundAppCount("https://www.example.com", 2);
         assertFoundApp("https://www.example.com", "1C-Bitrix"); // Matched
-        assertFoundApp("https://www.example.com", "PHP"); // Implied
+        // No evidence when implied
+        assertFoundApp("https://www.example.com", "PHP", false); // Implied
     }
 
     @Test
@@ -431,11 +438,72 @@ class PassiveScannerUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveSc
         assertNothingFound("https://www.example.com");
     }
 
+    @Test
+    void shouldMatchHeaderNameAndValueInRequestWhenBothExpected()
+            throws HttpMalformedHeaderException {
+        // Given
+        String site = "https://www.example.com";
+        HttpMessage msg = makeHttpMessage();
+        msg.setRequestHeader("GET " + site + "/test HTTP/1.1");
+        msg.getResponseHeader().addHeader("Test", "Test Entry");
+        // When
+        scan(msg);
+        // Then
+        assertFoundAppCount(site, 1);
+        assertFoundApp(site, "Test Entry");
+    }
+
+    @Test
+    void shouldNotMatchHeaderNameAndValueInRequestWhenBothExpectedAndValueNotPresent()
+            throws HttpMalformedHeaderException {
+        // Given
+        String site = "https://www.example.com";
+        HttpMessage msg = makeHttpMessage();
+        msg.setRequestHeader("GET " + site + "/test HTTP/1.1");
+        msg.getResponseHeader().addHeader("Test", "");
+        // When
+        scan(msg);
+        // Then
+        assertNothingFound(site);
+    }
+
+    @Test
+    void shouldMatchHeaderNameInRequestWhenValueNotExpected() throws HttpMalformedHeaderException {
+        // Given
+        String site = "https://www.example.com";
+        HttpMessage msg = makeHttpMessage();
+        msg.setRequestHeader("GET " + site + "/test HTTP/1.1");
+        msg.getResponseHeader().addHeader("Foo", "");
+        // When
+        scan(msg);
+        // Then
+        assertFoundAppCount(site, 1);
+        assertFoundApp(site, "Test Entry");
+    }
+
+    @Test
+    void shouldNotMatchMultipleTimesAgainstSameMessage() throws HttpMalformedHeaderException {
+        // Given
+        String site = "https://www.example.com";
+        HttpMessage msg = makeHttpMessage();
+        msg.setRequestHeader("GET " + site + "/test HTTP/1.1");
+        msg.getResponseHeader().addHeader("Test", "Test Entry");
+        // When
+        scan(msg);
+        int initialCount = getDefaultHolder().getAppsForSite(site).size();
+        scan(msg);
+        int secondaryCount = getDefaultHolder().getAppsForSite(site).size();
+        // Then
+        assertThat(initialCount, is(equalTo(secondaryCount)));
+        assertFoundAppCount(site, 1);
+        assertFoundApp(site, "Test Entry");
+    }
+
     private void scan(HttpMessage msg) {
         rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
     }
 
-    private HttpMessage makeHttpMessage() throws HttpMalformedHeaderException {
+    private static HttpMessage makeHttpMessage() throws HttpMalformedHeaderException {
         HttpMessage httpMessage = new HttpMessage();
 
         HistoryReference ref = mock(HistoryReference.class);
@@ -461,10 +529,18 @@ class PassiveScannerUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveSc
     }
 
     private void assertFoundApp(String site, String appName) {
-        assertFoundApp(site, appName, null);
+        assertFoundApp(site, appName, null, true);
+    }
+
+    private void assertFoundApp(String site, String appName, boolean withEvidence) {
+        assertFoundApp(site, appName, null, withEvidence);
     }
 
     private void assertFoundApp(String site, String appName, String version) {
+        assertFoundApp(site, appName, version, true);
+    }
+
+    private void assertFoundApp(String site, String appName, String version, boolean withEvidence) {
         List<ApplicationMatch> appsForSite = getDefaultHolder().getAppsForSite(site);
         assertThat(appsForSite, notNullValue());
 
@@ -476,6 +552,78 @@ class PassiveScannerUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveSc
         assertThat("Application '" + appName + "' not present", app.isPresent(), is(true));
         if (version != null) {
             assertThat(app.get().getVersion(), is(version));
+        }
+        if (withEvidence) {
+            assertThat(app.get().getEvidences(), is(not(empty())));
+        }
+    }
+
+    @Nested
+    class AlertsUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveScanner> {
+
+        @Override
+        protected WappalyzerPassiveScanner createScanner() {
+            getDefaultHolder().resetApplicationsToSite();
+            return new WappalyzerPassiveScanner(getDefaultHolder());
+        }
+
+        @Test
+        void shouldHaveCpeAndVersionInAlertIfAvailable() throws HttpMalformedHeaderException {
+            // Given
+            HttpMessage msg = new HttpMessage();
+            msg.setRequestHeader("GET https://www.example.com/test HTTP/1.1");
+            msg.getResponseHeader().addHeader("Server", "Apache/2.4.7 (Ubuntu)");
+            // When
+            Application app = new Application();
+            app.setCpe("cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*");
+            ApplicationMatch appMatch = new ApplicationMatch(app);
+            appMatch.addVersion("2.4.7");
+            Alert alert = rule.createAlert(msg, appMatch);
+            // Then
+            assertThat(
+                    alert.getOtherInfo(),
+                    is(
+                            equalTo(
+                                    "The following CPE is associated with the identified tech: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*\n"
+                                            + "The following version(s) is/are associated with the identified tech: 2.4.7")));
+            assertThat(alert.getWascId(), is(equalTo(13)));
+            assertThat(alert.getCweId(), is(equalTo(200)));
+        }
+
+        @Test
+        void shouldNotHaveCpeAndVersionInAlertIfNotAvailablet()
+                throws HttpMalformedHeaderException {
+            // Given
+            HttpMessage msg = new HttpMessage();
+            msg.setRequestHeader("GET https://www.example.com/test HTTP/1.1");
+            msg.getResponseHeader().addHeader("Server", "Apache/2.4.7 (Ubuntu)");
+            // When
+            Application app = new Application();
+            ApplicationMatch appMatch = new ApplicationMatch(app);
+            Alert alert = rule.createAlert(msg, appMatch);
+            // Then
+            assertThat(alert.getOtherInfo(), is(equalTo("")));
+            assertThat(alert.getReference(), is(equalTo("")));
+            assertThat(alert.getWascId(), is(equalTo(13)));
+            assertThat(alert.getCweId(), is(equalTo(200)));
+        }
+
+        @Test
+        void shouldHaveRefInAlertIfWebsiteAvailable() throws HttpMalformedHeaderException {
+            // Given
+            HttpMessage msg = new HttpMessage();
+            msg.setRequestHeader("GET https://www.example.com/test HTTP/1.1");
+            msg.getResponseHeader().addHeader("Server", "Apache/2.4.7 (Ubuntu)");
+            // When
+            Application app = new Application();
+            app.setWebsite("https://httpd.apache.org");
+            ApplicationMatch appMatch = new ApplicationMatch(app);
+            Alert alert = rule.createAlert(msg, appMatch);
+            // Then
+            assertThat(alert.getOtherInfo(), is(equalTo("")));
+            assertThat(alert.getReference(), is(equalTo("https://httpd.apache.org")));
+            assertThat(alert.getWascId(), is(equalTo(13)));
+            assertThat(alert.getCweId(), is(equalTo(200)));
         }
     }
 }

--- a/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
+++ b/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
@@ -9,7 +9,8 @@
         "<!-- (?:End )?Test Entry -->"
       ],
       "headers": {
-        "Test": "Test Entry"
+        "Test": "Test Entry",
+        "Foo": ""
       },
       "icon": "Test Entry.svg",
       "js": {

--- a/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/categories.json
+++ b/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/categories.json
@@ -7,8 +7,43 @@
     "name": "Message boards",
     "priority": 1
   },
+  "6": {
+    "groups": [
+      1
+    ],
+    "name": "Ecommerce",
+    "priority": 1
+  },
+  "22": {
+    "groups": [
+      7
+    ],
+    "name": "Web servers",
+    "priority": 8
+  },
+  "27": {
+    "groups": [
+      9
+    ],
+    "name": "Programming languages",
+    "priority": 5
+  },
   "36": {
     "name": "Advertising",
+    "priority": 9
+  },
+  "57": {
+    "groups": [
+      9
+    ],
+    "name": "Static site generator",
+    "priority": 1
+  },
+  "59": {
+    "groups": [
+      9
+    ],
+    "name": "JavaScript libraries",
     "priority": 9
   }
 }


### PR DESCRIPTION
<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/4012c4b2-68a7-44ba-9879-507fe70221bc)

![image](https://github.com/user-attachments/assets/e7c7ecd8-f7b4-4448-9e26-ef40c2be7cc1)

</details>

## Overview

- Help > Updated help components to accommodate a separate Options page.
- TechOptionsPanel > Now include help index (balloon button).
- WappalyzerPassiveScanner > Add support for adding alerts. Reduce processing by synchronizing details in a Map. Updated cookie and header handling to address possible FP/FN situations.
- WappalyzerParam - Add handling for raise alerts option.
- CHANGELOG > Add change note.
- PassiveScannerUnitTest > Updated to test and handle new behavior. Created nested class to to assert alert handling behavior.
- Test resource categories.json > Added missing categories to make unit tests less 'chatty'.
- ApplicationMatch > Updated to track evidence.
- AppPattern > Updated to set evidence.
- ExtensionWappalyzer > Updated to reset the tracking objects in the scan rule on session change.

## Related Issues
- Fixes zaproxy/zaproxy#8361
- Ref zaproxy/zaproxy#8140

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
