### PR TITLE
Auto: Added env/continueOnFailure

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Env / continueOnFailure option.
 ### Changed
 - Maintenance changes.
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
@@ -414,9 +414,14 @@ public class AutomationEnvironment {
         return this.getData().getParameters().getFailOnWarning();
     }
 
+    public boolean isContinueOnFailure() {
+        return this.getData().getParameters().getContinueOnFailure();
+    }
+
     public boolean isTimeToQuit() {
-        return (isFailOnError() && progress.hasErrors())
-                || (isFailOnWarning() && progress.hasWarnings());
+        return !isContinueOnFailure()
+                && ((isFailOnError() && progress.hasErrors())
+                        || (isFailOnWarning() && progress.hasWarnings()));
     }
 
     public void showDialog() {
@@ -487,14 +492,20 @@ public class AutomationEnvironment {
         private boolean failOnError = true;
         private boolean failOnWarning;
         private boolean progressToStdout = true;
+        private boolean continueOnFailure = false;
 
         public Parameters() {}
 
-        public Parameters(boolean failOnError, boolean failOnWarning, boolean progressToStdout) {
+        public Parameters(
+                boolean failOnError,
+                boolean failOnWarning,
+                boolean progressToStdout,
+                boolean continueOnFailure) {
             super();
             this.failOnError = failOnError;
             this.failOnWarning = failOnWarning;
             this.progressToStdout = progressToStdout;
+            this.continueOnFailure = continueOnFailure;
         }
 
         public boolean getFailOnError() {
@@ -503,6 +514,10 @@ public class AutomationEnvironment {
 
         public boolean getFailOnWarning() {
             return failOnWarning;
+        }
+
+        public boolean getContinueOnFailure() {
+            return continueOnFailure;
         }
 
         public boolean getProgressToStdout() {
@@ -515,6 +530,10 @@ public class AutomationEnvironment {
 
         public void setFailOnWarning(boolean failOnWarning) {
             this.failOnWarning = failOnWarning;
+        }
+
+        public void setContinueOnFailure(boolean continueOnFailure) {
+            this.continueOnFailure = continueOnFailure;
         }
 
         public void setProgressToStdout(boolean progressToStdout) {

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvironmentDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvironmentDialog.java
@@ -51,6 +51,7 @@ public class EnvironmentDialog extends StandardFieldsDialog {
     private static final String TITLE = "automation.dialog.env.title";
     private static final String FAIL_ON_ERROR_PARAM = "automation.dialog.env.failonerror";
     private static final String FAIL_ON_WARNING_PARAM = "automation.dialog.env.failonwarning";
+    private static final String CONTINUE_ON_FAILURE_PARAM = "automation.dialog.env.continueonfail";
     private static final String PROGRESS_TO_STDOUT_PARAM = "automation.dialog.env.progresstostdout";
 
     private static final String PROXY_HOSTNAME = "automation.dialog.env.proxyhost";
@@ -95,6 +96,8 @@ public class EnvironmentDialog extends StandardFieldsDialog {
         this.addCheckBoxField(
                 1, FAIL_ON_WARNING_PARAM, env.getData().getParameters().getFailOnWarning());
         this.addCheckBoxField(
+                1, CONTINUE_ON_FAILURE_PARAM, env.getData().getParameters().getContinueOnFailure());
+        this.addCheckBoxField(
                 1, PROGRESS_TO_STDOUT_PARAM, env.getData().getParameters().getProgressToStdout());
         this.addPadding(1);
 
@@ -120,6 +123,10 @@ public class EnvironmentDialog extends StandardFieldsDialog {
                 .getData()
                 .getParameters()
                 .setFailOnWarning(this.getBoolValue(FAIL_ON_WARNING_PARAM));
+        this.env
+                .getData()
+                .getParameters()
+                .setContinueOnFailure(this.getBoolValue(CONTINUE_ON_FAILURE_PARAM));
         this.env
                 .getData()
                 .getParameters()

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/environment.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/environment.html
@@ -67,6 +67,7 @@ env:                                   # The environment, mandatory
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
+    continueOnFailure: false           # Continue running all jobs, even if one fails
     progressToStdout: true             # If set will write job progress to stdout
   proxy:                               # Optional upstream proxy settings
     hostname:                          # String, the proxy host

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -112,11 +112,12 @@ automation.dialog.delay.fileName = File Name:
 automation.dialog.delay.summary = Time: {0} file name: {1}
 automation.dialog.delay.time = Time:
 automation.dialog.delay.title = Delay Job
+automation.dialog.env.continueonfail = Continue On Failure:
 
 automation.dialog.env.error.nocontext = You must define at least one Context
 automation.dialog.env.failonerror = Fail On Error:
 automation.dialog.env.failonwarning = Fail On Warning:
-automation.dialog.env.progresstostdout = Progresss To Stdout:
+automation.dialog.env.progresstostdout = Progress To Stdout:
 automation.dialog.env.proxyhost = Hostname:
 automation.dialog.env.proxyport = Port:
 automation.dialog.env.proxypwd = Password: 

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env-max.yaml
@@ -44,6 +44,7 @@ env:                                   # The environment, mandatory
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
+    continueOnFailure: false           # Continue running all jobs, even if one fails
     progressToStdout: true             # If set will write job progress to stdout
   proxy:                               # Optional upstream proxy settings
     hostname:                          # String, the proxy host

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env-min.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env-min.yaml
@@ -9,6 +9,7 @@ env:                                   # The environment, mandatory
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
+    continueOnFailure: false           # Continue running all jobs, even if one fails
     progressToStdout: true             # If set will write job progress to stdout
 
 jobs:

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
@@ -9,6 +9,7 @@ env:                                   # The environment, mandatory
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
+    continueOnFailure: false           # Continue running all jobs, even if one fails
     progressToStdout: true             # If set will write job progress to stdout
 
 jobs:

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -44,6 +44,7 @@ env:                                   # The environment, mandatory
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
+    continueOnFailure: false           # Continue running all jobs, even if one fails
     progressToStdout: true             # If set will write job progress to stdout
   proxy:                               # Optional upstream proxy settings
     hostname:                          # String, the proxy host

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
@@ -9,6 +9,7 @@ env:                                   # The environment, mandatory
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
+    continueOnFailure: false           # Continue running all jobs, even if one fails
     progressToStdout: true             # If set will write job progress to stdout
 
 jobs:

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-continueonerror.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-continueonerror.yaml
@@ -1,0 +1,20 @@
+env:
+  contexts:
+    - name: example
+      urls: 
+      - https://www.example.com/
+  parameters:
+    failOnError: true                  
+    failOnWarning: false               
+    progressToStdout: false         
+    continueOnFailure: true   
+
+jobs:
+  - type: job1
+    parameters:
+
+  - type: job2
+    parameters:
+
+  - type: job3
+    parameters:

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-continueonwarning.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-continueonwarning.yaml
@@ -1,0 +1,20 @@
+env:
+  contexts:
+    - name: example
+      urls: 
+      - https://www.example.com/
+  parameters:
+    failOnError: true                  
+    failOnWarning: true               
+    progressToStdout: false            
+    continueOnFailure: true   
+
+jobs:
+  - type: job1
+    parameters:
+
+  - type: job2
+    parameters:
+
+  - type: job3
+    parameters:


### PR DESCRIPTION
## Overview
Add a new env parameter: continueOnFailure.
By default this is false, but if set means that jobs will keep running even if an earlier job fails.
A key usecase for this is collecting suitable diagnostics if an integration test fails.

## Related Issues

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
