### PR TITLE
automation: replace hardcoded checks

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
@@ -497,6 +497,10 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
         return false;
     }
 
+    public String getKeyAlertTestsResultData() {
+        return null;
+    }
+
     public boolean supportsMonitorTests() {
         return false;
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -72,6 +72,11 @@ public class ActiveScanJob extends AutomationJob {
         return true;
     }
 
+    @Override
+    public String getKeyAlertTestsResultData() {
+        return ActiveScanJobResultData.KEY;
+    }
+
     private ExtensionActiveScan getExtAScan() {
         if (extAScan == null) {
             extAScan =

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJob.java
@@ -53,6 +53,11 @@ public class PassiveScanWaitJob extends AutomationJob {
     }
 
     @Override
+    public String getKeyAlertTestsResultData() {
+        return PassiveScanJobResultData.KEY;
+    }
+
+    @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
         ExtensionPassiveScan extPScan = getExtPassiveScan();
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/tests/AutomationAlertTest.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/tests/AutomationAlertTest.java
@@ -31,11 +31,7 @@ import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.addon.automation.JobResultData;
 import org.zaproxy.addon.automation.gui.AlertTestDialog;
-import org.zaproxy.addon.automation.jobs.ActiveScanJob;
-import org.zaproxy.addon.automation.jobs.ActiveScanJobResultData;
 import org.zaproxy.addon.automation.jobs.JobUtils;
-import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData;
-import org.zaproxy.addon.automation.jobs.PassiveScanWaitJob;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 
 public class AutomationAlertTest extends AbstractAutomationTest {
@@ -76,8 +72,7 @@ public class AutomationAlertTest extends AbstractAutomationTest {
                     Constant.messages.getString(
                             "automation.tests.alert.nullExtension", job.getType()));
         }
-        if (!(job.getType().equals(ActiveScanJob.JOB_NAME)
-                || job.getType().equals(PassiveScanWaitJob.JOB_NAME))) {
+        if (!job.supportsAlertTests()) {
             progress.error(
                     Constant.messages.getString(
                             "automation.tests.alert.invalidJobType", job.getType()));
@@ -168,10 +163,7 @@ public class AutomationAlertTest extends AbstractAutomationTest {
     @Override
     public boolean runTest(AutomationProgress progress) {
         boolean passIfAbsent = this.getData().getAction().equals(ACTION_PASS_IF_ABSENT);
-        String key =
-                (getJobType().equals(ActiveScanJob.JOB_NAME))
-                        ? ActiveScanJobResultData.KEY
-                        : PassiveScanJobResultData.KEY;
+        String key = getJob().getKeyAlertTestsResultData();
         JobResultData resultData = progress.getJobResultData(key);
         List<Alert> alerts =
                 resultData.getAllAlertData().stream()

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationJobUnitTest.java
@@ -45,7 +45,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
-import org.zaproxy.addon.automation.jobs.ActiveScanJob;
 import org.zaproxy.addon.automation.tests.AbstractAutomationTest;
 import org.zaproxy.addon.automation.tests.AbstractAutomationTest.OnFail;
 import org.zaproxy.addon.automation.tests.AutomationAlertTest;
@@ -485,8 +484,8 @@ class AutomationJobUnitTest {
         AutomationJob job =
                 new AutomationJobImpl(tpc) {
                     @Override
-                    public String getType() {
-                        return ActiveScanJob.JOB_NAME;
+                    public boolean supportsAlertTests() {
+                        return true;
                     }
                 };
 
@@ -567,8 +566,8 @@ class AutomationJobUnitTest {
         AutomationJob job =
                 new AutomationJobImpl(tpc) {
                     @Override
-                    public String getType() {
-                        return ActiveScanJob.JOB_NAME;
+                    public boolean supportsAlertTests() {
+                        return true;
                     }
                 };
 
@@ -627,8 +626,8 @@ class AutomationJobUnitTest {
         AutomationJob job =
                 new AutomationJobImpl(tpc) {
                     @Override
-                    public String getType() {
-                        return ActiveScanJob.JOB_NAME;
+                    public boolean supportsAlertTests() {
+                        return true;
                     }
                 };
 
@@ -696,8 +695,8 @@ class AutomationJobUnitTest {
         AutomationJob job =
                 new AutomationJobImpl(tpc) {
                     @Override
-                    public String getType() {
-                        return ActiveScanJob.JOB_NAME;
+                    public boolean supportsAlertTests() {
+                        return true;
                     }
 
                     @Override


### PR DESCRIPTION
Use the information from the job when checking for alert tests.

Part of zaproxy/zaproxy#7959.