### PR TITLE
ascanrulesBeta: Fix Source Code Disclosure File Inc. False Positives

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Potential false positives in the Source Code Disclosure - File Inclusion scan rule when responses are empty or the original message resulted in an error to start with (Issue 8517).
 
 ## [54] - 2024-07-22
 ### Changed
@@ -12,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 
 ### Fixed
-- Fixed regex for Relative Path Confusion, which detected absolute url as relative
+- Fixed regex for Relative Path Confusion, which detected absolute URL as relative.
 - Alert text for various rules has been updated to more consistently use periods and spaces in a uniform manner.
 
 ## [53] - 2024-03-28

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -177,6 +177,7 @@ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/42/">42</a>.
 
 <H2 id="id-43">Source Code Disclosure - File Inclusion</H2>
 Uses local file inclusion techniques to scan for files containing source code on the web server.
+Skips messages which originally resulted in a client or server error response status code.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java">SourceCodeDisclosureFileInclusionScanRule.java</a>
 <br>

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
@@ -19,21 +19,40 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.ScannerParam;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerabilities;
 import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
+import org.zaproxy.zap.testutils.NanoServerHandler;
 
 class SourceCodeDisclosureFileInclusionScanRuleUnitTest
         extends ActiveScannerTest<SourceCodeDisclosureFileInclusionScanRule> {
+
+    private static final String DEFAULT_RESPONSE_STRING = "<html><body></body></html>";
 
     @Override
     protected SourceCodeDisclosureFileInclusionScanRule createScanner() {
@@ -84,5 +103,163 @@ class SourceCodeDisclosureFileInclusionScanRuleUnitTest
         assertThat(alert.getSolution(), is(equalTo(vuln.getSolution())));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+    }
+
+    @Test
+    void shouldSkipUrlParams() {
+        // Given
+        HttpMessage msg = createMessage("/param/test/");
+        rule.init(msg, parent);
+        scannerParam.setTargetParamsInjectable(ScannerParam.TARGET_URLPATH);
+        // When
+        rule.scan();
+        // Then
+        assertThat(countMessagesSent, is(equalTo(0)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    void shouldSkipIfNoOrEmptyPath(String path) {
+        // Given
+        HttpMessage msg = createMessage(path);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(countMessagesSent, is(equalTo(0)));
+    }
+
+    @Test
+    void shouldNotContinueIfRandomBodyIsEmpty() throws IOException {
+        // Given
+        String path = "/shouldNotContinueIfRandomBodyIsEmpty";
+        nano.addHandler(new FiHandler(path, Response.Status.OK, ""));
+        HttpMessage msg = getHttpMessage(path + "?inc=bar");
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, is(empty()));
+        assertThat(httpMessagesSent, is(not(empty())));
+    }
+
+    @Test
+    void shouldNotContinueIfRandomBodyIsTooSimilar() throws IOException {
+        // Given
+        String path = "/shouldNotContinueIfRandomBodyIsTooSimilar";
+        nano.addHandler(new FiHandler(path, Response.Status.OK, DEFAULT_RESPONSE_STRING));
+        HttpMessage msg = this.getHttpMessage("GET", path + "?inc=bar", DEFAULT_RESPONSE_STRING);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, is(empty()));
+        assertThat(httpMessagesSent, is(not(empty())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"php", "jsp", "war", "ear", "rar"})
+    void shouldAlertWhenConditionsRightAndExtensionMatchesContent(String ext) throws IOException {
+        // Given
+        String path = "/shouldAlertWhenConditionsRightAndExtensionMatchesContent." + ext;
+        nano.addHandler(new FiHandler(path, Response.Status.OK, "different"));
+        HttpMessage msg = this.getHttpMessage("GET", path + "?inc=bar", DEFAULT_RESPONSE_STRING);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(httpMessagesSent, is(not(empty())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {403, 404, 405, 500, 503})
+    void shouldNotContinueIfOriginalMessageWasAnEroor(int status) throws IOException {
+        // Given
+        String path = "/shouldNotContinueIfOriginalMessageWasAnEroor.";
+        nano.addHandler(new FiHandler(path, Response.Status.OK, "different"));
+        HttpMessage msg = this.getHttpMessage("GET", path + "?inc=bar", DEFAULT_RESPONSE_STRING);
+        msg.getResponseHeader().setStatusCode(status);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, is(empty()));
+        assertThat(httpMessagesSent, is(empty()));
+    }
+
+    @Test
+    void shouldAlertWhenConditionsRightAndNoExtensionMatchesAnyContent() throws IOException {
+        // Given
+        String path = "/shouldAlertWhenConditionsRightAndNoExtensionMatchesAnyContent";
+        nano.addHandler(new FiHandler(path, Response.Status.OK, "different"));
+        HttpMessage msg = this.getHttpMessage("GET", path + "?inc=bar", DEFAULT_RESPONSE_STRING);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    void shouldNotAlertWhenConditionsRightAndDisclosureResponseEmpty() throws IOException {
+        // Given
+        String path = "/empty";
+        nano.addHandler(new FiHandler(path, Response.Status.OK, "different"));
+        HttpMessage msg = this.getHttpMessage("GET", path + "?inc=bar", DEFAULT_RESPONSE_STRING);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent.size(), is(equalTo(14)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    private static HttpMessage createMessage(String path) {
+        try {
+
+            HttpMessage msg = new HttpMessage(new URI("https://example.com" + path, true));
+            msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+            return msg;
+        } catch (URIException | HttpMalformedHeaderException | NullPointerException e) {
+            // Ignore
+        }
+        return null;
+    }
+
+    private static class FiHandler extends NanoServerHandler {
+        private final Response.IStatus status;
+        private final String randBody;
+
+        public FiHandler(String path, Response.IStatus status, String randBody) {
+            super(path);
+            this.status = status;
+            this.randBody = randBody;
+        }
+
+        @Override
+        protected Response serve(IHTTPSession session) {
+            String pValue = getFirstParamValue(session, "inc");
+
+            if (pValue.length() == 38) {
+                return newFixedLengthResponse(status, NanoHTTPD.MIME_HTML, randBody);
+            }
+
+            String uri = session.getUri();
+            uri = uri.replace(session.getQueryParameterString(), "");
+            if (uri.endsWith(".php")) {
+                return newFixedLengthResponse("<?php");
+            } else if (uri.endsWith(".jsp")) {
+                return newFixedLengthResponse("<%.*%>");
+            } else if (uri.endsWith(".war") || uri.endsWith(".ear") || uri.endsWith(".rar")) {
+                return newFixedLengthResponse(".class");
+            } else if (uri.endsWith("empty")) {
+                return newFixedLengthResponse("");
+            } else if (uri.endsWith(pValue)) {
+                return newFixedLengthResponse("something");
+            }
+            return newFixedLengthResponse(
+                    NanoHTTPD.Response.Status.OK, NanoHTTPD.MIME_HTML, DEFAULT_RESPONSE_STRING);
+        }
     }
 }


### PR DESCRIPTION
## Overview
- CHANGELOG > Added fix note.
- SourceCodeDisclosureFileInclusionScanRule > Adjusted behavior.
- SourceCodeDisclosureFileInclusionScanRule > Added tests to assert the expected behaviors.
- ascanrulesBeta.html > Added details on the error conditions skip.

## Related Issues
- Fixes zaproxy/zaproxy#8517

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage (Now 68.8%, was 38.7%)
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
