### PR TITLE
automation: reorder load of last plan

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Address errors when the last plan loaded had a `passiveScan-config` job with configured rules.
+
 ## [0.40.1] - 2024-05-28
 ### Fixed
 - Address HTTP authentication failure when the realm is not configured.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -197,7 +197,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
     }
 
     @Override
-    public void postInit() {
+    public void start() {
         if (hasView() && this.getParam().isOpenLastPlan()) {
             String path = getParam().getLastPlanPath();
             if (path != null) {


### PR DESCRIPTION
Move the load from `postInit` to `start`, to ensure all other add-ons had time to fully initialize, addressing errors when the last plan loaded had a `passiveScan-config` job with configured rules.