### PR TITLE
domxss: address FNs through query parameter

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Include the whole HTTP message in the raised alerts.
 
+### Fixed
+- Address false negatives through query parameters.
+
 ## [19] - 2024-05-07
 ### Changed
 - Update minimum ZAP version to 2.15.0.

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -107,9 +107,10 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
         HASH_HASH_IMG_ALERT,
     };
 
-    private static final String IMG_ALERT = "<img src=\"random.gif\" onerror=alert(1)>";
-    private static final String SCRIPT_ALERT = "<script>alert(1)</script>";
-    private static final String JAVASCRIPT_ALERT = "javascript:alert(1)";
+    private static final String IMG_ALERT =
+            "<img src=\"random.gif\" onerror=alert(" + UNLIKELY_INT + ")>";
+    private static final String SCRIPT_ALERT = "<script>alert(" + UNLIKELY_INT + ")</script>";
+    static final String JAVASCRIPT_ALERT = "javascript:alert(" + UNLIKELY_INT + ")";
 
     private static final String[] PARAM_ATTACK_STRINGS = {
         SCRIPT_ALERT, JAVASCRIPT_ALERT, IMG_ALERT


### PR DESCRIPTION
Correct values used for the evidence that the expected alert message was shown.