### PR TITLE
ascanrulesAlpha: Be More defensive for LDAPi False Positives

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Alert text for various rules has been updated to more consistently use periods and spaces in a uniform manner.
+- Potential false positives in the LDAP Injection scan rule when the original message resulted in an error to start with (Issue 8519).
 
 ## [47] - 2024-03-28
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -193,6 +193,14 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
     }
 
     @Override
+    public void scan() {
+        if (isClientError(getBaseMsg()) || isServerError(getBaseMsg())) {
+            return;
+        }
+        super.scan();
+    }
+
+    @Override
     public void scan(HttpMessage msg, NameValuePair originalParam) {
         /*
          * Scan everything _except_ URL path parameters.
@@ -210,7 +218,6 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
      */
     @Override
     public void scan(HttpMessage originalmsg, String paramname, String paramvalue) {
-
         // for the purposes of our logic, we can handle a NULL parameter as an empty string. Saves
         // on NPEs.
         if (paramvalue == null) paramvalue = "";

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -25,6 +25,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 
 <H2 id="id-40015">LDAP Injection</H2>
 LDAP Injection may be possible. It may be possible for an attacker to bypass authentication controls, and to view and modify arbitrary data in the LDAP directory.
+Skips messages which originally resulted in a client or server error response status code.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java">LdapInjectionScanRule.java</a>
 <br>


### PR DESCRIPTION
## Overview
- CHANGELOG > Added fix note.
- LdapInjectionScanRule > Adjust behavior, return early if original was client or server error.
- LdapInjectionScanRuleUnitTest > Test/ssert the new behavior.
- ascanslpha.html > Noted the updated behavior.

## Related Issues
- Fixes zaproxy/zaproxy#8519

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
