### PR TITLE
alertFilters: handle deleted alerts

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Handle deleted alerts gracefully.
 
 ## [21] - 2024-05-07
 ### Changed


### PR DESCRIPTION
Skip the notified alert if it was already deleted instead of letting the NPE happen.
Also, remove compatibility code with older ZAP versions.