### PR TITLE
quickstart: correct Mode handling in URL field

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Do not change the URL field of the Manual Explore panel when the Mode changes (Issue 8591).
 
 ## [48] - 2024-07-08
 ### Changed

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -263,6 +263,7 @@ public class AttackPanel extends QuickStartSubPanel {
             case safe:
             case protect:
                 this.getUrlField().setEnabled(false);
+                this.getUrlField().setModel(new DefaultComboBoxModel<>());
                 this.getUrlField()
                         .setSelectedItem(
                                 Constant.messages.getString("quickstart.field.url.disabled.mode"));
@@ -272,6 +273,7 @@ public class AttackPanel extends QuickStartSubPanel {
             case standard:
             case attack:
                 this.getUrlField().setEnabled(true);
+                this.getUrlField().setModel(getUrlModel());
                 this.getUrlField().setSelectedItem(DEFAULT_VALUE_URL_FIELD);
                 this.selectButton.setEnabled(true);
                 this.getAttackButton().setEnabled(true);


### PR DESCRIPTION
Use other model before changing the URL of the Automated Scan panel to ensure the Mode's info message is not shown/used as a URL in the Manual Explore panel.

Fix zaproxy/zaproxy#8591.