### PR TITLE
authhelper: replace direct task helper usage

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.14.0] - 2024-07-31
 ### Fixed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -103,8 +103,7 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                             AuthUtils.findSessionTokenSource(st.getValue());
                     if (smrd != null) {
                         // Yes, found the token in a 'non standard' place
-                        this.getTaskHelper()
-                                .raiseAlert(smrd.getMsg().getHistoryRef(), getAlert(smrd).build());
+                        getAlert(smrd).raise();
                         LOGGER.debug(
                                 "Found {} 'unknown' response session token(s) in {}",
                                 responseTokens.size(),


### PR DESCRIPTION
Use the raise method from the `PluginPassiveScanner.AlertBuilder` instead of raising the alert through the task helper class to not directly depend on it.