### PR TITLE
webuipoc: handle other endpoints

### DIFF
--- a/addOns/webuipoc/src/main/java/org/zaproxy/addon/webuipoc/TestProxyServer.java
+++ b/addOns/webuipoc/src/main/java/org/zaproxy/addon/webuipoc/TestProxyServer.java
@@ -202,6 +202,7 @@ public class TestProxyServer {
         String path = msg.getRequestHeader().getURI().getEscapedPath();
         return path.startsWith("/UI/")
                 || path.startsWith("/JSON/")
+                || path.startsWith("/OTHER/")
                 || path.startsWith("/script.js");
     }
 


### PR DESCRIPTION
Check for `/OTHER/` to include other API endpoints.