### PR TITLE
retire: improve add-on description

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- A helpful description for the add-on.
 
 ## [0.38.0] - 2024-08-05
 ### Changed

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -1,6 +1,5 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-
 description = "Use Retire.js to identify vulnerable or out-dated JavaScript packages."
 
 zapAddOn {

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -1,6 +1,7 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-description = "Retire.js"
+
+description = "Use Retire.js to identify vulnerable or out-dated JavaScript packages."
 
 zapAddOn {
     addOnName.set("Retire.js")


### PR DESCRIPTION
## Overview
The current description on Retire.js as seen in the update add-ons dialog is unhelpful:
![image](https://github.com/user-attachments/assets/64389824-e88d-40b8-aebe-c106702853ee)

## Related Issues


## Checklist
- [ ] Update help
- [x] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
