### PR TITLE
Update CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.0
+        uses: contributor-assistant/github-action@v2.5.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.ZAP_CLA_PAT }}


### PR DESCRIPTION
- 2.5.1 which uses node 20 vs node 16

Ref: https://github.com/search?q=org%3Azaproxy+contributor-assistant%2Fgithub-action%40v2.3.0&type=code
Ref: https://github.com/contributor-assistant/github-action/issues/149
