### PR TITLE
pscanrules: ignore cache-control for POST method

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Clarified Missing Anti-clickjacking Header description.
 - Depend on Passive Scanner add-on to include it by default (Issue 7959).
+- Re-examine Cache-control Directives scan rule now ignores cache-control for POST method requests (Issue 8592).
 
 ## [59] - 2024-07-24
 ### Added

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
@@ -47,6 +48,7 @@ public class CacheControlScanRule extends PluginPassiveScanner
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getRequestHeader().isSecure()
                 && msg.getResponseBody().length() > 0
+                && !HttpRequestHeader.POST.equals(msg.getRequestHeader().getMethod())
                 && !ResourceIdentificationUtils.isImage(msg)) {
 
             if (!AlertThreshold.LOW.equals(this.getAlertThreshold())

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRuleUnitTest.java
@@ -83,6 +83,27 @@ class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheControlScanRu
     }
 
     @Test
+    void shouldNotAlertOnHttpsPostRequest() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("POST https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        given(passiveScanData.isClientError(any())).willReturn(false);
+        given(passiveScanData.isServerError(any())).willReturn(false);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
     void shouldNotAlertOnHttpsAllPresentCacheRequest() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();


### PR DESCRIPTION
## Overview
This PR is to update the current CacheControlScanRule to ignore the cache-control requirement for POST method.

## Related Issues
Fixes https://github.com/zaproxy/zaproxy/issues/8592

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [na] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
