### PR TITLE
Selenium: add no-browser link to warnings

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Link to "no browser" FAQ in warning messages.
 
 ## [15.28.0] - 2024-08-12
 ### Changed

--- a/addOns/selenium/src/main/resources/org/zaproxy/zap/extension/selenium/resources/Messages.properties
+++ b/addOns/selenium/src/main/resources/org/zaproxy/zap/extension/selenium/resources/Messages.properties
@@ -81,7 +81,7 @@ selenium.options.webdrivers.title = WebDrivers
 selenium.scripts.interface.error = The provided Selenium script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
 selenium.scripts.type.selenium = Selenium
 
-selenium.warn.message.browser.not.found = {0} not found. Are you sure it's in your PATH?
-selenium.warn.message.failed.start.browser = Failed to start/connect to ''{0}'', is the browser available/supported?
+selenium.warn.message.browser.not.found = {0} not found. Are you sure it's in your PATH?\nSee https://www.zaproxy.org/faq/no-browser/
+selenium.warn.message.failed.start.browser = Failed to start/connect to ''{0}'', is the browser available/supported?\nSee https://www.zaproxy.org/faq/no-browser/
 selenium.warn.message.failed.start.browser.chrome = Failed to start Chrome browser.\nMake sure that Chrome and ChromeDriver are available.\nFor more details refer to "Options Selenium screen" help page.
-selenium.warn.message.failed.start.browser.notfound = The provided browser was not found.
+selenium.warn.message.failed.start.browser.notfound = The provided browser was not found.\nSee https://www.zaproxy.org/faq/no-browser/


### PR DESCRIPTION
## Overview
Add a link to the "no-browser" FAQ in related warning messages.

<img width="484" alt="Screenshot 2024-08-20 at 10 38 28" src="https://github.com/user-attachments/assets/eb930191-2ab7-4c66-ba6f-110d2c58147a">

## Related Issues
https://github.com/zaproxy/zaproxy-website/pull/2768

## Checklist
- [ ] Update help
- [x] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
