### PR TITLE
ascanrules: add example alerts to Spring Actuator

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- The Spring Actuator Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [67] - 2024-07-22
 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SpringActuatorScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SpringActuatorScanRuleUnitTest.java
@@ -22,12 +22,14 @@ package org.zaproxy.zap.extension.ascanrules;
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -343,6 +345,10 @@ class SpringActuatorScanRuleUnitTest extends ActiveScannerTest<SpringActuatorSca
         assertThat(cwe, is(equalTo(215)));
         assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
+        assertBaseTags(tags);
+    }
+
+    private static void assertBaseTags(Map<String, String> tags) {
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()),
                 is(equalTo(true)));
@@ -361,5 +367,22 @@ class SpringActuatorScanRuleUnitTest extends ActiveScannerTest<SpringActuatorSca
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+
+        Alert alert = alerts.get(0);
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        Map<String, String> tags = alert.getTags();
+        assertThat(tags.size(), is(equalTo(4)));
+        assertBaseTags(tags);
+        assertThat(tags, hasKey("CWE-215"));
     }
 }


### PR DESCRIPTION
## Overview
Me and [Lucas Bergholz](github.com/lucasbergholz) worked on this together, with the porpuse of adding the alert for SpringActuatorScanRule. We are open for any feedbacks of our work, as this is our first contribution on this issue.

## Related Issues
Part of zaproxy/zaproxy#6119.

## Checklist
- [ ] Update help
- [x] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
