### PR TITLE
tech detection: Example alerts

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The add-on now also has the ability to optionally raise Alerts for each technology identified. The default setting is enabled. (Issue 8361)
 - Maintenance changes.
     - This may be a breaking change for anyone that has code using the Automation Framework's Tech Detection (Wappalyzer) data.
+- The scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
+- Link website alert page and help (Issues 8189).
 
 ## [21.39.0] - 2024-07-04
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -50,6 +51,7 @@ import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
 import org.zaproxy.zap.utils.ThreadUtils;
@@ -58,7 +60,10 @@ import org.zaproxy.zap.view.SiteMapListener;
 import org.zaproxy.zap.view.SiteMapTreeCellRenderer;
 
 public class ExtensionWappalyzer extends ExtensionAdaptor
-        implements SessionChangedListener, SiteMapListener, ApplicationHolder {
+        implements SessionChangedListener,
+                SiteMapListener,
+                ApplicationHolder,
+                ExampleAlertProvider {
 
     public static final String NAME = "ExtensionWappalyzer";
 
@@ -463,5 +468,14 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
         if (updateLoggers) {
             ctx.updateLoggers();
         }
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return passiveScanner.getExampleAlerts();
+    }
+
+    public String getHelpLink() {
+        return passiveScanner.getHelpLink();
     }
 }

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/options.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/options.html
@@ -17,8 +17,13 @@ The Mode which controls the behavior of the technology detection passive scan ru
   <li>Exhaustive > Keep matching and don't return early; likely slightly less performant.</li>
 </ul>
 
-<H3>Alerts</H3>
+<H3 id="10004">Alerts</H3>
 Allows the user to select whether or not the technology detection passive scan rule should raise alerts as technologies are identified (Enabled by default).
+Alerts are Informational and include the Tech Name, a Description of the tech if available, Other Info may include CPE or version details, and References may contain Tech specific URLs.
+<p>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPassiveScanner.java">TechPassiveScanner.java</a>
+<br>
+Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10004/">10004</a>
 
 </BODY>
 </HTML>

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -33,7 +33,7 @@ The toolbar also includes:
 <H2>Reporting</H2>
 
 Technology data is available to reports via the 
-<a href="https://github.com/zaproxy/zap-extensions/tree/main/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/WappalyzerJobResultData.java">WappalyzerJobResultData</a> class.
+<a href="https://github.com/zaproxy/zap-extensions/tree/main/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/TechJobResultData.java">TechJobResultData</a> class.
 
 <H2>External Links</H2>
 <table>


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- ExtensionWappalyzer > Implements ExampleAlertProvider, and calls to the passive scan rule to get the details.
- TechPassiveScanner > Adjusted alert creation, added example alert method, added help link method.
- PassiveScannerUnitTest > Added tests for example alerts and help link.
- options.html > Updated to facilitate help link.
- wappalyzer.html > Update WappalyzerJobResultData reference to TechJobResultData. (Follow-up to zaproxy/zap-extensions#5651)

## Related Issues
N/A

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
