### PR TITLE
Auth Helper: fix session detection performance issue

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+### Fixed
+- Bug in session detection scan rule which impacted performance.
 
 ## [0.14.0] - 2024-07-31
 ### Fixed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -78,7 +78,7 @@ public class AuthUtils {
     public static final String AUTH_NO_USER_FIELD_STATS = "stats.auth.browser.nouserfield";
     public static final String AUTH_NO_PASSWORD_FIELD_STATS = "stats.auth.browser.nopasswordfield";
     public static final String AUTH_FOUND_FIELDS_STATS = "stats.auth.browser.foundfields";
-    public static final String AUTH_SESSION_TOKEN_STATS_PREFIX = "stats.auth.sessiontoken.";
+    public static final String AUTH_SESSION_TOKENS_MAX = "stats.auth.sessiontokens.max";
     public static final String AUTH_BROWSER_PASSED_STATS = "stats.auth.browser.passed";
     public static final String AUTH_BROWSER_FAILED_STATS = "stats.auth.browser.failed";
 
@@ -448,11 +448,6 @@ public class AuthUtils {
         }
         if (!map.isEmpty()) {
             LOGGER.debug("Found session tokens in {} : {}", msg.getRequestHeader().getURI(), map);
-            map.forEach(
-                    (k, v) ->
-                            AuthUtils.incStatsCounter(
-                                    msg.getRequestHeader().getURI(),
-                                    AUTH_SESSION_TOKEN_STATS_PREFIX + v.getKey()));
         }
 
         return map;
@@ -604,9 +599,6 @@ public class AuthUtils {
                                     .filter(v -> v.getValue().equals(token))
                                     .findFirst();
                     if (es.isPresent()) {
-                        AuthUtils.incStatsCounter(
-                                msg.getRequestHeader().getURI(),
-                                AuthUtils.AUTH_SESSION_TOKEN_STATS_PREFIX + es.get().getKey());
                         List<SessionToken> tokens = new ArrayList<>();
                         tokens.add(
                                 new SessionToken(
@@ -656,6 +648,7 @@ public class AuthUtils {
 
     public static void recordSessionToken(SessionToken token) {
         knownTokenMap.put(token.getValue(), token);
+        Stats.setHighwaterMark(AUTH_SESSION_TOKENS_MAX, knownTokenMap.size());
     }
 
     public static SessionToken getSessionToken(String value) {

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -149,7 +149,6 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                         }
                     }
                 }
-                foundTokens.forEach(t -> AuthUtils.removeSessionToken(t));
             } else if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(
                         "Failed to find source of session management tokens in {}:",


### PR DESCRIPTION
## Overview
The problem was that we were deleting the session tokens from our cache once we had found them once.
But session tokens get reused a lot, of course, so we kept on searching through the old history records because we had taken them out of the cache - doh!
Who wrote this code??
Oh, I did ;)
Also removed the stats per token as we're getting so many they are useless, instead added a stat for the max tokens cached.

## Related Issues


## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
