### PR TITLE
Tech: Added request stats

### DIFF
--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Tech stats to telemetry.
 
 ## [0.12.0] - 2024-05-07
 ### Changed

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
@@ -306,6 +306,7 @@ public class ExtensionCallHome extends ExtensionAdaptor
                     || key.startsWith("stats.script.")
                     || key.startsWith("stats.selenium.")
                     || key.startsWith("stats.spider.")
+                    || key.startsWith("stats.tech.")
                     || key.startsWith("stats.ui.")
                     || key.startsWith("stats.websockets.")
                     || PSCAN_PATTERN.matcher(key).matches();

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Request stats.
 
 ## [21.40.0] - 2024-08-28
 ### Changed


### PR DESCRIPTION
## Overview
Add request stats to the tech add-on so that we can tell if its worth limiting the number of URLs it analyses in order to speed it up.
Note that the change to `getSite(msg)` is so that it is compatible with the site based stats.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
