### PR TITLE
Automation: Fix GUI NPE if tech not specified.

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Allow to configure the structural parameters of a context (Issue 7780).
 
+### Fixed
+- NPE in GUI if the technology was not specified.
+
 ### Changed
 - Rely on Passive Scanner add-on for the passive scan related jobs (Issue 7959).
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
@@ -133,11 +133,19 @@ public class ContextDialog extends StandardFieldsDialog {
         this.context.setUrls(stringParamToList(URLS_PARAM));
         this.context.setIncludePaths(stringParamToList(INCLUDE_PARAM));
         this.context.setExcludePaths(stringParamToList(EXCLUDE_PARAM));
-        this.context
-                .getTechnology()
-                .setExclude(
-                        TechnologyUtils.techSetToExcludeList(
-                                this.getTechnologyPanel().getTechSet()));
+
+        TechnologyData tech = this.context.getTechnology();
+        List<String> excludeTech =
+                TechnologyUtils.techSetToExcludeList(this.getTechnologyPanel().getTechSet());
+        if (tech == null && excludeTech.size() == 0) {
+            // Can ignore
+        } else {
+            if (tech == null) {
+                tech = new TechnologyData();
+            }
+            tech.setExclude(excludeTech);
+            this.context.setTechnology(tech);
+        }
         context.setStructure(getStructurePanel().getStructure());
         if (this.isNew) {
             envDialog.addContext(context);


### PR DESCRIPTION
## Overview
The GUI can NPE if tech not specified.

At test:

1. Create an AF plan with no tech in the env - this is allowed as its optional
2. Open the plan in the GUI
3. Open the env, then the context
4. Save the context

Without this fix it will NPE

## Related Issues
Specify any related issues or pull requests by linking to them.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
