### PR TITLE
pscanrules: add examples alerts to Insecure JSF ViewState

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Rename Mac OSX salted SHA-1 in the Hash Disclosure scan rule to "Salted SHA-1", reduce the associated alerts to Low risk and Low confidence, to align with other SHA related patterns it will only be evaluated a Low Threshold. (Note such matches may indicate leaks related but not limited to: MacOS X, Oracle, Tiger-192, Haval-192) (Issue 8624).
+- The Insecure JSF ViewState now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [60] - 2024-09-02
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
@@ -116,7 +116,7 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner
                         // If the ViewState is not secured cryptographic
                         // protections then raise an alert.
                         if (!isViewStateSecure(val, msg.getRequestBody().getCharset())) {
-                            raiseAlert(msg, id, src);
+                            createAlert(src).setMessage(msg).raise();
                         }
                     }
                 }
@@ -202,8 +202,8 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner
         return true;
     }
 
-    private void raiseAlert(HttpMessage msg, int id, String viewState) {
-        newAlert()
+    private AlertBuilder createAlert(String viewState) {
+        return newAlert()
                 .setRisk(getRisk())
                 .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(getDescription())
@@ -211,8 +211,7 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setCweId(getCweId())
-                .setWascId(getWascId())
-                .raise();
+                .setWascId(getWascId());
     }
 
     // jsf server side implementation in com.sun.faces.renderkit.ServerSideStateHelper
@@ -253,5 +252,12 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner
 
     public int getWascId() {
         return 14; // WASC Id - Server Misconfiguration
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                createAlert("<input type=\"hidden\" id=\"javax.faces.viewstate\" value=\"1231\"")
+                        .build());
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRuleUnitTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.io.IOUtils;
@@ -269,5 +270,19 @@ class InsecureJsfViewStatePassiveScanRuleUnitTest
                 "HTTP/1.1 200 OK\r\n"
                         + "Server: Apache-Coyote/1.1\r\n"
                         + "Content-Type: text/html;charset=UTF-8\r\n");
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 }


### PR DESCRIPTION
## Overview
Me and [Lucas Bergholz](https://github.com/zaproxy/zap-extensions/pull/github.com/lucasbergholz) worked on this together, with the porpuse of adding the alert for Insecure JSF ViewState - P. We are open for any feedbacks of our work, as this is our first contribution on this issue.

## Related Issues
Part of zaproxy/zaproxy#6119.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
