### PR TITLE
spider: expose the user to the parsers

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Allow the parsers to obtain the user being used by/in the current spidering scan (Issue 7739).
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderTask.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderTask.java
@@ -379,6 +379,7 @@ public class SpiderTask implements Runnable {
                 new ParseContext(
                         parent.getSpiderParam(),
                         parent.getExtensionSpider().getValueGenerator(),
+                        parent.getScanUser(),
                         message,
                         path,
                         depth);

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/ParseContext.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/ParseContext.java
@@ -24,6 +24,7 @@ import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.spider.SpiderParam;
 import org.zaproxy.zap.model.ValueGenerator;
+import org.zaproxy.zap.users.User;
 
 /**
  * A parse context.
@@ -36,6 +37,7 @@ public class ParseContext {
     private final ValueGenerator valueGenerator;
     private final HttpMessage httpMessage;
     private final String path;
+    private final User user;
     private final int depth;
     private String baseUrl;
     private Source source;
@@ -57,8 +59,32 @@ public class ParseContext {
             HttpMessage httpMessage,
             String path,
             int depth) {
+        this(spiderParam, valueGenerator, null, httpMessage, path, depth);
+    }
+
+    /**
+     * Constructs a {@code ParseContext} with the given values.
+     *
+     * @param spiderParam the spider options, must not be {@code null}.
+     * @param valueGenerator the value generator, must not be {@code null}.
+     * @param user the user being used by/in the current spidering scan.
+     * @param httpMessage the message, must not be {@code null}.
+     * @param path the path of the HTTP message.
+     * @param depth the current depth of the parsing.
+     * @throws NullPointerException if any of {@code spiderParam}, {@code valueGenerator}, or {@code
+     *     httpMessage} is {@code null}.
+     * @since 0.12.0
+     */
+    public ParseContext(
+            SpiderParam spiderParam,
+            ValueGenerator valueGenerator,
+            User user,
+            HttpMessage httpMessage,
+            String path,
+            int depth) {
         this.spiderParam = Objects.requireNonNull(spiderParam);
         this.valueGenerator = Objects.requireNonNull(valueGenerator);
+        this.user = user;
         this.httpMessage = Objects.requireNonNull(httpMessage);
         this.path = path;
         this.depth = depth;
@@ -80,6 +106,16 @@ public class ParseContext {
      */
     public ValueGenerator getValueGenerator() {
         return valueGenerator;
+    }
+
+    /**
+     * Gets the user used by/in the spidering scan.
+     *
+     * @return the user, or {@code null}.
+     * @since 0.12.0
+     */
+    public User getUser() {
+        return user;
     }
 
     /**

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/ParseContextUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/ParseContextUnitTest.java
@@ -38,12 +38,14 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.spider.SpiderParam;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.network.HttpResponseBody;
+import org.zaproxy.zap.users.User;
 
 /** Unit test for {@link ParseContext}. */
 class ParseContextUnitTest {
 
     private SpiderParam spiderParam;
     private ValueGenerator valueGenerator;
+    private User user;
     private HttpMessage httpMessage;
     private String responseData;
     private String path;
@@ -56,6 +58,7 @@ class ParseContextUnitTest {
     void setup() throws Exception {
         spiderParam = mock(SpiderParam.class);
         valueGenerator = mock(ValueGenerator.class);
+        user = mock(User.class);
         httpMessage = mock(HttpMessage.class);
         responseData = "<html></html>";
         path = "/path";
@@ -76,6 +79,10 @@ class ParseContextUnitTest {
         // Given / When
         ctx = new ParseContext(spiderParam, valueGenerator, httpMessage, path, depth);
         // Then
+        assertInitialConstructorValues();
+    }
+
+    private void assertInitialConstructorValues() {
         assertThat(ctx.getSpiderParam(), is(sameInstance(spiderParam)));
         assertThat(ctx.getValueGenerator(), is(sameInstance(valueGenerator)));
         assertThat(ctx.getHttpMessage(), is(sameInstance(httpMessage)));
@@ -84,6 +91,15 @@ class ParseContextUnitTest {
         assertThat(ctx.getBaseUrl(), is(equalTo(uri)));
         assertThat(ctx.getSource(), is(notNullValue()));
         assertThat(ctx.getSource().toString(), is(equalTo(responseData)));
+    }
+
+    @Test
+    void shouldCreateWithGivenAdditionalValues() {
+        // Given / When
+        ctx = new ParseContext(spiderParam, valueGenerator, user, httpMessage, path, depth);
+        // Then
+        assertInitialConstructorValues();
+        assertThat(ctx.getUser(), is(sameInstance(user)));
     }
 
     @Test


### PR DESCRIPTION
Allow the parsers to obtain the user being used by/in the current spidering scan.

Related to zaproxy/zaproxy#7739.