### PR TITLE
Authhelper: Restore stats

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Restored stats removed in previous release as these could be used in AF tests.
 
 ## [0.15.0] - 2024-08-28
 ### Changed

--- a/addOns/authhelper/gradle.properties
+++ b/addOns/authhelper/gradle.properties
@@ -1,2 +1,2 @@
-version=0.16.0
+version=0.15.1
 release=false

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -78,6 +78,7 @@ public class AuthUtils {
     public static final String AUTH_NO_USER_FIELD_STATS = "stats.auth.browser.nouserfield";
     public static final String AUTH_NO_PASSWORD_FIELD_STATS = "stats.auth.browser.nopasswordfield";
     public static final String AUTH_FOUND_FIELDS_STATS = "stats.auth.browser.foundfields";
+    public static final String AUTH_SESSION_TOKEN_STATS_PREFIX = "stats.auth.sessiontoken.";
     public static final String AUTH_SESSION_TOKENS_MAX = "stats.auth.sessiontokens.max";
     public static final String AUTH_BROWSER_PASSED_STATS = "stats.auth.browser.passed";
     public static final String AUTH_BROWSER_FAILED_STATS = "stats.auth.browser.failed";
@@ -448,6 +449,11 @@ public class AuthUtils {
         }
         if (!map.isEmpty()) {
             LOGGER.debug("Found session tokens in {} : {}", msg.getRequestHeader().getURI(), map);
+            map.forEach(
+                    (k, v) ->
+                            AuthUtils.incStatsCounter(
+                                    msg.getRequestHeader().getURI(),
+                                    AUTH_SESSION_TOKEN_STATS_PREFIX + v.getKey()));
         }
 
         return map;
@@ -599,6 +605,9 @@ public class AuthUtils {
                                     .filter(v -> v.getValue().equals(token))
                                     .findFirst();
                     if (es.isPresent()) {
+                        AuthUtils.incStatsCounter(
+                                msg.getRequestHeader().getURI(),
+                                AuthUtils.AUTH_SESSION_TOKEN_STATS_PREFIX + es.get().getKey());
                         List<SessionToken> tokens = new ArrayList<>();
                         tokens.add(
                                 new SessionToken(


### PR DESCRIPTION
## Overview
Put back the stats removed by the related PR - they were used in our integration tests.
If other people use them then they would break their tests too.
https://github.com/zaproxy/zaproxy/actions/runs/10659233723

## Related Issues
https://github.com/zaproxy/zap-extensions/pull/5672

## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
