### PR TITLE
openapi: allow to import as a user

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Allow to import the OpenAPI definitions with a user (Issue 7739).
+
 ### Fixed
 - Allow to select the contexts of the Automation Framework plan when configuring the job.
 - Correctly handle empty context name in the Automation Framework job.

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -32,7 +32,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("spider") {
-                            version.set(">=0.1.0")
+                            version.set(">=0.12.0")
                         }
                     }
                 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -74,6 +74,7 @@ import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.ValueGenerator;
+import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -234,13 +235,24 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
      */
     public List<String> importOpenApiDefinition(
             final URI uri, final String targetUrl, boolean initViaUi, int contextId) {
-        return this.importOpenApiDefinitionV2(uri, targetUrl, initViaUi, contextId).getErrors();
+        return importOpenApiDefinition(uri, targetUrl, initViaUi, contextId, null);
+    }
+
+    List<String> importOpenApiDefinition(
+            final URI uri, final String targetUrl, boolean initViaUi, int contextId, User user) {
+        return importOpenApiDefinitionV2(uri, targetUrl, initViaUi, contextId, user).getErrors();
     }
 
     public OpenApiResults importOpenApiDefinitionV2(
             final URI uri, final String targetUrl, boolean initViaUi, int contextId) {
+        return importOpenApiDefinitionV2(uri, targetUrl, initViaUi, contextId, null);
+    }
+
+    public OpenApiResults importOpenApiDefinitionV2(
+            final URI uri, final String targetUrl, boolean initViaUi, int contextId, User user) {
         OpenApiResults results = new OpenApiResults();
         Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+        requestor.setUser(user);
         requestor.addListener(new HistoryPersister(results));
         try {
             String path = uri.getPath();
@@ -318,14 +330,26 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
      */
     public List<String> importOpenApiDefinition(
             final File file, final String targetUrl, boolean initViaUi, int contextId) {
-        return this.importOpenApiDefinitionV2(file, targetUrl, initViaUi, contextId).getErrors();
+        return importOpenApiDefinition(file, targetUrl, initViaUi, contextId, null);
+    }
+
+    List<String> importOpenApiDefinition(
+            final File file, final String targetUrl, boolean initViaUi, int contextId, User user) {
+        return this.importOpenApiDefinitionV2(file, targetUrl, initViaUi, contextId, user)
+                .getErrors();
     }
 
     public OpenApiResults importOpenApiDefinitionV2(
             final File file, final String targetUrl, boolean initViaUi, int contextId) {
+        return importOpenApiDefinitionV2(file, targetUrl, initViaUi, contextId, null);
+    }
+
+    public OpenApiResults importOpenApiDefinitionV2(
+            final File file, final String targetUrl, boolean initViaUi, int contextId, User user) {
         OpenApiResults results = new OpenApiResults();
         try {
             Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+            requestor.setUser(user);
             requestor.addListener(new HistoryPersister(results));
 
             if (!file.exists()) {

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
@@ -39,11 +39,12 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
     private static final String API_URL_PARAM = "openapi.automation.dialog.apiurl";
     private static final String TARGET_URL_PARAM = "openapi.automation.dialog.targeturl";
     private static final String CONTEXT_PARAM = "openapi.automation.dialog.context";
+    private static final String USER_PARAM = "automation.dialog.all.user";
 
     private OpenApiJob job;
 
     public OpenApiJobDialog(OpenApiJob job) {
-        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 250));
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 300));
         this.job = job;
 
         this.addTextField(NAME_PARAM, this.job.getData().getName());
@@ -69,6 +70,10 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
         List<String> contextNames = job.getEnv().getContextNames();
         contextNames.add(0, "");
         this.addComboField(CONTEXT_PARAM, contextNames, job.getParameters().getContext());
+
+        List<String> users = job.getEnv().getAllUserNames();
+        users.add(0, "");
+        addComboField(USER_PARAM, users, job.getData().getParameters().getUser());
         this.addPadding();
     }
 
@@ -79,6 +84,7 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
         this.job.getParameters().setApiUrl(this.getStringValue(API_URL_PARAM));
         this.job.getParameters().setTargetUrl(this.getStringValue(TARGET_URL_PARAM));
         this.job.getParameters().setContext(getStringValue(CONTEXT_PARAM));
+        this.job.getParameters().setUser(getStringValue(USER_PARAM));
         this.job.resetAndSetChanged();
     }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/network/Requestor.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/network/Requestor.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.network.HttpRedirectionValidator;
 import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.users.User;
 
 public class Requestor {
 
@@ -48,6 +49,10 @@ public class Requestor {
     }
 
     public List<String> run(List<RequestModel> requestsModel) {
+        return run(null, requestsModel);
+    }
+
+    public List<String> run(User user, List<RequestModel> requestsModel) {
         List<String> errors = new ArrayList<>();
         try {
             for (RequestModel requestModel : requestsModel) {
@@ -61,6 +66,8 @@ public class Requestor {
                 httpRequest
                         .getRequestHeader()
                         .setContentLength(httpRequest.getRequestBody().length());
+
+                httpRequest.setRequestingUser(user);
 
                 try {
 
@@ -102,6 +109,10 @@ public class Requestor {
 
     public void removeListener(RequesterListener listener) {
         this.listeners.remove(listener);
+    }
+
+    public void setUser(User user) {
+        sender.setUser(user);
     }
 
     /** Notifies the {@link #listeners} of the messages sent. */

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpider.java
@@ -57,7 +57,7 @@ public class OpenApiSpider extends SpiderParser {
                             message.getRequestHeader().getURI().toString(),
                             message.getResponseBody().toString(),
                             valGenSupplier.get());
-            requestor.run(converter.getRequestModels());
+            requestor.run(ctx.getUser(), converter.getRequestModels());
         } catch (Exception e) {
             LOGGER.debug(e.getMessage(), e);
             return false;

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
@@ -24,6 +24,7 @@ It is covered in the video: <a href="https://youtu.be/xuP00Ri460k">ZAP Chat 11 A
       apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
       apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
       context:                         # String: Context to use when importing the OpenAPI definition, default: null, no context will be used
+      user:                            # String: An optional user to use for authentication, must be defined in the env.
       targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden
 </pre>
 

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -24,13 +24,16 @@ A menu item is added to the Import menu:
 The dialogue allows overriding the server URL present in the OpenAPI definition (or specify one if not present) through the Target URL field.
 The import progress is shown in the progress tab.
 
-<H3>Context for Adding DDNs</H3>
+<H3>Context</H3>
 The dialogues also allow selecting a Context, optionally. If a context is selected,
 <ul>
     <li>each imported endpoint is included in the context, unless its URL matches an already existing <em>Include in Context</em> regex entry.</li>
     <li>the imported spec is saved to the session database</li>
     <li>data driven nodes are generated for endpoints with path parameters</li>
 </ul>
+
+<H3>User</H3>
+The dialogues also allow selecting a User, optionally, to do authenticated imports.
 
 <h3>Target URL Format</h3>
 The Target URL has the following format:<br>
@@ -47,8 +50,8 @@ Following some examples, overriding:
 <H2>API</H2>
 The following operations are added to the API:
 <ul>
-<li>ACTION importFile (file, target, contextId)</li>
-<li>ACTION importUrl (url, hostOverride, contextId)</li>
+<li>ACTION importFile (file, target, contextId, userId)</li>
+<li>ACTION importUrl (url, hostOverride, contextId, userId)</li>
 </ul>
 Both <code>target</code> and <code>hostOverride</code> support the <code>Target URL</code> format explained earlier.
 

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -1,9 +1,14 @@
 openapi.api.action.importFile = Imports an OpenAPI definition from a local file.
+openapi.api.action.importFile.param.contextId = The ID of the context. Defaults to the first context, if any.
 openapi.api.action.importFile.param.file = The file that contains the OpenAPI definition.
 openapi.api.action.importFile.param.target = The Target URL to override the server URL present in the definition.
+openapi.api.action.importFile.param.userId = The ID of the user.
 openapi.api.action.importUrl = Imports an OpenAPI definition from a URL.
+openapi.api.action.importUrl.param.contextId = The ID of the context. Defaults to the first context, if any.
 openapi.api.action.importUrl.param.hostOverride = The Target URL (called hostOverride for historical reasons) to override the server URL present in the definition.
 openapi.api.action.importUrl.param.url = The URL locating the OpenAPI definition.
+openapi.api.action.importUrl.param.userId = The ID of the user.
+openapi.api.desc = Allows to import OpenAPI definitions.
 
 openapi.automation.desc = OpenAPI Automation Framework Integration
 openapi.automation.dialog.apifile = API File:
@@ -37,9 +42,10 @@ openapi.importDialog.chooseFileButton = Choose File
 openapi.importDialog.error.missingDefinition = A definition file or URL must be specified.
 openapi.importDialog.importButton = Import
 openapi.importDialog.invalidUrl = Invalid URL:\n{0}
-openapi.importDialog.labelContext = Context For Adding DDNs
+openapi.importDialog.labelContext = Context
 openapi.importDialog.labelDefinition = Definition File or URL
 openapi.importDialog.labelTarget = Target URL
+openapi.importDialog.labelUser = User
 openapi.importDialog.pasteAction = Paste
 openapi.importDialog.requiredFields = indicates a required field
 openapi.importDialog.title = Import OpenAPI Definition

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
@@ -3,4 +3,5 @@
       apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
       apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
       context:                         # String: Context to use when importing the OpenAPI definition, default: null, no context will be used
+      user:                            # String: An optional user to use for authentication, must be defined in the env.
       targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/OpenApiAPIUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/OpenApiAPIUnitTest.java
@@ -21,70 +21,334 @@ package org.zaproxy.zap.extension.openapi;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Collectors;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.quality.Strictness;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.api.API.RequestType;
+import org.zaproxy.zap.extension.api.ApiElement;
 import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiParameter;
+import org.zaproxy.zap.extension.users.ContextUserAuthManager;
+import org.zaproxy.zap.extension.users.ExtensionUserManagement;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.DefaultNameValuePair;
 import org.zaproxy.zap.model.NameValuePair;
+import org.zaproxy.zap.users.User;
 
 /** Unit test for {@link OpenApiAPI}. */
 class OpenApiAPIUnitTest extends AbstractServerTest {
 
+    private Session session;
+    private Model model;
+    private ExtensionLoader extensionLoader;
+    private ExtensionUserManagement extensionUserManagement;
     private ExtensionOpenApi extension;
 
     private OpenApiAPI openApiAPI;
 
     @BeforeEach
     void prepare() {
-        extension = mock(ExtensionOpenApi.class);
+        session = mock(Session.class);
+        model = mock(Model.class, withSettings().strictness(Strictness.LENIENT));
+        given(model.getSession()).willReturn(session);
+        extension = mock(ExtensionOpenApi.class, withSettings().strictness(Strictness.LENIENT));
+        given(extension.getModel()).willReturn(model);
+
+        extensionLoader = mock(ExtensionLoader.class);
+        Control.initSingletonForTesting(model, extensionLoader);
+
         openApiAPI = new OpenApiAPI(extension);
-        Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        Model.setSingletonForTesting(model);
     }
 
-    @Test
-    void shouldThrowBadActionIfActionUnknown() {
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"unknown", "something"})
+    void shouldThrowApiExceptionForUnknownAction(String name) throws Exception {
         // Given
-        String actionName = "_NotKnownAction_";
-        // When / Then
+        JSONObject params = params();
+        // When
         ApiException exception =
-                assertThrows(
-                        ApiException.class, () -> openApiAPI.handleApiAction(actionName, params()));
+                assertThrows(ApiException.class, () -> openApiAPI.handleApiAction(name, params));
+        // Then
         assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_ACTION)));
     }
 
-    @Nested
-    class ApiImportUrl {
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"unknown", "something"})
+    void shouldThrowApiExceptionForUnknownView(String name) throws Exception {
+        // Given
+        JSONObject params = params();
+        // When
+        ApiException exception =
+                assertThrows(ApiException.class, () -> openApiAPI.handleApiView(name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_VIEW)));
+    }
 
-        private static final String ACTION = "importUrl";
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"unknown", "something"})
+    void shouldThrowApiExceptionForUnknownOther(String name) throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        JSONObject params = params();
+        // When
+        ApiException exception =
+                assertThrows(
+                        ApiException.class, () -> openApiAPI.handleApiOther(message, name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_OTHER)));
+    }
+
+    @Test
+    void shouldHaveDescriptionsForAllApiElements() {
+        openApiAPI = new OpenApiAPI(extension);
+        List<String> missingKeys = new ArrayList<>();
+        checkKey(openApiAPI.getDescriptionKey(), missingKeys);
+        checkApiElements(
+                openApiAPI, openApiAPI.getApiActions(), API.RequestType.action, missingKeys);
+        checkApiElements(openApiAPI, openApiAPI.getApiOthers(), API.RequestType.other, missingKeys);
+        checkApiElements(openApiAPI, openApiAPI.getApiViews(), API.RequestType.view, missingKeys);
+        assertThat(missingKeys, is(empty()));
+    }
+
+    private static void checkKey(String key, List<String> missingKeys) {
+        if (!Constant.messages.containsKey(key)) {
+            missingKeys.add(key);
+        }
+    }
+
+    private static void checkApiElements(
+            ApiImplementor api,
+            List<? extends ApiElement> elements,
+            RequestType type,
+            List<String> missingKeys) {
+        elements.sort((a, b) -> a.getName().compareTo(b.getName()));
+        for (ApiElement element : elements) {
+            assertThat(
+                    "API " + type + " element: " + api.getPrefix() + "/" + element.getName(),
+                    element.getDescriptionTag(),
+                    is(not(emptyString())));
+            checkKey(element.getDescriptionTag(), missingKeys);
+            element.getParameters().stream()
+                    .map(ApiParameter::getDescriptionKey)
+                    .forEach(key -> checkKey(key, missingKeys));
+        }
+    }
+
+    private abstract class BaseImportTests {
+
+        abstract String getAction();
+
+        abstract NameValuePair getImportParam();
 
         @Test
-        void shouldThrowIllegalParameterIfFailedToAccessTarget() {
+        void shouldThrowApiExceptionIfUserProvidedButNoContextExists() {
             // Given
-            JSONObject params = params(param("url", "http://not-reachable.example.com"));
-            given(extension.importOpenApiDefinition(any(URI.class), eq(""), eq(false), eq(-1)))
+            JSONObject params = params(getImportParam(), param("userId", "1"));
+            // When / Then
+            ApiException exception =
+                    assertThrows(
+                            ApiException.class,
+                            () -> openApiAPI.handleApiAction(getAction(), params));
+            assertThat(exception.getType(), is(equalTo(ApiException.Type.MISSING_PARAMETER)));
+            assertThat(exception.toString(), containsString("(missing_parameter): contextId"));
+        }
+
+        @Test
+        void shouldThrowApiExceptionIfUserExtensionNotEnabled() {
+            // Given
+            JSONObject params = params(getImportParam(), param("userId", "1"));
+            defaultContext();
+            // When / Then
+            ApiException exception =
+                    assertThrows(
+                            ApiException.class,
+                            () -> openApiAPI.handleApiAction(getAction(), params));
+            assertThat(exception.getType(), is(equalTo(ApiException.Type.NO_IMPLEMENTOR)));
+            assertThat(
+                    exception.toString(),
+                    containsString("(no_implementor): ExtensionUserManagement"));
+        }
+
+        @Test
+        void shouldThrowApiExceptionIfUserNotFound() {
+            // Given
+            JSONObject params = params(getImportParam(), param("userId", "1"));
+            userExtensionEnabled();
+            defaultContext();
+            userIdsDefaultContext(2);
+            // When / Then
+            ApiException exception =
+                    assertThrows(
+                            ApiException.class,
+                            () -> openApiAPI.handleApiAction(getAction(), params));
+            assertThat(exception.getType(), is(equalTo(ApiException.Type.USER_NOT_FOUND)));
+            assertThat(exception.toString(), containsString("(user_not_found): userId"));
+        }
+    }
+
+    @Nested
+    class ApiImportFile extends BaseImportTests {
+
+        private static final String ACTION = "importFile";
+
+        private File importFile;
+
+        @Override
+        String getAction() {
+            return ACTION;
+        }
+
+        @Override
+        NameValuePair getImportParam() {
+            try {
+                importFile = Files.createTempFile("openapi", "").toFile();
+                return param("file", importFile.getAbsolutePath());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Test
+        void shouldUseProvidedUser() throws Exception {
+            // Given
+            JSONObject params = params(getImportParam(), param("userId", "1"));
+            userExtensionEnabled();
+            defaultContext();
+            userIdsDefaultContext(1);
+            given(
+                            extension.importOpenApiDefinition(
+                                    any(File.class),
+                                    any(String.class),
+                                    anyBoolean(),
+                                    anyInt(),
+                                    any(User.class)))
+                    .willReturn(List.of());
+            // When
+            openApiAPI.handleApiAction(ACTION, params);
+            // Then
+            verify(extension)
+                    .importOpenApiDefinition(
+                            importFile,
+                            "",
+                            false,
+                            1,
+                            extensionUserManagement.getContextUserAuthManager(1).getUserById(1));
+        }
+
+        @Test
+        void shouldThrowApiExceptionIfUnableToParseFile() {
+            // Given
+            JSONObject params = params(getImportParam());
+            given(
+                            extension.importOpenApiDefinition(
+                                    any(File.class), eq(""), eq(false), eq(-1), eq(null)))
                     .willReturn(null);
             // When / Then
             ApiException exception =
                     assertThrows(
-                            ApiException.class, () -> openApiAPI.handleApiAction(ACTION, params));
+                            ApiException.class,
+                            () -> openApiAPI.handleApiAction(getAction(), params));
+            assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_EXTERNAL_DATA)));
+            assertThat(exception.toString(), containsString("(bad_external_data): file"));
+        }
+    }
+
+    @Nested
+    class ApiImportUrl extends BaseImportTests {
+
+        private static final String ACTION = "importUrl";
+
+        @Override
+        String getAction() {
+            return ACTION;
+        }
+
+        @Override
+        NameValuePair getImportParam() {
+            return param("url", "http://example.com");
+        }
+
+        @Test
+        void shouldUseProvidedUser() throws Exception {
+            // Given
+            JSONObject params = params(getImportParam(), param("userId", "1"));
+            userExtensionEnabled();
+            defaultContext();
+            userIdsDefaultContext(1);
+            given(
+                            extension.importOpenApiDefinition(
+                                    any(URI.class),
+                                    any(String.class),
+                                    anyBoolean(),
+                                    anyInt(),
+                                    any(User.class)))
+                    .willReturn(List.of());
+            // When
+            openApiAPI.handleApiAction(ACTION, params);
+            // Then
+            verify(extension)
+                    .importOpenApiDefinition(
+                            new URI("http://example.com", true),
+                            "",
+                            false,
+                            1,
+                            extensionUserManagement.getContextUserAuthManager(1).getUserById(1));
+        }
+
+        @Test
+        void shouldThrowIllegalParameterIfFailedToAccessTarget() {
+            // Given
+            JSONObject params = params(getImportParam());
+            given(
+                            extension.importOpenApiDefinition(
+                                    any(URI.class), eq(""), eq(false), eq(-1), eq(null)))
+                    .willReturn(null);
+            // When / Then
+            ApiException exception =
+                    assertThrows(
+                            ApiException.class,
+                            () -> openApiAPI.handleApiAction(getAction(), params));
             assertThat(exception.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
             assertThat(exception.toString(), containsString("Failed to access the target."));
         }
@@ -99,6 +363,31 @@ class OpenApiAPIUnitTest extends AbstractServerTest {
                 Arrays.asList(params).stream()
                         .collect(
                                 Collectors.toMap(NameValuePair::getName, NameValuePair::getValue)));
+    }
+
+    void userExtensionEnabled() {
+        extensionUserManagement = mock(ExtensionUserManagement.class);
+        given(extensionLoader.getExtension(ExtensionUserManagement.class))
+                .willReturn(extensionUserManagement);
+    }
+
+    void defaultContext() {
+        var context = mock(Context.class);
+        given(context.getId()).willReturn(1);
+        given(session.getContexts()).willReturn(List.of(context));
+    }
+
+    void userIdsDefaultContext(int... ids) {
+        var userAuthManager =
+                mock(ContextUserAuthManager.class, withSettings().strictness(Strictness.LENIENT));
+        given(extensionUserManagement.getContextUserAuthManager(1)).willReturn(userAuthManager);
+        if (ids != null && ids.length != 0) {
+            Arrays.stream(ids)
+                    .forEach(
+                            e ->
+                                    given(userAuthManager.getUserById(e))
+                                            .willReturn(mock(User.class)));
+        }
     }
 
     private static NameValuePair param(String name, String value) {

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,11 +91,12 @@ class OpenApiJobUnitTest extends TestUtils {
         Map<String, String> params = job.getCustomConfigParameters();
 
         // Then
-        assertThat(params.size(), is(equalTo(4)));
+        assertThat(params.size(), is(equalTo(5)));
         assertThat(params.get("apiFile"), is(equalTo("")));
         assertThat(params.get("apiUrl"), is(equalTo("")));
         assertThat(params.get("targetUrl"), is(equalTo("")));
         assertThat(params.get("context"), is(equalTo("")));
+        assertThat(params.get("user"), is(equalTo("")));
     }
 
     @Test
@@ -105,6 +107,7 @@ class OpenApiJobUnitTest extends TestUtils {
         String apiUrl = "https://example.com/test%20file.json";
         String targetUrl = "https://example.com/endpoint/";
         String context = "My Context";
+        String user = "My User";
         String yamlStr =
                 "parameters:\n"
                         + "  apiUrl: "
@@ -117,11 +120,18 @@ class OpenApiJobUnitTest extends TestUtils {
                         + targetUrl
                         + "\n"
                         + "  context: "
-                        + context;
+                        + context
+                        + "\n"
+                        + "  user: "
+                        + user;
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
 
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getAllUserNames()).willReturn(List.of(user));
+
         OpenApiJob job = new OpenApiJob();
+        job.setEnv(env);
         job.setJobData(((LinkedHashMap<?, ?>) data));
 
         // When
@@ -133,6 +143,7 @@ class OpenApiJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getApiUrl(), is(equalTo(apiUrl)));
         assertThat(job.getParameters().getTargetUrl(), is(equalTo(targetUrl)));
         assertThat(job.getParameters().getContext(), is(equalTo(context)));
+        assertThat(job.getParameters().getUser(), is(equalTo(user)));
         assertThat(progress.hasErrors(), is(equalTo(false)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));
     }


### PR DESCRIPTION
Allow to import as user through the spider, API, GUI, and AF.

Fix zaproxy/zaproxy#7739.