### PR TITLE
openapi: correct contexts shown in job dialogue

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Allow to select the contexts of the Automation Framework plan when configuring the job.
 
 ## [42] - 2024-07-04
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
@@ -21,9 +21,9 @@ package org.zaproxy.zap.extension.openapi.automation;
 
 import java.awt.Component;
 import java.io.File;
+import java.util.List;
 import javax.swing.JFileChooser;
 import javax.swing.JTextField;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -66,11 +66,10 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
         if (targetUrlField instanceof JTextField) {
             ((JTextField) targetUrlField).setText(this.job.getParameters().getTargetUrl());
         }
-        this.addContextSelectField(
-                CONTEXT_PARAM,
-                Model.getSingleton()
-                        .getSession()
-                        .getContext(this.job.getParameters().getContext()));
+
+        List<String> contextNames = job.getEnv().getContextNames();
+        contextNames.add(0, "");
+        this.addComboField(CONTEXT_PARAM, contextNames, job.getParameters().getContext());
         this.addPadding();
     }
 


### PR DESCRIPTION
Allow to select the contexts of the plan not the ones present in the session.