### PR TITLE
tech detection: Adjust example alert

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [21.41.0] - 2024-09-02
 ### Added

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPassiveScanner.java
@@ -524,19 +524,19 @@ public class TechPassiveScanner implements PassiveScanner, OptionsChangedListene
     }
 
     public List<Alert> getExampleAlerts() {
-        return List.of(createAlert("https://example.org/", getAppForExample()).build());
+        return List.of(
+                createAlert("https://example.org/", getAppForExample()).setName(getName()).build());
     }
 
     private static ApplicationMatch getAppForExample() {
         Application exampleApp = new Application();
-        exampleApp.setCategories(List.of("Web servers"));
-        exampleApp.setName("Apache HTTP Server");
-        exampleApp.setCpe("cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*");
-        exampleApp.setWebsite("https://httpd.apache.org");
+        exampleApp.setCategories(List.of("Widgets"));
+        exampleApp.setName("Example Software");
+        exampleApp.setCpe("cpe:2.3:a:example_vendor:example_software:55.4.3:*:*:*:*:*:*:*");
 
         ApplicationMatch exampleMatch = new ApplicationMatch(exampleApp);
-        exampleMatch.addEvidence("Apache");
-        exampleMatch.addVersion("2.4.7");
+        exampleMatch.addEvidence("Exampleware");
+        exampleMatch.addVersion("55.4.3");
         return exampleMatch;
     }
 

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/TechPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/TechPassiveScannerUnitTest.java
@@ -683,22 +683,21 @@ class TechPassiveScannerUnitTest extends PassiveScannerTestUtils<TechPassiveScan
             // Then
             assertThat(alerts, hasSize(1));
             Alert alert = alerts.get(0);
-            assertThat(alert.getName(), is(equalTo("Tech Detected - Apache HTTP Server")));
+            assertThat(alert.getName(), is(equalTo("Tech Detection Passive Scanner")));
             assertThat(
                     alert.getDescription(),
                     is(
                             equalTo(
-                                    "The following \"Web servers\" technology was identified: Apache HTTP Server.")));
+                                    "The following \"Widgets\" technology was identified: Example Software.")));
             assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
             assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-            assertThat(alert.getReference(), is(equalTo("https://httpd.apache.org")));
-            assertThat(alert.getEvidence(), is(equalTo("Apache")));
+            assertThat(alert.getEvidence(), is(equalTo("Exampleware")));
             assertThat(
                     alert.getOtherInfo(),
                     is(
                             equalTo(
-                                    "The following CPE is associated with the identified tech: cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*\n"
-                                            + "The following version(s) is/are associated with the identified tech: 2.4.7")));
+                                    "The following CPE is associated with the identified tech: cpe:2.3:a:example_vendor:example_software:55.4.3:*:*:*:*:*:*:*\n"
+                                            + "The following version(s) is/are associated with the identified tech: 55.4.3")));
             assertThat(alert.getWascId(), is(equalTo(13)));
             assertThat(alert.getCweId(), is(equalTo(200)));
         }


### PR DESCRIPTION
As discussed via Slack after: https://github.com/zaproxy/zaproxy-website/pull/2785

## Overview
- CHANGELOG > Add maint note.
- TechPassiveScanner > Use fake app details, and rule name (vs. specific tech).
- TechPassiveScannerUnitTest > Assert details for the example alert.

## Related Issues
- zaproxy/zaproxy-website#2779
- zaproxy/zap-extensions#5668
- zaproxy/zap-extensions#5686

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
