### PR TITLE
openapi: fix context handling in AF job

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Allow to select the contexts of the Automation Framework plan when configuring the job.
+- Correctly handle empty context name in the Automation Framework job.
 
 ## [42] - 2024-07-04
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
@@ -31,7 +31,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
@@ -111,11 +110,15 @@ public class OpenApiJob extends AutomationJob {
         if (!StringUtils.isEmpty(targetStr)) {
             targetUrl = env.replaceVars(targetStr);
         }
-        String context = this.getParameters().getContext();
-        int contextId =
-                context != null
-                        ? Model.getSingleton().getSession().getContext(context).getId()
-                        : -1;
+
+        var contextWrapper = env.getContextWrapper(getParameters().getContext());
+        if (contextWrapper == null) {
+            progress.error(
+                    Constant.messages.getString(
+                            "automation.error.context.unknown", getParameters().getContext()));
+            return;
+        }
+        int contextId = contextWrapper.getContext().getId();
 
         if (!StringUtils.isEmpty(apiFile)) {
             File file = JobUtils.getFile(apiFile, getPlan());

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
@@ -25,7 +25,6 @@ import java.util.List;
 import javax.swing.JFileChooser;
 import javax.swing.JTextField;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
@@ -79,8 +78,7 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
         this.job.getParameters().setApiFile(this.getStringValue(API_FILE_PARAM));
         this.job.getParameters().setApiUrl(this.getStringValue(API_URL_PARAM));
         this.job.getParameters().setTargetUrl(this.getStringValue(TARGET_URL_PARAM));
-        Context context = this.getContextValue(CONTEXT_PARAM);
-        this.job.getParameters().setContext(context != null ? context.getName() : null);
+        this.job.getParameters().setContext(getStringValue(CONTEXT_PARAM));
         this.job.resetAndSetChanged();
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
@@ -43,7 +44,9 @@ import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationPlan;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.ContextWrapper;
 import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.I18N;
 
@@ -140,6 +143,8 @@ class OpenApiJobUnitTest extends TestUtils {
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
+        ContextWrapper contextWrapper = new ContextWrapper(mock(Context.class));
+        given(env.getContextWrapper(any())).willReturn(contextWrapper);
         String yamlStr = "parameters:\n" + "  apiUrl: 'Invalid URL.'";
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
@@ -163,7 +168,9 @@ class OpenApiJobUnitTest extends TestUtils {
         mockMessages(new ExtensionOpenApi());
         AutomationPlan plan = new AutomationPlan();
         AutomationProgress progress = plan.getProgress();
-        AutomationEnvironment env = plan.getEnv();
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        ContextWrapper contextWrapper = new ContextWrapper(mock(Context.class));
+        given(env.getContextWrapper(any())).willReturn(contextWrapper);
         String yamlStr = "parameters:\n" + "  apiFile: 'Invalid file path'";
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);


### PR DESCRIPTION
Use the default context when the context name is empty.