### PR TITLE
ascanrulesBeta: include exception in log message

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Log exception details in Out of Band XSS scan rule.
 
 ## [55] - 2024-09-02
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/OutOfBandXssScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/OutOfBandXssScanRule.java
@@ -139,7 +139,7 @@ public class OutOfBandXssScanRule extends AbstractAppParamPlugin
                 scanWithExternalOastService(param);
             }
         } catch (Exception e) {
-            LOGGER.warn("Could not perform Out of Band XSS Attack.");
+            LOGGER.warn("Could not perform Out of Band XSS Attack:", e);
         }
     }
 


### PR DESCRIPTION
Allow to know what went wrong when using the Out of Band XSS scan rule.