### PR TITLE
oast: make boast entity detachable

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -9,6 +9,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added 
 - API support.
 
+### Fixed
+- Address warnings when using BOAST payloads.
+
 ## [0.19.0] - 2024-07-18
 ### Changed
 - Update BOAST port, use 2096 instead of 1337.

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastEntity.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastEntity.java
@@ -25,7 +25,7 @@ import javax.jdo.annotations.PrimaryKey;
 import org.datanucleus.api.jdo.annotations.CreateTimestamp;
 import org.zaproxy.addon.oast.OastEntity;
 
-@PersistenceCapable
+@PersistenceCapable(detachable = "true")
 public class BoastEntity implements OastEntity {
 
     @PrimaryKey private String id;


### PR DESCRIPTION
Declare the `BoastEntity` detachable as it is used that way (and is the current default), addressing warnings like:
`WARN Persistence - Object with id "BoastEntity" is to be detached...`