### PR TITLE
spider: expose the context to the parsers

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Allow the parsers to obtain the user being used by/in the current spidering scan (Issue 7739).
+- Allow the parsers to obtain the context and user being used by/in the current spidering scan (Issue 8021 and 7739).
 
 ### Changed
 - Maintenance changes.

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/Spider.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/Spider.java
@@ -651,6 +651,16 @@ public class Spider {
     }
 
     /**
+     * Gets the context that will be used in the scanning.
+     *
+     * @return the context
+     * @since 0.12.0
+     */
+    protected Context getScanContext() {
+        return scanContext;
+    }
+
+    /**
      * Sets the spider so it will scan from the point of view of a user.
      *
      * @param user the user to be scanned as

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderTask.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderTask.java
@@ -379,6 +379,7 @@ public class SpiderTask implements Runnable {
                 new ParseContext(
                         parent.getSpiderParam(),
                         parent.getExtensionSpider().getValueGenerator(),
+                        parent.getScanContext(),
                         parent.getScanUser(),
                         message,
                         path,

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/ParseContext.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/ParseContext.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.spider.SpiderParam;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.users.User;
 
@@ -37,6 +38,7 @@ public class ParseContext {
     private final ValueGenerator valueGenerator;
     private final HttpMessage httpMessage;
     private final String path;
+    private final Context context;
     private final User user;
     private final int depth;
     private String baseUrl;
@@ -59,7 +61,7 @@ public class ParseContext {
             HttpMessage httpMessage,
             String path,
             int depth) {
-        this(spiderParam, valueGenerator, null, httpMessage, path, depth);
+        this(spiderParam, valueGenerator, null, null, httpMessage, path, depth);
     }
 
     /**
@@ -67,6 +69,7 @@ public class ParseContext {
      *
      * @param spiderParam the spider options, must not be {@code null}.
      * @param valueGenerator the value generator, must not be {@code null}.
+     * @param context the context being used by/in the current spidering scan.
      * @param user the user being used by/in the current spidering scan.
      * @param httpMessage the message, must not be {@code null}.
      * @param path the path of the HTTP message.
@@ -78,12 +81,14 @@ public class ParseContext {
     public ParseContext(
             SpiderParam spiderParam,
             ValueGenerator valueGenerator,
+            Context context,
             User user,
             HttpMessage httpMessage,
             String path,
             int depth) {
         this.spiderParam = Objects.requireNonNull(spiderParam);
         this.valueGenerator = Objects.requireNonNull(valueGenerator);
+        this.context = context;
         this.user = user;
         this.httpMessage = Objects.requireNonNull(httpMessage);
         this.path = path;
@@ -106,6 +111,16 @@ public class ParseContext {
      */
     public ValueGenerator getValueGenerator() {
         return valueGenerator;
+    }
+
+    /**
+     * Gets the context used by/in the spidering scan.
+     *
+     * @return the context, or {@code null}.
+     * @since 0.12.0
+     */
+    public Context getContext() {
+        return context;
     }
 
     /**

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/ParseContextUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/ParseContextUnitTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.spider.SpiderParam;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.network.HttpResponseBody;
 import org.zaproxy.zap.users.User;
@@ -45,6 +46,7 @@ class ParseContextUnitTest {
 
     private SpiderParam spiderParam;
     private ValueGenerator valueGenerator;
+    private Context context;
     private User user;
     private HttpMessage httpMessage;
     private String responseData;
@@ -58,6 +60,7 @@ class ParseContextUnitTest {
     void setup() throws Exception {
         spiderParam = mock(SpiderParam.class);
         valueGenerator = mock(ValueGenerator.class);
+        context = mock(Context.class);
         user = mock(User.class);
         httpMessage = mock(HttpMessage.class);
         responseData = "<html></html>";
@@ -96,9 +99,12 @@ class ParseContextUnitTest {
     @Test
     void shouldCreateWithGivenAdditionalValues() {
         // Given / When
-        ctx = new ParseContext(spiderParam, valueGenerator, user, httpMessage, path, depth);
+        ctx =
+                new ParseContext(
+                        spiderParam, valueGenerator, context, user, httpMessage, path, depth);
         // Then
         assertInitialConstructorValues();
+        assertThat(ctx.getContext(), is(sameInstance(context)));
         assertThat(ctx.getUser(), is(sameInstance(user)));
     }
 


### PR DESCRIPTION
Allow the parsers to obtain the context being used by/in the current spidering scan.

Part of zaproxy/zaproxy#8021.