### PR TITLE
pscanrules: Adjust Mac OSX Salted SHA-1 name, risk, and confidence

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Rename Mac OSX salted SHA-1 in the Hash Disclosure scan rule to "Salted SHA-1", reduce the associated alerts to Low risk and Low confidence, to align with other SHA related patterns it will only be evaluated a Low Threshold. (Note such matches may indicate leaks related but not limited to: MacOS X, Oracle, Tiger-192, Haval-192) (Issue 8624).
 
 ## [60] - 2024-09-02
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
@@ -115,11 +115,11 @@ public class HashDisclosureScanRule extends PluginPassiveScanner
                 Pattern.compile("\\$NT\\$[0-9a-f]{32}"),
                 new HashAlert("NTLM", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
-        // Mac OS X salted SHA-1
+        // Salted SHA-1 - MacOS X, Oracle, Tiger-192, Haval-192
         // Example: 0E6A48F765D0FFFFF6247FA80D748E615F91DD0C7431E4D9
         hashPatterns.put(
                 Pattern.compile("\\b[0-9A-F]{48}\\b"),
-                new HashAlert("Mac OSX salted SHA-1", Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+                new HashAlert("Salted SHA-1", Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
 
         // SHA hashes occur fairly frequently in various legitimate uses, and are not necessarily
         // indicative of an issue.

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -228,9 +228,14 @@ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10033/">10033</a>.
 
 <H2 id="id-10097">Hash Disclosure</H2>
 Passively scans for password hashes disclosed by the web server. <br>
-Various formats are including, including some formats such as MD4, MD5, and SHA*, which are sometimes used for purposes other than to contain password hashes.
+Various formats are included, including some formats such as MD4, MD5, and SHA*, which are sometimes used for purposes other than to contain password hashes.
 <br>
-<strong>Note:</strong> This scan rule will only analyze text responses, and only analyze JavaScript responses on LOW Threshold. 
+<strong>Note:</strong>
+<ul>
+    <li>This scan rule will only analyze text responses, and only analyze JavaScript responses on LOW Threshold.<li>
+    <li>The selection of Hash patterns which are evaluated is tied to the Confidence we have in the pattern and the Threshold set for the scan rule.
+        In other words: Low confidence patterns will only be included for evaluation at Low Threshold, etc.</li>
+</ul> 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java">HashDisclosureScanRule.java</a>
 <br>

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRuleUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.pscanrules;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,7 @@ class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDisclosureSc
     }
 
     @Test
-    void shouldRaiseAlertWhenResponseContainsOsxSha1AtLowThreshold() throws Exception {
+    void shouldRaiseAlertWhenJavascriptResponseContainsHashAtLowThreshold() throws Exception {
         // Given
         String hashVal = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFEE37";
         HttpMessage msg = createMsg(hashVal);
@@ -112,15 +113,16 @@ class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDisclosureSc
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), is(1));
-        assertThat(alertsRaised.get(0).getName(), is("Hash Disclosure - Mac OSX salted SHA-1"));
+        assertThat(alertsRaised.get(0).getName(), startsWith("Hash Disclosure - "));
         assertThat(alertsRaised.get(0).getEvidence(), is(hashVal));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_LOW)));
     }
 
     @ParameterizedTest
     @EnumSource(
             value = Plugin.AlertThreshold.class,
             names = {"HIGH", "MEDIUM"})
-    void shouldNotRaiseAlertWhenResponseContainsOsxSha1InJsAtNonLowThreshold(
+    void shouldNotRaiseAlertWhenJavascriptResponseContainsHashAtNonLowThreshold(
             AlertThreshold threshold) throws Exception {
         // Given
         String hashVal = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFEE37";


### PR DESCRIPTION
## Overview
- CHANGELOG > Add change note.
- HashDisclosureScanRule > Adjust pattern's name, risk, and confidence.
- HashDisclosureScanRuleUnitTest > Adjust assertions related to this pattern/alert.
- pscanrules.html > Added help note outlining the confidence/threshold association under which patterns are evaluated.

## Related Issues
Fixes zaproxy/zaproxy#8624

Other ref: https://github.com/s0md3v/Bolt/blob/37aa096db93e026f0524fe94c67dc1dae8985f3e/db/hashes.json#L291-L299

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
