### PR TITLE
openapi: honour context exclusions

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Allow to import the OpenAPI definitions with a user (Issue 7739).
+- Honour context exclusions when importing (Issue 8021).
 
 ### Fixed
 - Allow to select the contexts of the Automation Framework plan when configuring the job.

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -423,15 +423,13 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                     public void run() {
                         ProgressPane currentImportPane = null;
                         try {
-                            List<RequestModel> requestModels = converter.getRequestModels();
-                            if (contextId != -1) {
-                                Context context = getModel().getSession().getContext(contextId);
-                                if (context != null) {
-                                    converter.updateVariantChecks(
-                                            context,
-                                            variantChecksMap.computeIfAbsent(
-                                                    contextId, VariantOpenApiChecks::new));
-                                }
+                            Context context = getModel().getSession().getContext(contextId);
+                            List<RequestModel> requestModels = converter.getRequestModels(context);
+                            if (context != null) {
+                                converter.updateVariantChecks(
+                                        context,
+                                        variantChecksMap.computeIfAbsent(
+                                                contextId, VariantOpenApiChecks::new));
                             }
                             if (requestor == null) {
                                 return;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/Converter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/Converter.java
@@ -22,8 +22,9 @@ package org.zaproxy.zap.extension.openapi.converter;
 import java.util.List;
 import org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerException;
 import org.zaproxy.zap.extension.openapi.network.RequestModel;
+import org.zaproxy.zap.model.Context;
 
 public interface Converter {
 
-    List<RequestModel> getRequestModels() throws SwaggerException;
+    List<RequestModel> getRequestModels(Context context) throws SwaggerException;
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpider.java
@@ -57,7 +57,7 @@ public class OpenApiSpider extends SpiderParser {
                             message.getRequestHeader().getURI().toString(),
                             message.getResponseBody().toString(),
                             valGenSupplier.get());
-            requestor.run(ctx.getUser(), converter.getRequestModels());
+            requestor.run(ctx.getUser(), converter.getRequestModels(ctx.getContext()));
         } catch (Exception e) {
             LOGGER.debug(e.getMessage(), e);
             return false;

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -31,6 +31,7 @@ The dialogues also allow selecting a Context, optionally. If a context is select
     <li>the imported spec is saved to the session database</li>
     <li>data driven nodes are generated for endpoints with path parameters</li>
 </ul>
+<strong>Note:</strong> Endpoints excluded by the Context will not be imported.
 
 <H3>User</H3>
 The dialogues also allow selecting a User, optionally, to do authenticated imports.

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v1/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v1/OpenApiUnitTest.java
@@ -84,7 +84,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStore2dot0Requests(accessedUrls, "localhost:" + nano.getListeningPort());
     }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiPrimitivesInBodyUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiPrimitivesInBodyUnitTest.java
@@ -83,7 +83,7 @@ class OpenApiPrimitivesInBodyUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkRequests(accessedUrls, "localhost:" + nano.getListeningPort());
     }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
@@ -76,7 +76,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequests(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -109,7 +109,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequests(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -145,7 +145,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequests(accessedUrls, altHost);
     }
@@ -183,7 +183,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                 };
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         checkPetStoreRequests(accessedUrls, defaultHost);
     }
@@ -220,7 +220,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                 };
         requestor.addListener(listener);
         // When / Then
-        assertThrows(SwaggerException.class, () -> requestor.run(converter.getRequestModels()));
+        assertThrows(SwaggerException.class, () -> requestor.run(converter.getRequestModels(null)));
     }
 
     @Test
@@ -256,7 +256,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                 };
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         checkPetStoreRequests(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -280,7 +280,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                         requestor.getResponseBody(defnMsg.getRequestHeader().getURI()),
                         null);
         // When / Then
-        assertThrows(SwaggerException.class, () -> converter.getRequestModels());
+        assertThrows(SwaggerException.class, () -> converter.getRequestModels(null));
     }
 
     @Test
@@ -312,7 +312,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                 };
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         assertThat(converter.getErrorMessages(), is(empty()));
         assertEquals(
@@ -382,7 +382,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequestsValGen(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -416,7 +416,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         assertEquals(accessedUrls.size(), 2);
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiDefaultValuesTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiDefaultValuesTest.java
@@ -58,7 +58,7 @@ class OpenApiDefaultValuesTest extends AbstractServerTest {
         Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         HttpMessage message = accessedMessages.get(0);
         assertThat(

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiEnumsUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiEnumsUnitTest.java
@@ -58,7 +58,7 @@ class OpenApiEnumsUnitTest extends AbstractServerTest {
         Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         HttpMessage message = accessedMessages.get(0);
         assertThat(message.getRequestHeader().getURI().getEscapedQuery(), is(equalTo("Name=123")));

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiExternalRefsUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiExternalRefsUnitTest.java
@@ -83,7 +83,7 @@ class OpenApiExternalRefsUnitTest extends AbstractServerTest {
         Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         assertThat(requestedUris, contains("/path/"));
         assertThat(serverHandler.getRequestedUris(), contains("/path/"));

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiGeneratedCookieValuesTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiGeneratedCookieValuesTest.java
@@ -58,7 +58,7 @@ class OpenApiGeneratedCookieValuesTest extends AbstractServerTest {
         Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         HttpMessage message = accessedMessages.get(0);
         assertThat(message.getRequestHeader().getHeader("Cookie"), is(equalTo("Name=true")));

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiPrimitivesInBodyUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiPrimitivesInBodyUnitTest.java
@@ -83,7 +83,7 @@ class OpenApiPrimitivesInBodyUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         checkRequests(accessedUrls, "localhost:" + nano.getListeningPort());
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
@@ -77,7 +77,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequests(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -110,7 +110,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequests(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -146,7 +146,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequests(accessedUrls, altHost);
     }
@@ -181,7 +181,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         assertTrue(
                 accessedUrls.containsKey(
@@ -233,7 +233,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                 };
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         checkPetStoreRequests(accessedUrls, "http", defaultHost, "");
     }
@@ -256,7 +256,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                         requestor.getResponseBody(defnMsg.getRequestHeader().getURI()),
                         null);
         // When / Then
-        assertThrows(SwaggerException.class, () -> converter.getRequestModels());
+        assertThrows(SwaggerException.class, () -> converter.getRequestModels(null));
     }
 
     @Test
@@ -276,7 +276,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                         requestor.getResponseBody(defnMsg.getRequestHeader().getURI()),
                         null);
         // When / Then
-        assertThrows(SwaggerException.class, () -> converter.getRequestModels());
+        assertThrows(SwaggerException.class, () -> converter.getRequestModels(null));
     }
 
     @Test
@@ -312,7 +312,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                 };
         requestor.addListener(listener);
 
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         // what is the expected behavior?
         assertEquals(accessedUrls.size(), 19);
@@ -388,7 +388,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                     }
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequestsValGen(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -419,7 +419,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                             message.getRequestBody().toString());
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkPetStoreRequests(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -450,7 +450,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                             message.getRequestBody().toString());
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         String baseUrl = "http://" + "localhost:" + nano.getListeningPort();
         assertTrue(accessedUrls.containsKey("POST " + baseUrl + "/example"));
@@ -482,7 +482,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                             message.getRequestBody().toString());
                 };
         requestor.addListener(listener);
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         String baseUrl = "http://" + "localhost:" + nano.getListeningPort();
         assertTrue(accessedUrls.containsKey("POST " + baseUrl + "/example"));
@@ -512,7 +512,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                                     + message.getRequestHeader().getURI().toString(),
                             message.getRequestHeader().getHeader("Accept"));
                 });
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkRequestAcceptHeaders(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -541,7 +541,7 @@ class OpenApiUnitTest extends AbstractServerTest {
                                     + message.getRequestHeader().getURI().toString(),
                             message.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE));
                 });
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
         checkRequestContentTypeHeaders(accessedUrls, "localhost:" + nano.getListeningPort());
     }
@@ -570,9 +570,9 @@ class OpenApiUnitTest extends AbstractServerTest {
                                     + message.getRequestHeader().getURI().toString(),
                             message.getRequestHeader().getHeader("Accept"));
                 });
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
 
-        assertEquals(19, converter.getRequestModels().size());
+        assertEquals(19, converter.getRequestModels(null).size());
     }
 
     private void checkRequestContentTypeHeaders(Map<String, String> accessedUrls, String host) {

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiValueGeneratorFormatsTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiValueGeneratorFormatsTest.java
@@ -79,7 +79,7 @@ class OpenApiValueGeneratorFormatsTest extends AbstractServerTest {
         Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
         requestor.addListener(listener);
         // When
-        requestor.run(converter.getRequestModels());
+        requestor.run(converter.getRequestModels(null));
         // Then
         HttpMessage message = accessedMessages.get(0);
         assertThat(

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/converter/swagger/openapi_paths_misc.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/converter/swagger/openapi_paths_misc.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: Paths Misc
+  version: 1.0.0
+servers:
+  - url: http://server.localhost/
+paths:
+  /path/a/:
+    get:
+      operationId: path/a/
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}
+  /path/b/:
+    get:
+      operationId: path/b/
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}
+  /path/b/1/:
+    get:
+      operationId: path/b/1/
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}
+  /path/c/:
+    get:
+      operationId: path/c/
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}
+  /path/c/1/:
+    get:
+      operationId: path/c/1/
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}
+  /path/c/2/:
+    get:
+      operationId: path/c/2/
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}


### PR DESCRIPTION
Do not import endpoints excluded by the provided context.

Part of zaproxy/zaproxy#8021.