### PR TITLE
graphql: Update dependencies

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [0.24.0] - 2024-05-07
 ### Changed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("spider")
 
-    implementation("com.graphql-java:graphql-java:22.0")
+    implementation("com.graphql-java:graphql-java:22.3")
 
     testImplementation(project(":testutils"))
     testImplementation(libs.log4j.core)


### PR DESCRIPTION
Update `graphql-java` from `22.0` to `22.3`.