### PR TITLE
Fix typos in log messages and JavaDoc

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [67] - 2024-07-22
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SstiBlindScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SstiBlindScanRule.java
@@ -222,8 +222,8 @@ public class SstiBlindScanRule extends AbstractAppParamPlugin implements CommonA
      * Check if the given payloadFormat causes an time delay in the server
      *
      * @param paramName the name of the parameter where to search for or injection
-     * @param payloadFormat format string that when formated with 1 argument makes a string that may
-     *     cause a delay equal to the number of second inserted by the format
+     * @param payloadFormat format string that when formatted with 1 argument makes a string that
+     *     may cause a delay equal to the number of second inserted by the format
      */
     private boolean checkIfCausesTimeDelay(String paramName, String payloadFormat) {
         AtomicReference<HttpMessage> message = new AtomicReference<>();

--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Send success/failure stats.
 
+### Fixed
+- Fix typo in log message.
+
 ## [0.17.0] - 2024-09-02
 ### Changed
 - Maintenance changes.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptionsPanel.java
@@ -488,7 +488,7 @@ class ServerCertificatesOptionsPanel extends AbstractParamPanel {
                 file = Files.createTempFile(ZAP_ROOT_CA_NAME, ZAP_ROOT_CA_FILE_EXT);
                 writePem(file);
             } catch (IOException e) {
-                LOGGER.error("An error occured while creating the temporary file", e);
+                LOGGER.error("An error occurred while creating the temporary file", e);
                 return;
             }
 

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fix typo in log message.
 
 ## [41] - 2024-09-02
 ### Fixed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SubResourceIntegrityAttributeScanRule.java
@@ -150,7 +150,7 @@ public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner
                                                                 .toString()));
             }
         } catch (Exception e) {
-            LOGGER.debug("Error occured while calculating the hash. Error: {}", e.getMessage(), e);
+            LOGGER.debug("Error occurred while calculating the hash. Error: {}", e.getMessage(), e);
         }
         return integrityHash;
     }


### PR DESCRIPTION
Fix typos in `occurred` and `formatted`.

Follow up to zaproxy/zaproxy#8623.