### PR TITLE
network: do not retry on 429 and 503

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Send success/failure stats.
 
+### Changed
+- Stop retrying 429 and 503 responses, instead of waiting for `retry-after` (Issue 8627).
+
 ### Fixed
 - Fix typo in log message.
 


### PR DESCRIPTION
## Overview
This is fix for when ZAP is stuck waiting to retry requests after receiving a response with the `retry-after` header set. See https://github.com/zaproxy/zaproxy/issues/8627

## Related Issues
Fix zaproxy/zaproxy#8627.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
