### PR TITLE
ascanrules: address FPs in scan rule 20017

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - The Spring Actuator Scan Rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
+### Fixed
+- Address false positives with Source Code Disclosure - CVE-2012-1823 scan rule, by not scanning binary responses and responses that already contain PHP source (Issue 8638).
+
 ## [67] - 2024-07-22
 
 ### Changed


### PR DESCRIPTION
Do not scan binary responses and responses that already contain PHP source.

Fix zaproxy/zaproxy#8638.