### PR TITLE
ascanrulesBeta: address FP in scan rule 10048

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Log exception details in Out of Band XSS scan rule.
 - Maintenance changes.
 
+### Fixed
+- Address time-based false positives in Remote Code Execution - Shell Shock scan rule (Issue 8516).
+
 ## [55] - 2024-09-02
 ### Changed
 - The following scan rules now include example alert functionality for documentation generation purposes (Issue 6119):


### PR DESCRIPTION
Use the `TimingUtils` for the time-based scan which provides more accurate verification.

Fix zaproxy/zaproxy#8516.