### PR TITLE
ascanrules: Fix XSS False positives

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Address false positives with Source Code Disclosure - CVE-2012-1823 scan rule, by not scanning binary responses and responses that already contain PHP source (Issue 8638).
+- Cross Site Scripting Rule false positives at medium threshold by matching the expected context (Issue 8640).
 
 ## [67] - 2024-07-22
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -258,20 +258,21 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin
         }
         HtmlContextAnalyser hca = new HtmlContextAnalyser(msg2);
         List<HtmlContext> contexts;
-        if (Plugin.AlertThreshold.HIGH.equals(this.getAlertThreshold())) {
-            // High level, so check all results are in the expected context
-            contexts =
-                    hca.getHtmlContexts(
-                            findDecoded ? getURLDecode(evidence) : evidence,
-                            targetContext,
-                            ignoreFlags,
-                            ignoreSafeParents);
-        } else {
+        if (Plugin.AlertThreshold.LOW.equals(this.getAlertThreshold())) {
+            // Low level, so don't check all results are in the expected context
             contexts =
                     hca.getHtmlContexts(
                             findDecoded ? getURLDecode(evidence) : evidence,
                             null,
                             0,
+                            ignoreSafeParents);
+        } else {
+            // High or Medium level, so check all results are in the expected context
+            contexts =
+                    hca.getHtmlContexts(
+                            findDecoded ? getURLDecode(evidence) : evidence,
+                            targetContext,
+                            ignoreFlags,
                             ignoreSafeParents);
         }
         if (mutateAttack || !contexts.isEmpty()) {
@@ -832,7 +833,9 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin
 
     private boolean performElementAttack(HtmlContext context, HttpMessage msg, String param) {
         String attackString1 = "tag " + ACCESSKEY_ATTRIBUTE_ALERT;
-        List<HtmlContext> context2 = performAttack(msg, param, attackString1, context, 0);
+        // In this case the parent effectively changes
+        List<HtmlContext> context2 =
+                performAttack(msg, param, attackString1, context, HtmlContext.IGNORE_PARENT);
         if (context2 == null) {
             context2 = performAttack(msg, param, TAG_ONCLICK_ALERT, context, 0);
             if (context2 == null) {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
@@ -1310,7 +1310,7 @@ class CrossSiteScriptingScanRuleUnitTest extends ActiveScannerTest<CrossSiteScri
     @Test
     void shouldReportXssInsideDivWithFilteredAnyCaseScript()
             throws NullPointerException, IOException {
-        String test = "/shouldReportXssInBodyWithFilteredScript/";
+        String test = "/shouldReportXssInsideDivWithFilteredAnyCaseScript/";
 
         this.nano.addHandler(
                 new NanoServerHandler(test) {
@@ -1347,6 +1347,111 @@ class CrossSiteScriptingScanRuleUnitTest extends ActiveScannerTest<CrossSiteScri
                 equalTo("</div>" + CrossSiteScriptingScanRule.GENERIC_ONERROR_ALERT + "<div>"));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_HIGH));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
+    void shouldNotReportXssInsideDivWithGoodFiltering() throws NullPointerException, IOException {
+        String test = "/shouldNotReportXssInsideDivWithGoodFiltering/";
+
+        this.nano.addHandler(
+                new NanoServerHandler(test) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response;
+                        if (name != null) {
+                            // Strip out <>
+                            name = name.replaceAll("<", "").replaceAll(">", "");
+                            response =
+                                    getHtml("InputInsideDiv.html", new String[][] {{"name", name}});
+                        } else {
+                            response = getHtml("NoInput.html");
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = this.getHttpMessage(test + "?name=test");
+
+        this.rule.init(msg, this.parent);
+
+        this.rule.scan();
+
+        assertThat(httpMessagesSent, hasSize(equalTo(9)));
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    void shouldNotReportXssInsideInputAndDivWithGoodFiltering()
+            throws NullPointerException, IOException {
+        String test = "/shouldNotReportXssInsideInputAndDivWithGoodFiltering/";
+
+        this.nano.addHandler(
+                new NanoServerHandler(test) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response;
+                        if (name != null) {
+                            // name1 is in an input field, name2 in a div - escape them correctly
+                            String name2 = name.replaceAll("<", "").replaceAll(">", "");
+                            String name1 = name2.replaceAll("\"", "");
+                            response =
+                                    getHtml(
+                                            "InputInsideInputAndDiv.html",
+                                            new String[][] {{"name1", name1}, {"name2", name2}});
+                        } else {
+                            response = getHtml("NoInput.html");
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = this.getHttpMessage(test + "?name=test");
+
+        this.rule.init(msg, this.parent);
+
+        this.rule.scan();
+
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    void shouldNotReportXssInsideInputAndScriptWithGoodFiltering()
+            throws NullPointerException, IOException {
+        String test = "/shouldNotReportXssInsideInputAndScriptWithGoodFiltering/";
+
+        this.nano.addHandler(
+                new NanoServerHandler(test) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response;
+                        if (name != null) {
+                            // name1 is in a script, name2 in an input field - escape them correctly
+                            String name1 = name.replaceAll("'", "");
+                            String name2 =
+                                    name.replaceAll("\"", "")
+                                            .replaceAll("<", "")
+                                            .replaceAll(">", "");
+                            response =
+                                    getHtml(
+                                            "InputInsideInputAndScript.html",
+                                            new String[][] {{"name1", name1}, {"name2", name2}});
+                        } else {
+                            response = getHtml("NoInput.html");
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = this.getHttpMessage(test + "?name=test");
+
+        this.rule.init(msg, this.parent);
+
+        this.rule.scan();
+
+        assertThat(alertsRaised.size(), equalTo(0));
     }
 
     @Test

--- a/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInsideInputAndDiv.html
+++ b/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInsideInputAndDiv.html
@@ -1,0 +1,12 @@
+<html>
+
+<body>
+  <h1>XSS test case with text and input value</h1>
+  <form method="POST" action="/text-and-input-value">
+    <input name="input" type="text" id="input" value="@@@name1@@@">
+    <button type="submit">POST</button>
+  </form>
+  <div>You submitted: @@@name2@@@</div>
+</body>
+
+</html>

--- a/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInsideInputAndScript.html
+++ b/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInsideInputAndScript.html
@@ -1,0 +1,13 @@
+<html>
+<script>var='@@@name1@@@'</script>
+
+<body>
+  <h1>XSS test case with script tag and input value</h1>
+  <form method="POST" action="/script-and-input-value">
+    <input name="input" type="text" id="input" value="@@@name2@@@">
+    <button type="submit">POST</button>
+  </form>
+  <div>You submitted: 0W45pz4p</div>
+</body>
+
+</html>


### PR DESCRIPTION
These occur when the payload is reflected in more than one HTML context.

## Overview
Fix the XSS rule so that it handles payloads reflected (and correctly escaped) in more than one element.

## Related Issues
Fixes https://github.com/zaproxy/zaproxy/issues/8640

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
