### PR TITLE
openapi: update docs to match latest behaviour

### DIFF
--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
@@ -23,7 +23,7 @@ It is covered in the video: <a href="https://youtu.be/xuP00Ri460k">ZAP Chat 11 A
     parameters:
       apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
       apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      context:                         # String: Context to use when importing the OpenAPI definition, default: null, no context will be used
+      context:                         # String: Context to use when importing the OpenAPI definition, default: first context.
       user:                            # String: An optional user to use for authentication, must be defined in the env.
       targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden
 </pre>

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
@@ -2,6 +2,6 @@
     parameters:
       apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
       apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      context:                         # String: Context to use when importing the OpenAPI definition, default: null, no context will be used
+      context:                         # String: Context to use when importing the OpenAPI definition, default: first context.
       user:                            # String: An optional user to use for authentication, must be defined in the env.
       targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-min.yaml
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-min.yaml
@@ -2,5 +2,5 @@
     parameters:
       apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
       apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      context:                         # String: Context to use when importing the OpenAPI definition, default: null, no context will be used
+      context:                         # String: Context to use when importing the OpenAPI definition, default: first context.
       targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden


### PR DESCRIPTION
Indicate that the AF job uses the first context by default (#5703).