### PR TITLE
exim: HarImporter - make invalid messages count towards progress

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Correctly load Automation Framework template plans.
 - Base64 decode the response body when importing HARs.
+- Count null messages as tasks done toward progress when importing HARs.
 
 ## [0.10.0] - 2024-07-22
 ### Changed

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- Count invalid messages as tasks done toward progress when importing HARs.
 
 
 ## [0.11.0] - 2024-09-24
@@ -16,7 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Correctly load Automation Framework template plans.
 - Base64 decode the response body when importing HARs.
-- Count null messages as tasks done toward progress when importing HARs.
 
 ## [0.10.0] - 2024-07-22
 ### Changed

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -133,6 +133,8 @@ public class HarImporter {
         int count = 0;
         for (HttpMessage msg : messages) {
             if (msg == null) {
+                updateProgress(
+                        ++count, Constant.messages.getString("exim.progress.invalidmessage"));
                 continue;
             }
             persistMessage(msg);

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/har/HarImporterUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/har/HarImporterUnitTest.java
@@ -228,6 +228,16 @@ class HarImporterUnitTest extends TestUtils {
         verify(listener).completed();
     }
 
+    @Test
+    void shouldCountNullMessagesTowardsTasksDone() {
+        // Given
+        ProgressPaneListener listener = mock(ProgressPaneListener.class);
+        // When
+        new HarImporter(getResourcePath("oneNullMessage.har").toFile(), listener);
+        // Then
+        verify(listener).setTasksDone(1);
+    }
+
     @ParameterizedTest
     @ValueSource(
             strings = {

--- a/addOns/exim/src/test/resources/org/zaproxy/addon/exim/har/oneNullMessage.har
+++ b/addOns/exim/src/test/resources/org/zaproxy/addon/exim/har/oneNullMessage.har
@@ -1,0 +1,47 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Firefox",
+      "version": "126.0"
+    },
+    "entries": [
+      {
+        "startedDateTime": "2024-05-22T08:41:18.352-04:00",
+        "request": {
+          "bodySize": 0,
+          "method": "GET",
+          "url": "",
+          "httpVersion": "",
+          "headers": [
+
+          ],
+          "cookies": [],
+          "queryString": [],
+          "headersSize": 0
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "mimeType": "",
+            "size": 0
+          },
+          "redirectURL": "",
+          "headersSize": 0,
+          "bodySize": 0
+        },
+        "cache": {},
+        "timings": {
+          "send": 0,
+          "wait": 0,
+          "receive": 0
+        },
+        "time": 0
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Found a bug when counting null messages when working on PR zaproxy/zap-extensions#5608 .

The counter should also be incremented when a null message is extracted (which happens if there is an exception when parsing the data to make the message),  otherwise if a null gets hit in the end it'll show an incomplete progress bar.

As in the PcapImporter, this fix makes the null message count towards progress and displays `Invalid message` on the progress bar.
