### PR TITLE
ascanrules: Fix FR false negative in XSS

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -448,7 +448,9 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin
                             param,
                             context.getSurroundingQuote() + " src=http://badsite.com",
                             context,
-                            HtmlContext.IGNORE_TAG);
+                            HtmlContext.IGNORE_TAG
+                                    | HtmlContext.IGNORE_IN_URL
+                                    | HtmlContext.IGNORE_WITH_SRC);
             if (contexts2 == null) {
                 return false;
             }
@@ -508,7 +510,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin
                                 + context.getSurroundingQuote()
                                 + "alert(1);",
                         context,
-                        HtmlContext.IGNORE_TAG);
+                        HtmlContext.IGNORE_TAG | HtmlContext.IGNORE_IN_URL);
         if (contexts2 == null) {
             return false;
         }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContext.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContext.java
@@ -230,7 +230,7 @@ public class HtmlContext {
         if (context == null) {
             return false;
         }
-        if ((ignoreFlags ^ IGNORE_TAG) > 0) {
+        if ((ignoreFlags & IGNORE_TAG) == 0) {
             // check the tag
             if (this.tagAttribute != null) {
                 if (!this.tagAttribute.equals(context.getTagAttribute())) {
@@ -242,7 +242,7 @@ public class HtmlContext {
                 }
             }
         }
-        if ((ignoreFlags ^ IGNORE_QUOTES) > 0) {
+        if ((ignoreFlags & IGNORE_QUOTES) == 0) {
             // check the quotes
             if (this.surroundingQuote != null) {
                 if (!this.surroundingQuote.equals(context.getSurroundingQuote())) {
@@ -254,7 +254,7 @@ public class HtmlContext {
                 }
             }
         }
-        if ((ignoreFlags ^ IGNORE_PARENT) > 0) {
+        if ((ignoreFlags & IGNORE_PARENT) == 0) {
             // check the parents
             if (this.getParentTag() != null) {
                 if (!this.getParentTag().equals(context.getParentTag())) {
@@ -266,22 +266,22 @@ public class HtmlContext {
                 }
             }
         }
-        if ((ignoreFlags ^ IGNORE_IN_SCRIPT) > 0
+        if ((ignoreFlags & IGNORE_IN_SCRIPT) == 0
                 && this.inScriptAttribute != context.isInScriptAttribute()) {
             return false;
         }
-        if ((ignoreFlags ^ IGNORE_IN_SAFE) > 0
+        if ((ignoreFlags & IGNORE_IN_SAFE) == 0
                 && this.isInSafeParentTag() != context.isInSafeParentTag()) {
             return false;
         }
-        if ((ignoreFlags ^ IGNORE_WITH_SRC) > 0 && this.inTagWithSrc != context.isInTagWithSrc()) {
+        if ((ignoreFlags & IGNORE_WITH_SRC) == 0 && this.inTagWithSrc != context.isInTagWithSrc()) {
             return false;
         }
-        if ((ignoreFlags ^ IGNORE_IN_URL) > 0
+        if ((ignoreFlags & IGNORE_IN_URL) == 0
                 && this.inUrlAttribute != context.isInUrlAttribute()) {
             return false;
         }
-        if ((ignoreFlags ^ IGNORE_HTML_COMMENT) > 0
+        if ((ignoreFlags & IGNORE_HTML_COMMENT) == 0
                 && this.htmlComment != context.isHtmlComment()) {
             return false;
         }

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
@@ -1060,6 +1060,42 @@ class CrossSiteScriptingScanRuleUnitTest extends ActiveScannerTest<CrossSiteScri
     }
 
     @Test
+    void shouldReportXssInScriptSrc() throws NullPointerException, IOException {
+        String test = "/shouldReportXssInScriptSrc/";
+
+        this.nano.addHandler(
+                new NanoServerHandler(test) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String name = getFirstParamValue(session, "param");
+                        String response;
+                        if (name != null) {
+                            response =
+                                    getHtml(
+                                            "InputInScriptSrc.html",
+                                            new String[][] {{"param", name}});
+                        } else {
+                            response = getHtml("NoInput.html");
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = this.getHttpMessage(test + "?param=test");
+
+        this.rule.init(msg, this.parent);
+
+        this.rule.scan();
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("\" src=http://badsite.com"));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("param"));
+        assertThat(alertsRaised.get(0).getAttack(), equalTo("\" src=http://badsite.com"));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_HIGH));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
     void shouldReportXssInReflectedUrl() throws NullPointerException, IOException {
         String test = "/shouldReportXssInReflectedUrl";
 
@@ -1429,9 +1465,9 @@ class CrossSiteScriptingScanRuleUnitTest extends ActiveScannerTest<CrossSiteScri
                         String response;
                         if (name != null) {
                             // name1 is in a script, name2 in an input field - escape them correctly
-                            String name1 = name.replaceAll("'", "");
+                            String name1 = name.replaceAll("'", "").replace("\"", "");
                             String name2 =
-                                    name.replaceAll("\"", "")
+                                    name1.replaceAll("\"", "")
                                             .replaceAll("<", "")
                                             .replaceAll(">", "");
                             response =

--- a/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInScriptSrc.html
+++ b/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInScriptSrc.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <script src="http://www.example.com?@@@param@@@"/>
+  </body>
+</html>


### PR DESCRIPTION
I dont think a changelog entry is required as this is a knock on from the last change.

## Overview
Fix a FN in the Firing Range tests.
Also fixed a set of bugs in the context testing logic.
It worked fine if only one flag supplied (which is what we were doing) but failed when I needed to specify more than one flag.

## Related Issues
https://github.com/zaproxy/zap-extensions/pull/5745

## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
