### PR TITLE
openapi: add Application/XML support for request bodies

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Allow to import the OpenAPI definitions with a user (Issue 7739).
 - Honour context exclusions when importing (Issue 8021).
+- Application/XML support for request bodies (Issue 6767).
 
 ### Fixed
 - Allow to select the contexts of the Automation Framework plan when configuring the job.

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/RequestModelConverter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/RequestModelConverter.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import java.util.List;
 import java.util.Map;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpHeaderField;
 import org.zaproxy.zap.extension.openapi.generators.Generators;
 import org.zaproxy.zap.extension.openapi.generators.HeadersGenerator;
@@ -85,13 +84,9 @@ public class RequestModelConverter {
                 return generators.getBodyGenerator().generateMultiPart(schema, encoding);
             }
 
-            if (content.containsKey(CONTENT_APPLICATION_XML)) {
-                generators.addErrorMessage(
-                        Constant.messages.getString(
-                                "openapi.unsupportedcontent",
-                                operation.getOperationId(),
-                                CONTENT_APPLICATION_XML));
-                return "";
+            if (content.containsKey("application/xml")) {
+                schema = content.get("application/xml").getSchema();
+                return generators.getBodyGenerator().generateXml(schema);
             }
 
             if (!content.isEmpty()) {

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
@@ -332,6 +332,44 @@ public class BodyGenerator {
         return "";
     }
 
+    @SuppressWarnings("rawtypes")
+    public String generateXml(Schema<?> schema) {
+        if (schema == null) {
+            return "";
+        }
+
+        StringBuilder xml = new StringBuilder();
+        String elementName = null;
+        generateXmlElements(schema, xml);
+        return xml.toString();
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void generateXmlElements(Schema<?> schema, StringBuilder xml) {
+        for (Map.Entry<String, Schema> property : schema.getProperties().entrySet()) {
+            String elementName = property.getKey();
+            xml.append("<");
+            xml.append(elementName);
+            xml.append(">");
+
+            if (property.getValue().getProperties() != null) {
+                generateXmlElements(property.getValue(), xml);
+            } else {
+                String value = dataGenerator.generateValue(elementName, property.getValue(), false);
+                if ("string".equalsIgnoreCase(property.getValue().getType())
+                        && value.startsWith("\"")
+                        && value.endsWith("\"")) {
+                    value = value.substring(1, value.length() - 1); // Remove surrounding quotes
+                }
+                xml.append(value);
+            }
+
+            xml.append("</");
+            xml.append(elementName);
+            xml.append(">\n");
+        }
+    }
+
     private static String getPropertyContentType(Schema<?> schema) {
         String type;
 

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -9,8 +9,6 @@ OpenAPI Support
 <BODY>
 <H1>OpenAPI Support</H1>
 This add-on allows you to spider and import OpenAPI (Swagger) definitions, versions 1.2, 2.0, and 3.0.
-<br>
-<strong>Note:</strong> Generation of XML content is currently not supported.
 <br><br>
 The add-on will automatically detect any OpenAPI definitions and spider them as long as they are in scope.
 <br><br>

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -19,10 +19,6 @@
  */
 package org.zaproxy.zap.extension.openapi.v3;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -716,19 +712,30 @@ class BodyGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldNotGenerateContentForApplicationXml() throws IOException {
+    void shouldGenerateXmlObject() throws IOException {
         // Given
-        OpenAPI definition = parseResource("openapi_xml_bodies.yaml");
-        OperationModel operationModel =
-                new OperationModel("/xml", definition.getPaths().get("/xml").getPost(), null);
+        OpenAPI openAPI = parseResource("openapi_xml_bodies.yaml");
+
         // When
-        String content = new RequestModelConverter().convert(operationModel, generators).getBody();
+        String xmlString =
+                generators
+                        .getBodyGenerator()
+                        .generateXml(
+                                openAPI.getPaths()
+                                        .get("/xml")
+                                        .getPost()
+                                        .getRequestBody()
+                                        .getContent()
+                                        .get("application/xml")
+                                        .getSchema());
+
         // Then
-        assertThat(content, is(emptyString()));
-        assertThat(
-                generators.getErrorMessages(),
-                contains(
-                        "Not generating request body for operation xml, the content type application/xml is not supported."));
+        String expectedOutput =
+                "<value-string>John Doe</value-string>\n"
+                        + "<value-boolean>true</value-boolean>\n"
+                        + "<value-integer>10</value-integer>\n";
+
+        assertEquals(expectedOutput, xmlString);
     }
 
     @Test


### PR DESCRIPTION
This commit adds support for handling Application/XML content types in request bodies for OpenAPI files


## Overview
I added a new functionality that creates the XML body for the application/XML from OpenAPI files. Below is the output I received from ZAP after implementing the code.In this example, I modified the application/json schemas of the Crapi OpenAPI file to application/XML and achieved this outcome.
![image](https://github.com/user-attachments/assets/c86df215-bc6e-4578-965d-c4717ac7ba00)

If you have any concerns or observations, please let me know.

## Related Issues
zaproxy/zaproxy#6767

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
