### PR TITLE
zest: fix NPE with added script

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correctly handle added scripts with no engine name.
 
 ## [46] - 2024-06-28
 ### Added

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -1766,7 +1766,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
 
     @Override
     public void scriptAdded(ScriptWrapper script, boolean display) {
-        if (script.getEngineName().equals(ZestScriptEngineFactory.NAME)) {
+        if (ZestScriptEngineFactory.NAME.equals(script.getEngineName())) {
 
             ScriptNode typeNode =
                     this.getExtScript().getTreeModel().getTypeNode(script.getTypeName());

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ExtensionZestUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ExtensionZestUnitTest.java
@@ -1,0 +1,48 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+/** Unit test for {@link ExtensionZest}. */
+class ExtensionZestUnitTest {
+
+    private ExtensionZest extension;
+
+    @BeforeEach
+    void setup() {
+        extension = new ExtensionZest();
+    }
+
+    @Test
+    void shouldHandleScriptAddedWithNoEngineName() {
+        // Given
+        ScriptWrapper sw = mock(ScriptWrapper.class);
+        given(sw.getEngineName()).willReturn(null);
+        // When/ Then
+        assertDoesNotThrow(() -> extension.scriptAdded(sw, false));
+    }
+}


### PR DESCRIPTION
Swap the operands to ensure the equality check does not fail even when the script engine name is null.

---
Mentioned in IRC, e.g.:
```
ZAP-BootstrapGUI] ERROR ExtensionScript - Error while notifying 'org.zaproxy.zap.extension.zest.ExtensionZest' with script 'Base64 Disclosure', cause: Cannot invoke "String.equals(Object)" because the return value of "org.zaproxy.zap.extension.script.ScriptWrapper.getEngineName()" is null
java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "org.zaproxy.zap.extension.script.ScriptWrapper.getEngineName()" is null
	at org.zaproxy.zap.extension.zest.ExtensionZest.scriptAdded(ExtensionZest.java:1769) ~[?:?]
	at org.zaproxy.zap.extension.script.ExtensionScript.addScript(ExtensionScript.java:711) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ExtensionScript.postInit(ExtensionScript.java:821) ~[zap-2.15.0.jar:2.15.0]
	at org.parosproxy.paros.extension.ExtensionLoader.hookAllExtension(ExtensionLoader.java:1001) ~[zap-2.15.0.jar:2.15.0]
	at org.parosproxy.paros.extension.ExtensionLoader.startLifeCycle(ExtensionLoader.java:836) ~[zap-2.15.0.jar:2.15.0]
	at org.parosproxy.paros.control.AbstractControl.loadExtension(AbstractControl.java:58) ~[zap-2.15.0.jar:2.15.0]
	at org.parosproxy.paros.control.Control.init(Control.java:156) ~[zap-2.15.0.jar:2.15.0]
	at org.parosproxy.paros.control.Control.initSingletonWithView(Control.java:389) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.GuiBootstrap.initControlAndPostViewInit(GuiBootstrap.java:229) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.GuiBootstrap$2.run(GuiBootstrap.java:174) ~[zap-2.15.0.jar:2.15.0]
	at java.lang.Thread.run(Thread.java:1583) [?:?]
```