### PR TITLE
pscanrules: increase allowed time in a test

### DIFF
--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PolyfillCdnScriptScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PolyfillCdnScriptScanRuleUnitTest.java
@@ -287,6 +287,6 @@ class PolyfillCdnScriptScanRuleUnitTest extends PassiveScannerTest<PolyfillCdnSc
         long end = System.currentTimeMillis();
 
         assertThat(alertsRaised.size(), equalTo(0));
-        assertThat(end - start, lessThan(200L));
+        assertThat(end - start, lessThan(275L));
     }
 }


### PR DESCRIPTION
Reduce failures when the test takes a little more time to run, e.g.:
```
PolyfillCdnScriptScanRuleUnitTest > shouldRunQuickly() FAILED
    java.lang.AssertionError:
    Expected: a value less than <200L>
         but: <249L> was greater than <200L>
```