### PR TITLE
scripts: address pscan concurrency issue

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Reuse script cache for all passive scan threads to avoid recompilation of Passive Rules scripts.
+- Address a concurrency issue when using Graal.js Passive Rules scripts as first-class scan rules.
 
 ## [45.6.0] - 2024-09-02
 ### Removed

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRuleUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRuleUnitTest.java
@@ -41,6 +41,7 @@ import org.zaproxy.addon.commonlib.scanrules.Risk;
 import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
 import org.zaproxy.zap.extension.pscan.PassiveScanData;
 import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptEngineWrapper;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.testutils.TestUtils;
 
@@ -105,6 +106,24 @@ public class PassiveScriptScanRuleUnitTest extends TestUtils {
         Alert alert = scanRule.newAlert().build();
         // Then
         assertThat(alert.getReference(), is(equalTo("")));
+    }
+
+    @Test
+    void shouldHonourScriptEngineThreadedPropertyOnAppliesToHistoryType() throws Exception {
+        // Given
+        PassiveScript scriptInterface = mock(PassiveScript.class);
+        ScriptWrapper script = createScriptWrapper(scriptInterface, PassiveScript.class);
+        var engine = mock(ScriptEngineWrapper.class);
+        given(engine.isSingleThreaded()).willReturn(true);
+        given(script.getEngine()).willReturn(engine);
+        int historyType = 1;
+        var scanRule = new PassiveScriptScanRule(script, null);
+        // When
+        scanRule.appliesToHistoryType(historyType);
+        scanRule.appliesToHistoryType(historyType);
+        // Then
+        verify(engine, times(2)).isSingleThreaded();
+        verify(scriptInterface, times(2)).appliesToHistoryType(historyType);
     }
 
     private <T> ScriptWrapper createScriptWrapper(T scriptInterface, Class<T> scriptClass)


### PR DESCRIPTION
Honour the threaded property of the script engine when checking if the scan rule applies to the history type, as it is called concurrently.