### PR TITLE
retire: Map severity to risk for Alerts

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The Risk level associated with Alerts raised by this scan rule are mapped to the severity ratings provided in the Retire.js data. If no severity is matched then a default of Medium Risk is used (Issue 7926).
 
 ## [0.41.0] - 2024-10-07
 ### Changed

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/Result.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/Result.java
@@ -20,15 +20,12 @@
 package org.zaproxy.addon.retire;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
+import org.zaproxy.addon.retire.model.Repo.VulnerabilityData;
 
 public class Result {
-    public static final String INFO = "info";
-    public static final String CVE = "CVE";
 
-    Map<String, Set<String>> information = new HashMap<>();
+    VulnerabilityData information;
     String version;
     String filename;
     String evidence;
@@ -37,7 +34,7 @@ public class Result {
     public Result(
             final String filename,
             final String version,
-            final Map<String, Set<String>> info,
+            final VulnerabilityData info,
             String evidence) {
         this.filename = filename;
         this.version = version;
@@ -45,7 +42,7 @@ public class Result {
         this.evidence = evidence;
     }
 
-    public Map<String, Set<String>> getInformation() {
+    public VulnerabilityData getInformation() {
         return information;
     }
 
@@ -74,9 +71,9 @@ public class Result {
     }
 
     public Set<String> getCves() {
-        if (information.isEmpty() || !information.containsKey(CVE)) {
+        if (information.isEmpty() || information.getCves().isEmpty()) {
             return Collections.emptySet();
         }
-        return information.get(CVE);
+        return information.getCves();
     }
 }

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -44,6 +45,7 @@ import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.retire.Result;
 import org.zaproxy.addon.retire.RetireUtil;
@@ -145,7 +147,7 @@ public class Repo {
      * This function computes the SHA 1 hash of the HTTP response body,
      * IF the hash matches that of an existing entry in the vulnerability database
      * corresponding info is returned.
-     * ELSE an empty HashSet is returned.
+     * ELSE null is returned.
      */
     private Result scanHash(String hash) {
         // Testable URL: https://ajax.googleapis.com/ajax/libs/dojo/1.1.1/dojo/dojo.js
@@ -158,10 +160,10 @@ public class Repo {
                     List<Vulnerability> vulnerabilities = repoEntry.getValue().getVulnerabilities();
 
                     if (hash.equalsIgnoreCase(hashEntry.getKey())) {
-                        Map<String, Set<String>> results =
+                        VulnerabilityData vulnData =
                                 isVersionVulnerable(vulnerabilities, hashEntry.getValue());
                         Result result =
-                                new Result(repoEntry.getKey(), hashEntry.getValue(), results, "");
+                                new Result(repoEntry.getKey(), hashEntry.getValue(), vulnData, "");
                         result.setOtherinfo(
                                 Constant.messages.getString(
                                         "retire.rule.otherinfo", hashEntry.getKey()));
@@ -199,13 +201,13 @@ public class Repo {
                             // Now try to determine if this version is vulnerable
                             List<Vulnerability> vulnerabilities =
                                     repoEntry.getValue().getVulnerabilities();
-                            Map<String, Set<String>> results =
+                            VulnerabilityData vulnData =
                                     isVersionVulnerable(vulnerabilities, versionString);
-                            if (!results.isEmpty()) {
+                            if (!vulnData.isEmpty()) {
                                 return new Result(
                                         repoEntry.getKey(),
                                         versionString,
-                                        results,
+                                        vulnData,
                                         matcher.group(0));
                             }
                         }
@@ -250,19 +252,17 @@ public class Repo {
     /*
      * This function depending on the vulnerability info of a passed JS library,
      * detects if the current version is vulnerable.
-     * If YES returns the HashSet of vulnerability info.
-     * else returns an empty HashSet.
+     * If YES returns the vulnerability data.
+     * else returns an empty data object.
      */
-    private static Map<String, Set<String>> isVersionVulnerable(
+    private static VulnerabilityData isVersionVulnerable(
             List<Vulnerability> vulnerabilities, String versionString) {
         if (!isGoodCandidate(versionString)) {
-            return Map.of();
+            return VulnerabilityData.EMPTY;
         }
         // Do a match for each of the above vulnerabilities
-        Map<String, Set<String>> results = new HashMap<>();
+        VulnerabilityData vulnData = new VulnerabilityData();
         ListIterator<Vulnerability> viterator = vulnerabilities.listIterator();
-        Set<String> cve = new HashSet<>();
-        Set<String> info = new HashSet<>();
 
         while (viterator.hasNext()) {
             boolean isVulnerable = false;
@@ -283,13 +283,12 @@ public class Repo {
                 }
             }
             if (isVulnerable) {
-                cve.addAll(vnext.getIdentifiers().getCve());
-                results.put(Result.CVE, cve);
-                info.addAll(vnext.getInfo());
-                results.put(Result.INFO, info);
+                vulnData.addCves(vnext.getIdentifiers().getCve());
+                vulnData.addInfo(vnext.getInfo());
+                vulnData.setRisk(vnext.getRisk());
             }
         }
-        return results;
+        return vulnData;
     }
 
     private static boolean isGoodCandidate(String version) {
@@ -306,5 +305,55 @@ public class Repo {
             // Nothing to do, it might happen
         }
         return isAllZeros != 0; // Not a good value if all zero
+    }
+
+    public static class VulnerabilityData {
+        public static final VulnerabilityData EMPTY = new VulnerabilityData();
+
+        static {
+            EMPTY.empty = true;
+            EMPTY.cves = Set.of();
+            EMPTY.info = Set.of();
+            EMPTY.risk = Alert.RISK_MEDIUM;
+        }
+
+        private Set<String> cves;
+        private Set<String> info;
+        private int risk;
+        private boolean empty;
+
+        public VulnerabilityData() {
+            this.empty = false;
+            this.cves = new HashSet<>();
+            this.info = new HashSet<>();
+        }
+
+        public Set<String> getCves() {
+            return cves;
+        }
+
+        public void addCves(Collection<String> cves) {
+            this.cves.addAll(cves);
+        }
+
+        public Set<String> getInfo() {
+            return info;
+        }
+
+        public void addInfo(Collection<String> info) {
+            this.info.addAll(info);
+        }
+
+        public int getRisk() {
+            return risk;
+        }
+
+        public void setRisk(int newRisk) {
+            this.risk = Math.max(risk, newRisk);
+        }
+
+        public boolean isEmpty() {
+            return empty;
+        }
     }
 }

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Vulnerability.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Vulnerability.java
@@ -22,15 +22,23 @@ package org.zaproxy.addon.retire.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.parosproxy.paros.core.scanner.Alert;
 
 @JsonIgnoreProperties({"above", "cwe"})
 public class Vulnerability {
+
+    private static final Map<String, Integer> SEVERITY_MAP =
+            Map.of("high", Alert.RISK_HIGH, "medium", Alert.RISK_MEDIUM, "low", Alert.RISK_LOW);
 
     private String below;
     private String atOrAbove;
     private String severity;
     private Identifiers identifiers;
     private List<String> info = null;
+
+    private int risk;
 
     public String getBelow() {
         return below;
@@ -61,7 +69,16 @@ public class Vulnerability {
     }
 
     public void setSeverity(String severity) {
-        this.severity = severity;
+        this.severity = severity.toLowerCase(Locale.ROOT);
+        this.risk = getRiskForSeverity(this.severity);
+    }
+
+    int getRisk() {
+        return risk;
+    }
+
+    static int getRiskForSeverity(String severity) {
+        return SEVERITY_MAP.getOrDefault(severity, Alert.RISK_MEDIUM);
     }
 
     public Identifiers getIdentifiers() {

--- a/addOns/retire/src/main/javahelp/org/zaproxy/addon/retire/resources/help/contents/retire.html
+++ b/addOns/retire/src/main/javahelp/org/zaproxy/addon/retire/resources/help/contents/retire.html
@@ -11,6 +11,8 @@ Retire.js
 This add-on includes a passive scan rule which implements checks provided by <a href="https://retirejs.github.io/retire.js/">Retire.js</a> 
 in order to identify vulnerable or out-dated JavaScript packages.
 <p>
+<strong>Note:</strong> The Risk level associated with Alerts raised by this scan rule are mapped to the severity ratings provided in the Retire.js data. If no severity is matched then a default of Medium Risk is used.
+<p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/retire/">Retire.js Add-on</a>
 <br>
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10003/">10003</a>.

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -107,6 +107,7 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_LOW)));
         assertEquals("/1.2.19/angular.min.js", alertsRaised.get(0).getEvidence());
         assertEquals(
                 "https://github.com/angular/angular.js/commit/8f31f1ff43b673a24f84422d5c13d6312b2c4d94\n",
@@ -137,6 +138,7 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
         assertEquals(fileName, alertsRaised.get(0).getEvidence());
         assertEquals(
                 "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/\n",
@@ -172,6 +174,7 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
         assertEquals("* Bootstrap v3.3.7", alertsRaised.get(0).getEvidence());
         assertEquals(
                 "https://github.com/twbs/bootstrap/issues/20184\n",
@@ -196,6 +199,7 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_LOW)));
         assertEquals(
                 "CVE-XXXX-XXX2\n"
                         + "CVE-XXXX-XXX1\n"
@@ -243,6 +247,7 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         List<Alert> alerts = rule.getExampleAlerts();
         // Then
         assertThat(alerts.size(), is(equalTo(1)));
+        assertThat(alerts.get(0).getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
     }
 
     @Test

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/model/VulnerabilityUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/model/VulnerabilityUnitTest.java
@@ -1,0 +1,38 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.retire.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Unit test for {@link Vulnerability}. */
+class VulnerabilityUnitTest {
+
+    @ParameterizedTest
+    @CsvSource({"null,2", "'',2", "'below',2", "'low',1", "'medium', 2", "'high', 3"})
+    void shouldMapSeverityToRiskAsExpected(String severity, int expectedRisk) {
+        // Given / When / Then
+        assertThat(Vulnerability.getRiskForSeverity(severity), is(equalTo(expectedRisk)));
+    }
+}


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- Repo > Updated revising the handling of vulnerability data.
- Result > Updated to accommodate the new vulnerability data handling.
- RetireScanRule > Updated to accommodate the new vulnerability data handling.
- RetireScanRuleUnitTest > Updated assertions to account for the new risk/severity handling.
- Vulnerability > Updated revising the handling of vulnerability data, mapping severity to risk at parse time.
- VulnerabilityUnitTest > Added test to assure proper mapping.
- retire.html > Added details about severity to risk mapping.

## Related Issues
Fixes zaproxy/zaproxy#7926

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
