### PR TITLE
scripts: handle exception when stopping script

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Reuse script cache for all passive scan threads to avoid recompilation of Passive Rules scripts.
 - Address a concurrency issue when using Graal.js Passive Rules scripts as first-class scan rules.
+- Handle gracefully the inability to force stop the running standalone script in newer Java versions.
 
 ## [45.6.0] - 2024-09-02
 ### Removed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -818,7 +818,11 @@ public class ConsolePanel extends AbstractPanel {
                 }
                 // Yes, its deprecated, but there are no alternatives, and we have to be able to
                 // stop scripts
-                stop();
+                try {
+                    stop();
+                } catch (UnsupportedOperationException e) {
+                    LOGGER.warn("Unable to force stop the script.");
+                }
             }
         }
     }


### PR DESCRIPTION
Catch the exception that's thrown when stopping the thread in newer Java versions to prevent the exception from bubbling up.