### PR TITLE
zest: deduplicate code

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [47] - 2024-09-24
 ### Fixed

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestZapUtilsUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestZapUtilsUnitTest.java
@@ -22,9 +22,13 @@ package org.zaproxy.zap.extension.zest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -33,6 +37,46 @@ import org.zaproxy.zest.core.v1.ZestRequest;
 
 /** Unit test for {@link ZestZapUtils}. */
 class ZestZapUtilsUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldIncludeRquestMethodWhenConvertingHttpMessageToZestRequest(boolean replaceTokens)
+            throws Exception {
+        // Given
+        HttpMessage httpMessage = createRequest("");
+        // When
+        ZestRequest zestRequest =
+                ZestZapUtils.toZestRequest(httpMessage, replaceTokens, false, createZestParam());
+        // Then
+        assertThat(zestRequest.getMethod(), is(equalTo("GET")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldIncludeTimeStampWhenConvertingHttpMessageToZestRequest(boolean replaceTokens)
+            throws Exception {
+        // Given
+        HttpMessage httpMessage = createRequest("");
+        httpMessage.setTimeSentMillis(42L);
+        // When
+        ZestRequest zestRequest =
+                ZestZapUtils.toZestRequest(httpMessage, replaceTokens, false, createZestParam());
+        // Then
+        assertThat(zestRequest.getTimestamp(), is(equalTo(42L)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldNotFollowRedirectsWhenConvertingHttpMessageToZestRequest(boolean replaceTokens)
+            throws Exception {
+        // Given
+        HttpMessage httpMessage = createRequest("");
+        // When
+        ZestRequest zestRequest =
+                ZestZapUtils.toZestRequest(httpMessage, replaceTokens, false, createZestParam());
+        // Then
+        assertThat(zestRequest.isFollowRedirects(), is(equalTo(false)));
+    }
 
     @Test
     void shouldKeepAllHeadersIfIncludingAllWhenConvertingHttpMessageToZestRequest()
@@ -63,6 +107,35 @@ class ZestZapUtilsUnitTest {
                 ZestZapUtils.toZestRequest(httpMessage, false, includeAllHeaders, zestParam);
         // Then
         assertThat(zestRequest.getHeaders(), is(equalTo("A: 1\r\nHost: example.com\r\n")));
+    }
+
+    @Test
+    void shouldIncludeResponseIfEnabledWhenConvertingHttpMessageToZestRequest() throws Exception {
+        // Given
+        ZestParam zestParam = createZestParam();
+        zestParam.setIncludeResponses(true);
+        HttpMessage httpMessage = createRequest("A: 1\r\nB: 2\r\nHost: example.com\r\n");
+        var response = "HTTP/1.1 200 OK\r\nC: 3\r\n\r\n";
+        httpMessage.setResponseHeader(response);
+        // When
+        ZestRequest zestRequest = ZestZapUtils.toZestRequest(httpMessage, false, false, zestParam);
+        // Then
+        assertThat(zestRequest.getResponse(), is(not(nullValue())));
+        assertThat(zestRequest.getResponse().getHeaders(), is(equalTo(response)));
+    }
+
+    @Test
+    void shouldNotIncludeResponseIfNotEnabledWhenConvertingHttpMessageToZestRequest()
+            throws Exception {
+        // Given
+        ZestParam zestParam = createZestParam();
+        zestParam.setIncludeResponses(false);
+        HttpMessage httpMessage = createRequest("A: 1\r\nB: 2\r\nHost: example.com\r\n");
+        httpMessage.setResponseHeader("HTTP/1.1 200 OK");
+        // When
+        ZestRequest zestRequest = ZestZapUtils.toZestRequest(httpMessage, false, false, zestParam);
+        // Then
+        assertThat(zestRequest.getResponse(), is(nullValue()));
     }
 
     private static ZestParam createZestParam() {


### PR DESCRIPTION
Remove duplication when converting `HttpMessage` to `ZestRequest` and `ZestResponse`.