### PR TITLE
sequence: depend on `ExtensionZest`

### DIFF
--- a/addOns/sequence/sequence.gradle.kts
+++ b/addOns/sequence/sequence.gradle.kts
@@ -13,3 +13,7 @@ zapAddOn {
         }
     }
 }
+
+dependencies {
+    zapAddOn("zest")
+}

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/ExtensionSequence.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/ExtensionSequence.java
@@ -40,11 +40,12 @@ import org.zaproxy.zap.extension.script.ScriptCollection;
 import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.script.SequenceScript;
+import org.zaproxy.zap.extension.zest.ExtensionZest;
 
 public class ExtensionSequence extends ExtensionAdaptor implements ScannerHook {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
-            List.of(ExtensionScript.class);
+            List.of(ExtensionScript.class, ExtensionZest.class);
 
     private ExtensionScript extScript;
     private ExtensionActiveScan extActiveScan;
@@ -118,7 +119,7 @@ public class ExtensionSequence extends ExtensionAdaptor implements ScannerHook {
                                                 .getResource("resources/icons/script-sequence.png"))
                                 : null,
                         false,
-                        new String[] {"append"});
+                        new String[] {ScriptType.CAPABILITY_APPEND});
         getExtScript().registerScriptType(scriptType);
 
         if (hasView()) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -1898,8 +1898,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     }
 
     /**
-     * Return all of the requests in the script ScriptWrapper is deliberately used to make it easier
-     * to call this method by reflection
+     * Return all of the requests in the script.
      *
      * @param script
      * @return


### PR DESCRIPTION
The extension is a core component of the functionality and it's already a dependency of the add-on, which also allows to remove usage of reflection.
Replace hardcoded string with respective constant.