### PR TITLE
zest: use semantic version

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 All notable changes to this add-on will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Changed
+- Use Semantic Version.
 - Maintenance changes.
 
 ## [47] - 2024-09-24

--- a/addOns/zest/gradle.properties
+++ b/addOns/zest/gradle.properties
@@ -1,2 +1,2 @@
-version=48
+version=48.0.0
 release=false


### PR DESCRIPTION
Allow other add-ons to reliable depend on specific versions.