### PR TITLE
automation: Tweak YAML serialization

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Handle exceptions while running jobs.
 
+### Changed
+- In saved YAML plans:
+  - Fields with default values are omitted.
+  - The "name" and "type" fields are added before other fields.
+  - Values are not quoted unless required.
+
 ## [0.42.0] - 2024-09-02
 ### Added
 - Allow to configure the structural parameters of a context (Issue 7780).

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationData.java
@@ -20,23 +20,15 @@
 package org.zaproxy.addon.automation;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
-import java.lang.reflect.Method;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-@JsonFilter("ignoreDefaultFilter")
+@JsonFilter(DefaultPropertyFilter.FILTER_ID)
+@JsonPropertyOrder({"name", "type"})
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public abstract class AutomationData {
 
-    private static final Logger LOGGER = LogManager.getLogger(AutomationData.class);
-
     public boolean isDefaultValue(String name) {
-        String getter = "get" + name.substring(0, 1).toUpperCase() + name.substring(1);
-        try {
-            Method method = this.getClass().getMethod(getter);
-            return method.invoke(this) == null;
-        } catch (Exception e) {
-            LOGGER.debug("Class {} no getter {}", this.getClass().getCanonicalName(), getter);
-        }
         return false;
     }
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/DefaultPropertyFilter.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/DefaultPropertyFilter.java
@@ -24,15 +24,22 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import java.util.Collection;
 
 public class DefaultPropertyFilter extends SimpleBeanPropertyFilter {
+
+    static final String FILTER_ID = "ignoreDefaultFilter";
+
     @Override
     public void serializeAsField(
             Object pojo, JsonGenerator jgen, SerializerProvider provider, PropertyWriter writer)
             throws Exception {
         if (include(writer)) {
-            if (pojo instanceof AutomationData
-                    && ((AutomationData) pojo).isDefaultValue(writer.getName())) {
+            Object value = writer.getMember().getValue(pojo);
+            if (value == null
+                    || (value instanceof Collection && ((Collection<?>) value).isEmpty())
+                    || (pojo instanceof AutomationData
+                            && ((AutomationData) pojo).isDefaultValue(writer.getName()))) {
                 return;
             }
             writer.serializeAsField(pojo, jgen, provider);

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobData.java
@@ -37,7 +37,7 @@ public abstract class JobData extends AutomationData {
     @Override
     public boolean isDefaultValue(String name) {
         if ("name".equals(name)) {
-            return name.equals(getType());
+            return getName().equals(getType());
         }
         return super.isDefaultValue(name);
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/tests/TestData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/tests/TestData.java
@@ -33,7 +33,7 @@ public abstract class TestData extends AutomationData {
     @Override
     public boolean isDefaultValue(String name) {
         if ("name".equals(name)) {
-            return name.equals(getType());
+            return getName().equals(getType());
         }
         return super.isDefaultValue(name);
     }

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
@@ -581,11 +581,11 @@ class AjaxSpiderJobUnitTest {
                 Files.readString(planFile),
                 containsString(
                         "    excludedElements:\n"
-                                + "    - description: \"Description\"\n"
-                                + "      element: \"Element\"\n"
-                                + "      xpath: \"XPath\"\n"
-                                + "      text: \"Text\"\n"
-                                + "      attributeName: \"Attribute Name\"\n"
-                                + "      attributeValue: \"Attribute Value\""));
+                                + "    - description: Description\n"
+                                + "      element: Element\n"
+                                + "      xpath: XPath\n"
+                                + "      text: Text\n"
+                                + "      attributeName: Attribute Name\n"
+                                + "      attributeValue: Attribute Value"));
     }
 }


### PR DESCRIPTION
## Overview
In saved YAML plans,
  - Fields with default values are omitted
  - The "name" and "type" fields are added before other fields
  - Values are not quoted unless required

## Example
<details>
<summary> <strong>Before / After Comparison (click to expand)</strong> </summary>
<table>
<tr>
<th> Before
<th> After
<tr>
<td>
<pre lang="yaml">
---
env:
  contexts:
  - name: "Default Context"
    urls: []
    includePaths: []
    excludePaths: []
    authentication:
      parameters: {}
      verification:
        method: "response"
        pollFrequency: 60
        pollUnits: "requests"
    sessionManagement:
      method: "cookie"
      parameters: {}
    technology:
      exclude: []
    structure:
      structuralParameters: []
  parameters:
    failOnError: true
    failOnWarning: false
    progressToStdout: true
    continueOnFailure: false
  vars: {}
jobs:
- parameters:
    scanOnlyInScope: true
    enableTags: false
    disableAllRules: false
  rules: []
  name: "passiveScan-config"
  type: "passiveScan-config"
- parameters: {}
  name: "script"
  type: "script"
- parameters: {}
  requests: []
  name: "requestor"
  type: "requestor"
- parameters:
    queryGenEnabled: true
    maxQueryDepth: 5
    lenientMaxQueryDepthEnabled: true
    maxAdditionalQueryDepth: 5
    maxArgsDepth: 5
    optionalArgsEnabled: true
    argsType: "both"
    querySplitType: "leaf"
    requestMethod: "post_json"
  name: "graphql"
  type: "graphql"
- parameters: {}
  name: "openapi"
  type: "openapi"
- parameters: {}
  name: "spider"
  type: "spider"
  tests:
  - onFail: "INFO"
    statistic: "automation.spider.urls.added"
    site: ""
    operator: ">="
    value: 100
    name: "At least 100 URLs found"
    type: "stats"
- parameters: {}
  name: "delay"
  type: "delay"
- parameters: {}
  name: "passiveScan-wait"
  type: "passiveScan-wait"
- parameters: {}
  policyDefinition:
    rules: []
  name: "activeScan"
  type: "activeScan"
</pre>
<td>

<pre lang="yaml">
env:
  contexts:
  - name: Default Context
    authentication:
      verification:
        method: response
        pollFrequency: 60
        pollUnits: requests
    sessionManagement:
      method: cookie
    technology: {}
    structure: {}
  parameters: {}
jobs:
- type: passiveScan-config
  parameters: {}
- type: script
  parameters: {}
- type: requestor
  parameters: {}
- type: graphql
  parameters: {}
- type: openapi
  parameters: {}
- type: spider
  parameters: {}
  tests:
  - name: At least 100 URLs found
    type: stats
    onFail: INFO
    statistic: automation.spider.urls.added
    operator: '>='
    value: 100
- type: delay
  parameters: {}
- type: passiveScan-wait
  parameters: {}
- type: activeScan
  parameters: {}
  policyDefinition: {}





































</pre>
</table>
</details>

Ideally we shouldn't have the `parameters: {}` field for each add-on job either but for that we'll need to update each of those manually by overriding `isDefaultValue()` for the jobs.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
