### PR TITLE
zest: validate URI presence on request conversion

### DIFF
--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapUtils.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapUtils.java
@@ -1062,15 +1062,17 @@ public class ZestZapUtils {
             HttpMessage msg, boolean replaceTokens, boolean incAllHeaders, ZestParam params)
             throws MalformedURLException, HttpMalformedHeaderException, SQLException {
         ZestRequest req = new ZestRequest();
+        var uri = msg.getRequestHeader().getURI();
+        if (uri == null) {
+            throw new HttpMalformedHeaderException("The request header does not have a URI.");
+        }
+
+        req.setUrl(new URL(uri.toString()));
         if (replaceTokens) {
-            if (msg.getRequestHeader().getURI() != null) {
-                req.setUrl(new URL(msg.getRequestHeader().getURI().toString()));
-            }
-            req.setUrlToken(correctTokens(msg.getRequestHeader().getURI().toString()));
+            req.setUrlToken(correctTokens(uri.toString()));
             req.setData(correctTokens(msg.getRequestBody().toString()));
 
         } else {
-            req.setUrl(new URL(msg.getRequestHeader().getURI().toString()));
             req.setData(msg.getRequestBody().toString());
         }
 

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestZapUtilsUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestZapUtilsUnitTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,21 @@ import org.zaproxy.zest.core.v1.ZestRequest;
 
 /** Unit test for {@link ZestZapUtils}. */
 class ZestZapUtilsUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldThrowIfNoUriWhenConvertingHttpMessageToZestRequest(boolean replaceTokens) {
+        // Given
+        HttpMessage httpMessage = new HttpMessage();
+        // When / Then
+        HttpMalformedHeaderException e =
+                assertThrows(
+                        HttpMalformedHeaderException.class,
+                        () ->
+                                ZestZapUtils.toZestRequest(
+                                        httpMessage, replaceTokens, false, createZestParam()));
+        assertThat(e.getMessage(), is(equalTo("The request header does not have a URI.")));
+    }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})


### PR DESCRIPTION
Validate upfront that the request does have a URI instead of letting a NPE happen later.
Remove some more duplicated code.