### PR TITLE
zest: allow to create script with HTTP messages

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Allow other add-ons to create a Zest script from a list of messages.
+
 ### Changed
 - Use Semantic Version.
 - Maintenance changes.

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/CreateScriptOptions.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/CreateScriptOptions.java
@@ -1,0 +1,135 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest;
+
+/**
+ * The options for script creation.
+ *
+ * @since 48.0.0
+ * @see ExtensionZest#createScript(String, org.zaproxy.zap.extension.script.ScriptType,
+ *     java.util.List, CreateScriptOptions)
+ */
+public class CreateScriptOptions {
+
+    /** The default options. */
+    public static final CreateScriptOptions DEFAULT = builder().build();
+
+    private final boolean addStatusAssertion;
+    private final boolean addLengthAssertion;
+    private final int lengthApprox;
+
+    private CreateScriptOptions(
+            boolean addStatusAssertion, boolean addLengthAssertion, int lengthApprox) {
+
+        this.addStatusAssertion = addStatusAssertion;
+        this.addLengthAssertion = addLengthAssertion;
+        this.lengthApprox = lengthApprox;
+    }
+
+    public boolean isAddStatusAssertion() {
+        return addStatusAssertion;
+    }
+
+    public boolean isAddLengthAssertion() {
+        return addLengthAssertion;
+    }
+
+    public int getLengthApprox() {
+        return lengthApprox;
+    }
+
+    /**
+     * Returns a new builder.
+     *
+     * @return the options builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder of options.
+     *
+     * @see #build()
+     */
+    public static class Builder {
+
+        private boolean addStatusAssertion;
+        private boolean addLengthAssertion;
+        private int lengthApprox = 1;
+
+        private Builder() {}
+
+        /**
+         * Sets whether or not the status assertion should be added to the requests.
+         *
+         * <p>Default value: {@code false}.
+         *
+         * @param addStatusAssertion {@code true} if the assertion should be added, {@code false}
+         *     otherwise.
+         * @return the builder for chaining.
+         */
+        public Builder setAddStatusAssertion(boolean addStatusAssertion) {
+            this.addStatusAssertion = addStatusAssertion;
+            return this;
+        }
+
+        /**
+         * Sets whether or not the length assertion should be added to the requests.
+         *
+         * <p>Default value: {@code false}.
+         *
+         * @param addLengthAssertion {@code true} if the assertion should be added, {@code false}
+         *     otherwise.
+         * @return the builder for chaining.
+         */
+        public Builder setAddLengthAssertion(boolean addLengthAssertion) {
+            this.addLengthAssertion = addLengthAssertion;
+            return this;
+        }
+
+        /**
+         * Sets the approximate value for the length assertions.
+         *
+         * <p>Default value: {@code 1}.
+         *
+         * @param lengthApprox the approximate value.
+         * @return the builder for chaining.
+         * @throws IllegalArgumentException if the given value is negative.
+         * @see #setAddLengthAssertion(boolean)
+         */
+        public Builder setLengthApprox(int lengthApprox) {
+            if (lengthApprox < 0) {
+                throw new IllegalArgumentException("The length must be zero or greater.");
+            }
+            this.lengthApprox = lengthApprox;
+            return this;
+        }
+
+        /**
+         * Builds the options from the specified data.
+         *
+         * @return the options with specified data.
+         */
+        public final CreateScriptOptions build() {
+            return new CreateScriptOptions(addStatusAssertion, addLengthAssertion, lengthApprox);
+        }
+    }
+}

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/CreateScriptOptionsUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/CreateScriptOptionsUnitTest.java
@@ -1,0 +1,88 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Unit test for {@link CreateScriptOptions}. */
+class CreateScriptOptionsUnitTest {
+
+    @Test
+    void shouldHaveExpectedDefaults() {
+        // Given / When
+        CreateScriptOptions options = CreateScriptOptions.DEFAULT;
+        // Then
+        assertThat(options.isAddStatusAssertion(), is(equalTo(false)));
+        assertThat(options.isAddLengthAssertion(), is(equalTo(false)));
+        assertThat(options.getLengthApprox(), is(equalTo(1)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAddStatusAssertion(boolean value) {
+        // Given
+        var builder = CreateScriptOptions.builder();
+        // When
+        builder.setAddStatusAssertion(value);
+        // Then
+        assertThat(builder.build().isAddStatusAssertion(), is(equalTo(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAddLengthAssertion(boolean value) {
+        // Given
+        var builder = CreateScriptOptions.builder();
+        // When
+        builder.setAddLengthAssertion(value);
+        // Then
+        assertThat(builder.build().isAddLengthAssertion(), is(equalTo(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 10, 100, Integer.MAX_VALUE})
+    void shouldSetLengthApprox(int value) {
+        // Given
+        var builder = CreateScriptOptions.builder();
+        // When
+        builder.setLengthApprox(value);
+        // Then
+        assertThat(builder.build().getLengthApprox(), is(equalTo(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {Integer.MIN_VALUE, -100, -10, -1})
+    void shouldThrowSettingNegativeLengthApprox(int value) {
+        // Given
+        var builder = CreateScriptOptions.builder();
+        // When
+        Exception ex =
+                assertThrows(IllegalArgumentException.class, () -> builder.setLengthApprox(value));
+        // Then
+        assertThat(ex.getMessage(), is(equalTo("The length must be zero or greater.")));
+    }
+}

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ExtensionZestUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ExtensionZestUnitTest.java
@@ -19,12 +19,38 @@
  */
 package org.zaproxy.zap.extension.zest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.ArgumentCaptor;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
 /** Unit test for {@link ExtensionZest}. */
@@ -44,5 +70,141 @@ class ExtensionZestUnitTest {
         given(sw.getEngineName()).willReturn(null);
         // When/ Then
         assertDoesNotThrow(() -> extension.scriptAdded(sw, false));
+    }
+
+    @Nested
+    class ScriptCreation {
+
+        private String name;
+        private ScriptType type;
+        private CreateScriptOptions options;
+        private ExtensionScript extensionScript;
+
+        @BeforeEach
+        void setup() {
+            name = "Script Name";
+            type = mock(ScriptType.class);
+            options = mock(CreateScriptOptions.class);
+            extensionScript = mock(ExtensionScript.class);
+
+            var extLoader = mock(ExtensionLoader.class);
+            Control.initSingletonForTesting(mock(Model.class), extLoader);
+
+            given(extLoader.getExtension(ExtensionScript.NAME)).willReturn(extensionScript);
+            given(extLoader.getExtension(ExtensionZest.NAME)).willReturn(extension);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldThrowForNullAndEmptyMessages(List<HttpMessage> messages) {
+            IllegalArgumentException e =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> extension.createScript(name, type, messages, options));
+            assertThat(e.getMessage(), is(equalTo("The messages should not be null nor empty.")));
+        }
+
+        @Test
+        void shouldThrowForNullMessage() {
+            // Given
+            List<HttpMessage> messages = new ArrayList<>();
+            messages.add(null);
+            // When / Then
+            IllegalArgumentException e =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> extension.createScript(name, type, messages, options));
+            assertThat(e.getMessage(), is(equalTo("A message should not be null.")));
+        }
+
+        @Test
+        void shouldThrowForMessageWithoutUri() {
+            // Given
+            List<HttpMessage> messages = new ArrayList<>();
+            messages.add(new HttpMessage());
+            // When / Then
+            IllegalArgumentException e =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> extension.createScript(name, type, messages, options));
+            assertThat(
+                    e.getMessage(),
+                    is(
+                            equalTo(
+                                    "Failed to convert message to ZestRequest: The request header does not have a URI.")));
+        }
+
+        @Test
+        void shouldAddScript() throws Exception {
+            // Given
+            List<HttpMessage> messages = new ArrayList<>();
+            messages.add(new HttpMessage(new URI("http://example.com", true)));
+            // When
+            var sw = extension.createScript(name, type, messages, options);
+            // Then
+            assertThat(
+                    sw.getContents(),
+                    allOf(
+                            containsString("\"url\": \"http://example.com\","),
+                            containsString("\"elementType\": \"ZestRequest\""),
+                            not(containsString("ZestExpressionStatusCode")),
+                            not(containsString("ZestExpressionLength"))));
+            var argCaptor = ArgumentCaptor.forClass(ScriptWrapper.class);
+            verify(extensionScript).addScript(argCaptor.capture(), eq(false));
+            assertThat(sw, is(sameInstance(argCaptor.getValue())));
+            assertThat(sw.getName(), is(equalTo(name)));
+            assertThat(sw.getType(), is(sameInstance(type)));
+            assertThat(sw.getEngine(), is(sameInstance(extension.getZestEngineWrapper())));
+        }
+
+        @Test
+        void shouldAddStatusAssertion() throws Exception {
+            // Given
+            List<HttpMessage> messages = new ArrayList<>();
+            messages.add(new HttpMessage(new URI("http://example.com", true)));
+            given(options.isAddStatusAssertion()).willReturn(true);
+            // When
+            var sw = extension.createScript(name, type, messages, options);
+            // Then
+            assertThat(
+                    sw.getContents(),
+                    allOf(
+                            containsString("ZestExpressionStatusCode"),
+                            not(containsString("ZestExpressionLength"))));
+        }
+
+        @Test
+        void shouldAddLengthAssertion() throws Exception {
+            // Given
+            List<HttpMessage> messages = new ArrayList<>();
+            messages.add(new HttpMessage(new URI("http://example.com", true)));
+            given(options.isAddLengthAssertion()).willReturn(true);
+            given(options.getLengthApprox()).willReturn(42);
+            // When
+            var sw = extension.createScript(name, type, messages, options);
+            // Then
+            assertThat(
+                    sw.getContents(),
+                    allOf(
+                            not(containsString("ZestExpressionStatusCode")),
+                            containsString("ZestExpressionLength"),
+                            containsString("\"approx\": 42,")));
+        }
+
+        @Test
+        void shouldThrowIfAddScriptThrows() throws Exception {
+            // Given
+            List<HttpMessage> messages = new ArrayList<>();
+            messages.add(new HttpMessage(new URI("http://example.com", true)));
+            Exception cause = new InvalidParameterException("Some Reason");
+            given(extensionScript.addScript(any(), anyBoolean())).willThrow(cause);
+            // When / Then
+            IllegalStateException e =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> extension.createScript(name, type, messages, options));
+            assertThat(e.getMessage(), is(equalTo("Failed to add the script: Some Reason")));
+            assertThat(e.getCause(), is(sameInstance(cause)));
+        }
     }
 }


### PR DESCRIPTION
Expose a method to create a Zest script containing the provided HTTP messages and of a given script type, to allow other add-ons to create their own scripts as needed.