### PR TITLE
ascanrules: Address SSTI false positive

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Server Side Template Injection (Blind)
   - XML External Entity Attack
 
+### Fixed
+- A situation where the Server-Side Template Injection (SSTI) scan rule might result in false positives related to the Go payloads (Issue 8622).
+
 ### Added
 - Standardized Scan Policy related alert tags on the rule.
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SstiScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SstiScanRule.java
@@ -414,7 +414,9 @@ public class SstiScanRule extends AbstractAppParamPlugin implements CommonActive
                                             + DELIMITER
                                             + "[\\w\\W]*";
 
-                            if (output.contains(renderResult) && output.matches(regex)) {
+                            if (output.contains(renderResult)
+                                    && output.matches(regex)
+                                    && sstiPayload.engineSpecificCheck(regex, output, renderTest)) {
 
                                 String attack = getOtherInfo(sink.getLocation(), output);
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ssti/GoTemplateFormat.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ssti/GoTemplateFormat.java
@@ -19,6 +19,9 @@
  */
 package org.zaproxy.zap.extension.ascanrules.ssti;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * This represents the code that is necessary to execute an arithmetic operation in Golang template
  * engine and the expected result of the operation.
@@ -35,5 +38,12 @@ public class GoTemplateFormat extends TemplateFormat {
     public int getExpectedResult(int number1, int number2) {
         String concatenated = String.format("%d%d", number1, number2);
         return Integer.parseInt(concatenated);
+    }
+
+    @Override
+    public boolean engineSpecificCheck(String regex, String output, String renderTest) {
+        Matcher matcher = Pattern.compile(regex).matcher(output);
+        matcher.matches();
+        return !matcher.group(0).contains(renderTest.replaceAll("[^A-Za-z0-9]+", ""));
     }
 }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ssti/TemplateFormat.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ssti/TemplateFormat.java
@@ -84,4 +84,8 @@ public class TemplateFormat {
 
         return values;
     }
+
+    public boolean engineSpecificCheck(String regex, String output, String renderTest) {
+        return true;
+    }
 }


### PR DESCRIPTION
## Overview
- CHANGELOG > Fix note
- SstiScanRule > Adjust logic to prevent False Positives.
- SstiScanRuleUnitTest > Updated for adjusted logic.

## Related Issues
- Fixes zaproxy/zaproxy#8622

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
