### PR TITLE
pscanrules: Reduce Suspicious Comments rule JS FPs

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - The Absence of Anti-CSRF Tokens scan rule now only considers forms with GET method at Low Threshold. (Forms submitted via GET, not forms delivered via GET.)
+- The Information Disclosure - Suspicious Comments scan rule:
+    - Should now be less false positive prone on JavaScript findings (Issues 6622 & 6736).
+    - Now skips obvious font requests even if their content type is text/html or text related.
 
 ### Changed
 - Replace usage of CWE-200 for the following rules (Issue 8712):

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Supplier;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Element;
@@ -77,36 +78,42 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
     private static final Supplier<Iterable<String>> DEFAULT_PAYLOAD_PROVIDER =
             () -> DEFAULT_PAYLOADS;
 
+    // https://github.com/antlr/grammars-v4/blob/c82c128d980f4ce46fb3536f87b06b45b9619922/javascript/javascript/JavaScriptLexer.g4#L49-L50
+    private static final Pattern JS_MULTILINE_COMMENT =
+            Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+    private static final Pattern JS_SINGLELINE_COMMENT = Pattern.compile("//.*");
+
     private static Supplier<Iterable<String>> payloadProvider = DEFAULT_PAYLOAD_PROVIDER;
 
     private List<Pattern> patterns = null;
 
+    private static List<String> getJsComments(String content) {
+        List<String> results = new ArrayList<>();
+        JS_SINGLELINE_COMMENT
+                .matcher(content)
+                .results()
+                .map(MatchResult::group)
+                .forEach(results::add);
+        JS_MULTILINE_COMMENT
+                .matcher(content)
+                .results()
+                .map(MatchResult::group)
+                .forEach(results::add);
+        return results;
+    }
+
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
-        List<Pattern> patterns = getPatterns();
+        patterns = getPatterns();
         Map<String, List<AlertSummary>> alertMap = new HashMap<>();
 
-        if (msg.getResponseBody().length() > 0 && msg.getResponseHeader().isText()) {
+        if (msg.getResponseBody().length() > 0
+                && msg.getResponseHeader().isText()
+                && !ResourceIdentificationUtils.isFont(msg)) {
 
             if (ResourceIdentificationUtils.isJavaScript(msg)) {
-                // Just treat as text
-                String[] lines = msg.getResponseBody().toString().split("\n");
-                for (String line : lines) {
-                    for (Pattern pattern : patterns) {
-                        Matcher m = pattern.matcher(line);
-                        if (m.find()) {
-                            recordAlertSummary(
-                                    alertMap,
-                                    new AlertSummary(
-                                            pattern.toString(),
-                                            line,
-                                            Alert.CONFIDENCE_LOW,
-                                            m.group()));
-                            break; // Only need to record this line once
-                        }
-                    }
-                }
+                checkJsComments(patterns, alertMap, msg.getResponseBody().toString());
             } else {
                 // Can use the parser
 
@@ -132,20 +139,7 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
                 Element el;
                 int offset = 0;
                 while ((el = source.getNextElement(offset, HTMLElementName.SCRIPT)) != null) {
-                    for (Pattern pattern : patterns) {
-                        String elStr = el.toString();
-                        Matcher m = pattern.matcher(elStr);
-                        if (m.find()) {
-                            recordAlertSummary(
-                                    alertMap,
-                                    new AlertSummary(
-                                            pattern.toString(),
-                                            elStr,
-                                            Alert.CONFIDENCE_LOW,
-                                            m.group()));
-                            break; // Only need to record this script once
-                        }
-                    }
+                    checkJsComments(patterns, alertMap, el.toString());
                     offset = el.getEnd();
                 }
             }
@@ -172,6 +166,32 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
             this.createAlert(other, firstSummary.getConfidence(), firstSummary.getEvidence())
                     .raise();
         }
+    }
+
+    private static void checkJsComments(
+            List<Pattern> patterns, Map<String, List<AlertSummary>> alertMap, String target) {
+        if (!isGoodCandidate(target)) {
+            return;
+        }
+        for (String candidate : getJsComments(target)) {
+            for (Pattern pattern : patterns) {
+                Matcher m = pattern.matcher(candidate);
+                if (m.find()) {
+                    recordAlertSummary(
+                            alertMap,
+                            new AlertSummary(
+                                    pattern.toString(),
+                                    candidate,
+                                    Alert.CONFIDENCE_LOW,
+                                    m.group()));
+                    return;
+                }
+            }
+        }
+    }
+
+    private static boolean isGoodCandidate(String target) {
+        return target.contains("//") || target.contains("/*");
     }
 
     private static void recordAlertSummary(

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -189,10 +189,10 @@ pscanrules.informationdisclosurereferrer.otherinfo.sensitiveinfo = The URL in th
 pscanrules.informationdisclosurereferrer.otherinfo.ssn = The URL in the HTTP referrer header field appears to contain US Social Security Number(s).
 pscanrules.informationdisclosurereferrer.soln = Do not pass sensitive information in URIs.
 
-pscanrules.informationdisclosuresuspiciouscomments.desc = The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.
+pscanrules.informationdisclosuresuspiciouscomments.desc = The response appears to contain suspicious comments which may help an attacker.
 pscanrules.informationdisclosuresuspiciouscomments.name = Information Disclosure - Suspicious Comments
-pscanrules.informationdisclosuresuspiciouscomments.otherinfo = The following pattern was used: {0} and was detected in the element starting with: "{1}", see evidence field for the suspicious comment/snippet.
-pscanrules.informationdisclosuresuspiciouscomments.otherinfo2 = The following pattern was used: {0} and was detected {2} times, the first in the element starting with: "{1}", see evidence field for the suspicious comment/snippet.
+pscanrules.informationdisclosuresuspiciouscomments.otherinfo = The following pattern was used: {0} and was detected in likely comment: "{1}", see evidence field for the suspicious comment/snippet.
+pscanrules.informationdisclosuresuspiciouscomments.otherinfo2 = The following pattern was used: {0} and was detected {2} times, the first in likely comment: "{1}", see evidence field for the suspicious comment/snippet.
 pscanrules.informationdisclosuresuspiciouscomments.soln = Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.
 
 pscanrules.infosessionidurl.desc = URL rewrite is used to track user session ID. The session ID may be disclosed via cross-site referer header. In addition, the session ID might be stored in browser history or server logs.


### PR DESCRIPTION
## Overview
- CHANGELOG > Added fix note.
- InformationDisclosureSuspiciousCommentsScanRule > Updated handling to target comments in JavaScript more specifically & skip font requests.
- InformationDisclosureSuspiciousCommentsScanRuleUnitTest > Updated and added tests.
- Messages.properties > Updated to detail/report the findings more specifically based on the new behavior.

---

**Note**: The regexes used for JS comments are based on https://github.com/antlr/grammars-v4/blob/c82c128d980f4ce46fb3536f87b06b45b9619922/javascript/javascript/JavaScriptLexer.g4#L49-L50

## Related Issues
- Fixes zaproxy/zaproxy#6622
- Fixes zaproxy/zaproxy#6736

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
