### PR TITLE
encoder: Add transliteration processor & help JavaDoc link updates

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- A predefined processor "Transliterate" which converts text removing accents/diacritics/ligatures (perhaps not fully, due to operation in compatibility mode) leaving only ASCII characters.
 
 ## [1.5.0] - 2024-05-07
 ### Added

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
@@ -55,6 +55,7 @@ import org.zaproxy.addon.encoder.processors.predefined.UrlEncoder;
 import org.zaproxy.addon.encoder.processors.predefined.utility.LowerCase;
 import org.zaproxy.addon.encoder.processors.predefined.utility.RemoveWhitespace;
 import org.zaproxy.addon.encoder.processors.predefined.utility.Reverse;
+import org.zaproxy.addon.encoder.processors.predefined.utility.Transliterate;
 import org.zaproxy.addon.encoder.processors.predefined.utility.UpperCase;
 import org.zaproxy.addon.encoder.processors.script.ScriptBasedEncodeDecodeProcessor;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
@@ -103,6 +104,7 @@ public class EncodeDecodeProcessors {
         addPredefined("lowercase", LowerCase.getSingleton());
         addPredefined("uppercase", UpperCase.getSingleton());
         addPredefined("powershellencode", PowerShellEncoder.getSingleton());
+        addPredefined("transliterate", Transliterate.getSingleton());
     }
 
     private Map<String, EncodeDecodeProcessorItem> scriptProcessors = new HashMap<>();

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/utility/Transliterate.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/utility/Transliterate.java
@@ -1,0 +1,39 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors.predefined.utility;
+
+import java.io.IOException;
+import java.text.Normalizer;
+import org.zaproxy.addon.encoder.processors.predefined.DefaultEncodeDecodeProcessor;
+
+public class Transliterate extends DefaultEncodeDecodeProcessor {
+
+    private static final Transliterate INSTANCE = new Transliterate();
+
+    @Override
+    protected String processInternal(String value) throws IOException {
+        // Normalize with compatible decomposition, then remove anything non-ASCII
+        return Normalizer.normalize(value, Normalizer.Form.NFKD).replaceAll("[^\\p{ASCII}]", "");
+    }
+
+    public static Transliterate getSingleton() {
+        return INSTANCE;
+    }
+}

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -152,7 +152,7 @@ If there is no valid decoding then the field will be disabled.
 
 <H4>Base 64 Decode</H4>
 Will display the base 64 decoding of the text you enter.<br/>
-Leveraging a <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Base64.html#getMimeDecoder()">Mime decoder</a> to handle wrapped lines.
+Leveraging a <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Base64.html#getMimeDecoder()">Mime decoder</a> to handle wrapped lines.
 
 <H4>Base 64 URL Decode</H4>
 Will display the base 64 URL decoding of the text you enter. Base64URL is a modification to the primary base 64 standard 
@@ -198,13 +198,22 @@ in the event that users aren't careful in doing so will return other data types 
 Converts the input to all lower case characters.
 
 <H4>Remove Whitespace</H4>
-Removes all whitespace characters from the text, based on <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Character.html#isWhitespace(char)">Character.isWhiteSpace(char)</a>.
+Removes all whitespace characters from the text, based on <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Character.html#isWhitespace(char)">Character.isWhiteSpace(char)</a>.
 
 <H4>Reverse</H4>
 Reverses the order of the input.
 
 <H4>To Upper Case</H4>
 Converts the input to all upper case characters.
+
+<H4>Transliterate</H4>
+Converts text removing accents/diacritics/ligatures (perhaps not fully, due to operation in compatibility mode) leaving only ASCII characters.
+Ex: <code>Tĥïŝ ĩš â fůňķŷ Šťŕĭńġ: ﬁ. étrange.</code> becomes <code>This is a funky String: fi. etrange.</code>.>br>
+See also:<br>
+<ul>
+    <li><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/text/Normalizer.html">Normalizer JavaDoc</a>. </li>
+    <li><a href="https://en.wikipedia.org/wiki/Transliteration">Wikipedia: Transliteration</a></li>
+</ul>
 
 <H3>Miscellaneous</H3>
 

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -59,6 +59,7 @@ encoder.predefined.tab.encode = Encode
 encoder.predefined.tab.hash = Hash
 encoder.predefined.tab.illegalUTF8 = Illegal UTF8
 encoder.predefined.tab.unicode = Unicode
+encoder.predefined.transliterate = Transliterate (Strip accents, etc)
 encoder.predefined.unicodedecode = Unicode Unescaped Text
 encoder.predefined.unicodeencode = Unicode Escaped Text
 encoder.predefined.uppercase = To Upper Case

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/utility/TransliterateUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/processors/predefined/utility/TransliterateUnitTest.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors.predefined.utility;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
+import org.zaproxy.addon.encoder.processors.predefined.ProcessorTests;
+
+class TransliterateUnitTest extends ProcessorTests<Transliterate> {
+
+    @Override
+    protected Transliterate createProcessor() {
+        return Transliterate.getSingleton();
+    }
+
+    @Test
+    void shouldEncodeWithoutError() throws Exception {
+        // Given / When
+        EncodeDecodeResult result = processor.process("Tĥïŝ ĩš â fůňķŷ Šťŕĭńġ: ﬁ. étrange.");
+        // Then
+        assertThat(result.hasError(), is(equalTo(false)));
+        assertThat(result.getResult(), is(equalTo("This is a funky String: fi. etrange.")));
+    }
+}


### PR DESCRIPTION
## Overview
- CHANGELOG.md > Add note.
- EncodeDecodeProcessors > Register the new processor.
- encoder.html > Add help content and behavior examples. (Update JavaDoc links to version 17 references.)
- Messages.properties > Add key/value pair for the name.
- Transliterate > New encoder.
- TransliterateUnitTest > Unit Test for the new encoder.

## Related Issues
n/a

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
