### PR TITLE
reports: In docker disable Display Report checkbox

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Stats counter to the main toolbar button (Issue 8375).
 
+### Changed
+- When running in a docker container disable Display Report checkbox (Issue 8345).
+
 ## [0.34.0] - 2024-10-07
 ### Changed
 - Checkmarx rebrand.

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
@@ -230,7 +230,8 @@ public class ReportDialog extends StandardFieldsDialog {
         this.addCustomComponent(
                 TAB_SCOPE, FIELD_SITES, getNewJScrollPane(getSitesSelector(), 400, 100));
         this.addCheckBoxField(TAB_SCOPE, FIELD_GENERATE_ANYWAY, false);
-        this.addCheckBoxField(TAB_SCOPE, FIELD_DISPLAY_REPORT, reportParam.isDisplayReport());
+        this.addCustomComponent(
+                TAB_SCOPE, FIELD_DISPLAY_REPORT, getDisplayCheckbox(reportParam.isDisplayReport()));
 
         Template defaultTemplate = extension.getTemplateByConfigName(reportParam.getTemplate());
         List<String> templates = extension.getTemplateNames();
@@ -276,6 +277,22 @@ public class ReportDialog extends StandardFieldsDialog {
         this.addPadding(TAB_FILTER);
 
         this.pack();
+    }
+
+    private static JCheckBox getDisplayCheckbox(boolean selected) {
+        JCheckBox displayCheckbox = new JCheckBox();
+        displayCheckbox.setSelected(selected);
+        if (isDocker()) {
+            displayCheckbox.setSelected(false);
+            displayCheckbox.setEnabled(false);
+        }
+        return displayCheckbox;
+    }
+
+    private static boolean isDocker() {
+        return Constant.isInContainer()
+                && !(Constant.getContainerName().equals(Constant.FLATPAK_NAME)
+                        || Constant.getContainerName().equals(Constant.SNAP_NAME));
     }
 
     private JScrollPane getSectionsScrollPane() {


### PR DESCRIPTION
## Overview
- CHANGELOG > Add change note.
- ReportDialog > Update checkbox handling to set false and disabled when in docker.

## Related Issues
- Fixes zaproxy/zaproxy#8345

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [na] Write tests
- [na] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
