### PR TITLE
exim: add export AF job

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Add Automation Framework job to export data (e.g. HAR, URLs).
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/Exporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/Exporter.java
@@ -1,0 +1,225 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.exim.har.HarExporter;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.utils.Stats;
+
+/**
+ * Exporter of data (e.g. HAR, URLs).
+ *
+ * @since 0.13.0
+ * @see ExtensionExim#getExporter()
+ */
+public class Exporter {
+
+    private static final int[] ALL_HISTORY_TYPES = {};
+    private static final int[] USER_HISTORY_TYPES = {
+        HistoryReference.TYPE_PROXIED, HistoryReference.TYPE_ZAP_USER
+    };
+
+    private final Model model;
+
+    Exporter(Model model) {
+        this.model = model;
+    }
+
+    /**
+     * Exports the data with the given options.
+     *
+     * @param options the exporter options.
+     * @return the result of the export.
+     */
+    public ExporterResult export(ExporterOptions options) {
+        ExporterResult result = exportImpl(options);
+        Stats.incCounter(
+                ExtensionExim.STATS_PREFIX + "exporter." + options.getType().getId() + ".count",
+                result.getCount());
+        return result;
+    }
+
+    private ExporterResult exportImpl(ExporterOptions options) {
+        ExporterResult result = new ExporterResult();
+        Path file = options.getOutputFile();
+        if (!isValid(file, result)) {
+            return result;
+        }
+
+        try (var writer =
+                Files.newBufferedWriter(
+                        file,
+                        StandardCharsets.UTF_8,
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING)) {
+
+            List<Integer> historyIds =
+                    model.getDb()
+                            .getTableHistory()
+                            .getHistoryIdsOfHistType(
+                                    model.getSession().getSessionId(), getHistoryTypes(options));
+
+            ExporterType type = createExporterType(options);
+            type.begin(writer);
+            Context context = options.getContext();
+            for (Integer id : historyIds) {
+                HistoryReference ref = new HistoryReference(id, true);
+                if (context != null && !context.isInContext(ref)) {
+                    continue;
+                }
+
+                result.incrementCount();
+                type.write(writer, ref);
+            }
+            type.end(writer);
+        } catch (IOException e) {
+            result.addError(
+                    Constant.messages.getString("exim.exporter.error.io", e.getLocalizedMessage()),
+                    e);
+        } catch (DatabaseException e) {
+            result.addError(
+                    Constant.messages.getString("exim.exporter.error.db", e.getLocalizedMessage()),
+                    e);
+        }
+
+        return result;
+    }
+
+    private static boolean isValid(Path file, ExporterResult result) {
+        if (Files.exists(file)) {
+            if (!Files.isRegularFile(file)) {
+                result.addError(
+                        Constant.messages.getString("exim.exporter.error.file.notfile", file));
+                return false;
+            }
+            if (!Files.isWritable(file)) {
+                result.addError(
+                        Constant.messages.getString("exim.exporter.error.file.notwritable", file));
+                return false;
+            }
+            return true;
+        }
+
+        Path parent = file.getParent();
+        if (Files.notExists(parent)) {
+            result.addError(
+                    Constant.messages.getString(
+                            "exim.exporter.error.file.parent.notexists", parent));
+            return false;
+        }
+        if (!Files.isDirectory(parent)) {
+            result.addError(
+                    Constant.messages.getString("exim.exporter.error.file.parent.notdir", parent));
+            return false;
+        }
+        if (!Files.isWritable(parent)) {
+            result.addError(
+                    Constant.messages.getString(
+                            "exim.exporter.error.file.parent.notwritable", parent));
+            return false;
+        }
+        return true;
+    }
+
+    private static ExporterType createExporterType(ExporterOptions options) {
+        switch (options.getType()) {
+            case URL:
+                return UrlExporter.INSTANCE;
+
+            case HAR:
+            default:
+                return new HarExporter();
+        }
+    }
+
+    private static int[] getHistoryTypes(ExporterOptions options) {
+        switch (options.getSource()) {
+            case ALL:
+                return ALL_HISTORY_TYPES;
+
+            case HISTORY:
+            default:
+                return USER_HISTORY_TYPES;
+        }
+    }
+
+    /** An exporter type, knows how to export a {@code HistoryReference} to specific data. */
+    public interface ExporterType {
+
+        /**
+         * Called when the export begins.
+         *
+         * @param writer to where to export the data.
+         * @throws IOException if an error occurs while beginning the export.
+         */
+        void begin(Writer writer) throws IOException;
+
+        /**
+         * Called when the export begins.
+         *
+         * @param writer to where to export to. the data
+         * @param ref the {@code HistoryReference} being exported.
+         * @throws IOException if an error occurs while exporting the given {@code
+         *     HistoryReference}.
+         */
+        void write(Writer writer, HistoryReference ref) throws IOException;
+
+        /**
+         * Called when the export ends.
+         *
+         * @param writer to where to export to the data.
+         * @throws IOException if an error occurs while ending the export.
+         */
+        void end(Writer writer) throws IOException;
+    }
+
+    private static class UrlExporter implements ExporterType {
+
+        static final UrlExporter INSTANCE = new UrlExporter();
+
+        @Override
+        public void begin(Writer writer) {
+            // Nothing to do.
+        }
+
+        @Override
+        public void write(Writer writer, HistoryReference ref) throws IOException {
+            writer.write(ref.getURI().getRawURI());
+            writer.write('\n');
+        }
+
+        @Override
+        public void end(Writer writer) {
+            // Nothing to do.
+        }
+    }
+}

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExporterOptions.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExporterOptions.java
@@ -1,0 +1,247 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.nio.file.Path;
+import java.util.Locale;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.model.Context;
+
+/**
+ * The options for the exporter.
+ *
+ * @since 0.13.0
+ * @see Exporter
+ */
+public class ExporterOptions {
+
+    private final Context context;
+    private final Type type;
+    private final Source source;
+    private final Path outputFile;
+
+    private ExporterOptions(Context context, Type type, Source source, Path outputFile) {
+        this.context = context;
+        this.type = type;
+        this.source = source;
+        this.outputFile = outputFile;
+    }
+
+    public Context getContext() {
+        return context;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
+    public Path getOutputFile() {
+        return outputFile;
+    }
+
+    /**
+     * Returns a new builder.
+     *
+     * @return the options builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder of options.
+     *
+     * @see #build()
+     */
+    public static class Builder {
+
+        private Context context;
+        private Type type;
+        private Source source;
+        private Path outputFile;
+
+        private Builder() {
+            type = Type.HAR;
+            source = Source.HISTORY;
+        }
+
+        /**
+         * Sets the context.
+         *
+         * <p>Default value: {@code null}.
+         *
+         * @param context the context.
+         * @return the builder for chaining.
+         */
+        public Builder setContext(Context context) {
+            this.context = context;
+            return this;
+        }
+
+        /**
+         * Sets the type.
+         *
+         * <p>Default value: {@link Type#HAR}.
+         *
+         * @param type the type.
+         * @return the builder for chaining.
+         * @throws IllegalArgumentException if the type is {@code null}.
+         */
+        public Builder setType(Type type) {
+            if (type == null) {
+                throw new IllegalArgumentException("The type must not be null.");
+            }
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Sets the source.
+         *
+         * <p>Default value: {@link Source#HISTORY}.
+         *
+         * @param source the source.
+         * @return the builder for chaining.
+         * @throws IllegalArgumentException if the source is {@code null}.
+         */
+        public Builder setSource(Source source) {
+            if (source == null) {
+                throw new IllegalArgumentException("The source must not be null.");
+            }
+            this.source = source;
+            return this;
+        }
+
+        /**
+         * Sets the output file.
+         *
+         * <p>Default value: {@code null}.
+         *
+         * @param outputFile the output file.
+         * @return the builder for chaining.
+         */
+        public Builder setOutputFile(Path outputFile) {
+            this.outputFile = outputFile;
+            return this;
+        }
+
+        /**
+         * Builds the options from the specified data.
+         *
+         * @return the options with specified data.
+         * @throws IllegalStateException if built without {@link #setOutputFile(Path) setting the
+         *     output file}.
+         */
+        public final ExporterOptions build() {
+            if (outputFile == null) {
+                throw new IllegalStateException("The outputFile must be set.");
+            }
+            return new ExporterOptions(context, type, source, outputFile);
+        }
+    }
+
+    /** The type of export. */
+    public enum Type {
+        /** The messages are exported as an HAR. */
+        HAR,
+        /** The messages are exported as URLs. */
+        URL;
+
+        private String id;
+        private String name;
+
+        private Type() {
+            id = name().toLowerCase(Locale.ROOT);
+            name = Constant.messages.getString("exim.exporter.type." + id);
+        }
+
+        @JsonValue
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        @JsonCreator
+        public static Type fromString(String value) {
+            if (value == null || value.isBlank()) {
+                return HAR;
+            }
+
+            if (HAR.id.equalsIgnoreCase(value)) {
+                return HAR;
+            }
+            if (URL.id.equalsIgnoreCase(value)) {
+                return URL;
+            }
+            return HAR;
+        }
+    }
+
+    /** The source of the data. */
+    public enum Source {
+        /** Exports the messages proxied and manually accessed by the user. */
+        HISTORY,
+        /** Exports all messages accessed, includes temporary messages. */
+        ALL;
+
+        private String id;
+        private String name;
+
+        private Source() {
+            id = name().toLowerCase(Locale.ROOT);
+            name = Constant.messages.getString("exim.exporter.source." + id);
+        }
+
+        @JsonValue
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        @JsonCreator
+        public static Source fromString(String value) {
+            if (value == null || value.isBlank()) {
+                return HISTORY;
+            }
+
+            if (HISTORY.id.equalsIgnoreCase(value)) {
+                return HISTORY;
+            }
+            if (ALL.id.equalsIgnoreCase(value)) {
+                return ALL;
+            }
+            return HISTORY;
+        }
+    }
+}

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExporterResult.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExporterResult.java
@@ -1,0 +1,88 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The result of the export.
+ *
+ * @see Exporter#export(ExporterOptions)
+ * @since 0.13.0
+ */
+public class ExporterResult {
+
+    private List<String> errors;
+    private Throwable cause;
+    private int count;
+
+    /**
+     * Gets the count of exported messages.
+     *
+     * @return the count.
+     */
+    public int getCount() {
+        return count;
+    }
+
+    void incrementCount() {
+        this.count++;
+    }
+
+    /**
+     * Gets the errors that happened while exporting, if any.
+     *
+     * @return the errors, never {@code null}.
+     */
+    public List<String> getErrors() {
+        if (errors == null) {
+            return List.of();
+        }
+        return Collections.unmodifiableList(errors);
+    }
+
+    /**
+     * Gets the cause of the error, if any.
+     *
+     * @return the cause of the error, might be {@code null}.
+     */
+    public Throwable getCause() {
+        return cause;
+    }
+
+    void addError(String error) {
+        createErrors();
+        errors.add(error);
+    }
+
+    private void createErrors() {
+        if (errors == null) {
+            errors = new ArrayList<>();
+        }
+    }
+
+    void addError(String error, Throwable cause) {
+        createErrors();
+        errors.add(error);
+        this.cause = cause;
+    }
+}

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.MainMenuBar;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.commonlib.ExtensionCommonlib;
@@ -46,6 +47,8 @@ public class ExtensionExim extends ExtensionAdaptor {
     private static final List<Class<? extends Extension>> DEPENDENCIES =
             List.of(ExtensionCommonlib.class);
 
+    private Exporter exporter;
+
     private JMenu menuExport;
 
     private PopupMenuExportMessages popupMenuExportResponses;
@@ -57,6 +60,13 @@ public class ExtensionExim extends ExtensionAdaptor {
 
     public ExtensionExim() {
         super(NAME);
+    }
+
+    @Override
+    public void initModel(Model model) {
+        super.initModel(model);
+
+        exporter = new Exporter(model);
     }
 
     @Override
@@ -121,6 +131,16 @@ public class ExtensionExim extends ExtensionAdaptor {
             MainMenuBar menuBar = getView().getMainFrame().getMainMenuBar();
             menuBar.remove(getMenuExport());
         }
+    }
+
+    /**
+     * Gets the exporter.
+     *
+     * @return the exporter, never {@code null}.
+     * @since 0.13.0
+     */
+    public Exporter getExporter() {
+        return exporter;
     }
 
     public static void updateOutput(String messageKey, String filePath) {

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ExportJob.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ExportJob.java
@@ -1,0 +1,256 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim.automation;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.parosproxy.paros.CommandLine;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.automation.AutomationData;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationJobException;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.ContextWrapper;
+import org.zaproxy.addon.automation.jobs.JobData;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.exim.ExporterOptions;
+import org.zaproxy.addon.exim.ExporterOptions.Source;
+import org.zaproxy.addon.exim.ExporterOptions.Type;
+import org.zaproxy.addon.exim.ExporterResult;
+import org.zaproxy.addon.exim.ExtensionExim;
+
+public class ExportJob extends AutomationJob {
+
+    private static final String JOB_NAME = "export";
+    private static final String RESOURCES_DIR = "/org/zaproxy/addon/exim/resources/";
+
+    private static final String PARAM_CONTEXT = "context";
+    private static final String PARAM_TYPE = "type";
+    private static final String PARAM_SOURCE = "source";
+    private static final String PARAM_FILE_NAME = "fileName";
+
+    private final ExtensionExim extension;
+
+    private Parameters parameters = new Parameters();
+    private Data data;
+
+    public ExportJob(ExtensionExim extension) {
+        this.extension = extension;
+        this.data = new Data(this, parameters);
+    }
+
+    @Override
+    public AutomationJob newJob() throws AutomationJobException {
+        return new ExportJob(extension);
+    }
+
+    @Override
+    public void verifyParameters(AutomationProgress progress) {
+        Map<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
+        }
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                this.parameters,
+                this.getName(),
+                null,
+                progress);
+    }
+
+    @Override
+    public void applyParameters(AutomationProgress progress) {
+        // Nothing to do
+    }
+
+    @Override
+    public Map<String, String> getCustomConfigParameters() {
+        Map<String, String> map = super.getCustomConfigParameters();
+        map.put(PARAM_CONTEXT, "");
+        map.put(PARAM_TYPE, "");
+        map.put(PARAM_SOURCE, "");
+        map.put(PARAM_FILE_NAME, "");
+        return map;
+    }
+
+    @Override
+    public void runJob(AutomationEnvironment env, AutomationProgress progress) {
+        String fileName = getParameters().getFileName();
+        if (StringUtils.isEmpty(fileName)) {
+            progress.info(Constant.messages.getString("exim.automation.export.nofile", getName()));
+            return;
+        }
+
+        ContextWrapper contextWrapper = env.getContextWrapper(getParameters().getContext());
+        if (contextWrapper == null) {
+            progress.error(
+                    Constant.messages.getString(
+                            "automation.error.context.unknown", getParameters().getContext()));
+            return;
+        }
+
+        ExporterOptions options =
+                ExporterOptions.builder()
+                        .setContext(contextWrapper.getContext())
+                        .setOutputFile(JobUtils.getFile(fileName, getPlan()).toPath())
+                        .setType(getParameters().getType())
+                        .setSource(getParameters().getSource())
+                        .build();
+
+        ExporterResult result = extension.getExporter().export(options);
+        progress.info(
+                Constant.messages.getString(
+                        "exim.automation.export.exportcount", getName(), result.getCount()));
+        result.getErrors()
+                .forEach(
+                        error ->
+                                progress.error(
+                                        Constant.messages.getString(
+                                                "exim.automation.export.error", getName(), error)));
+    }
+
+    @Override
+    public String getTemplateDataMin() {
+        return getResourceAsString(getType() + "-min.yaml");
+    }
+
+    @Override
+    public String getTemplateDataMax() {
+        return getResourceAsString(getType() + "-max.yaml");
+    }
+
+    private static String getResourceAsString(String name) {
+        try {
+            return IOUtils.toString(
+                    ExportJob.class.getResourceAsStream(RESOURCES_DIR + name),
+                    StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            CommandLine.error(
+                    Constant.messages.getString(
+                            "exim.automation.error.noresourcefile", RESOURCES_DIR + name));
+        }
+        return "";
+    }
+
+    @Override
+    public Order getOrder() {
+        return Order.AFTER_ATTACK;
+    }
+
+    @Override
+    public String getType() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public Object getParamMethodObject() {
+        return null;
+    }
+
+    @Override
+    public String getParamMethodName() {
+        return null;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public void showDialog() {
+        new ExportJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "exim.automation.export.dialog.summary",
+                getParameters().getType(),
+                getParameters().getSource(),
+                JobUtils.unBox(getParameters().getFileName(), "''"));
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+
+        public void setParameters(Parameters parameters) {
+            this.parameters = parameters;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+
+        private String context;
+        private Type type = Type.HAR;
+        private Source source = Source.HISTORY;
+        private String fileName;
+
+        public String getContext() {
+            return context;
+        }
+
+        public void setContext(String context) {
+            this.context = context;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        public void setType(Type type) {
+            this.type = type;
+        }
+
+        public Source getSource() {
+            return source;
+        }
+
+        public void setSource(Source source) {
+            this.source = source;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public void setFileName(String fileName) {
+            this.fileName = fileName;
+        }
+    }
+}

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ExportJobDialog.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ExportJobDialog.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2022 The ZAP Development Team
+ * Copyright 2024 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,62 +20,70 @@
 package org.zaproxy.addon.exim.automation;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Locale;
+import java.util.List;
+import java.util.stream.Stream;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JFileChooser;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.exim.ExporterOptions;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
 @SuppressWarnings("serial")
-public class ImportJobDialog extends StandardFieldsDialog {
+public class ExportJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String TITLE = "exim.automation.import.dialog.title";
+    private static final String TITLE = "exim.automation.export.dialog.title";
     private static final String NAME_PARAM = "exim.automation.dialog.name";
+    private static final String CONTEXT_PARAM = "openapi.automation.dialog.context";
     private static final String TYPE_PARAM = "exim.automation.dialog.type";
+    private static final String SOURCE_PARAM = "exim.automation.export.dialog.source";
     private static final String FILE_NAME_PARAM = "exim.automation.dialog.filename";
 
-    private ImportJob job;
+    private ExportJob job;
 
-    private DefaultComboBoxModel<ImportJob.TypeOption> typeOptionModel;
+    private DefaultComboBoxModel<ExporterOptions.Type> typeOptionModel;
+    private DefaultComboBoxModel<ExporterOptions.Source> sourceOptionModel;
 
-    public ImportJobDialog(ImportJob job) {
-        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 200));
+    public ExportJobDialog(ExportJob job) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(550, 250));
         this.job = job;
 
         this.addTextField(NAME_PARAM, this.job.getData().getName());
 
+        List<String> contextNames = job.getEnv().getContextNames();
+        contextNames.add(0, "");
+        this.addComboField(CONTEXT_PARAM, contextNames, job.getParameters().getContext());
+
         typeOptionModel = new DefaultComboBoxModel<>();
-        Arrays.stream(ImportJob.TypeOption.values()).forEach(v -> typeOptionModel.addElement(v));
-        ImportJob.TypeOption typeOption = null;
-        if (this.job.getParameters().getType() != null) {
-            typeOption =
-                    ImportJob.TypeOption.valueOf(
-                            this.job.getParameters().getType().toUpperCase(Locale.ROOT));
-        } else {
-            typeOption = ImportJob.TypeOption.HAR;
-        }
-        typeOptionModel.setSelectedItem(typeOption);
+        Stream.of(ExporterOptions.Type.values()).forEach(typeOptionModel::addElement);
+        typeOptionModel.setSelectedItem(job.getParameters().getType());
         this.addComboField(TYPE_PARAM, typeOptionModel);
 
-        String fileName = this.job.getData().getParameters().getFileName();
+        String fileName = job.getData().getParameters().getFileName();
         File f = null;
         if (fileName != null && !fileName.isEmpty()) {
             f = new File(fileName);
         }
         this.addFileSelectField(FILE_NAME_PARAM, f, JFileChooser.FILES_AND_DIRECTORIES, null);
+
+        sourceOptionModel = new DefaultComboBoxModel<>();
+        Stream.of(ExporterOptions.Source.values()).forEach(sourceOptionModel::addElement);
+        sourceOptionModel.setSelectedItem(job.getParameters().getSource());
+        this.addComboField(SOURCE_PARAM, sourceOptionModel);
+
         this.addPadding();
     }
 
     @Override
     public void save() {
-        this.job.getData().setName(this.getStringValue(NAME_PARAM));
-        ImportJob.TypeOption typeOption = (ImportJob.TypeOption) typeOptionModel.getSelectedItem();
-        this.job.getParameters().setType(typeOption.name().toLowerCase(Locale.ROOT));
-        this.job.getParameters().setFileName(this.getStringValue(FILE_NAME_PARAM));
+        this.job.getData().setName(getStringValue(NAME_PARAM));
+        this.job.getParameters().setType((ExporterOptions.Type) typeOptionModel.getSelectedItem());
+        this.job.getParameters().setFileName(getStringValue(FILE_NAME_PARAM));
+        this.job
+                .getParameters()
+                .setSource((ExporterOptions.Source) sourceOptionModel.getSelectedItem());
         this.job.resetAndSetChanged();
     }
 

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ExtensionEximAutomation.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ExtensionEximAutomation.java
@@ -36,6 +36,7 @@ public class ExtensionEximAutomation extends ExtensionAdaptor {
             List.of(ExtensionExim.class, ExtensionAutomation.class);
 
     private ImportJob importJob;
+    private ExportJob exportJob;
 
     public ExtensionEximAutomation() {
         super(NAME);
@@ -49,10 +50,15 @@ public class ExtensionEximAutomation extends ExtensionAdaptor {
     @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
-        ExtensionAutomation extAuto =
-                Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutomation.class);
+        ExtensionAutomation extAuto = getExtension(ExtensionAutomation.class);
         importJob = new ImportJob();
         extAuto.registerAutomationJob(importJob);
+        exportJob = new ExportJob(getExtension(ExtensionExim.class));
+        extAuto.registerAutomationJob(exportJob);
+    }
+
+    private static <T extends Extension> T getExtension(Class<T> clazz) {
+        return Control.getSingleton().getExtensionLoader().getExtension(clazz);
     }
 
     @Override
@@ -62,10 +68,10 @@ public class ExtensionEximAutomation extends ExtensionAdaptor {
 
     @Override
     public void unload() {
-        ExtensionAutomation extAuto =
-                Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutomation.class);
+        ExtensionAutomation extAuto = getExtension(ExtensionAutomation.class);
 
         extAuto.unregisterAutomationJob(importJob);
+        extAuto.unregisterAutomationJob(exportJob);
     }
 
     @Override

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ImportJob.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ImportJob.java
@@ -157,7 +157,7 @@ public class ImportJob extends AutomationJob {
         } catch (IOException e) {
             CommandLine.error(
                     Constant.messages.getString(
-                            "exim.automation.import.error.nofile", RESOURCES_DIR + name));
+                            "exim.automation.error.noresourcefile", RESOURCES_DIR + name));
         }
         return "";
     }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarExporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarExporter.java
@@ -1,0 +1,64 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim.har;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import de.sstoehr.harreader.model.HarLog;
+import java.io.IOException;
+import java.io.Writer;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.model.HistoryReference;
+import org.zaproxy.addon.exim.Exporter.ExporterType;
+
+public class HarExporter implements ExporterType {
+
+    private JsonGenerator generator;
+
+    @Override
+    public void begin(Writer writer) throws IOException {
+        generator = HarUtils.JSON_MAPPER.createGenerator(writer).useDefaultPrettyPrinter();
+
+        generator.writeStartObject();
+        generator.writeObjectFieldStart("log");
+        HarLog log = HarUtils.createZapHarLog();
+        generator.writeStringField("version", log.getVersion());
+        generator.writePOJOField("creator", log.getCreator());
+        generator.writeArrayFieldStart("entries");
+    }
+
+    @Override
+    public void write(Writer writer, HistoryReference ref) throws IOException {
+        try {
+            generator.writePOJO(
+                    HarUtils.createHarEntry(
+                            ref.getHistoryId(), ref.getHistoryType(), ref.getHttpMessage()));
+        } catch (DatabaseException ignore) {
+            // The message is cached in the HistoryReference.
+        }
+    }
+
+    @Override
+    public void end(Writer writer) throws IOException {
+        generator.writeEndArray();
+        generator.writeEndObject();
+        generator.writeEndObject();
+        generator.flush();
+    }
+}

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarUtils.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarUtils.java
@@ -96,7 +96,7 @@ public final class HarUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(HarUtils.class);
 
-    private static final ObjectMapper JSON_MAPPER =
+    public static final ObjectMapper JSON_MAPPER =
             JsonMapper.builder()
                     .serializationInclusion(JsonInclude.Include.NON_DEFAULT)
                     .build()

--- a/addOns/exim/src/main/javahelp/help/contents/automation.html
+++ b/addOns/exim/src/main/javahelp/help/contents/automation.html
@@ -21,5 +21,16 @@ The import job allows you to import HAR(HTTP Archive File), ModSecurity2 Logs, Z
       fileName:                        # String: Name of the file containing the data
 </pre>
 
+<H2>Job: export</H2>
+The export job allows you to export messages in HAR format or as URLs. I also allows to choose which messages to export with <code>source</code> of History or All, meaning the manually/proxied messages or all messages.
+<pre>
+  - type: export            # Exports data into a file
+      parameters:
+        context:            # String: Name of the context from which to export. Default: first context
+        type:               # String: One of 'har', 'url'. Default: 'har'
+        source:             # String: One of 'history', 'all'. Default: 'history'
+        fileName:           # String: Name/path to the file
+</pre>
+
 </BODY>
 </HTML>

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -14,18 +14,36 @@ exim.api.other.sendHarRequest.param.followRedirects = True if redirects should b
 exim.api.other.sendHarRequest.param.request = The raw JSON of a HAR request.
 
 exim.automation.desc = Import/Export Automation Framework Integration
-exim.automation.import.dialog.filename = File:
-exim.automation.import.dialog.name = Job Name:
+exim.automation.dialog.filename = File:
+exim.automation.dialog.name = Job Name:
+exim.automation.dialog.type = Type:
+exim.automation.error.noresourcefile = Cannot access file: {0}
+exim.automation.export.dialog.source = Source:
+exim.automation.export.dialog.summary = Type: {0}, Source: {1}, File: {2}
+exim.automation.export.dialog.title = Export Job
+exim.automation.export.error = Job {0} Error: {1}
+exim.automation.export.error.type = Job {0} Invalid type: {1}
+exim.automation.export.exportcount = Job {0}: Exported {1} message(s).
+exim.automation.export.nofile = Job {0}: No file specified, the export will be skipped.
 exim.automation.import.dialog.summary = Type: {0}, File: {1}
 exim.automation.import.dialog.title = Import Job
-exim.automation.import.dialog.type = Type:
 exim.automation.import.error = Error importing the file {0} as {1}
 exim.automation.import.error.file = Job {0} cannot read file: {1}
-exim.automation.import.error.nofile = Cannot access file: {0}
 exim.automation.import.error.type = Job {0} Invalid type: {1}
 exim.automation.name = Import/Export Automation
 
 exim.description = Import and Export functionality supporting multiple formats.
+exim.exporter.error.db = Failed to read from session: {0}
+exim.exporter.error.file.notfile = Cannot write to non-file: {0}
+exim.exporter.error.file.notwritable = Cannot write to file: {0}
+exim.exporter.error.file.parent.notdir = Cannot write file to non-directory: {0}
+exim.exporter.error.file.parent.notexists = Cannot write file to nonexistent directory: {0}
+exim.exporter.error.file.parent.notwritable = Cannot write file to directory: {0}
+exim.exporter.error.io = Failed to write to file: {0}
+exim.exporter.source.all = All
+exim.exporter.source.history = History
+exim.exporter.type.har = HAR
+exim.exporter.type.url = URLs
 
 exim.file.save.error = Error saving file to {0}.
 

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/export-max.yaml
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/export-max.yaml
@@ -1,0 +1,6 @@
+- type: export            # Exports data into a file
+    parameters:
+      context:            # String: Name of the context from which to export. Default: first context
+      type:               # String: One of 'har', 'url'. Default: 'har'
+      source:             # String: One of 'history', 'all'. Default: 'history'
+      fileName:           # String: Name/path to the file

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/export-min.yaml
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/export-min.yaml
@@ -1,0 +1,3 @@
+- type: export            # Exports data into a file
+    parameters:
+      fileName:           # String: Name/path to the file

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/ExporterOptionsUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/ExporterOptionsUnitTest.java
@@ -1,0 +1,199 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.zaproxy.addon.exim.ExporterOptions.Builder;
+import org.zaproxy.addon.exim.ExporterOptions.Source;
+import org.zaproxy.addon.exim.ExporterOptions.Type;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link ExporterOptions}. */
+class ExporterOptionsUnitTest extends TestUtils {
+
+    private Path outputFile;
+
+    @BeforeAll
+    static void setupMessages() {
+        mockMessages(new ExtensionExim());
+    }
+
+    @BeforeEach
+    void setup() {
+        outputFile = Paths.get("/dir/file");
+    }
+
+    @Test
+    void shouldFailToBuildWithoutOutputFile() {
+        // Given
+        Builder builder = ExporterOptions.builder();
+        // When / Then
+        Exception ex = assertThrows(IllegalStateException.class, () -> builder.build());
+        assertThat(ex.getMessage(), containsString("outputFile"));
+    }
+
+    @Test
+    void shouldBuildWithJustOutputFile() {
+        // Given
+        Builder builder = ExporterOptions.builder();
+        // When
+        ExporterOptions options = builder.setOutputFile(outputFile).build();
+        // Then
+        assertThat(options.getContext(), is(nullValue()));
+        assertThat(options.getType(), is(equalTo(Type.HAR)));
+        assertThat(options.getSource(), is(equalTo(Source.HISTORY)));
+        assertThat(options.getOutputFile(), is(equalTo(outputFile)));
+    }
+
+    @Test
+    void shouldSetContext() {
+        // Given
+        ExporterOptions.Builder builder = builderWithOutputFile();
+        Context context = mock(Context.class);
+        // When
+        ExporterOptions options = builder.setContext(context).build();
+        // Then
+        assertThat(options.getContext(), is(equalTo(context)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Type.class)
+    void shouldSetType(Type type) {
+        // Given
+        ExporterOptions.Builder builder = builderWithOutputFile();
+        // When
+        ExporterOptions options = builder.setType(type).build();
+        // Then
+        assertThat(options.getType(), is(equalTo(type)));
+    }
+
+    @Test
+    void shouldThrowSettingNullType() {
+        // Given
+        Builder builder = ExporterOptions.builder();
+        // When / Then
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> builder.setType(null));
+        assertThat(ex.getMessage(), containsString("type"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Source.class)
+    void shouldSetSource(Source source) {
+        // Given
+        ExporterOptions.Builder builder = builderWithOutputFile();
+        // When
+        ExporterOptions options = builder.setSource(source).build();
+        // Then
+        assertThat(options.getSource(), is(equalTo(source)));
+    }
+
+    @Test
+    void shouldThrowSettingNullSource() {
+        // Given
+        Builder builder = ExporterOptions.builder();
+        // When / Then
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> builder.setSource(null));
+        assertThat(ex.getMessage(), containsString("source"));
+    }
+
+    private Builder builderWithOutputFile() {
+        return ExporterOptions.builder().setOutputFile(outputFile);
+    }
+
+    /** Unit test for {@link ExporterOptions.Type}. */
+    @Nested
+    class TypeUnitTest {
+
+        @ParameterizedTest
+        @EnumSource(value = Type.class)
+        void shouldHaveToStringRepresentation(Type type) {
+            assertThat(type.toString(), is(notNullValue()));
+        }
+
+        @ParameterizedTest
+        @CsvSource({"HAR, har", "URL, url"})
+        void shouldReturnId(Type type, String expectedId) {
+            assertThat(type.getId(), is(equalTo(expectedId)));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            ", HAR",
+            "'', HAR",
+            "Something, HAR",
+            "har, HAR",
+            "haR, HAR",
+            "url, URL",
+            "urL, URL"
+        })
+        void shouldConvertFromString(String value, Type expectedType) {
+            assertThat(Type.fromString(value), is(equalTo(expectedType)));
+        }
+    }
+
+    /** Unit test for {@link ExporterOptions.Source}. */
+    @Nested
+    class SourceUnitTest {
+
+        @ParameterizedTest
+        @EnumSource(value = Source.class)
+        void shouldHaveToStringRepresentation(Source type) {
+            assertThat(type.toString(), is(notNullValue()));
+        }
+
+        @ParameterizedTest
+        @CsvSource({"HISTORY, history", "ALL, all"})
+        void shouldReturnId(Source type, String expectedId) {
+            assertThat(type.getId(), is(equalTo(expectedId)));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+            ", HISTORY",
+            "'', HISTORY",
+            "Something, HISTORY",
+            "history, HISTORY",
+            "historY, HISTORY",
+            "all, ALL",
+            "alL, ALL"
+        })
+        void shouldConvertFromString(String value, Source expectedSource) {
+            assertThat(Source.fromString(value), is(equalTo(expectedSource)));
+        }
+    }
+}

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/ExporterResultUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/ExporterResultUnitTest.java
@@ -1,0 +1,101 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link ExporterResult}. */
+class ExporterResultUnitTest {
+
+    @Test
+    void shouldHaveZeroCountByDefault() {
+        // Given
+        ExporterResult result = new ExporterResult();
+        // When
+        int count = result.getCount();
+        // Then
+        assertThat(count, is(equalTo(0)));
+    }
+
+    @Test
+    void shouldIncrementCount() {
+        // Given
+        ExporterResult result = new ExporterResult();
+        // When
+        result.incrementCount();
+        result.incrementCount();
+        // Then
+        assertThat(result.getCount(), is(equalTo(2)));
+    }
+
+    @Test
+    void shouldNotHaveErrorsByDefault() {
+        // Given
+        ExporterResult result = new ExporterResult();
+        // When / Then
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+    }
+
+    @Test
+    void shouldHaveAddedErrors() {
+        // Given
+        ExporterResult result = new ExporterResult();
+        // When
+        result.addError("Error 1");
+        result.addError("Error 2");
+        // Then
+        assertThat(result.getErrors(), contains("Error 1", "Error 2"));
+        assertThat(result.getCause(), is(nullValue()));
+    }
+
+    @Test
+    void shouldHaveErrorAndCause() {
+        // Given
+        ExporterResult result = new ExporterResult();
+        Exception exception = new Exception();
+        // When
+        result.addError("Error A", exception);
+        // Then
+        assertThat(result.getErrors(), contains("Error A"));
+        assertThat(result.getCause(), is(equalTo(exception)));
+    }
+
+    @Test
+    void shouldOverrideCauses() {
+        // Given
+        ExporterResult result = new ExporterResult();
+        Exception exceptionA = new Exception();
+        Exception exceptionB = new Exception();
+        // When
+        result.addError("Error A", exceptionA);
+        result.addError("Error B", exceptionB);
+        // Then
+        assertThat(result.getErrors(), contains("Error A", "Error B"));
+        assertThat(result.getCause(), is(equalTo(exceptionB)));
+    }
+}

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/ExporterUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/ExporterUnitTest.java
@@ -1,0 +1,326 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.MockSettings;
+import org.mockito.quality.Strictness;
+import org.parosproxy.paros.db.Database;
+import org.parosproxy.paros.db.RecordHistory;
+import org.parosproxy.paros.db.TableHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.Session;
+import org.zaproxy.addon.exim.ExporterOptions.Source;
+import org.zaproxy.addon.exim.ExporterOptions.Type;
+import org.zaproxy.zap.extension.stats.InMemoryStats;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.Stats;
+
+/** Unit test for {@link Exporter}. */
+class ExporterUnitTest extends TestUtils {
+
+    private static final MockSettings LENIENT = withSettings().strictness(Strictness.LENIENT);
+    private long sessionId;
+    private TableHistory tableHistory;
+    private Path outputDir;
+    private Path outputFile;
+    private ExporterOptions options;
+    private InMemoryStats stats;
+
+    private Exporter exporter;
+
+    @BeforeAll
+    static void setupMessages() {
+        mockMessages(new ExtensionExim());
+    }
+
+    @BeforeEach
+    void setup(@TempDir Path dir) {
+        outputDir = dir;
+        outputFile = dir.resolve("outputfile");
+
+        sessionId = 1234L;
+        Session session = mock(Session.class, LENIENT);
+        given(session.getSessionId()).willReturn(sessionId);
+
+        tableHistory = mock(TableHistory.class, LENIENT);
+        HistoryReference.setTableHistory(tableHistory);
+
+        Database db = mock(Database.class, LENIENT);
+        given(db.getTableHistory()).willReturn(tableHistory);
+
+        Model model = mock(Model.class, LENIENT);
+        Model.setSingletonForTesting(model);
+        given(model.getSession()).willReturn(session);
+        given(model.getDb()).willReturn(db);
+
+        options = mock(ExporterOptions.class, LENIENT);
+        optionsWithType(Type.HAR);
+        optionsWithSource(Source.HISTORY);
+        given(options.getOutputFile()).willReturn(outputFile);
+
+        stats = new InMemoryStats();
+        Stats.addListener(stats);
+
+        exporter = new Exporter(model);
+    }
+
+    @AfterEach
+    void cleanup() {
+        Stats.removeListener(stats);
+    }
+
+    private void optionsWithType(Type type) {
+        given(options.getType()).willReturn(type);
+    }
+
+    private void optionsWithSource(Source source) {
+        given(options.getSource()).willReturn(source);
+    }
+
+    private void databaseWithHistoryMessage() throws Exception {
+        databaseWithMessageForTypes(HistoryReference.TYPE_PROXIED, HistoryReference.TYPE_ZAP_USER);
+    }
+
+    private void databaseWithAllMessage() throws Exception {
+        databaseWithMessageForTypes();
+    }
+
+    private void databaseWithMessageForTypes(int... types) throws Exception {
+        given(tableHistory.getHistoryIdsOfHistType(sessionId, types)).willReturn(List.of(1));
+
+        given(tableHistory.read(1))
+                .willReturn(
+                        new RecordHistory(
+                                1,
+                                42,
+                                sessionId,
+                                1L,
+                                2,
+                                "GET http://example.com/1 HTTP/1.1",
+                                new byte[] {0x01},
+                                "HTTP/1.1 200",
+                                new byte[] {0x02},
+                                "",
+                                "note 1",
+                                true));
+    }
+
+    @Test
+    void shouldExportEmptyHarIfNothingToExport() throws Exception {
+        // Given
+        optionsWithType(Type.HAR);
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 0);
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(
+                Files.readString(outputFile),
+                is(
+                        equalTo(
+                                "{\n"
+                                        + "  \"log\" : {\n"
+                                        + "    \"version\" : \"1.2\",\n"
+                                        + "    \"creator\" : {\n"
+                                        + "      \"name\" : \"ZAP\",\n"
+                                        + "      \"version\" : \"Dev Build\"\n"
+                                        + "    },\n"
+                                        + "    \"entries\" : [ ]\n"
+                                        + "  }\n"
+                                        + "}")));
+    }
+
+    @Test
+    void shouldExportHistoryToHar() throws Exception {
+        // Given
+        optionsWithType(Type.HAR);
+        databaseWithHistoryMessage();
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 1);
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(
+                Files.readString(outputFile),
+                containsString("\"url\" : \"http://example.com/1\",\n"));
+    }
+
+    private void assertCount(ExporterResult result, int count) {
+        assertThat(result.getCount(), is(equalTo(count)));
+        assertThat(
+                stats.getStat("stats.exim.exporter." + options.getType().getId() + ".count"),
+                is(equalTo((long) count)));
+    }
+
+    @Test
+    void shouldExportAllToHar() throws Exception {
+        // Given
+        optionsWithType(Type.HAR);
+        optionsWithSource(Source.ALL);
+        databaseWithAllMessage();
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 1);
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(
+                Files.readString(outputFile),
+                containsString("\"url\" : \"http://example.com/1\",\n"));
+    }
+
+    @Test
+    void shouldExportNoUrlsIfNothingToExport() throws Exception {
+        // Given
+        optionsWithType(Type.URL);
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 0);
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(Files.readString(outputFile), is(equalTo("")));
+    }
+
+    @Test
+    void shouldExportHistoryToUrls() throws Exception {
+        // Given
+        optionsWithType(Type.URL);
+        databaseWithHistoryMessage();
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 1);
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(Files.readString(outputFile), is(equalTo("http://example.com/1\n")));
+    }
+
+    @Test
+    void shouldExportAllToUrls() throws Exception {
+        // Given
+        optionsWithType(Type.URL);
+        optionsWithSource(Source.ALL);
+        databaseWithAllMessage();
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 1);
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(Files.readString(outputFile), is(equalTo("http://example.com/1\n")));
+    }
+
+    @Test
+    void shouldErrorIfOutputFileNotValid() {
+        // Given
+        given(options.getOutputFile()).willReturn(outputDir);
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 0);
+        assertThat(result.getErrors(), contains(startsWith("Cannot write to non-file: ")));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(Files.notExists(outputFile), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldErrorIfParentOutputFileNotValid() {
+        // Given
+        given(options.getOutputFile()).willReturn(Paths.get("/parent/invalid/outputfile"));
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 0);
+        assertThat(
+                result.getErrors(),
+                contains(startsWith("Cannot write file to nonexistent directory: ")));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(Files.notExists(outputFile), is(equalTo(true)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Type.class)
+    void shouldIncludeMessageInContext(Type type) throws Exception {
+        // Given
+        optionsWithType(type);
+        databaseWithHistoryMessage();
+        Context context = mock(Context.class);
+        given(options.getContext()).willReturn(context);
+        given(context.isInContext(any(HistoryReference.class))).willReturn(true);
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 1);
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(Files.readString(outputFile), containsString("http://example.com/1"));
+        verify(context).isInContext(any(HistoryReference.class));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Type.class)
+    void shouldNotIncludeMessageNotInContext(Type type) throws Exception {
+        // Given
+        optionsWithType(type);
+        databaseWithHistoryMessage();
+        Context context = mock(Context.class);
+        given(options.getContext()).willReturn(context);
+        given(context.isInContext(any(HistoryReference.class))).willReturn(false);
+        // When
+        ExporterResult result = exporter.export(options);
+        // Then
+        assertCount(result, 0);
+        assertThat(result.getErrors(), is(empty()));
+        assertThat(result.getCause(), is(nullValue()));
+        assertThat(Files.readString(outputFile), not(containsString("http://example.com/1")));
+        verify(context).isInContext(any(HistoryReference.class));
+    }
+}

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/ExtensionEximUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/ExtensionEximUnitTest.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.model.Model;
+
+/** Unit test for {@link ExtensionExim}. */
+class ExtensionEximUnitTest {
+
+    private ExtensionExim extension;
+
+    @BeforeEach
+    void setup() {
+        extension = new ExtensionExim();
+    }
+
+    @Test
+    void shouldNotHaveExporterBeforeInitModel() {
+        // Given / When
+        Exporter exporter = extension.getExporter();
+        // Then
+        assertThat(exporter, is(nullValue()));
+    }
+
+    @Test
+    void shouldInitModelAndExporter() {
+        // Given
+        Model model = mock(Model.class);
+        // When
+        extension.initModel(model);
+        // Then
+        assertThat(extension.getModel(), is(notNullValue()));
+        assertThat(extension.getExporter(), is(notNullValue()));
+    }
+}

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/ExportJobUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/ExportJobUnitTest.java
@@ -1,0 +1,199 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim.automation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.quality.Strictness;
+import org.parosproxy.paros.model.Model;
+import org.yaml.snakeyaml.Yaml;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationPlan;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.ContextWrapper;
+import org.zaproxy.addon.exim.Exporter;
+import org.zaproxy.addon.exim.ExporterOptions;
+import org.zaproxy.addon.exim.ExporterResult;
+import org.zaproxy.addon.exim.ExtensionExim;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link ExportJob}. */
+class ExportJobUnitTest extends TestUtils {
+
+    private ExtensionExim extension;
+    private Exporter exporter;
+    private ExportJob job;
+
+    @BeforeEach
+    void setUp() {
+        mockMessages(new ExtensionExim());
+
+        Model model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        extension = mock(ExtensionExim.class, withSettings().strictness(Strictness.LENIENT));
+        exporter = mock();
+        given(extension.getExporter()).willReturn(exporter);
+
+        job = new ExportJob(extension);
+    }
+
+    @Test
+    void shouldReturnDefaultFields() {
+        assertThat(job.getType(), is(equalTo("export")));
+        assertThat(job.getName(), is(equalTo("export")));
+        assertThat(job.getOrder(), is(equalTo(AutomationJob.Order.AFTER_ATTACK)));
+        assertThat(job.getTemplateDataMin(), is(not(equalTo(""))));
+        assertThat(job.getTemplateDataMax(), is(not(equalTo(""))));
+        assertThat(job.getParamMethodObject(), is(nullValue()));
+        assertThat(job.getParamMethodName(), is(nullValue()));
+    }
+
+    @Test
+    void shouldReturnCustomConfigParams() {
+        // Given / When
+        Map<String, String> params = job.getCustomConfigParameters();
+
+        // Then
+        assertThat(params, is(aMapWithSize(4)));
+        assertThat(
+                params,
+                allOf(
+                        hasEntry("type", ""),
+                        hasEntry("fileName", ""),
+                        hasEntry("source", ""),
+                        hasEntry("context", "")));
+    }
+
+    @Test
+    void shouldApplyCustomConfigParams() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        String type = "har";
+        String source = "all";
+        String fileName = "/output/data";
+        String context = "My Context";
+        String yamlStr =
+                "parameters:\n"
+                        + "  type: "
+                        + type
+                        + "\n"
+                        + "  source: "
+                        + source
+                        + "\n"
+                        + "  fileName: "
+                        + fileName
+                        + "\n"
+                        + "  context: "
+                        + context;
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+
+        // When
+        job.verifyParameters(progress);
+        job.applyParameters(progress);
+
+        // Then
+        assertThat(job.getParameters().getType(), is(equalTo(ExporterOptions.Type.HAR)));
+        assertThat(job.getParameters().getSource(), is(equalTo(ExporterOptions.Source.ALL)));
+        assertThat(job.getParameters().getFileName(), is(equalTo(fileName)));
+        assertThat(job.getParameters().getContext(), is(equalTo(context)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldReportExporterCount() {
+        // Given
+        AutomationPlan plan = new AutomationPlan();
+        AutomationProgress progress = plan.getProgress();
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        ContextWrapper contextWrapper = new ContextWrapper(mock(Context.class));
+        given(env.getContextWrapper(any())).willReturn(contextWrapper);
+        String yamlStr = "parameters:\n  fileName: /some/file";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+        ExporterResult result = mock();
+        given(result.getCount()).willReturn(42);
+        given(exporter.export(any())).willReturn(result);
+
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+        job.setPlan(plan);
+
+        // When
+        job.verifyParameters(progress);
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.getInfos(), hasItem("Job export: Exported 42 message(s)."));
+    }
+
+    @Test
+    void shouldReportExporterErrors() {
+        // Given
+        AutomationPlan plan = new AutomationPlan();
+        AutomationProgress progress = plan.getProgress();
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        ContextWrapper contextWrapper = new ContextWrapper(mock(Context.class));
+        given(env.getContextWrapper(any())).willReturn(contextWrapper);
+        String yamlStr = "parameters:\n  fileName: /some/file";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+        ExporterResult result = mock();
+        String exporterError = "Error while exporting";
+        given(result.getErrors()).willReturn(List.of(exporterError));
+        given(exporter.export(any())).willReturn(result);
+
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+        job.setPlan(plan);
+
+        // When
+        job.verifyParameters(progress);
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors(), contains("Job export Error: Error while exporting"));
+    }
+}


### PR DESCRIPTION
Allow to export messages in HAR and as URLs through the Automation Framework and also programmatically through the extension.