### PR TITLE
exim: correct export of body with no content type

### DIFF
--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarUtils.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarUtils.java
@@ -318,9 +318,13 @@ public final class HarUtils {
         String text = null;
         String encoding = null;
         String contentType = responseHeader.getHeader(HttpHeader.CONTENT_TYPE);
-        if (contentType == null) {
+        if (contentType == null || contentType.isEmpty()) {
             contentType = "";
-        } else if (!contentType.isEmpty()) {
+            if (httpMessage.getResponseBody().length() != 0) {
+                encoding = "base64";
+                text = Base64.getEncoder().encodeToString(httpMessage.getResponseBody().getBytes());
+            }
+        } else {
             String lcContentType = contentType.toLowerCase(Locale.ROOT);
             final int pos = lcContentType.indexOf(';');
             if (pos != -1) {

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/har/HarUtilsUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/har/HarUtilsUnitTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
 import de.sstoehr.harreader.model.HarEntry;
+import de.sstoehr.harreader.model.HarResponse;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -134,6 +135,20 @@ class HarUtilsUnitTest extends TestUtils {
                 entry.getAdditional().get(HarUtils.MESSAGE_TYPE_CUSTOM_FIELD), is(equalTo(type)));
         assertThat(
                 entry.getAdditional().get(HarUtils.MESSAGE_NOTE_CUSTOM_FIELD), is(equalTo(note)));
+    }
+
+    @Test
+    void shouldCreateHarResponseWithBodyEvenIfNoContentType() throws Exception {
+        // Given
+        HttpMessage message = createHttpMessage();
+        message.getResponseBody().setBody("123");
+        // When
+        HarResponse response = HarUtils.createHarResponse(message);
+        // Then
+        assertThat(response.getBodySize(), is(equalTo(3L)));
+        assertThat(response.getContent().getMimeType(), is(equalTo("")));
+        assertThat(response.getContent().getEncoding(), is(equalTo("base64")));
+        assertThat(response.getContent().getText(), is(equalTo("MTIz")));
     }
 
     @Test


### PR DESCRIPTION
Add the response body even if it does not have a content-type.