### PR TITLE
automation: Tweak docs

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update help for the "requestor" job.
 
 ## [0.43.0] - 2024-10-07
 ### Fixed

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-requestor.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-requestor.html
@@ -21,11 +21,12 @@ It is covered in the video: <a href="https://youtu.be/4phnMy9iCPY">ZAP Chat 09 A
       user:                            # String: An optional user to use for authenticated requests, must be defined in the env
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
+        name:                          # String: Optional name for the request, for documentation only
         method:                        # String: A non-empty request method, default: GET
         httpVersion:                   # String: The HTTP version to send the request with, default: HTTP/1.1
         headers:                       # An optional list of additional headers to include in the request
             - "header1:value1"
-        data:                          # String: Optional data to send in the request body
+        data:                          # String: Optional data to send in the request body, supports vars
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched
 </pre>
 

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-max.yaml
@@ -6,7 +6,7 @@
         name:                          # String: Optional name for the request, for documentation only
         method:                        # String: A non-empty request method, default: GET
         httpVersion:                   # String: The HTTP version to send the request with, default: HTTP/1.1
-        headers:                       # An optional list of headers
+        headers:                       # An optional list of additional headers to include in the request
             # - "header1:value1"
         data:                          # String: Optional data to send in the request body, supports vars
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Typo in automation job help.
 
 ## [19] - 2024-10-07
 ### Changed

--- a/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/automation.html
+++ b/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/automation.html
@@ -8,7 +8,7 @@
 	<H1>Replacer Automation Framework Support</H1>
 	This add-on supports the Automation Framework.
 
-	<H2>Job: requester</H2>
+	<H2>Job: replacer</H2>
 	The replacer job allows you to add replacer rules.
 	<p>
 	It is covered in the video: <a href="https://youtu.be/4phnMy9iCPY">ZAP Chat 09 Automation Framework Part 3 - Requests</a>.

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Stats counter to the main toolbar button (Issue 8375).
 
+### Changed
+- Update automation job help.
+
 ## [0.34.0] - 2024-10-07
 ### Changed
 - Checkmarx rebrand.

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/automation.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/automation.html
@@ -14,7 +14,8 @@
 	<pre>
   - type: report                       # Report generation
     parameters:
-      template:                        # String: The template id, default : traditional-html
+      template:                        # String: The template id, default: risk-confidence-html
+      theme:                           # String: The template theme, default: the first theme defined for the template (if any)
       reportDir:                       # String: The directory into which the report will be written
       reportFile:                      # String: The report file name pattern, default: {{yyyy-MM-dd}}-ZAP-Report-[[site]]
       reportTitle:                     # String: The report title

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-max.yaml
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-max.yaml
@@ -1,6 +1,6 @@
   - type: report                       # Report generation
     parameters:
-      template:                        # String: The template id, default : modern
+      template:                        # String: The template id, default: risk-confidence-html
       theme:                           # String: The template theme, default: the first theme defined for the template (if any)
       reportDir:                       # String: The directory into which the report will be written
       reportFile:                      # String: The report file name pattern, default: {{yyyy-MM-dd}}-ZAP-Report-[[site]]

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-min.yaml
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-min.yaml
@@ -1,6 +1,6 @@
   - type: report                       # Report generation
     parameters:
-      template:                        # String: The template id, default : modern
+      template:                        # String: The template id, default: risk-confidence-html
       theme:                           # String: The template theme, default: the first theme defined for the template (if any)
       reportDir:                       # String: The directory into which the report will be written
       reportFile:                      # String: The report file name pattern, default: {{yyyy-MM-dd}}-ZAP-Report-[[site]]


### PR DESCRIPTION
Fix typos and add missing fields in automation docs for requestor, replacer, and report jobs.