### PR TITLE
automation, exim: Fix generated AF templates

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update help for the "requestor" job.
 
+### Fixed
+- Templates generated with `-autogenmin` or `-autogenmax` were invalid in some cases.
+
 ## [0.43.0] - 2024-10-07
 ### Fixed
 - Handle exceptions while running jobs.

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -56,7 +56,6 @@ env:                                   # The environment, mandatory
     password:                          # String, the proxy password
 
 jobs:
-
   - type: requestor                    # Used to send specific requests to targets
     parameters:
       user:                            # String: An optional user to use for authenticated requests, must be defined in the env
@@ -69,10 +68,12 @@ jobs:
             # - "header1:value1"
         data:                          # String: Optional data to send in the request body, supports vars
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched
+
   - type: delay                        # Pause the plan for a set period of time or event (file created, programmatic method called, API endpoint called)
     parameters:
       time:                            # String: The time to wait, format any of ['hh:mm:ss', 'mm:ss', 'ss'], default: 0
       fileName:                        # String: Name of a file which will cause the job to end early if created, default: empty
+
   - type: activeScan                   # The active scanner - this actively attacks the target so should only be used with permission
     parameters:
       context:                         # String: Name of the context to attack, default: first context
@@ -111,3 +112,4 @@ jobs:
         risk:                                  # String: The risk of the alert, one of 'Informational', 'Low', 'Medium', 'High', optional
         otherInfo:                             # String: Addional information corresponding to the alert, optional
         onFail: 'info'                         # String: One of 'warn', 'error', 'info', mandatory
+

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
@@ -13,16 +13,17 @@ env:                                   # The environment, mandatory
     progressToStdout: true             # If set will write job progress to stdout
 
 jobs:
-
   - type: requestor                    # Used to send specific requests to targets
     parameters:
       user:                            # String: An optional user to use for authenticated requests, must be defined in the env
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
+
   - type: delay                        # Pause the plan for a set period of time or event (file created, programmatic method called, API endpoint called)
     parameters:
       time:                            # String: The time to wait, format any of ['hh:mm:ss', 'mm:ss', 'ss'], default: 0
       fileName:                        # String: Name of a file which will cause the job to end early if created, default: empty
+
   - type: activeScan                   # The active scanner - this actively attacks the target so should only be used with permission
     parameters:
       context:                         # String: Name of the context to attack, default: first context
@@ -45,3 +46,4 @@ jobs:
         risk:                                  # String: The risk of the alert, one of 'Informational', 'Low', 'Medium', 'High', optional
         otherInfo:                             # String: Addional information corresponding to the alert, optional
         onFail: 'info'                         # String: One of 'warn', 'error', 'info', mandatory
+

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/export-max.yaml
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/export-max.yaml
@@ -1,4 +1,4 @@
-- type: export            # Exports data into a file
+  - type: export            # Exports data into a file
     parameters:
       context:            # String: Name of the context from which to export. Default: first context
       type:               # String: One of 'har', 'url'. Default: 'har'

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/export-min.yaml
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/export-min.yaml
@@ -1,3 +1,3 @@
-- type: export            # Exports data into a file
+  - type: export            # Exports data into a file
     parameters:
       fileName:           # String: Name/path to the file

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/import-max.yaml
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/import-max.yaml
@@ -1,4 +1,4 @@
   - type: import                        # Import a file of requests
-      parameters:
-        type:                            # String: One of ['har', 'modsec2', 'url', 'zap_messages']
-        fileName:                        # String: Name of the file containing the data
+    parameters:
+      type:                            # String: One of ['har', 'modsec2', 'url', 'zap_messages']
+      fileName:                        # String: Name of the file containing the data

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/import-min.yaml
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/import-min.yaml
@@ -1,4 +1,4 @@
   - type: import                        # Import a file of requests
-      parameters:
-        type:                            # String: One of ['har', 'modsec2', 'url', 'zap_messages']
-        fileName:                        # String: Name of the file containing the data
+    parameters:
+      type:                            # String: One of ['har', 'modsec2', 'url', 'zap_messages']
+      fileName:                        # String: Name of the file containing the data

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/ExportJobUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/ExportJobUnitTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -79,8 +80,8 @@ class ExportJobUnitTest extends TestUtils {
         assertThat(job.getType(), is(equalTo("export")));
         assertThat(job.getName(), is(equalTo("export")));
         assertThat(job.getOrder(), is(equalTo(AutomationJob.Order.AFTER_ATTACK)));
-        assertThat(job.getTemplateDataMin(), is(not(equalTo(""))));
-        assertThat(job.getTemplateDataMax(), is(not(equalTo(""))));
+        assertValidTemplate(job.getTemplateDataMin());
+        assertValidTemplate(job.getTemplateDataMax());
         assertThat(job.getParamMethodObject(), is(nullValue()));
         assertThat(job.getParamMethodName(), is(nullValue()));
     }
@@ -195,5 +196,10 @@ class ExportJobUnitTest extends TestUtils {
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(progress.hasErrors(), is(equalTo(true)));
         assertThat(progress.getErrors(), contains("Job export Error: Error while exporting"));
+    }
+
+    private static void assertValidTemplate(String value) {
+        assertThat(value, is(not(equalTo(""))));
+        assertDoesNotThrow(() -> new Yaml().load(value));
     }
 }

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/ImportJobUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/ImportJobUnitTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
@@ -73,8 +74,8 @@ class ImportJobUnitTest {
         assertThat(job.getType(), is(equalTo("import")));
         assertThat(job.getName(), is(equalTo("import")));
         assertThat(job.getOrder(), is(equalTo(AutomationJob.Order.EXPLORE)));
-        assertThat(job.getTemplateDataMin(), is(not(equalTo(""))));
-        assertThat(job.getTemplateDataMax(), is(not(equalTo(""))));
+        assertValidTemplate(job.getTemplateDataMin());
+        assertValidTemplate(job.getTemplateDataMax());
         assertThat(job.getParamMethodObject(), is(nullValue()));
         assertThat(job.getParamMethodName(), is(nullValue()));
     }
@@ -141,5 +142,10 @@ class ImportJobUnitTest {
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(progress.hasErrors(), is(equalTo(true)));
         assertThat(progress.getErrors().get(0), is(equalTo("!exim.automation.import.error.file!")));
+    }
+
+    private static void assertValidTemplate(String value) {
+        assertThat(value, is(not(equalTo(""))));
+        assertDoesNotThrow(() -> new Yaml().load(value));
     }
 }


### PR DESCRIPTION
## Overview
Some AF templates do not end with an empty line (e.g. [`passiveScan-config-max.yaml`](https://github.com/zaproxy/zap-extensions/blob/f53114fa7b11453f2ed4c641ac86710e4c90d9cd/addOns/pscan/src/main/resources/org/zaproxy/addon/pscan/automation/jobs/passiveScan-config-max.yaml)) and result in invalid templates being generated:

![image](https://github.com/user-attachments/assets/162d4010-7f49-41a0-a230-6bf4872e545e)

This is fixed by normalizing the trailing newlines at the time of template generation in the automation add-on. Also, deprecated jobs and data jobs are skipped, and jobs are sorted by their types.

The indentation in exim templates was not correct and was also adjusted.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title