### PR TITLE
graphql: Add tech detection for GraphQL Engines

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
     - Hot Chocolate
     - Inigo
 - Support for importing an introspection query response from a file (Issue 8569).
+- If the Tech Detection (Wappalyzer) add-on is installed and a GraphQL engine is successfully fingerprinted, it is added to the Technology tab/data.
 
 ## [0.25.0] - 2024-09-24
 ### Changed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -39,6 +39,19 @@ zapAddOn {
                     }
                 }
             }
+
+            register("org.zaproxy.addon.graphql.techdetection.ExtensionTechDetectionGraphQl") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.addon.graphql.techdetection"))
+                }
+                dependencies {
+                    addOns {
+                        register("wappalyzer") {
+                            version.set(">= 21.44.0")
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -61,6 +74,7 @@ dependencies {
     zapAddOn("automation")
     zapAddOn("commonlib")
     zapAddOn("spider")
+    zapAddOn("wappalyzer")
 
     implementation("com.graphql-java:graphql-java:22.3")
 

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/DiscoveredGraphQlEngineHandler.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/DiscoveredGraphQlEngineHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import org.zaproxy.addon.graphql.GraphQlFingerprinter.DiscoveredGraphQlEngine;
+
+public interface DiscoveredGraphQlEngineHandler {
+
+    void process(DiscoveredGraphQlEngine engine);
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,6 +43,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.commonlib.ExtensionCommonlib;
 import org.zaproxy.addon.commonlib.ValueProvider;
+import org.zaproxy.addon.graphql.GraphQlFingerprinter.DiscoveredGraphQlEngine;
 import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.view.ZapMenuItem;
@@ -295,8 +297,16 @@ public class ExtensionGraphQl extends ExtensionAdaptor
 
     @Override
     public List<Alert> getExampleAlerts() {
+        URI uri = null;
+        try {
+            uri = new URI("https://example.com", false);
+        } catch (URIException | NullPointerException e) {
+            // Ignore
+        }
         return List.of(
                 GraphQlParser.createIntrospectionAlert().build(),
-                GraphQlFingerprinter.createFingerprintingAlert("example").build());
+                GraphQlFingerprinter.createFingerprintingAlert(
+                                new DiscoveredGraphQlEngine("example", uri))
+                        .build());
     }
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/techdetection/ExtensionTechDetectionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/techdetection/ExtensionTechDetectionGraphQl.java
@@ -1,0 +1,101 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql.techdetection;
+
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.addon.graphql.GraphQlFingerprinter;
+import org.zaproxy.addon.graphql.GraphQlFingerprinter.DiscoveredGraphQlEngine;
+import org.zaproxy.zap.extension.wappalyzer.Application;
+import org.zaproxy.zap.extension.wappalyzer.ApplicationMatch;
+import org.zaproxy.zap.extension.wappalyzer.ExtensionWappalyzer;
+
+public class ExtensionTechDetectionGraphQl extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtensionTechDetectionGraphQl";
+
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionWappalyzer.class);
+
+    private static ExtensionWappalyzer extTech;
+
+    public ExtensionTechDetectionGraphQl() {
+        super(NAME);
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("graphql.techdetection.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("graphql.techdetection.desc");
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+        GraphQlFingerprinter.addEngineHandler(ExtensionTechDetectionGraphQl::addApp);
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        GraphQlFingerprinter.resetHandlers();
+    }
+
+    private static ApplicationMatch getAppForEngine(DiscoveredGraphQlEngine engine) {
+        Application gqlEngine = new Application();
+        gqlEngine.setName(engine.getName());
+        gqlEngine.setCategories(List.of("GraphQL Engine"));
+        gqlEngine.setWebsite(engine.getDocsUrl());
+        gqlEngine.setImplies(List.of(engine.getTechnologies()));
+
+        return new ApplicationMatch(gqlEngine);
+    }
+
+    private static void addApp(DiscoveredGraphQlEngine engine) {
+        getExtTech().addApplicationsToSite(engine.getUri(), getAppForEngine(engine));
+    }
+
+    private static ExtensionWappalyzer getExtTech() {
+        if (extTech == null) {
+            extTech =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionWappalyzer.class);
+        }
+        return extTech;
+    }
+}

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/alerts.html
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/alerts.html
@@ -22,7 +22,8 @@
         <td><a href="https://www.zaproxy.org/docs/alerts/50007-2/">50007-2</a>
         <td>GraphQL Server Implementation Identified
         <td>This alert is raised when the GraphQL implementation used by the server is identified. It utilises
-            fingerprinting techniques adapted from the tool <a href="https://github.com/dolevf/graphw00f">graphw00f</a>.
+            fingerprinting techniques adapted from the tool <a href="https://github.com/dolevf/graphw00f">graphw00f</a>.<br>
+            <strong>Note:</strong> If the Tech Detection (Wappalyzer) add-on is installed the fingerprinter will also add identified GraphQL Engines to the Technology tab/data. 
         <td><a href="https://github.com/zaproxy/zap-extensions/tree/main/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlFingerprinter.java">GraphQlFingerprinter.java</a>
 </table>
 

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -258,5 +258,8 @@ graphql.options.value.split.rootField = Each Field of an Operation
 graphql.spider.desc = GraphQL Spider Integration
 graphql.spider.name = GraphQL Spider
 
+graphql.techdetection.desc = GraphQL Technology Detection Integration
+graphql.techdetection.name = GraphQL Tech Detection
+
 graphql.topmenu.import.importgraphql = Import a GraphQL Schema
 graphql.topmenu.import.importgraphql.tooltip = Specify a GraphQL endpoint and optionally a GraphQL schema file to import.

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/techdetection/ExtensionTechDetectionUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/techdetection/ExtensionTechDetectionUnitTest.java
@@ -1,0 +1,57 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql.techdetection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.graphql.ExtensionGraphQl;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class ExtensionTechDetectionUnitTest extends TestUtils {
+
+    @Test
+    void shouldHaveName() {
+        // Given
+        ExtensionTechDetectionGraphQl td = new ExtensionTechDetectionGraphQl();
+        mockMessages(new ExtensionGraphQl());
+        // When / Then
+        assertThat(td.getName(), is(equalTo("ExtensionTechDetectionGraphQl")));
+    }
+
+    @Test
+    void shouldHaveUiName() {
+        // Given
+        ExtensionTechDetectionGraphQl td = new ExtensionTechDetectionGraphQl();
+        mockMessages(new ExtensionGraphQl());
+        // When / Then
+        assertThat(td.getUIName(), is(equalTo("GraphQL Tech Detection")));
+    }
+
+    @Test
+    void shouldBeUnloadable() {
+        // Given
+        ExtensionTechDetectionGraphQl td = new ExtensionTechDetectionGraphQl();
+        // When / Then
+        assertThat(td.canUnload(), is(equalTo(true)));
+    }
+}

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -294,6 +294,18 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
         }
     }
 
+    /**
+     * Accept an {@code URI} which will be normalized into a site string usable by the Tech
+     * Detection add-on and adds the provided {@code ApplicationMatch}
+     *
+     * @param uri The URI to be normalized and used
+     * @param applicationMatch the ApplicationMatch for the tech to be added
+     * @since 21.44.0
+     */
+    public void addApplicationsToSite(URI uri, ApplicationMatch applicationMatch) {
+        this.addApplicationsToSite(normalizeSite(uri), applicationMatch);
+    }
+
     public Application getSelectedApp() {
         if (hasView()) {
             String appName = this.getTechPanel().getSelectedApplicationName();


### PR DESCRIPTION
## Overview
- CHANGELOG > Added note.
- build file > Added dependency.
- GraphQlFingerprinter > Updated to add Technology matches when GraphQL engines are fingerprinted.
- GraphQlFingerprinterUnitTest > Updated for new handling.
- DiscoveredGraphQlEngineHandler > An interface to be implemented for consumption/handling of discovered GraphQL engines.
- ExtensionTechDetection > Added to facilitate optional dependence.
- ExtensionTechDetectionUnitTest > Tests :)
- Messages.properties > Added key/value pairs to support the optional dependency.
- alert.html > Added note about the new functionality.

Ex: See the Apollo entry:
![image](https://github.com/user-attachments/assets/872f3ca5-b98f-405b-9bcd-5abae5e8a633)

This seems to be a decent place for testing: https://countries.trevorblades.com/graphql
(Note if you do serial imports you will hit a limit and need to wait a min or so.)

## Related Issues
N/A

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
