### PR TITLE
network: handle another `unknown_ca` exception

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Improve error handling on client's unknown CA TLS alert.
 
 ## [0.18.0] - 2024-09-24
 ### Added

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
@@ -33,6 +33,7 @@ import io.netty.handler.timeout.ReadTimeoutException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -101,6 +102,36 @@ class ServerExceptionHandlerUnitTest {
                 hasItem(
                         startsWith(
                                 "WARN Failed while establishing secure connection, cause: missing protocol")));
+    }
+
+    @Test
+    void shouldLogUnknownCaSslHandshakeExceptionAsDebug() throws Exception {
+        // Given
+        Exception cause = new SSLHandshakeException("unknown_ca");
+        Exception exception = new DecoderException(cause);
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(
+                logEvents,
+                hasItem(
+                        startsWith(
+                                "DEBUG Failed while establishing secure connection, cause: the client does not trust ZAP's Root CA Certificate.")));
+    }
+
+    @Test
+    void shouldLogUnknownCaSslExceptionAsDebug() throws Exception {
+        // Given
+        Exception cause = new SSLException("unknown_ca");
+        Exception exception = new DecoderException(cause);
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(
+                logEvents,
+                hasItem(
+                        startsWith(
+                                "DEBUG Failed while establishing secure connection, cause: the client does not trust ZAP's Root CA Certificate.")));
     }
 
     @Test


### PR DESCRIPTION
Check also for `unknown_ca` with `SSLException` which might happen with other `SSLEngine` implementations.
Prevent errors like:
```
ERROR ServerExceptionHandler - javax.net.ssl.SSLException: org.bouncycastle.tls.TlsFatalAlertReceived: unknown_ca(48)
javax.net.ssl.SSLException: org.bouncycastle.tls.TlsFatalAlertReceived: unknown_ca(48)
	at org.bouncycastle.jsse.provider.ProvSSLEngine.unwrap(ProvSSLEngine.java:505) ~[bctls-fips-2.0.19.jar:2.0.19]
	at java.base/javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:679) ~[?:?]
	at io.netty.handler.ssl.SslHandler$SslEngineType$3.unwrap(SslHandler.java:309) ~[?:?]
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1441) ~[?:?]
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1334) ~[?:?]
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1383) ~[?:?]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529) ~[?:?]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468) ~[?:?]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[?:?]
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[?:?]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[?:?]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[?:?]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[?:?]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788) ~[?:?]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[?:?]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[?:?]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[?:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[?:?]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: org.bouncycastle.tls.TlsFatalAlertReceived: unknown_ca(48)
	at org.bouncycastle.tls.TlsProtocol.handleAlertMessage(TlsProtocol.java:245) ~[bctls-fips-2.0.19.jar:2.0.19]
	at org.bouncycastle.tls.TlsProtocol.processAlertQueue(TlsProtocol.java:740) ~[bctls-fips-2.0.19.jar:2.0.19]
	at org.bouncycastle.tls.TlsProtocol.processRecord(TlsProtocol.java:563) ~[bctls-fips-2.0.19.jar:2.0.19]
	at org.bouncycastle.tls.RecordStream.readFullRecord(RecordStream.java:209) ~[bctls-fips-2.0.19.jar:2.0.19]
	at org.bouncycastle.tls.TlsProtocol.safeReadFullRecord(TlsProtocol.java:926) ~[bctls-fips-2.0.19.jar:2.0.19]
	at org.bouncycastle.tls.TlsProtocol.offerInput(TlsProtocol.java:1368) ~[bctls-fips-2.0.19.jar:2.0.19]
	at org.bouncycastle.jsse.provider.ProvSSLEngine.unwrap(ProvSSLEngine.java:486) ~[bctls-fips-2.0.19.jar:2.0.19]
	... 28 more
```