### PR TITLE
custompayloads: SAST Fixes (SonarLint), Options panel help, & drop ID

### DIFF
--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.16.0.
 - Maintenance changes.
+- The superfluous/unused ID element of the custom payloads has been removed from the GUI and config.
+
+### Added
+- Add help button to Options panel and add further detailed Help content.
 
 ## [0.13.0] - 2023-11-10
 ### Changed

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnDialog.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnDialog.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.custompayloads;
 
 import java.awt.Dimension;
 import java.awt.Window;
-import java.util.ArrayList;
 import java.util.List;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
@@ -95,7 +94,7 @@ public class AbstractColumnDialog<T> extends StandardFieldsDialog {
     private void createStringComboFieldForColumn(Column<T> column) {
         EditableSelectColumn<T> selectColumn = (EditableSelectColumn<T>) column;
         String value = column.getTypedValue(model);
-        ArrayList<String> selectableValues = selectColumn.getTypedSelectableValues(model);
+        List<String> selectableValues = selectColumn.getTypedSelectableValues(model);
         this.addComboField(column.getNameKey(), selectableValues, value);
     }
 

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/Column.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/Column.java
@@ -19,11 +19,11 @@
  */
 package org.zaproxy.zap.extension.custompayloads;
 
-public abstract class Column<T> {
+abstract class Column<T> {
     Class<?> columnClass;
     String nameKey;
 
-    public Column(Class<?> columnClass, String nameKey) {
+    Column(Class<?> columnClass, String nameKey) {
         this.columnClass = columnClass;
         this.nameKey = nameKey;
     }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayload.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayload.java
@@ -23,7 +23,6 @@ import org.zaproxy.zap.utils.EnableableInterface;
 
 public class CustomPayload implements EnableableInterface {
 
-    private int id;
     private boolean enabled;
     private String category;
     private String payload;
@@ -33,18 +32,9 @@ public class CustomPayload implements EnableableInterface {
     }
 
     public CustomPayload(boolean enabled, String category, String payload) {
-        this(-1, enabled, category, payload);
-    }
-
-    public CustomPayload(int id, boolean enabled, String category, String payload) {
-        this.id = id;
         this.enabled = enabled;
         this.category = category;
         this.payload = payload;
-    }
-
-    public void setId(int id) {
-        this.id = id;
     }
 
     public void setCategory(String category) {
@@ -73,11 +63,7 @@ public class CustomPayload implements EnableableInterface {
         return payload;
     }
 
-    public int getId() {
-        return id;
-    }
-
     public CustomPayload copy() {
-        return new CustomPayload(id, enabled, category, payload);
+        return new CustomPayload(enabled, category, payload);
     }
 }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadCategoryColumn.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadCategoryColumn.java
@@ -61,7 +61,7 @@ public class CustomPayloadCategoryColumn extends EditableSelectColumn<CustomPayl
         return categoryObjects;
     }
 
-    private ExtensionCustomPayloads getExtension() {
+    private static ExtensionCustomPayloads getExtension() {
         return Control.getSingleton()
                 .getExtensionLoader()
                 .getExtension(ExtensionCustomPayloads.class);

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadColumns.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadColumns.java
@@ -25,10 +25,13 @@ import java.util.List;
 
 public final class CustomPayloadColumns {
 
+    private CustomPayloadColumns() {
+        // Nothing to do
+    }
+
     public static List<Column<CustomPayload>> createColumns() {
         ArrayList<Column<CustomPayload>> columns = new ArrayList<>();
         columns.add(createEnabledColumn());
-        columns.add(createIdColumn());
         columns.add(createCategoryColumn());
         columns.add(createPayloadColumn());
         return columns;
@@ -37,9 +40,8 @@ public final class CustomPayloadColumns {
     public static List<Column<CustomPayload>> createColumnsForOptionsTable() {
         ArrayList<Column<CustomPayload>> columns = new ArrayList<>();
         columns.add(createEnabledColumn());
-        columns.add(createIdColumn());
-        columns.add(createCategoryColumn().AsReadonly());
-        columns.add(createPayloadColumn().AsReadonly());
+        columns.add(createCategoryColumn().asReadonly());
+        columns.add(createPayloadColumn().asReadonly());
         return columns;
     }
 
@@ -58,16 +60,6 @@ public final class CustomPayloadColumns {
             @Override
             public Object getValue(CustomPayload payload) {
                 return payload.isEnabled();
-            }
-        };
-    }
-
-    private static Column<CustomPayload> createIdColumn() {
-        return new Column<CustomPayload>(Integer.class, "custompayloads.options.dialog.id") {
-
-            @Override
-            public Object getValue(CustomPayload payload) {
-                return payload.getId();
             }
         };
     }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadMultipleOptionsTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadMultipleOptionsTableModel.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.custompayloads;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -29,7 +28,6 @@ public class CustomPayloadMultipleOptionsTableModel
 
     private static final long serialVersionUID = 1L;
     private List<CustomPayload> defaultPayloads;
-    private int nextPayloadId;
 
     public CustomPayloadMultipleOptionsTableModel() {
         super(CustomPayloadColumns.createColumnsForOptionsTable());
@@ -39,36 +37,16 @@ public class CustomPayloadMultipleOptionsTableModel
         this.defaultPayloads = defaultPayloads;
     }
 
-    public void setNextPayloadId(int nextPayloadId) {
-        this.nextPayloadId = nextPayloadId;
-    }
-
-    public int getNextPayloadId() {
-        return nextPayloadId;
-    }
-
-    public void resetPayloadIds() {
-        nextPayloadId = 1;
-        for (CustomPayload payload : getElements()) {
-            setNextIdToPayload(payload);
-        }
-        if (this.getRowCount() > 0) {
-            fireTableRowsUpdated(0, getElements().size() - 1);
-        }
-    }
-
     public void resetToDefaults() {
         clear();
         for (CustomPayload defaultPayload : defaultPayloads) {
             CustomPayload newPayload = defaultPayload.copy();
-            setNextIdToPayload(newPayload);
             addModel(newPayload);
         }
     }
 
-    public void addToTable(ArrayList<CustomPayload> payloads) {
+    public void addToTable(List<CustomPayload> payloads) {
         for (CustomPayload payload : payloads) {
-            payload.setId(nextPayloadId++);
             addModel(payload);
         }
     }
@@ -79,10 +57,6 @@ public class CustomPayloadMultipleOptionsTableModel
                 payloads.add(existingPayload.getPayload());
             }
         }
-    }
-
-    public void setNextIdToPayload(CustomPayload payload) {
-        payload.setId(nextPayloadId++);
     }
 
     public void addMissingDefaultPayloads() {
@@ -98,7 +72,6 @@ public class CustomPayloadMultipleOptionsTableModel
 
             if (!alreadyExisting) {
                 CustomPayload newPayload = defaultPayload.copy();
-                setNextIdToPayload(newPayload);
                 addModel(newPayload);
             }
         }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsMultipleOptionsTablePanel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsMultipleOptionsTablePanel.java
@@ -46,8 +46,6 @@ public class CustomPayloadsMultipleOptionsTablePanel
 
     private static final String RESET_BUTTON =
             Constant.messages.getString("custompayloads.options.button.reset");
-    private static final String RESET_ID_BUTTON =
-            Constant.messages.getString("custompayloads.options.button.resetIds");
     private static final String ADD_MISSING_DEFAULTS_BUTTON =
             Constant.messages.getString("custompayloads.options.button.addMissingDefaults");
 
@@ -67,7 +65,6 @@ public class CustomPayloadsMultipleOptionsTablePanel
             LogManager.getLogger(CustomPayloadsMultipleOptionsTablePanel.class);
 
     private JButton resetButton;
-    private JButton resetButtonId;
     private JButton addMissingDefaultsButton;
     private JButton fileButton;
     private CustomPayloadMultipleOptionsTableModel tableModel;
@@ -79,7 +76,6 @@ public class CustomPayloadsMultipleOptionsTablePanel
         addButtonSpacer();
         addMissingDefaultsButton();
         addResetButton();
-        addResetIdButton();
         addButtonSpacer();
         addPayloadFileButton();
         getTable().setHorizontalScrollEnabled(true);
@@ -89,12 +85,6 @@ public class CustomPayloadsMultipleOptionsTablePanel
         addMissingDefaultsButton = new JButton(ADD_MISSING_DEFAULTS_BUTTON);
         addMissingDefaultsButton.addActionListener(e -> tableModel.addMissingDefaultPayloads());
         addButton(addMissingDefaultsButton);
-    }
-
-    private void addResetIdButton() {
-        resetButtonId = new JButton(RESET_ID_BUTTON);
-        resetButtonId.addActionListener(e -> tableModel.resetPayloadIds());
-        addButton(resetButtonId);
     }
 
     private void addResetButton() {
@@ -107,7 +97,7 @@ public class CustomPayloadsMultipleOptionsTablePanel
         fileButton = new JButton(ADD_MULTIPLE_PAYLOADS_BUTTON);
         fileButton.addActionListener(
                 e -> {
-                    CustomPayload multiplePayloads = new CustomPayload(-1, true, "", "");
+                    CustomPayload multiplePayloads = new CustomPayload(true, "", "");
                     CustomMultiplePayloadDialog dialog =
                             new CustomMultiplePayloadDialog(
                                     View.getSingleton().getOptionsDialog(null), multiplePayloads);
@@ -161,15 +151,14 @@ public class CustomPayloadsMultipleOptionsTablePanel
 
     @Override
     public CustomPayload showAddDialogue() {
-        CustomPayload payload = new CustomPayload(-1, true, "", "");
+        CustomPayload payload = new CustomPayload(true, "", "");
         if (showDialog(payload)) {
-            tableModel.setNextIdToPayload(payload);
             return payload;
         }
         return null;
     }
 
-    private boolean showDialog(CustomPayload payload) {
+    private static boolean showDialog(CustomPayload payload) {
         CustomPayloadDialog dialog =
                 new CustomPayloadDialog(
                         View.getSingleton().getOptionsDialog(null),

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsOptionsPanel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsOptionsPanel.java
@@ -58,7 +58,6 @@ public class CustomPayloadsOptionsPanel extends AbstractParamPanel {
         tableModel.clear();
         tableModel.addModels(param.getPayloads());
         tableModel.setDefaultPayloads(param.getDefaultPayloads());
-        tableModel.setNextPayloadId(param.getNextPayloadId());
         tablePanel.setRemoveWithoutConfirmation(param.isConfirmRemoveToken());
     }
 
@@ -67,7 +66,11 @@ public class CustomPayloadsOptionsPanel extends AbstractParamPanel {
         OptionsParam optionsParam = (OptionsParam) obj;
         CustomPayloadsParam param = optionsParam.getParamSet(CustomPayloadsParam.class);
         param.setPayloads(tableModel.getElements());
-        param.setNextPayloadId(tableModel.getNextPayloadId());
         param.setConfirmRemoveToken(tablePanel.isRemoveWithoutConfirmation());
+    }
+
+    @Override
+    public String getHelpIndex() {
+        return "custompayloads.options";
     }
 }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/EditableColumn.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/EditableColumn.java
@@ -19,9 +19,9 @@
  */
 package org.zaproxy.zap.extension.custompayloads;
 
-public abstract class EditableColumn<T> extends Column<T> {
+abstract class EditableColumn<T> extends Column<T> {
 
-    public EditableColumn(Class<?> columnClass, String name) {
+    EditableColumn(Class<?> columnClass, String name) {
         super(columnClass, name);
     }
 
@@ -32,7 +32,7 @@ public abstract class EditableColumn<T> extends Column<T> {
 
     public abstract void setValue(T model, Object value);
 
-    public Column<T> AsReadonly() {
+    public Column<T> asReadonly() {
         return new Column<T>(this.columnClass, this.nameKey) {
 
             @Override

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/EditableSelectColumn.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/EditableSelectColumn.java
@@ -20,19 +20,20 @@
 package org.zaproxy.zap.extension.custompayloads;
 
 import java.util.ArrayList;
+import java.util.List;
 
-public abstract class EditableSelectColumn<T> extends EditableColumn<T> {
+abstract class EditableSelectColumn<T> extends EditableColumn<T> {
 
-    public EditableSelectColumn(Class<?> columnClass, String name) {
+    EditableSelectColumn(Class<?> columnClass, String name) {
         super(columnClass, name);
     }
 
-    public abstract ArrayList<Object> getSelectableValues(T model);
+    public abstract List<Object> getSelectableValues(T model);
 
-    public <V> ArrayList<V> getTypedSelectableValues(T model) {
-        ArrayList<Object> values = getSelectableValues(model);
+    public <V> List<V> getTypedSelectableValues(T model) {
+        List<Object> values = getSelectableValues(model);
 
-        ArrayList<V> typedValues = new ArrayList<>();
+        List<V> typedValues = new ArrayList<>();
         for (Object value : values) {
             V typedValue = getTypedObject(value);
             typedValues.add(typedValue);

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/contents/options.html
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/contents/options.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Options Custom Payloads screen</TITLE>
+</HEAD>
+<BODY>
+<H1>Options Custom Payloads screen</H1>
+<p>
+This screen/table allows you to configure <a href="custompayloads.html">Custom Payload</a> options:
+
+<H2>Custom Payloads Table</H2>
+
+<H3>Enabled</H3>
+A checkbox indicating whether or not the particular custom payload is to be used or not.
+
+<H3>Category</H3>
+Indicates the category and by association the scan rule for which the custpm payload value should be used.
+The categories are also mentioned in the help entry for the applicable scan rules.
+
+<h3>Payload</H3>
+The value of the specific custom payload.
+
+<H2>Custom Payloads Buttons</H2>
+
+<H3>Add</H3>
+Allows users to add a custom payload, setting the enable state, category, and payload value.
+</p>
+<strong>Note</strong>: Payload categories which are not listed in the table may be available via the Add button as not all rules which support
+custom payloads have default payloads.
+
+<H3>Modify/Remove</H3>
+Either modify or remove the custom payload defined by the selected row.
+
+<H3>Enable All/Disable All</h3>
+Sets the enable state of all custom payloads as applicable.
+
+<H3>Add Missing Defaults</H3>
+Facilitates restoration of missing default custom payloads if they've been previously removed.
+
+<H3>Reset to Defaults</H3>
+Removes all payloads and restores just the defaults. <strong>Note</strong>: User added payloads will be lost.
+
+<H3>Add Multiple Payloads</H3>
+Allows the user to import a text file of payloads (one payload per line) for the selected category.
+
+</BODY>
+</HTML>

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/index.xml
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/index.xml
@@ -7,4 +7,5 @@
     <!-- index entries are merged (sorted) into core index -->
     <indexitem text="custompayloads" target="custompayloads" />
     <indexitem text="Custom Payloads API" target="custompayloads.api" />
+    <indexitem text="Custom Payloads Options" target="custompayloads.options" />
 </index>

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/map.jhm
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/map.jhm
@@ -6,4 +6,5 @@
 <map version="1.0">
     <mapID target="custompayloads" url="contents/custompayloads.html" />
     <mapID target="custompayloads.api" url="contents/api.html" />
+    <mapID target="custompayloads.options" url="contents/options.html" />
 </map>

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/toc.xml
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/toc.xml
@@ -8,6 +8,7 @@
 		<tocitem text="Add Ons" tocid="addons">
 			<tocitem text="Custom Payloads" target="custompayloads">
 				<tocitem text="API" target="custompayloads.api" />
+				<tocitem text="Options" target="custompayloads.options" />
 			</tocitem>
 		</tocitem>
 	</tocitem>

--- a/addOns/custompayloads/src/main/resources/org/zaproxy/zap/extension/custompayloads/resources/Messages.properties
+++ b/addOns/custompayloads/src/main/resources/org/zaproxy/zap/extension/custompayloads/resources/Messages.properties
@@ -28,7 +28,6 @@ custompayloads.name = Custom Payloads
 
 custompayloads.options.button.addMissingDefaults = Add Missing Defaults
 custompayloads.options.button.reset = Reset to Defaults
-custompayloads.options.button.resetIds = Reset IDs
 custompayloads.options.dialog.addMultiplePayload.add.button.name = Add
 custompayloads.options.dialog.addMultiplePayload.addPayload.button.name = Add Multiple Payloads
 custompayloads.options.dialog.addMultiplePayload.duplicates.checkbox.label = Prevent Duplicates
@@ -38,7 +37,6 @@ custompayloads.options.dialog.addMultiplePayload.selectFile.button.name = Select
 custompayloads.options.dialog.addMultiplePayload.title = Add Multiple Payloads
 custompayloads.options.dialog.category = Category
 custompayloads.options.dialog.enabled = Enabled
-custompayloads.options.dialog.id = ID
 custompayloads.options.dialog.payload = Payload
 custompayloads.options.dialog.remove.button.cancel = Cancel
 custompayloads.options.dialog.remove.button.confirm = Remove

--- a/addOns/custompayloads/src/test/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsApiUnitTest.java
+++ b/addOns/custompayloads/src/test/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsApiUnitTest.java
@@ -31,8 +31,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
-import org.zaproxy.zap.extension.api.API;
-import org.zaproxy.zap.extension.api.API.RequestType;
 import org.zaproxy.zap.extension.api.ApiElement;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiParameter;
@@ -50,7 +48,7 @@ class CustomPayloadsApiUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldHavePrefix() throws Exception {
+    void shouldHavePrefix() {
         // Given / When
         String prefix = api.getPrefix();
         // Then
@@ -61,17 +59,14 @@ class CustomPayloadsApiUnitTest extends TestUtils {
     void shouldHaveDescriptionsForAllApiElements() {
         List<String> missingKeys = new ArrayList<>();
         checkKey(api.getDescriptionKey(), missingKeys);
-        checkApiElements(api, api.getApiActions(), API.RequestType.action, missingKeys);
-        checkApiElements(api, api.getApiOthers(), API.RequestType.other, missingKeys);
-        checkApiElements(api, api.getApiViews(), API.RequestType.view, missingKeys);
+        checkApiElements(api, api.getApiActions(), missingKeys);
+        checkApiElements(api, api.getApiOthers(), missingKeys);
+        checkApiElements(api, api.getApiViews(), missingKeys);
         assertThat(missingKeys, is(empty()));
     }
 
     private static void checkApiElements(
-            ApiImplementor api,
-            List<? extends ApiElement> elements,
-            RequestType type,
-            List<String> missingKeys) {
+            ApiImplementor api, List<? extends ApiElement> elements, List<String> missingKeys) {
         elements.sort((a, b) -> a.getName().compareTo(b.getName()));
         for (ApiElement element : elements) {
             assertThat(

--- a/addOns/custompayloads/src/test/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParamUnitTest.java
+++ b/addOns/custompayloads/src/test/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParamUnitTest.java
@@ -1,0 +1,138 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link CustomPayloadsParam}. */
+class CustomPayloadsParamUnitTest {
+
+    private static CustomPayloadsParam param;
+    private ZapXmlConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        param = new CustomPayloadsParam();
+        configuration = new ZapXmlConfiguration();
+    }
+
+    @Test
+    void shouldHaveConfigVersionKey() {
+        // Given / When / Then
+        assertThat(param.getConfigVersionKey(), is(equalTo("custompayloads[@version]")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void shouldLoadConfirmRemoveFromConfig(boolean state) {
+        // Given
+        configuration.setProperty(CustomPayloadsParam.CONFIRM_REMOVE_PAYLOAD_KEY, state);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.isConfirmRemoveToken(), is(equalTo(state)));
+    }
+
+    @Test
+    void shouldDefaultConfirmRemoveTrue() {
+        // Given / When
+        param.load(configuration);
+        // Then
+        assertThat(param.isConfirmRemoveToken(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotHaveNextPayloadIdOnUpdateFromUnversioned() {
+        // Given
+        String configKey = "custompayloads.nextPayloadId";
+        configuration.setProperty(configKey, 72);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(
+                (int) configuration.getProperty("custompayloads[@version]"),
+                is(greaterThanOrEqualTo(1)));
+        assertThat(configuration.getProperty(configKey), is(nullValue()));
+    }
+
+    @Test
+    void shouldRemoveIdsFromCustomPayloadsOnUpdate() {
+        // Given
+        String configKey = "custompayloads.categories.category(0).payloads.payload(0).";
+        configuration = createUnversionedConfig();
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(
+                (int) configuration.getProperty("custompayloads[@version]"),
+                is(greaterThanOrEqualTo(1)));
+        assertThat(configuration.getProperty(configKey + "id"), is(nullValue()));
+        assertThat(configuration.getBoolean(configKey + "enabled"), is(equalTo(true)));
+        assertThat(configuration.getProperty(configKey + "payload"), is(equalTo("bar")));
+    }
+
+    private static ZapXmlConfiguration createUnversionedConfig() {
+        ZapXmlConfiguration testConfig = new ZapXmlConfiguration();
+
+        Map<String, PayloadCategory> payloadCategories = new HashMap<>();
+        CustomPayload testPayload = new CustomPayload(true, "foo", "bar");
+        payloadCategories.put(
+                testPayload.getCategory(),
+                new PayloadCategory(testPayload.getCategory(), List.of(), List.of(testPayload)));
+        int catIdx = 0;
+        for (PayloadCategory category : payloadCategories.values()) {
+            String catElementBaseKey = CustomPayloadsParam.ALL_CATEGORIES_KEY + "(" + catIdx + ")";
+            List<CustomPayload> payloads = category.getPayloads();
+            testConfig.setProperty(
+                    catElementBaseKey + CustomPayloadsParam.CATEGORY_NAME_KEY, category.getName());
+            for (int i = 0, size = payloads.size(); i < size; ++i) {
+                String elementBaseKey =
+                        catElementBaseKey
+                                + ".payloads."
+                                + CustomPayloadsParam.PAYLOAD_KEY
+                                + "("
+                                + i
+                                + ").";
+                CustomPayload payload = payloads.get(i);
+                testConfig.setProperty(elementBaseKey + "id", i);
+                testConfig.setProperty(
+                        elementBaseKey + CustomPayloadsParam.PAYLOAD_ENABLED_KEY,
+                        Boolean.valueOf(payload.isEnabled()));
+                testConfig.setProperty(
+                        elementBaseKey + CustomPayloadsParam.PAYLOAD_KEY, payload.getPayload());
+            }
+            catIdx++;
+        }
+        return testConfig;
+    }
+}


### PR DESCRIPTION
## Overview
- AbstractColumnDialog > Use List interface vs ArrayList.
- Column > Reduce visibility.
- CustomPayload > Remove ID and related handling.
- CustomPayloadColumns > Add private constructor to hide implicit one. Remove ID and related handling.
- CustomPayloadMultipleOptionsTableModel > Use List interface vs ArrayList for params. Remove ID and related handling.
- CustomPayloadsCategoryColumn > Make getExtension static.
- CustomPayloadsMultipleOptionsTablePanel > Make showDialog static. Remove ID and related handling.
- CustomPayloadsParam > Remove ID and related handling, switched to versioned config.
- EditableColumn > Reduce visibility.
- EditableSelectColumn > Reduce visibility, adjust method naming to proper Java camelCase.
- CustomPayloadsApiUnitTest > Remove unused param API.RequestType, and pointless declared throw on shouldHavePrefix.
- Messages.properties > Remove no longer needed ID key value pair.

* CHANGELOG > Already has a maint note, added a note about the Options panel help button, and one about ID.
* CustomPayloadsOptionsPanel > Added overridden getHelpIndex method.

- Help files > Updated to include more detailed info about the functionality.

## Related Issues
N/A

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [na] Write tests
- [na] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
