### PR TITLE
automation: correct min threads ascan job dialog

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Templates generated with `-autogenmin` or `-autogenmax` were invalid in some cases.
+- Allow to choose one thread for the `activeScan` job through the GUI.
 
 ## [0.43.0] - 2024-10-07
 ### Fixed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
@@ -28,7 +28,6 @@ import org.zaproxy.addon.automation.jobs.ActiveScanJob;
 import org.zaproxy.addon.automation.jobs.ActiveScanJob.Parameters;
 import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.addon.automation.jobs.PolicyDefinition.Rule;
-import org.zaproxy.addon.commonlib.Constants;
 import org.zaproxy.zap.utils.DisplayUtils;
 
 @SuppressWarnings("serial")
@@ -84,13 +83,13 @@ public class ActiveScanJobDialog extends ActiveScanPolicyDialog {
                 MAX_RULE_DURATION_PARAM,
                 0,
                 Integer.MAX_VALUE,
-                JobUtils.unBox(JobUtils.unBox(job.getParameters().getMaxRuleDurationInMins())));
+                JobUtils.unBox(job.getParameters().getMaxRuleDurationInMins()));
         this.addNumberField(
                 0,
                 MAX_SCAN_DURATION_PARAM,
                 0,
                 Integer.MAX_VALUE,
-                JobUtils.unBox(JobUtils.unBox(job.getParameters().getMaxScanDurationInMins())));
+                JobUtils.unBox(job.getParameters().getMaxScanDurationInMins()));
         addNumberField(
                 0,
                 MAX_ALERTS_PER_RULE_PARAM,
@@ -149,13 +148,13 @@ public class ActiveScanJobDialog extends ActiveScanPolicyDialog {
                 DELAY_IN_MS_PARAM,
                 0,
                 Integer.MAX_VALUE,
-                JobUtils.unBox(JobUtils.unBox(job.getParameters().getDelayInMs())));
+                JobUtils.unBox(job.getParameters().getDelayInMs()));
         this.addNumberField(
                 3,
                 THREADS_PER_HOST_PARAM,
-                Constants.getDefaultThreadCount(),
+                1,
                 Integer.MAX_VALUE,
-                JobUtils.unBox(JobUtils.unBox(job.getParameters().getThreadPerHost())));
+                JobUtils.unBox(job.getParameters().getThreadPerHost()));
         this.addCheckBoxField(
                 3, ADD_QUERY_PARAM, JobUtils.unBox(job.getParameters().getAddQueryParam()));
         this.addCheckBoxField(


### PR DESCRIPTION
Use one as minimum threads instead of the default number of threads, otherwise it would not be possible to set less than the default through the dialogue.
Remove double unboxings, which were a noop.