### PR TITLE
network: use default sec random for Root CA cert

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configure the logging to prevent verbose log messages when using BC JSSE provider.
 - Improve error handling on client's unknown CA TLS alert.
 - Report available TLS providers when failed to query the TLS/SSL protocol versions.
+- Rely on the default secure random generator when creating the Root CA certificate to use the most appropriate defined by the security provider.
 
 ## [0.18.0] - 2024-09-24
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
@@ -340,7 +340,7 @@ public final class CertificateUtils {
      * @throws NoSuchAlgorithmException if no provider supports the used algorithms.
      */
     private static KeyPair generateKeyPair() throws NoSuchAlgorithmException {
-        SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+        SecureRandom random = new SecureRandom();
         random.setSeed(Long.toString(System.currentTimeMillis()).getBytes());
         KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
         keyGenerator.initialize(2048, random);


### PR DESCRIPTION
Rely on the default secure random generator when creating the Root CA certificate to use the most appropriate defined by the security provider.