### PR TITLE
ascanrulesBeta: fix NPE in username enumeration

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Address exception when scanning a message without path with Possible Username Enumeration scan rule.
 
 ## [56] - 2024-09-24
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeSet;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -69,11 +70,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin
                     CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG,
                     CommonAlertTag.WSTG_V42_IDNT_04_ACCOUNT_ENUMERATION);
 
-    private static ExtensionAuthentication extAuth =
-            (ExtensionAuthentication)
-                    Control.getSingleton()
-                            .getExtensionLoader()
-                            .getExtension(ExtensionAuthentication.NAME);
+    private ExtensionAuthentication extAuth;
 
     @Override
     public int getId() {
@@ -108,6 +105,11 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin
     @Override
     public void init() {
         LOGGER.debug("Initialising");
+
+        extAuth =
+                Control.getSingleton()
+                        .getExtensionLoader()
+                        .getExtension(ExtensionAuthentication.class);
 
         if (!shouldContinue(extAuth.getModel().getSession().getContexts())) {
             LOGGER.info(
@@ -153,7 +155,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin
                         && requestUri.getScheme().equals(loginUri.getScheme())
                         && requestUri.getHost().equals(loginUri.getHost())
                         && requestUri.getPort() == loginUri.getPort()
-                        && requestUri.getPath().equals(loginUri.getPath())) {
+                        && Objects.equals(requestUri.getPath(), loginUri.getPath())) {
                     // we got this far.. only the method (GET/POST), user details, query params,
                     // fragment, and POST params are possibly different from the login page.
                     loginUrl = true;

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRuleUnitTest.java
@@ -21,28 +21,61 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
 
+import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockSettings;
+import org.mockito.quality.Strictness;
+import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.authentication.FormBasedAuthenticationMethodType.FormBasedAuthenticationMethod;
+import org.zaproxy.zap.extension.authentication.ExtensionAuthentication;
+import org.zaproxy.zap.model.Context;
 
 class UsernameEnumerationScanRuleUnitTest extends ActiveScannerTest<UsernameEnumerationScanRule> {
 
+    private static final MockSettings LENIENT = withSettings().strictness(Strictness.LENIENT);
+
+    private ExtensionAuthentication extAuth;
+    private Session session;
+
     @Override
     protected UsernameEnumerationScanRule createScanner() {
+        Model model = mock(Model.class, LENIENT);
+        session = mock(Session.class, LENIENT);
+        given(model.getSession()).willReturn(session);
+
+        ExtensionLoader extensionLoader = mock(ExtensionLoader.class, LENIENT);
+        extAuth = mock(ExtensionAuthentication.class, LENIENT);
+        given(extAuth.getModel()).willReturn(model);
+        given(extensionLoader.getExtension(ExtensionAuthentication.class)).willReturn(extAuth);
+
+        Control.initSingletonForTesting(model, extensionLoader);
+
         return new UsernameEnumerationScanRule();
     }
 
-    @Disabled("Fails due to session/context involvement")
     @Override
     protected void shouldSendReasonableNumberOfMessages(
             AttackStrength strength, int maxNumberMessages, String defaultPath)
             throws HttpMalformedHeaderException {
-        // Disabled - Fails due to session/context involvement
+        contextWithLoginUrl(defaultPath);
+        super.shouldSendReasonableNumberOfMessages(strength, maxNumberMessages, defaultPath);
     }
 
     @Test
@@ -73,5 +106,65 @@ class UsernameEnumerationScanRuleUnitTest extends ActiveScannerTest<UsernameEnum
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_IDNT_04_ACCOUNT_ENUMERATION.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_IDNT_04_ACCOUNT_ENUMERATION.getValue())));
+    }
+
+    @Test
+    void shouldSkipIfNoContexts() throws Exception {
+        // Given
+        given(session.getContexts()).willReturn(List.of());
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        verify(parent).pluginSkipped(rule);
+    }
+
+    @Test
+    void shouldSkipIfNoContextsWithFormBasedAuthenticationMethod() throws Exception {
+        // Given
+        Context context = mock(Context.class);
+        given(session.getContexts()).willReturn(List.of(context));
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        verify(parent).pluginSkipped(rule);
+    }
+
+    @Test
+    void shouldNotScanIfLoginUrlDoesNotMatchMessage() throws Exception {
+        // Given
+        contextWithLoginUrl("/login");
+        HttpMessage msg = getHttpMessage("/not-login");
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(0));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    void shouldScanMessageWithoutPath() throws Exception {
+        // Given
+        contextWithLoginUrl("");
+        HttpMessage msg = getHttpMessage("");
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(0)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    private Context contextWithLoginUrl(String path) throws HttpMalformedHeaderException {
+        Context context = mock(Context.class);
+        FormBasedAuthenticationMethod authMethod = mock(FormBasedAuthenticationMethod.class);
+        given(context.getAuthenticationMethod()).willReturn(authMethod);
+        given(extAuth.getLoginRequestURIForContext(context))
+                .willReturn(getHttpMessage(path).getRequestHeader().getURI());
+        given(session.getContexts()).willReturn(List.of(context));
+        given(session.getContextsForUrl(anyString())).willReturn(List.of(context));
+        return context;
     }
 }


### PR DESCRIPTION
Check the URI paths taking into account that they might be null, for messages that don't have one.