### PR TITLE
client: fix exception with deleted messages

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -8,7 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.15.0.
 
 ### Added
-- Support for menu weights (Issue 8369)
+- Support for menu weights (Issue 8369).
+
+### Fixed
+- Address exception with deleted messages while handling client event.
 
 ## [0.8.0] - 2024-01-16
 ### Changed

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/pscan/ClientPassiveScanHelper.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/pscan/ClientPassiveScanHelper.java
@@ -53,7 +53,7 @@ public class ClientPassiveScanHelper {
         LOGGER.debug("Searching for history reference for {}", url);
         for (int i = lastId; i >= limit; i--) {
             HistoryReference hr = extHistory.getHistoryReference(i);
-            if (url.equals(hr.getURI().toString())) {
+            if (hr != null && url.equals(hr.getURI().toString())) {
                 LOGGER.debug("Found history reference {} for {}", hr.getHistoryId(), url);
                 Stats.incCounter("stats.client.pscan.href.found");
                 return hr;


### PR DESCRIPTION
Check that the message exists before checking its URI.