### PR TITLE
sequence: include responses when importing

### DIFF
--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceImportJob.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceImportJob.java
@@ -159,6 +159,7 @@ public class SequenceImportJob extends AutomationJob {
     private static CreateScriptOptions createScriptOptions(Parameters parameters) {
         CreateScriptOptions.Builder builder =
                 CreateScriptOptions.builder()
+                        .setIncludeResponses(CreateScriptOptions.IncludeResponses.ALWAYS)
                         .setAddStatusAssertion(JobUtils.unBox(parameters.getAssertCode()));
         Integer assertLengthValue = parameters.getAssertLength();
         if (assertLengthValue != null) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/CreateScriptOptions.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/CreateScriptOptions.java
@@ -31,16 +31,33 @@ public class CreateScriptOptions {
     /** The default options. */
     public static final CreateScriptOptions DEFAULT = builder().build();
 
+    /** When should the responses be included in the corresponding Zest requests. */
+    public enum IncludeResponses {
+        NEVER,
+        ALWAYS,
+        /**
+         * Uses the value defined in the global option.
+         *
+         * @see ZestParam#isIncludeResponses()
+         */
+        GLOBAL_OPTION,
+    }
+
     private final boolean addStatusAssertion;
     private final boolean addLengthAssertion;
     private final int lengthApprox;
+    private final IncludeResponses includeResponses;
 
     private CreateScriptOptions(
-            boolean addStatusAssertion, boolean addLengthAssertion, int lengthApprox) {
+            boolean addStatusAssertion,
+            boolean addLengthAssertion,
+            int lengthApprox,
+            IncludeResponses includeResponses) {
 
         this.addStatusAssertion = addStatusAssertion;
         this.addLengthAssertion = addLengthAssertion;
         this.lengthApprox = lengthApprox;
+        this.includeResponses = includeResponses;
     }
 
     public boolean isAddStatusAssertion() {
@@ -53,6 +70,10 @@ public class CreateScriptOptions {
 
     public int getLengthApprox() {
         return lengthApprox;
+    }
+
+    public IncludeResponses getIncludeResponses() {
+        return includeResponses;
     }
 
     /**
@@ -74,6 +95,7 @@ public class CreateScriptOptions {
         private boolean addStatusAssertion;
         private boolean addLengthAssertion;
         private int lengthApprox = 1;
+        private IncludeResponses includeResponses = IncludeResponses.GLOBAL_OPTION;
 
         private Builder() {}
 
@@ -124,12 +146,30 @@ public class CreateScriptOptions {
         }
 
         /**
+         * Sets the include responses option.
+         *
+         * <p>Default value: {@code GLOBAL_OPTION}.
+         *
+         * @param includeResponses the include responses option.
+         * @return the builder for chaining.
+         * @throws IllegalArgumentException if the given value is null.
+         */
+        public Builder setIncludeResponses(IncludeResponses includeResponses) {
+            if (includeResponses == null) {
+                throw new IllegalArgumentException("The include responses must not be null.");
+            }
+            this.includeResponses = includeResponses;
+            return this;
+        }
+
+        /**
          * Builds the options from the specified data.
          *
          * @return the options with specified data.
          */
         public final CreateScriptOptions build() {
-            return new CreateScriptOptions(addStatusAssertion, addLengthAssertion, lengthApprox);
+            return new CreateScriptOptions(
+                    addStatusAssertion, addLengthAssertion, lengthApprox, includeResponses);
         }
     }
 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -74,6 +74,7 @@ import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.zest.ZestResultsTableModel.ZestResultsTableEntry;
 import org.zaproxy.zap.extension.zest.dialogs.ZestDialogManager;
 import org.zaproxy.zap.extension.zest.menu.ZestMenuManager;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
 import org.zaproxy.zap.view.ZapToggleButton;
 import org.zaproxy.zest.core.v1.ZestActionFail;
 import org.zaproxy.zest.core.v1.ZestAssertion;
@@ -1920,6 +1921,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             throw new IllegalArgumentException("The messages should not be null nor empty.");
         }
 
+        ZestParam conversionOptions = getParam(options);
         ZestScript sz = new ZestScript();
         sz.setTitle(name);
         for (var msg : messages) {
@@ -1927,7 +1929,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
                 throw new IllegalArgumentException("A message should not be null.");
             }
             try {
-                var request = ZestZapUtils.toZestRequest(msg, false, true, getParam());
+                var request = ZestZapUtils.toZestRequest(msg, false, true, conversionOptions);
                 if (options.isAddStatusAssertion()) {
                     addStatusCodeAssertion(msg, request);
                 }
@@ -1955,6 +1957,22 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             throw new IllegalStateException("Failed to add the script: " + e.getMessage(), e);
         }
         return zsw;
+    }
+
+    private ZestParam getParam(CreateScriptOptions options) {
+        switch (options.getIncludeResponses()) {
+            case ALWAYS:
+            case NEVER:
+                ZestParam copy = new ZestParam(getParam());
+                copy.load(new ZapXmlConfiguration());
+                copy.setIncludeResponses(
+                        options.getIncludeResponses()
+                                == CreateScriptOptions.IncludeResponses.ALWAYS);
+                return copy;
+
+            default:
+                return getParam();
+        }
     }
 
     /**

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
@@ -101,6 +101,13 @@ public class ZestParam extends AbstractParam {
     /** Instantiates a new Zest param. */
     public ZestParam() {}
 
+    public ZestParam(ZestParam param) {
+        allHeaders.addAll(param.allHeaders);
+        ignoredHeaders.addAll(param.ignoredHeaders);
+        includeResponses = param.includeResponses;
+        scriptFormat = param.scriptFormat;
+    }
+
     @Override
     protected void parse() {
         this.includeResponses = getBoolean(INCLUDE_RESPONSES_KEY, true);

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/CreateScriptOptionsUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/CreateScriptOptionsUnitTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /** Unit test for {@link CreateScriptOptions}. */
@@ -39,6 +40,9 @@ class CreateScriptOptionsUnitTest {
         assertThat(options.isAddStatusAssertion(), is(equalTo(false)));
         assertThat(options.isAddLengthAssertion(), is(equalTo(false)));
         assertThat(options.getLengthApprox(), is(equalTo(1)));
+        assertThat(
+                options.getIncludeResponses(),
+                is(equalTo(CreateScriptOptions.IncludeResponses.GLOBAL_OPTION)));
     }
 
     @ParameterizedTest
@@ -84,5 +88,28 @@ class CreateScriptOptionsUnitTest {
                 assertThrows(IllegalArgumentException.class, () -> builder.setLengthApprox(value));
         // Then
         assertThat(ex.getMessage(), is(equalTo("The length must be zero or greater.")));
+    }
+
+    @ParameterizedTest
+    @EnumSource(CreateScriptOptions.IncludeResponses.class)
+    void shouldSetIncludeResponses(CreateScriptOptions.IncludeResponses value) {
+        // Given
+        var builder = CreateScriptOptions.builder();
+        // When
+        builder.setIncludeResponses(value);
+        // Then
+        assertThat(builder.build().getIncludeResponses(), is(equalTo(value)));
+    }
+
+    @Test
+    void shouldThrowSettingNullIncludeResponses() {
+        // Given
+        var builder = CreateScriptOptions.builder();
+        // When
+        Exception ex =
+                assertThrows(
+                        IllegalArgumentException.class, () -> builder.setIncludeResponses(null));
+        // Then
+        assertThat(ex.getMessage(), is(equalTo("The include responses must not be null.")));
     }
 }

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestParamUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestParamUnitTest.java
@@ -1,0 +1,58 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ZestParam}. */
+class ZestParamUnitTest {
+
+    @Test
+    void shouldCopyStateWithCopyConstructor() {
+        // Given
+        ZestParam original = new ZestParam();
+        original.load(new ZapXmlConfiguration());
+        original.setIgnoredHeaders(List.of("A", "B"));
+        original.setIncludeResponses(false);
+        original.setScriptFormat("YAML");
+        // When
+        ZestParam copy = new ZestParam(original);
+        // Then
+        assertEqualsNotSameInstance(copy.getIgnoredHeaders(), original.getIgnoredHeaders());
+        assertThat(copy.isIncludeResponses(), is(equalTo(original.isIncludeResponses())));
+        assertThat(copy.getScriptFormat(), is(equalTo(original.getScriptFormat())));
+        assertEqualsNotSameInstance(copy.getAllHeaders(), original.getAllHeaders());
+        assertThat(copy.getConfig(), is(nullValue()));
+    }
+
+    private static void assertEqualsNotSameInstance(Object actual, Object expected) {
+        assertThat(actual, is(equalTo(expected)));
+        assertThat(actual, is(not(sameInstance(expected))));
+    }
+}


### PR DESCRIPTION
Include the responses always as that's useful for verification of the assertions.