### PR TITLE
authhelper: address concurrency issue

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Address concurrency issue while passive scanning with the Session Management Response Identified scan rule (Issue 8187).
 
 ## [0.15.1] - 2024-09-02
 ### Changed


### PR DESCRIPTION
Use a synchronized map for the token map and sync the stream access to prevent concurrency exceptions.
Reduce accessibility of method that's only used for tests and remove the token directly.

Fix zaproxy/zaproxy#8187.