### PR TITLE
automation & sequence: fix use of default policies and set Sequence as default sequence policy

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Templates generated with `-autogenmin` or `-autogenmax` were invalid in some cases.
 - Allow to choose one thread for the `activeScan` job through the GUI.
+- Active Scan jobs will once again use the default policy if neither a policy nor a policyDefinition has been set.
 
 ## [0.43.0] - 2024-10-07
 ### Fixed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -98,10 +98,6 @@ public class ActiveScanJob extends AutomationJob {
                             params, this.parameters, this.getName(), null, progress);
                     break;
                 case "policyDefinition":
-                    // Parse the policy defn
-                    PolicyDefinition.parsePolicyDefinition(
-                            jobData.get(key), policyDefinition, this.getName(), progress);
-                    break;
                 case "name":
                 case "tests":
                 case "type":
@@ -115,7 +111,8 @@ public class ActiveScanJob extends AutomationJob {
                     break;
             }
         }
-
+        policyDefinition.parsePolicyDefinition(
+                jobData.get("policyDefinition"), this.getName(), progress);
         this.verifyUser(this.getParameters().getUser(), progress);
     }
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJob.java
@@ -86,8 +86,8 @@ public class ActiveScanPolicyJob extends AutomationJob {
                     break;
                 case "policyDefinition":
                     // Parse the policy defn
-                    PolicyDefinition.parsePolicyDefinition(
-                            jobData.get(key), policyDefinition, this.getName(), progress);
+                    policyDefinition.parsePolicyDefinition(
+                            jobData.get(key), this.getName(), progress);
                     break;
                 case "name":
                 case "tests":

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PolicyDefinition.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PolicyDefinition.java
@@ -31,7 +31,6 @@ import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.core.scanner.PluginFactory;
 import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationProgress;
-import org.zaproxy.addon.automation.jobs.PolicyDefinition.Rule;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
 
 @Getter
@@ -53,6 +52,11 @@ public class PolicyDefinition extends AutomationData {
         if (policyDefnObj instanceof LinkedHashMap<?, ?>) {
             LinkedHashMap<?, ?> policyDefnData = (LinkedHashMap<?, ?>) policyDefnObj;
 
+            if (policyDefnData.isEmpty()) {
+                policyDefinition.setDefaultStrength(null);
+                return;
+            }
+
             JobUtils.applyParamsToObject(
                     policyDefnData,
                     policyDefinition,
@@ -65,6 +69,7 @@ public class PolicyDefinition extends AutomationData {
             PluginFactory pluginFactory = scanPolicy.getPluginFactory();
 
             Object o = policyDefnData.get(RULES_ELEMENT_NAME);
+
             if (o instanceof ArrayList<?>) {
                 ArrayList<?> ruleData = (ArrayList<?>) o;
                 for (Object ruleObj : ruleData) {
@@ -118,6 +123,11 @@ public class PolicyDefinition extends AutomationData {
     }
 
     public ScanPolicy getScanPolicy(String jobName, AutomationProgress progress) {
+        if (getDefaultStrength() == null) {
+            // Nothing defined
+            return null;
+        }
+
         ScanPolicy scanPolicy = new ScanPolicy();
 
         // Set default strength

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
@@ -44,6 +44,8 @@ This job supports <a href="test-monitor.html">monitor</a> tests.
         threshold:                     # String: The Alert Threshold for this rule, one of Off, Low, Medium, High, default: Medium
 </pre>
 
+<strong>Note</strong>: Unless the <code>defaultThreshold</code> of the <code>policyDefinition</code> is <code>OFF</code> all rules will be enabled to start with.
+
 <p>
 The policy can be one defined by a previous <a href="job-ascanpolicy.html">activeScan-policy</a> job, or by a scan policy file
 that has been put in <code>policies</code> directory under ZAP's <a href="https://www.zaproxy.org/faq/what-is-the-default-directory-that-zap-uses/">HOME directory</a> .

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJobUnitTest.java
@@ -65,7 +65,7 @@ import org.zaproxy.zap.extension.ascan.ScanPolicy;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-class ActiveScanPolicyJobPolicyUnitTest {
+class ActiveScanPolicyJobUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
     private ExtensionActiveScan extAScan;

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `sequence-import` to import HARs as sequences.
   - `sequence-activeScan` to active scan sequences.
 - Data for reporting.
-- Sequence active scan policy.
 - Stats for import automation and active scan.
+- Sequence active scan policy which will be used if neither a policy nor policyDefinition are set.
 
 ### Changed
 - Update minimum ZAP version to 2.15.0.

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceActiveScanJob.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceActiveScanJob.java
@@ -117,10 +117,6 @@ public class SequenceActiveScanJob extends AutomationJob {
                             params, this.parameters, this.getName(), null, progress);
                     break;
                 case "policyDefinition":
-                    // Parse the policy defn
-                    policyDefinition.parsePolicyDefinition(
-                            jobData.get(key), policyDefinition, this.getName(), progress);
-                    break;
                 case "name":
                 case "tests":
                 case "type":
@@ -134,6 +130,8 @@ public class SequenceActiveScanJob extends AutomationJob {
                     break;
             }
         }
+        policyDefinition.parsePolicyDefinition(
+                jobData.get("policyDefinition"), this.getName(), progress);
 
         this.verifyUser(this.getParameters().getUser(), progress);
     }

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceActiveScanJob.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceActiveScanJob.java
@@ -70,6 +70,8 @@ public class SequenceActiveScanJob extends AutomationJob {
     private static final String PARAM_SEQUENCE = "sequence";
     private static final String PARAM_USER = "user";
 
+    private static final String DEFAULT_SEQ_POLICY = "Sequence";
+
     private final ExtensionActiveScan extAScan;
     private final ExtensionScript extScript;
 
@@ -116,7 +118,7 @@ public class SequenceActiveScanJob extends AutomationJob {
                     break;
                 case "policyDefinition":
                     // Parse the policy defn
-                    PolicyDefinition.parsePolicyDefinition(
+                    policyDefinition.parsePolicyDefinition(
                             jobData.get(key), policyDefinition, this.getName(), progress);
                     break;
                 case "name":
@@ -376,6 +378,6 @@ public class SequenceActiveScanJob extends AutomationJob {
         private String sequence = "";
         private String context = "";
         private String user = "";
-        private String policy = "";
+        private String policy = DEFAULT_SEQ_POLICY;
     }
 }

--- a/addOns/sequence/src/main/javahelp/org/zaproxy/zap/extension/sequence/resources/help/contents/automation.html
+++ b/addOns/sequence/src/main/javahelp/org/zaproxy/zap/extension/sequence/resources/help/contents/automation.html
@@ -31,7 +31,7 @@ The <code>sequence-activeScan</code> job allows you to active scan sequences.
       sequence:                                # String: The name of the sequence, or empty to active scan all sequences.
       context:                                 # String: Context to use when active scanning, default: first context.
       user:                                    # String: An optional user to use for authentication, must be defined in the env.
-      policy:                                  # String: Name of the scan policy to be used, default: Default Policy.
+      policy:                                  # String: Name of the scan policy to be used, default: Sequence.
     policyDefinition:                          # The policy definition - only used if the 'policy' is not set
       defaultStrength:                         # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                        # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
@@ -56,6 +56,8 @@ The <code>sequence-activeScan</code> job allows you to active scan sequences.
         otherInfo:                             # String: Addional information corresponding to the alert, optional
         onFail: 'info'                         # String: One of 'warn', 'error', 'info', mandatory
 </pre>
+
+<strong>Note</strong>: Unless the <code>defaultThreshold</code> of the <code>policyDefinition</code> is <code>OFF</code> all rules will be enabled to start with.
 
 </BODY>
 </HTML>

--- a/addOns/sequence/src/main/resources/org/zaproxy/zap/extension/sequence/resources/sequence-activeScan-max.yaml
+++ b/addOns/sequence/src/main/resources/org/zaproxy/zap/extension/sequence/resources/sequence-activeScan-max.yaml
@@ -3,7 +3,7 @@
       sequence:                                # String: The name of the sequence, or empty to active scan all sequences.
       context:                                 # String: Context to use when active scanning, default: first context.
       user:                                    # String: An optional user to use for authentication, must be defined in the env.
-      policy:                                  # String: Name of the scan policy to be used, default: Default Policy.
+      policy:                                  # String: Name of the scan policy to be used, default: Sequence.
     policyDefinition:                          # The policy definition - only used if the 'policy' is not set
       defaultStrength:                         # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                        # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium


### PR DESCRIPTION
## Overview
Modify automation and sequence to properly build and use a policy from policyDefinition if present in the plan. If neither policy nor policyDefinition are defined fall back to `Default Policy` or `Sequence` respectively.

## Related Issues
n/a

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
