### PR TITLE
scripts: report indirect script errors in AF

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Report indirect script errors while the Automation Framework plans are running (Issue 8586).
+
 ### Changed
 - Fields with default or missing values are omitted for the `script` job in saved Automation Framework plans.
 

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -85,6 +85,7 @@ scripts.automation.error.inline.file = Job {0} Only one of Path or Inline should
 scripts.automation.error.loadDir.failed = Job {0} Failed to load script {1}: {2}
 scripts.automation.error.name.missing = Job {0} Script Name not specified
 scripts.automation.error.nofile = Cannot access source:  {0}
+scripts.automation.error.script = An error occurred with the script: {0}. Error: {1}
 scripts.automation.error.scriptEngineNotFound = Job {0} Script Engine: {1} not found
 scripts.automation.error.scriptError = Job {0} Error occurred during executing Script {1}: {2}
 scripts.automation.error.scriptNameIsNull = Job: {0} Script name is required, but not specified


### PR DESCRIPTION
Report errors that happen by scripts that are running in the background (e.g. HTTP Sender, passive/active rules) while the automation framework plans are running.

Fix zaproxy/zaproxy#8586.