### PR TITLE
Sequence - use new seq scan in desktop

### DIFF
--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.15.0.
 - Maintenance changes.
+- To use new sequence scan from the desktop.
 
 ## [7] - 2023-10-23
 ### Changed


### PR DESCRIPTION
## Overview
Switch to use the new seq ascan - it works better and is faster.
We should revisit the help at some point.

## Related Issues
https://github.com/zaproxy/zap-extensions/pull/5897 - mayneed to change to use this for the default policy

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
