### PR TITLE
Dev: make seq performance test testable

### DIFF
--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Sequence performance test to make it actually possible to test it using automation.
 
 ## [0.7.0] - 2024-10-07
 ### Added


### PR DESCRIPTION
## Overview

Added option to go back to previous steps.
Stopped it invalidating the seq as aggressively.
Moved the XSS vuln to an earlier page so that it happens while the seq is still valid.
Changed the number of steps - otherwise the spider stopped just short of invalidating the seq

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
