### PR TITLE
graphql: Support importing introspection responses

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
     - pg_graphql
     - tailcall
     - Hot Chocolate
+- Support for importing an introspection query response from a file (Issue 8569).
 
 ## [0.25.0] - 2024-09-24
 ### Changed

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -202,11 +202,14 @@ graphql.engine.wpgraphql.docsUrl = https://github.com/wp-graphql/wp-graphql
 graphql.engine.wpgraphql.name = WPGraphQL WordPress Plugin
 graphql.engine.wpgraphql.technologies = PHP
 
+graphql.error.emptySchema = The imported schema was empty.
 graphql.error.filenotfound = Cannot find the file:\n{0}
 graphql.error.import = Could not import the schema.\n{0}
 graphql.error.importfile = An error occurred while importing from file.
 graphql.error.introspection = Introspection failed for the specified endpoint.
+graphql.error.invalidJson = The imported schema was not valid JSON.
 graphql.error.invalidurl = Please enter a valid URL.\n{0}
+graphql.error.nullData = The "data" object in the imported schema was null.
 
 graphql.fingerprinting.alert.desc = The server is using "{0}", which is a GraphQL implementation for {1}.
 graphql.fingerprinting.alert.name = GraphQL Server Implementation Identified

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParserUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParserUnitTest.java
@@ -20,10 +20,12 @@
 package org.zaproxy.addon.graphql;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
@@ -101,5 +103,21 @@ class GraphQlParserUnitTest extends TestUtils {
         assertThat(alert.getValue().getPluginId(), is(ExtensionGraphQl.TOOL_ALERT_ID));
         assertThat(alert.getValue().getAlertRef(), is(ExtensionGraphQl.TOOL_ALERT_ID + "-1"));
         assertThat(alert.getValue().getName(), is("!graphql.introspection.alert.name!"));
+    }
+
+    @Test
+    void shouldImportIntrospectionResponse() throws Exception {
+        // Given
+        GraphQlParser gqp = spy(new GraphQlParser(endpointUrl));
+        var schemaCaptor = ArgumentCaptor.forClass(String.class);
+        String expectedSchema =
+                "type Query {\n"
+                        + "  searchSongsByLyrics(lyrics: String = \"Never gonna give you up\"): String\n"
+                        + "}";
+        // When
+        gqp.importFile(getResourcePath("introspectionResponse.json").toString());
+        // Then
+        verify(gqp).parse(schemaCaptor.capture());
+        assertThat(schemaCaptor.getValue(), containsString(expectedSchema));
     }
 }

--- a/addOns/graphql/src/test/resources/org/zaproxy/addon/graphql/introspectionResponse.json
+++ b/addOns/graphql/src/test/resources/org/zaproxy/addon/graphql/introspectionResponse.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "fields": [
+            {
+              "name": "searchSongsByLyrics",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              },
+              "args": [
+                {
+                  "name": "lyrics",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  },
+                  "defaultValue": "\"Never gonna give you up\""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Add support for importing an introspection query response from a file.

## Related Issues
Closes zaproxy/zaproxy#8569.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
