### PR TITLE
sequence & callhome: Add sequence automation stats

### DIFF
--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Network stats to telemetry.
+- Sequence stats to telemetry.
 
 ## [0.13.0] - 2024-09-02
 ### Added

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
@@ -306,6 +306,7 @@ public class ExtensionCallHome extends ExtensionAdaptor
                     || key.startsWith("stats.reports.")
                     || key.startsWith("stats.script.")
                     || key.startsWith("stats.selenium.")
+                    || key.startsWith("stats.sequence.")
                     || key.startsWith("stats.spider.")
                     || key.startsWith("stats.tech.")
                     || key.startsWith("stats.ui.")

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `sequence-activeScan` to active scan sequences.
 - Data for reporting.
 - Sequence active scan policy.
+- Stats for import automation and active scan.
 
 ### Changed
 - Update minimum ZAP version to 2.15.0.

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/ExtensionSequenceAutomation.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/ExtensionSequenceAutomation.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.extension.zest.ExtensionZest;
 public class ExtensionSequenceAutomation extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionSequenceAutomation";
+    public static final String STATS_PREFIX = "stats.sequence.automation.";
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
             List.of(ExtensionAutomation.class, ExtensionExim.class, ExtensionSequence.class);

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceActiveScanJob.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceActiveScanJob.java
@@ -55,6 +55,7 @@ import org.zaproxy.zap.extension.sequence.StdActiveScanRunner;
 import org.zaproxy.zap.extension.sequence.StdActiveScanRunner.SequenceStepData;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.users.User;
+import org.zaproxy.zap.utils.Stats;
 
 public class SequenceActiveScanJob extends AutomationJob {
 
@@ -255,6 +256,8 @@ public class SequenceActiveScanJob extends AutomationJob {
                 new StdActiveScanRunner(
                         script, contextWrapper.getContext(), user, contextSpecificObjects);
 
+        Stats.incCounter(ExtensionSequenceAutomation.STATS_PREFIX + "ascan.scan");
+
         try {
             zzr.run(null, null);
             ascans.put(script.getName(), zzr.getSteps());
@@ -264,6 +267,7 @@ public class SequenceActiveScanJob extends AutomationJob {
                     Constant.messages.getString(
                             "automation.error.unexpected.internal", e.getMessage()));
             LOGGER.error(e.getMessage(), e);
+            Stats.incCounter(ExtensionSequenceAutomation.STATS_PREFIX + "ascan.exception");
         }
         return List.of();
     }

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceImportJob.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceImportJob.java
@@ -46,6 +46,7 @@ import org.zaproxy.addon.exim.ImporterResult;
 import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.zest.CreateScriptOptions;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
+import org.zaproxy.zap.utils.Stats;
 
 public class SequenceImportJob extends AutomationJob {
 
@@ -129,16 +130,18 @@ public class SequenceImportJob extends AutomationJob {
 
         result.getErrors()
                 .forEach(
-                        error ->
-                                progress.error(
-                                        Constant.messages.getString(
-                                                "sequence.automation.import.error",
-                                                getName(),
-                                                error)));
+                        error -> {
+                            progress.error(
+                                    Constant.messages.getString(
+                                            "sequence.automation.import.error", getName(), error));
+                            Stats.incCounter(
+                                    ExtensionSequenceAutomation.STATS_PREFIX + "import.error");
+                        });
         if (result.getCount() == 0) {
             progress.warn(
                     Constant.messages.getString(
                             "sequence.automation.import.nomessages", getName(), result.getCount()));
+            Stats.incCounter(ExtensionSequenceAutomation.STATS_PREFIX + "import.nomessages");
             return;
         }
 
@@ -149,10 +152,15 @@ public class SequenceImportJob extends AutomationJob {
                             "sequence.automation.import.sequencecreated",
                             getName(),
                             result.getCount()));
+            Stats.incCounter(ExtensionSequenceAutomation.STATS_PREFIX + "import");
+            Stats.incCounter(
+                    ExtensionSequenceAutomation.STATS_PREFIX + "import.messages",
+                    result.getCount());
         } catch (Exception e) {
             progress.error(
                     Constant.messages.getString(
                             "sequence.automation.import.script.error", getName(), e.getMessage()));
+            Stats.incCounter(ExtensionSequenceAutomation.STATS_PREFIX + "import.script.error");
         }
     }
 


### PR DESCRIPTION
## Overview
- CHANGELOGs > Added notes.
- ExtensionCallHome > Add stats key for telemetry.
- SequenceActiveScanJob > Add stats counters.
- StdActiveScanRunner > Add stats counters.
- SequenceImportJob > Add stats counters.

## Related Issues
N/A

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [na] Write tests
- [na] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
