### PR TITLE
zest: use values from responses in added scripts

### DIFF
--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/CreateScriptOptions.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/CreateScriptOptions.java
@@ -47,17 +47,20 @@ public class CreateScriptOptions {
     private final boolean addLengthAssertion;
     private final int lengthApprox;
     private final IncludeResponses includeResponses;
+    private final boolean replaceRequestValues;
 
     private CreateScriptOptions(
             boolean addStatusAssertion,
             boolean addLengthAssertion,
             int lengthApprox,
-            IncludeResponses includeResponses) {
+            IncludeResponses includeResponses,
+            boolean replaceRequestValues) {
 
         this.addStatusAssertion = addStatusAssertion;
         this.addLengthAssertion = addLengthAssertion;
         this.lengthApprox = lengthApprox;
         this.includeResponses = includeResponses;
+        this.replaceRequestValues = replaceRequestValues;
     }
 
     public boolean isAddStatusAssertion() {
@@ -74,6 +77,10 @@ public class CreateScriptOptions {
 
     public IncludeResponses getIncludeResponses() {
         return includeResponses;
+    }
+
+    public boolean isReplaceRequestValues() {
+        return replaceRequestValues;
     }
 
     /**
@@ -96,6 +103,7 @@ public class CreateScriptOptions {
         private boolean addLengthAssertion;
         private int lengthApprox = 1;
         private IncludeResponses includeResponses = IncludeResponses.GLOBAL_OPTION;
+        private boolean replaceRequestValues = true;
 
         private Builder() {}
 
@@ -163,13 +171,34 @@ public class CreateScriptOptions {
         }
 
         /**
+         * Sets whether or not the request values should be automatically replaced.
+         *
+         * <p>Values present in later requests that are found in earlier responses are automatically
+         * replaced (e.g. anti-CSRF token).
+         *
+         * <p>Default value: {@code true}.
+         *
+         * @param replaceRequestValues {@code true} if the values should be replaced, {@code false}
+         *     otherwise.
+         * @return the builder for chaining.
+         */
+        public Builder setReplaceRequestValues(boolean replaceRequestValues) {
+            this.replaceRequestValues = replaceRequestValues;
+            return this;
+        }
+
+        /**
          * Builds the options from the specified data.
          *
          * @return the options with specified data.
          */
         public final CreateScriptOptions build() {
             return new CreateScriptOptions(
-                    addStatusAssertion, addLengthAssertion, lengthApprox, includeResponses);
+                    addStatusAssertion,
+                    addLengthAssertion,
+                    lengthApprox,
+                    includeResponses,
+                    replaceRequestValues);
         }
     }
 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -73,6 +73,9 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.zest.ZestResultsTableModel.ZestResultsTableEntry;
 import org.zaproxy.zap.extension.zest.dialogs.ZestDialogManager;
+import org.zaproxy.zap.extension.zest.internal.DefaultRequestValueReplacer;
+import org.zaproxy.zap.extension.zest.internal.NoopRequestValueReplacer;
+import org.zaproxy.zap.extension.zest.internal.RequestValueReplacer;
 import org.zaproxy.zap.extension.zest.menu.ZestMenuManager;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 import org.zaproxy.zap.view.ZapToggleButton;
@@ -1924,12 +1927,16 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
         ZestParam conversionOptions = getParam(options);
         ZestScript sz = new ZestScript();
         sz.setTitle(name);
+        RequestValueReplacer requestValueReplacer =
+                options.isReplaceRequestValues()
+                        ? new DefaultRequestValueReplacer(getModel().getSession())
+                        : NoopRequestValueReplacer.getInstance();
         for (var msg : messages) {
             if (msg == null) {
                 throw new IllegalArgumentException("A message should not be null.");
             }
             try {
-                var request = ZestZapUtils.toZestRequest(msg, false, true, conversionOptions);
+                ZestRequest request = requestValueReplacer.process(sz, msg, conversionOptions);
                 if (options.isAddStatusAssertion()) {
                     addStatusCodeAssertion(msg, request);
                 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/DefaultRequestValueReplacer.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/DefaultRequestValueReplacer.java
@@ -1,0 +1,219 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest.internal;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.htmlparser.jericho.Element;
+import net.htmlparser.jericho.HTMLElementName;
+import net.htmlparser.jericho.Source;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.zest.ZestParam;
+import org.zaproxy.zap.extension.zest.ZestZapUtils;
+import org.zaproxy.zap.model.DefaultNameValuePair;
+import org.zaproxy.zap.model.NameValuePair;
+import org.zaproxy.zap.model.ParameterParser;
+import org.zaproxy.zest.core.v1.ZestAssignFieldValue;
+import org.zaproxy.zest.core.v1.ZestFieldDefinition;
+import org.zaproxy.zest.core.v1.ZestRequest;
+import org.zaproxy.zest.core.v1.ZestScript;
+
+public class DefaultRequestValueReplacer implements RequestValueReplacer {
+
+    private static final Logger LOGGER = LogManager.getLogger(DefaultRequestValueReplacer.class);
+
+    private final Session session;
+    private final Map<String, Map<String, ValueSource>> values;
+
+    private int messageCount;
+    private String rawUrl;
+
+    public DefaultRequestValueReplacer(Session session) {
+        this.session = session;
+        values = new HashMap<>();
+    }
+
+    @Override
+    public ZestRequest process(ZestScript script, HttpMessage message, ZestParam conversionOptions)
+            throws IOException, SQLException {
+        replaceValues(script, message);
+        extractVariables(script, message);
+
+        ZestRequest request = ZestZapUtils.toZestRequest(message, false, true, conversionOptions);
+        if (rawUrl != null) {
+            request.setUrl(null);
+            request.setUrlToken(rawUrl);
+
+            rawUrl = null;
+        }
+        return request;
+    }
+
+    private void replaceValues(ZestScript script, HttpMessage message) {
+        if (values.isEmpty()) {
+            return;
+        }
+
+        Set<ValueSource> usedValues = new HashSet<>();
+        String url = message.getRequestHeader().getURI().toString();
+        replaceQueryValues(session.getUrlParamParser(url), message, usedValues);
+        replaceBodyValues(session.getFormParamParser(url), message, usedValues);
+
+        usedValues.forEach(
+                e -> {
+                    ZestFieldDefinition fd = new ZestFieldDefinition();
+                    fd.setFormIndex(e.getFormIndex());
+                    fd.setFieldName(e.getName());
+
+                    ZestAssignFieldValue fv = new ZestAssignFieldValue();
+                    fv.setVariableName(e.getVarName());
+                    fv.setFieldDefinition(fd);
+
+                    script.add(fv);
+                });
+    }
+
+    private void replaceQueryValues(
+            ParameterParser parser, HttpMessage message, Set<ValueSource> usedValues) {
+        URI uri = message.getRequestHeader().getURI();
+        List<NameValuePair> parameters = parser.parseRawParameters(uri.getEscapedQuery());
+        if (parameters.isEmpty()) {
+            return;
+        }
+
+        String result = replaceValues(usedValues, parser, parameters);
+
+        try {
+            URI replacedUri = (URI) uri.clone();
+            replacedUri.setEscapedQuery(null);
+            rawUrl = replacedUri.toString() + "?" + result;
+        } catch (Exception e) {
+            LOGGER.error("An error occurred while creating the URI:", e);
+        }
+    }
+
+    private String replaceValues(
+            Set<ValueSource> usedValues, ParameterParser parser, List<NameValuePair> parameters) {
+        for (int i = 0; i < parameters.size(); i++) {
+            NameValuePair nvp = parameters.get(i);
+            Map<String, ValueSource> sources = values.get(nvp.getValue());
+            if (sources != null) {
+                String name = nvp.getName();
+                ValueSource source = sources.get(name);
+                if (source != null) {
+                    parameters.set(i, new DefaultNameValuePair(name, source.getVarToken()));
+                    usedValues.add(source);
+                }
+            }
+        }
+
+        return toString(parser, parameters);
+    }
+
+    private static String toString(ParameterParser parser, List<NameValuePair> parameters) {
+        StringBuilder data = new StringBuilder();
+
+        for (NameValuePair parameter : parameters) {
+            if (data.length() > 0) {
+                data.append(parser.getDefaultKeyValuePairSeparator());
+            }
+
+            data.append(parameter.getName());
+            data.append(parser.getDefaultKeyValueSeparator());
+            data.append(parameter.getValue());
+        }
+
+        return data.toString();
+    }
+
+    private void replaceBodyValues(
+            ParameterParser parser, HttpMessage message, Set<ValueSource> usedValues) {
+        List<NameValuePair> parameters =
+                parser.parseRawParameters(message.getRequestBody().toString());
+        if (parameters.isEmpty()) {
+            return;
+        }
+
+        String result = replaceValues(usedValues, parser, parameters);
+
+        message.setRequestBody(result);
+    }
+
+    private void extractVariables(ZestScript sz, HttpMessage message) {
+        messageCount++;
+        values.clear();
+
+        List<Element> formElements =
+                new Source(message.getResponseBody().toString())
+                        .getAllElements(HTMLElementName.FORM);
+        if (formElements.isEmpty()) {
+            return;
+        }
+
+        for (int formIndex = 0; formIndex < formElements.size(); formIndex++) {
+            Element formElement = formElements.get(formIndex);
+            List<Element> inputElements = formElement.getAllElements(HTMLElementName.INPUT);
+            if (inputElements.isEmpty()) {
+                continue;
+            }
+
+            for (Element inputElement : inputElements) {
+                String value = inputElement.getAttributeValue("VALUE");
+                if (StringUtils.isEmpty(value)) {
+                    continue;
+                }
+
+                String name = inputElement.getAttributeValue("NAME");
+                if (!StringUtils.isBlank(name)) {
+                    String varName = "Msg" + messageCount + "Form" + formIndex + "Field" + name;
+                    String varToken =
+                            sz.getParameters().getTokenStart()
+                                    + varName
+                                    + sz.getParameters().getTokenEnd();
+                    values.computeIfAbsent(value, e -> new HashMap<>())
+                            .put(name, new ValueSource(varName, varToken, formIndex, name, value));
+                }
+            }
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class ValueSource {
+
+        private final String varName;
+        private final String varToken;
+        private final int formIndex;
+        private final String name;
+        private final String value;
+    }
+}

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/NoopRequestValueReplacer.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/NoopRequestValueReplacer.java
@@ -1,0 +1,50 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest.internal;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.zest.ZestParam;
+import org.zaproxy.zap.extension.zest.ZestZapUtils;
+import org.zaproxy.zest.core.v1.ZestRequest;
+import org.zaproxy.zest.core.v1.ZestScript;
+
+public final class NoopRequestValueReplacer implements RequestValueReplacer {
+
+    private static final RequestValueReplacer INSTANCE = new NoopRequestValueReplacer();
+
+    private NoopRequestValueReplacer() {}
+
+    /**
+     * Gets the instance of the noop request value replacer.
+     *
+     * @return the instance, never {@code null}.
+     */
+    public static RequestValueReplacer getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public ZestRequest process(ZestScript script, HttpMessage message, ZestParam conversionOptions)
+            throws IOException, SQLException {
+        return ZestZapUtils.toZestRequest(message, false, true, conversionOptions);
+    }
+}

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/RequestValueReplacer.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/RequestValueReplacer.java
@@ -1,0 +1,33 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest.internal;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.zest.ZestParam;
+import org.zaproxy.zest.core.v1.ZestRequest;
+import org.zaproxy.zest.core.v1.ZestScript;
+
+public interface RequestValueReplacer {
+
+    ZestRequest process(ZestScript sz, HttpMessage msg, ZestParam conversionOptions)
+            throws IOException, SQLException;
+}

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/CreateScriptOptionsUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/CreateScriptOptionsUnitTest.java
@@ -43,6 +43,7 @@ class CreateScriptOptionsUnitTest {
         assertThat(
                 options.getIncludeResponses(),
                 is(equalTo(CreateScriptOptions.IncludeResponses.GLOBAL_OPTION)));
+        assertThat(options.isReplaceRequestValues(), is(equalTo(true)));
     }
 
     @ParameterizedTest
@@ -111,5 +112,16 @@ class CreateScriptOptionsUnitTest {
                         IllegalArgumentException.class, () -> builder.setIncludeResponses(null));
         // Then
         assertThat(ex.getMessage(), is(equalTo("The include responses must not be null.")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetReplaceRequestValues(boolean value) {
+        // Given
+        var builder = CreateScriptOptions.builder();
+        // When
+        builder.setReplaceRequestValues(value);
+        // Then
+        assertThat(builder.build().isReplaceRequestValues(), is(equalTo(value)));
     }
 }

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/internal/DefaultRequestValueReplacerUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/internal/DefaultRequestValueReplacerUnitTest.java
@@ -1,0 +1,138 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.zest.ZestParam;
+import org.zaproxy.zap.model.ParameterParser;
+import org.zaproxy.zap.model.StandardParameterParser;
+import org.zaproxy.zest.core.v1.ZestAssignFieldValue;
+import org.zaproxy.zest.core.v1.ZestFieldDefinition;
+import org.zaproxy.zest.core.v1.ZestRequest;
+import org.zaproxy.zest.core.v1.ZestScript;
+import org.zaproxy.zest.core.v1.ZestVariables;
+
+/** Unit test for {@link DefaultRequestValueReplacer}. */
+class DefaultRequestValueReplacerUnitTest {
+
+    private Session session;
+    private ZestScript script;
+    private ZestParam conversionOptions;
+
+    private RequestValueReplacer replacer;
+
+    @BeforeEach
+    void setup() {
+        session = mock(Session.class);
+        ParameterParser parser = new StandardParameterParser();
+        given(session.getUrlParamParser(anyString())).willReturn(parser);
+        given(session.getFormParamParser(anyString())).willReturn(parser);
+
+        script = mock(ZestScript.class);
+        ZestVariables parameters = mock();
+        given(script.getParameters()).willReturn(parameters);
+        given(parameters.getTokenStart()).willReturn("{{");
+        given(parameters.getTokenEnd()).willReturn("}}");
+
+        conversionOptions = mock(ZestParam.class);
+
+        replacer = new DefaultRequestValueReplacer(session);
+    }
+
+    @Test
+    void shouldReplaceFollowingQueryRequestValuesWithPreviousFormFields() throws Exception {
+        // Given
+        List<HttpMessage> messages = new ArrayList<>();
+        HttpMessage msgStep1 = createHttpMessageWithForm();
+        messages.add(msgStep1);
+        HttpMessage msgStep2 = createHttpMessage();
+        msgStep2.getRequestHeader().getURI().setEscapedQuery("a=token&x=UserValue&c=");
+        messages.add(msgStep2);
+        // When
+        replacer.process(script, msgStep1, conversionOptions);
+        ZestRequest request = replacer.process(script, msgStep2, conversionOptions);
+        /// Then
+        ArgumentCaptor<ZestAssignFieldValue> argCaptor =
+                ArgumentCaptor.forClass(ZestAssignFieldValue.class);
+        verify(script).add(argCaptor.capture());
+        ZestAssignFieldValue fv = argCaptor.getValue();
+        assertThat(fv.getVariableName(), is(equalTo("Msg1Form0Fielda")));
+        ZestFieldDefinition fd = fv.getFieldDefinition();
+        assertThat(fd.getFormIndex(), is(equalTo(0)));
+        assertThat(fd.getFieldName(), is(equalTo("a")));
+        assertThat(
+                request.getUrlToken(),
+                is(equalTo("http://example.com?a={{Msg1Form0Fielda}}&x=UserValue&c=")));
+    }
+
+    @Test
+    void shouldReplaceFollowingBodyRequestValuesWithPreviousFormFields() throws Exception {
+        // Given
+        List<HttpMessage> messages = new ArrayList<>();
+        HttpMessage msgStep1 = createHttpMessageWithForm();
+        messages.add(msgStep1);
+        HttpMessage msgStep2 = createHttpMessage();
+        msgStep2.setRequestBody("a=token&x=UserValue&c=");
+        messages.add(msgStep2);
+        // When
+        replacer.process(script, msgStep1, conversionOptions);
+        replacer.process(script, msgStep2, conversionOptions);
+        /// Then
+        ArgumentCaptor<ZestAssignFieldValue> argCaptor =
+                ArgumentCaptor.forClass(ZestAssignFieldValue.class);
+        verify(script).add(argCaptor.capture());
+        ZestAssignFieldValue fv = argCaptor.getValue();
+        assertThat(fv.getVariableName(), is(equalTo("Msg1Form0Fielda")));
+        ZestFieldDefinition fd = fv.getFieldDefinition();
+        assertThat(fd.getFormIndex(), is(equalTo(0)));
+        assertThat(fd.getFieldName(), is(equalTo("a")));
+        assertThat(
+                msgStep2.getRequestBody().toString(),
+                is(equalTo("a={{Msg1Form0Fielda}}&x=UserValue&c=")));
+    }
+
+    private static HttpMessage createHttpMessageWithForm() throws Exception {
+        HttpMessage message = createHttpMessage();
+        message.setResponseBody(
+                "<form><input type='hidden' name='a' value='token' /> <input type='text' name='x' value='y' /> <input type='text' name='c' value='' /> </form>");
+        return message;
+    }
+
+    private static HttpMessage createHttpMessage() throws Exception {
+        HttpMessage msg = new HttpMessage(new URI("http://example.com", true));
+        msg.setResponseHeader("HTTP/1.1 200 OK");
+        return msg;
+    }
+}


### PR DESCRIPTION
Replace values in the request (query/body) that were found in the previous response's form fields.