### PR TITLE
sequence: provide alert result data

### DIFF
--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- Add `sequence-import` Automation Framework job.
-- Initial sequence-activeScan implementation.
+- Add Automation Framework jobs:
+  - `sequence-import` to import HARs as sequences.
+  - `sequence-activeScan` to active scan sequences.
 - Data for reporting.
 - Sequence active scan policy.
 

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceAScanJobResultData.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceAScanJobResultData.java
@@ -20,17 +20,30 @@
 package org.zaproxy.zap.extension.sequence.automation;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.Getter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.db.RecordAlert;
+import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.automation.JobResultData;
 import org.zaproxy.zap.extension.sequence.StdActiveScanRunner.SequenceStepData;
 
 @Getter
 public class SequenceAScanJobResultData extends JobResultData {
 
+    private static final Logger LOGGER = LogManager.getLogger(SequenceAScanJobResultData.class);
+
     public static final String KEY = "seqAScanData";
 
     private List<SequenceData> seqData = new ArrayList<>();
+    private Map<Integer, Alert> alertDataMap;
 
     public SequenceAScanJobResultData(String jobName) {
         super(jobName);
@@ -43,6 +56,42 @@ public class SequenceAScanJobResultData extends JobResultData {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public Alert getAlertData(int alertId) {
+        return getAlertDataMap().get(alertId);
+    }
+
+    @Override
+    public Collection<Alert> getAllAlertData() {
+        return getAlertDataMap().values();
+    }
+
+    private Map<Integer, Alert> getAlertDataMap() {
+        if (alertDataMap == null) {
+            Map<Integer, Alert> data = new HashMap<Integer, Alert>();
+            seqData.forEach(
+                    sequenceData ->
+                            sequenceData.getSteps().forEach(step -> addStepAlerts(data, step)));
+
+            alertDataMap = Collections.unmodifiableMap(data);
+        }
+        return alertDataMap;
+    }
+
+    private static void addStepAlerts(Map<Integer, Alert> data, SequenceStepData step) {
+        List<Integer> alertIds = step.getAlertIds();
+        for (int id : alertIds) {
+            try {
+                RecordAlert recordAlert = Model.getSingleton().getDb().getTableAlert().read(id);
+                if (recordAlert != null) {
+                    data.put(id, new Alert(recordAlert));
+                }
+            } catch (DatabaseException e) {
+                LOGGER.error("Could not read alert with ID {} from the database:", id, e);
+            }
+        }
     }
 
     @Getter


### PR DESCRIPTION
Change the active scan job to provide alert result data for the alert tests.
Tweak the changelog as the active scan job is no longer just initial implementation.