### PR TITLE
ascanrulesBeta: Replace usage of CWE-200

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- The following scan rules now use more specific CWE IDs:
+    - Proxy Disclosure (Issue 8713)
+    - Possible Username Enumeration (Issue 8715)
+
 ### Fixed
 - Address exception when scanning a message without path with Possible Username Enumeration scan rule.
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
@@ -784,7 +784,7 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin implements Common
 
     @Override
     public int getCweId() {
-        return 200; // Information Exposure (primarily via TRACE / OPTIONS / TRACK)
+        return 204; // Observable Response Discrepancy
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
@@ -745,7 +745,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin
 
     @Override
     public int getCweId() {
-        return 200; // CWE-200: Information Exposure
+        return 204; // CWE-204: Observable Response Discrepancy
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRuleUnitTest.java
@@ -41,7 +41,7 @@ class ProxyDisclosureScanRuleUnitTest extends ActiveScannerTest<ProxyDisclosureS
         int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
+        assertThat(cwe, is(equalTo(204)));
         assertThat(wasc, is(equalTo(45)));
         assertThat(tags.size(), is(equalTo(2)));
         assertThat(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRuleUnitTest.java
@@ -85,7 +85,7 @@ class UsernameEnumerationScanRuleUnitTest extends ActiveScannerTest<UsernameEnum
         int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
+        assertThat(cwe, is(equalTo(204)));
         assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- Scan rules > In both cases CWE-200 was replaced with CWE-204 "Observable Response Discrepancy".
- Unit Tests > Updated to assert the new CWE ID.

## Related Issues
- Fixes zaproxy/zaproxy#8713
- Fixes zaproxy/zaproxy#8715

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
