### PR TITLE
commonlib: Add PolicyTags

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependency updates.
 - Let the Value Generator add-on provide the custom values through this add-on (Issue 8016).
 
+### Added
+- Policy tags for use with scan rules and the new Scan Policies add-on.
+
 ## [1.28.0] - 2024-09-24
 ### Changed
 - Maintenance changes.

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/PolicyTag.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/PolicyTag.java
@@ -1,0 +1,46 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+/**
+ * Tags to be associated with standardized scan policies which will be distributed as an add-on.
+ *
+ * @since 1.29.0
+ */
+public enum PolicyTag {
+    DEV_CICD,
+    DEV_STD,
+    DEV_FULL,
+    QA_STD,
+    QA_FULL,
+    SEQUENCE,
+    API;
+
+    protected static final String PREFIX = "POLICY_";
+    private final String tag;
+
+    private PolicyTag() {
+        this.tag = PREFIX + this.name();
+    }
+
+    public String getTag() {
+        return this.tag;
+    }
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/PolicyTagUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/PolicyTagUnitTest.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.core.DescribedAs.describedAs;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class PolicyTagUnitTest {
+
+    @ParameterizedTest
+    @EnumSource(PolicyTag.class)
+    void shouldHaveAllTagsStartingWithPolicyyUnderscoreInCapsEnumNamesWithout(PolicyTag tag) {
+        // Given / When / Then
+        assertThat(
+                tag.getTag(),
+                describedAs(
+                        "Tag should start with expected prefix", is(startsWith(PolicyTag.PREFIX))));
+        assertThat(
+                tag.name(),
+                describedAs(
+                        "Enum element name should not start with prefix",
+                        not(startsWith(PolicyTag.PREFIX))));
+    }
+}


### PR DESCRIPTION
## Overview
- CHANGELOG > Add note.
- PolicyTags > New enum for use with rules and the scan policies add-on.
- PolicyTagsUnitTest > Unit test for the new tags enum.

## Related Issues
N/A

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
