### PR TITLE
pscan: set config always to the scan rules

### DIFF
--- a/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/ExtensionPassiveScan2.java
+++ b/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/ExtensionPassiveScan2.java
@@ -109,16 +109,16 @@ public class ExtensionPassiveScan2 extends ExtensionAdaptor {
                                         PassiveScanner scanner = (PassiveScanner) args[0];
                                         try {
                                             boolean added = scanRuleManager.add(scanner);
-                                            if (added
-                                                    && hasView()
-                                                    && scanner instanceof PluginPassiveScanner) {
+                                            if (added && scanner instanceof PluginPassiveScanner) {
                                                 PluginPassiveScanner pps =
                                                         (PluginPassiveScanner) scanner;
                                                 pps.setConfig(
                                                         getModel().getOptionsParam().getConfig());
-                                                getPolicyPanel()
-                                                        .getPassiveScanTableModel()
-                                                        .addScanner(pps);
+                                                if (hasView()) {
+                                                    getPolicyPanel()
+                                                            .getPassiveScanTableModel()
+                                                            .addScanner(pps);
+                                                }
                                             }
                                             return added;
 


### PR DESCRIPTION
Move the view check to the correct place to set the config to the scan rules always (headless and GUI).