### PR TITLE
SOAP: Add policy alert tags

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Depend on newer version of Common Library add-on (Issue 8016).
 - Fields with default or missing values are omitted for the `soap` job in saved Automation Framework plans.
 
+### Added
+- Standardized Scan Policy related alert tags on scan rules.
+
 ## [23] - 2024-05-07
 ### Changed
 - Update minimum ZAP version to 2.15.0.

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRule.java
@@ -24,6 +24,8 @@ import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPFault;
 import jakarta.xml.soap.SOAPMessage;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -41,6 +43,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.PolicyTag;
 
 /**
  * SOAP Action Spoofing Active scan rule
@@ -53,10 +56,23 @@ public class SOAPActionSpoofingActiveScanRule extends AbstractAppPlugin
     private static final String MESSAGE_PREFIX = "soap.soapactionspoofing.";
     private static final Logger LOGGER =
             LogManager.getLogger(SOAPActionSpoofingActiveScanRule.class);
-    private static final Map<String, String> ALERT_TAGS =
-            CommonAlertTag.toMap(
-                    CommonAlertTag.OWASP_2021_A03_INJECTION,
-                    CommonAlertTag.OWASP_2017_A01_INJECTION);
+    private static final Map<String, String> ALERT_TAGS;
+
+    static {
+        Map<String, String> alertTags =
+                new HashMap<>(
+                        CommonAlertTag.toMap(
+                                CommonAlertTag.OWASP_2021_A03_INJECTION,
+                                CommonAlertTag.OWASP_2017_A01_INJECTION));
+        alertTags.put(PolicyTag.API.getTag(), "");
+        alertTags.put(PolicyTag.DEV_CICD.getTag(), "");
+        alertTags.put(PolicyTag.DEV_STD.getTag(), "");
+        alertTags.put(PolicyTag.DEV_FULL.getTag(), "");
+        alertTags.put(PolicyTag.QA_STD.getTag(), "");
+        alertTags.put(PolicyTag.QA_FULL.getTag(), "");
+        alertTags.put(PolicyTag.SEQUENCE.getTag(), "");
+        ALERT_TAGS = Collections.unmodifiableMap(alertTags);
+    }
 
     public enum ResponseType {
         INVALID_FORMAT,

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRule.java
@@ -23,6 +23,8 @@ import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPMessage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
@@ -35,6 +37,7 @@ import org.parosproxy.paros.network.HttpBody;
 import org.parosproxy.paros.network.HttpMessage;
 import org.w3c.dom.NodeList;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.PolicyTag;
 
 /**
  * SOAP XML Injection Active scan rule
@@ -46,10 +49,23 @@ public class SOAPXMLInjectionActiveScanRule extends AbstractAppParamPlugin
 
     private static final String MESSAGE_PREFIX = "soap.soapxmlinjection.";
     private static final Logger LOGGER = LogManager.getLogger(SOAPXMLInjectionActiveScanRule.class);
-    private static final Map<String, String> ALERT_TAGS =
-            CommonAlertTag.toMap(
-                    CommonAlertTag.OWASP_2021_A03_INJECTION,
-                    CommonAlertTag.OWASP_2017_A01_INJECTION);
+    private static final Map<String, String> ALERT_TAGS;
+
+    static {
+        Map<String, String> alertTags =
+                new HashMap<>(
+                        CommonAlertTag.toMap(
+                                CommonAlertTag.OWASP_2021_A03_INJECTION,
+                                CommonAlertTag.OWASP_2017_A01_INJECTION));
+        alertTags.put(PolicyTag.API.getTag(), "");
+        alertTags.put(PolicyTag.DEV_CICD.getTag(), "");
+        alertTags.put(PolicyTag.DEV_STD.getTag(), "");
+        alertTags.put(PolicyTag.DEV_FULL.getTag(), "");
+        alertTags.put(PolicyTag.QA_STD.getTag(), "");
+        alertTags.put(PolicyTag.QA_FULL.getTag(), "");
+        alertTags.put(PolicyTag.SEQUENCE.getTag(), "");
+        ALERT_TAGS = Collections.unmodifiableMap(alertTags);
+    }
 
     @Override
     public int getId() {

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRuleTestCase.java
@@ -19,18 +19,25 @@
  */
 package org.zaproxy.zap.extension.soap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.PolicyTag;
 import org.zaproxy.zap.extension.soap.SOAPActionSpoofingActiveScanRule.ResponseType;
 
 class SOAPActionSpoofingActiveScanRuleTestCase {
 
     private HttpMessage originalMsg = new HttpMessage();
     private HttpMessage modifiedMsg = new HttpMessage();
+    private SOAPActionSpoofingActiveScanRule rule = new SOAPActionSpoofingActiveScanRule();
 
     @BeforeEach
     void setUp() throws HttpMalformedHeaderException {
@@ -66,5 +73,37 @@ class SOAPActionSpoofingActiveScanRuleTestCase {
         Sample.setInvalidFormatResponse(modifiedMsg);
         result = scanner.scanResponse(modifiedMsg, originalMsg);
         assertEquals(ResponseType.INVALID_FORMAT, result);
+    }
+
+    @Test
+    void shouldReturnExpectedMappings() {
+        // Given / When
+        int cwe = rule.getCweId();
+        int wasc = rule.getWascId();
+        Map<String, String> tags = rule.getAlertTags();
+        // Then
+        assertThat(cwe, is(equalTo(0)));
+        assertThat(wasc, is(equalTo(0)));
+        assertThat(tags.size(), is(equalTo(9)));
+
+        assertThat(
+                tags.containsKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
+                is(equalTo(true)));
+        assertThat(
+                tags.containsKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
+                is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.API.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.DEV_CICD.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.DEV_STD.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.DEV_FULL.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.QA_STD.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.QA_FULL.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.SEQUENCE.getTag()), is(equalTo(true)));
+        assertThat(
+                tags.get(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2021_A03_INJECTION.getValue())));
+        assertThat(
+                tags.get(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2017_A01_INJECTION.getValue())));
     }
 }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRuleTestCase.java
@@ -23,10 +23,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.PolicyTag;
 
 class SOAPXMLInjectionActiveScanRuleTestCase {
+
+    private SOAPXMLInjectionActiveScanRule rule = new SOAPXMLInjectionActiveScanRule();
 
     @Test
     void craftAttackMessageTest() throws Exception {
@@ -50,5 +55,37 @@ class SOAPXMLInjectionActiveScanRuleTestCase {
         assertThat(
                 actualMsg.getRequestBody().toString(),
                 is(equalTo(expectedMsg.getRequestBody().toString())));
+    }
+
+    @Test
+    void shouldReturnExpectedMappings() {
+        // Given / When
+        int cwe = rule.getCweId();
+        int wasc = rule.getWascId();
+        Map<String, String> tags = rule.getAlertTags();
+        // Then
+        assertThat(cwe, is(equalTo(0)));
+        assertThat(wasc, is(equalTo(0)));
+        assertThat(tags.size(), is(equalTo(9)));
+
+        assertThat(
+                tags.containsKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
+                is(equalTo(true)));
+        assertThat(
+                tags.containsKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
+                is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.API.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.DEV_CICD.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.DEV_STD.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.DEV_FULL.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.QA_STD.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.QA_FULL.getTag()), is(equalTo(true)));
+        assertThat(tags.containsKey(PolicyTag.SEQUENCE.getTag()), is(equalTo(true)));
+        assertThat(
+                tags.get(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2021_A03_INJECTION.getValue())));
+        assertThat(
+                tags.get(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2017_A01_INJECTION.getValue())));
     }
 }


### PR DESCRIPTION
## Overview
- CHANGELOG > Add note.
- Scan rules > Add PolicyTag values.
- Unit tests > Assert the new tags.

## Related Issues
- zaproxy/zap-extensions#5930

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
