### PR TITLE
Update Selenium library

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Depend on Passive Scanner add-on (Issue 7959).
+- Address deprecation warnings with newer Selenium version (4.27).
 
 ## [0.16.0] - 2024-11-06
 ### Fixed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -146,10 +146,10 @@ public class AuthUtils {
                 inputElements.stream()
                         .filter(
                                 elem ->
-                                        "text".equalsIgnoreCase(elem.getAttribute("type"))
+                                        "text".equalsIgnoreCase(elem.getDomAttribute("type"))
                                                 || "email"
                                                         .equalsIgnoreCase(
-                                                                elem.getAttribute("type")))
+                                                                elem.getDomAttribute("type")))
                         .collect(Collectors.toList());
 
         if (!filteredList.isEmpty()) {
@@ -161,27 +161,27 @@ public class AuthUtils {
                             || attributeContains(we, "name", USERNAME_FIELD_INDICATORS)) {
                         LOGGER.debug(
                                 "Choosing 'best' user field: name={} id={}",
-                                we.getAttribute("name"),
-                                we.getAttribute("id"));
+                                we.getDomAttribute("name"),
+                                we.getDomAttribute("id"));
                         return we;
                     }
                     LOGGER.debug(
                             "Not yet choosing user field: name={} id={}",
-                            we.getAttribute("name"),
-                            we.getAttribute("id"));
+                            we.getDomAttribute("name"),
+                            we.getDomAttribute("id"));
                 }
             }
             LOGGER.debug(
                     "Choosing first user field: name={} id={}",
-                    filteredList.get(0).getAttribute("name"),
-                    filteredList.get(0).getAttribute("id"));
+                    filteredList.get(0).getDomAttribute("name"),
+                    filteredList.get(0).getDomAttribute("id"));
             return filteredList.get(0);
         }
         return null;
     }
 
     static boolean attributeContains(WebElement we, String attribute, String[] strings) {
-        String att = we.getAttribute(attribute);
+        String att = we.getDomAttribute(attribute);
         if (att == null) {
             return false;
         }
@@ -196,7 +196,7 @@ public class AuthUtils {
 
     static WebElement getPasswordField(List<WebElement> inputElements) {
         for (WebElement element : inputElements) {
-            if ("password".equalsIgnoreCase(element.getAttribute("type"))) {
+            if ("password".equalsIgnoreCase(element.getDomAttribute("type"))) {
                 return element;
             }
         }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -108,7 +108,7 @@ class AuthUtilsUnitTest extends TestUtils {
 
         // Then
         assertThat(field, is(notNullValue()));
-        assertThat(field.getAttribute("type"), is(equalTo("text")));
+        assertThat(field.getDomAttribute("type"), is(equalTo("text")));
     }
 
     @Test
@@ -124,7 +124,7 @@ class AuthUtilsUnitTest extends TestUtils {
 
         // Then
         assertThat(field, is(notNullValue()));
-        assertThat(field.getAttribute("type"), is(equalTo("email")));
+        assertThat(field.getDomAttribute("type"), is(equalTo("email")));
     }
 
     @Test
@@ -141,7 +141,7 @@ class AuthUtilsUnitTest extends TestUtils {
 
         // Then
         assertThat(field, is(notNullValue()));
-        assertThat(field.getAttribute("id"), is(equalTo("email")));
+        assertThat(field.getDomAttribute("id"), is(equalTo("email")));
     }
 
     @Test
@@ -158,7 +158,7 @@ class AuthUtilsUnitTest extends TestUtils {
 
         // Then
         assertThat(field, is(notNullValue()));
-        assertThat(field.getAttribute("name"), is(equalTo("username")));
+        assertThat(field.getDomAttribute("name"), is(equalTo("username")));
     }
 
     @Test
@@ -189,7 +189,7 @@ class AuthUtilsUnitTest extends TestUtils {
 
         // Then
         assertThat(field, is(notNullValue()));
-        assertThat(field.getAttribute("type"), is(equalTo("password")));
+        assertThat(field.getDomAttribute("type"), is(equalTo("password")));
     }
 
     @Test
@@ -666,7 +666,7 @@ class AuthUtilsUnitTest extends TestUtils {
         }
 
         @Override
-        public String getAttribute(String name) {
+        public String getDomAttribute(String name) {
             switch (name) {
                 case "id":
                     return id;
@@ -677,6 +677,12 @@ class AuthUtilsUnitTest extends TestUtils {
                 default:
                     return null;
             }
+        }
+
+        @Override
+        @Deprecated
+        public String getAttribute(String name) {
+            return null;
         }
 
         @Override

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Address deprecation warnings with newer Selenium version (4.27).
 - Include the whole HTTP message in the raised alerts.
 - Include the steps to reproduce the DOM XSS in the other info of the alert.
 - Do not request URLs explicitly excluded from the context or global excludes

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -543,8 +543,8 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
             try {
                 // Save for the evidence
                 tagName = element.getTagName();
-                attributeId = element.getAttribute("id");
-                attributeName = element.getAttribute("name");
+                attributeId = element.getDomAttribute("id");
+                attributeName = element.getDomAttribute("name");
 
                 if (tagName.equals("input")) {
                     steps.add(
@@ -611,8 +611,8 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
             try {
                 // Save for the evidence
                 tagName = element.getTagName();
-                attributeId = element.getAttribute("id");
-                attributeName = element.getAttribute("name");
+                attributeId = element.getDomAttribute("id");
+                attributeName = element.getDomAttribute("name");
 
                 addClickStep(xpath);
                 element.click();

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update Selenium to version 4.26.0.
+- Update Selenium to version 4.27.0.
 
 ## [15.30.0] - 2024-09-24
 ### Changed

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -36,7 +36,7 @@ zapAddOn {
 }
 
 dependencies {
-    var seleniumVersion = "4.26.0"
+    var seleniumVersion = "4.27.0"
     selenium("org.seleniumhq.selenium:selenium-java:$seleniumVersion")
     selenium("org.seleniumhq.selenium:htmlunit3-driver:$seleniumVersion")
     implementation(libs.log4j.slf4j) {


### PR DESCRIPTION
Update Selenium library to version 4.27.0.
Address deprecation warnings in `authhelper` and `domxss`.