### PR TITLE
pscanrulesBeta: fix isolation scan rule isPage200 check

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix typo in log message.
+- Fix Insufficient Site Isolation scan rule check that filters responses based on whether a response is a success or not.
 
 ### Changed
 - Maintenance changes.

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
@@ -83,17 +83,13 @@ public class SiteIsolationScanRule extends PluginPassiveScanner
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-
-        // Specs don't state that errors pages should be excluded
-        // However, successful responses are associated to a resource
-        // that should be protected.
-        // Only consider HTTP Status code 2XX to avoid a False Positive
-        if (!HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode())
+        // Specs don't state that errors pages should be excluded. However, successful responses are
+        // associated to a resource that should be protected, while error pages are not. Therefore,
+        // only consider HTTP Status code 2XX to avoid a False Positive
+        if (HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode())
                 || getHelper().isPage200(msg)) {
-            return;
+            rules.forEach(s -> s.build(msg.getResponseHeader()).forEach(AlertBuilder::raise));
         }
-
-        rules.forEach(s -> s.build(msg.getResponseHeader()).forEach(AlertBuilder::raise));
     }
 
     @Override

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
@@ -34,7 +34,6 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -86,10 +85,11 @@ public class SiteIsolationScanRule extends PluginPassiveScanner
         // Specs don't state that errors pages should be excluded. However, successful responses are
         // associated to a resource that should be protected, while error pages are not. Therefore,
         // only consider HTTP Status code 2XX to avoid a False Positive
-        if (HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode())
-                || getHelper().isPage200(msg)) {
-            rules.forEach(s -> s.build(msg.getResponseHeader()).forEach(AlertBuilder::raise));
+        if (!getHelper().isSuccess(msg)) {
+            return;
         }
+
+        rules.forEach(s -> s.build(msg.getResponseHeader()).forEach(AlertBuilder::raise));
     }
 
     @Override

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRuleTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRuleTest.java
@@ -42,7 +42,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 200 OK\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -106,22 +105,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
         given(passiveScanData.isPage200(any())).willReturn(true);
-
-        // When
-        scanHttpResponseReceive(msg);
-
-        // Then
-        assertThat(alertsRaised, hasSize(0));
-    }
-
-    @Test
-    void shouldNotRaiseAlertGivenSiteIsNotIsolatedWhenFailureIdentifiedByCustomPage()
-            throws Exception {
-        // Given
-        HttpMessage msg = new HttpMessage();
-        msg.setRequestHeader("GET / HTTP/1.1");
-        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Content-Type: text/html");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRuleTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRuleTest.java
@@ -42,6 +42,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 200 OK\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -64,7 +65,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -84,7 +85,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(true);
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -104,13 +105,45 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(true);
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
 
         // Then
         assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    void shouldNotRaiseAlertGivenSiteIsNotIsolatedWhenSuccessNotIdentifiedByCustomPage()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Content-Type: text/html\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(false);
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    void shouldRaiseAlertGivenSiteIsNotIsolatedWhenSuccessIdentifiedByCustomPage()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 400 OK\r\n" + "Content-Type: text/html\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(3));
     }
 
     @Test
@@ -122,6 +155,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                 "HTTP/1.1 200 OK\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -144,6 +178,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-site\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -166,6 +201,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: unexpected\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -188,6 +224,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-SITE\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -211,6 +248,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: cross-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -225,6 +263,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 500 Internal Server Error\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -245,6 +284,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + ": *\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -263,6 +303,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Content-Type: application/xml\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -286,6 +327,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: unsafe-none\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -308,6 +350,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Content-Type: text/html;charset=utf-8\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -331,6 +374,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin-allow-popups\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -353,6 +397,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                 "HTTP/1.1 200 OK\r\n"
                         + "Content-Type: application/json\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -371,6 +416,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n" + "Cross-Origin-Resource-Policy: same-origin\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -390,6 +436,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "cross-origin-embedder-policy: require-corp;report-to=\"coep\"\r\n"
                         + "cross-origin-opener-policy: same-origin;report-to=\"coop\"\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin;report-to=\"corp\"\r\n");
+        given(passiveScanData.isSuccess(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRuleTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRuleTest.java
@@ -37,6 +37,25 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 
 class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule> {
     @Test
+    void shouldRaiseCorpAlertGivenSiteIsNotIsolated() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(true);
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(
+                alertsRaised.get(0).getParam(),
+                equalTo(SiteIsolationScanRule.CorpHeaderScanRule.HEADER));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo(""));
+    }
+
+    @Test
     void shouldNotRaiseAlertGivenSiteIsIsolated() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -96,6 +115,22 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
+    void shouldNotRaiseAlertGivenSiteIsNotIsolatedWhenFailureIdentifiedByCustomPage()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Content-Type: text/html");
+        given(passiveScanData.isPage200(any())).willReturn(false);
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
     void shouldRaiseCorpAlertGivenResponseDoesntSendCorpHeader() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -104,7 +139,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                 "HTTP/1.1 200 OK\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -149,7 +183,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: unexpected\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -172,7 +205,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-SITE\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -196,7 +228,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: cross-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -211,7 +242,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 500 Internal Server Error\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -232,7 +262,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + ": *\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -251,7 +280,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Content-Type: application/xml\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -275,7 +303,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: unsafe-none\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -298,7 +325,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Content-Type: text/html;charset=utf-8\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -322,7 +348,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin-allow-popups\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -345,7 +370,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                 "HTTP/1.1 200 OK\r\n"
                         + "Content-Type: application/json\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -364,7 +388,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n" + "Cross-Origin-Resource-Policy: same-origin\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -384,7 +407,6 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "cross-origin-embedder-policy: require-corp;report-to=\"coep\"\r\n"
                         + "cross-origin-opener-policy: same-origin;report-to=\"coop\"\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin;report-to=\"corp\"\r\n");
-        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);


### PR DESCRIPTION
## Overview
Fix a bug in the site isolation scan rule.

## Related Issues
https://github.com/zaproxy/zaproxy/issues/8735

## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
