### PR TITLE
scripts: Add Policy Tags to ScriptsActiveScanner

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Report indirect script errors while the Automation Framework plans are running (Issue 8586).
+- Standardized Policy Tags to the base Scripts Active Scanner.
 
 ### Changed
 - Fields with default or missing values are omitted for the `script` job in saved Automation Framework plans.
+- Depends on an updated version of the Common Library add-on.
 
 ## [45.7.0] - 2024-10-07
 ### Fixed

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -30,7 +30,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">=1.25.0")
+                    version.set(">=1.29.0")
                 }
             }
         }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScanner.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScanner.java
@@ -22,7 +22,10 @@ package org.zaproxy.zap.extension.scripts.scanrules;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -30,6 +33,7 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.PolicyTag;
 import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -45,6 +49,9 @@ public class ScriptsActiveScanner extends ActiveScriptHelper {
     private ScriptsCache<ActiveScript> cachedScripts;
 
     private static final Logger LOGGER = LogManager.getLogger(ScriptsActiveScanner.class);
+    private static final Map<String, String> POLICY_ALERT_TAGS =
+            Stream.of(PolicyTag.values())
+                    .collect(Collectors.toUnmodifiableMap(k -> k.getTag(), v -> ""));
 
     /**
      * A {@code Set} containing the scripts that do not implement {@code ActiveScript2}, to show an
@@ -251,5 +258,10 @@ public class ScriptsActiveScanner extends ActiveScriptHelper {
     @Override
     public int getWascId() {
         return 0;
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return POLICY_ALERT_TAGS;
     }
 }

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScannerUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptsActiveScannerUnitTest.java
@@ -49,6 +49,7 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.PolicyTag;
 import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.VariantFactory;
@@ -429,6 +430,16 @@ class ScriptsActiveScannerUnitTest extends TestUtils {
         verify(extensionScript, times(1)).handleScriptException(scriptWrapper1, exception);
         verify(script2, times(1)).scan(scriptsActiveScanner, message, name1, value1);
         verify(script2, times(1)).scan(scriptsActiveScanner, message, name2, value2);
+    }
+
+    @Test
+    void shouldHaveExpectedNumberOfAlertTags() {
+        // Given
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        int tagCount = scriptsActiveScanner.getAlertTags().size();
+        // Then
+        assertThat(tagCount, is(equalTo(PolicyTag.values().length)));
     }
 
     private <T> ScriptWrapper createScriptWrapper(T script, Class<T> scriptClass) throws Exception {


### PR DESCRIPTION
## Overview
- CHANGELOG > Add notes.
- scripts.gradle.kts > Newer commonlib dependency.
- ScriptsActiveScanner > Override getAlertTags method.
- ScriptsActiveScannerUnitTest> Add test for the new tags.

## Related Issues
- zaproxy/zap-extensions#5930

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
