### PR TITLE
Automation: added method for setting exit value

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Active scan policy job.
 - Add job to configure the active scanner, `activeScan-config`.
 - Allow to enable/disable jobs (Issue 5845).
+- Method to allow the user to set the exit code via a script.
 
 ### Changed
 - Updated automation framework documentation and templates for `activeScan` job to reflect changes to the default value of threadPerHost parameter

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -114,6 +114,8 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
 
     private AutomationPanel automationPanel;
 
+    private Integer exitOverride;
+
     public ExtensionAutomation() {
         super(NAME);
         setI18nPrefix(PREFIX);
@@ -696,11 +698,21 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
         }
 
         AutomationProgress progress = runAutomationFile(source);
-        if (progress == null || progress.hasErrors()) {
+        if (exitOverride != null) {
+            setExitStatus(exitOverride, "set by user", false);
+        } else if (progress == null || progress.hasErrors()) {
             setExitStatus(1, "plan errors", false);
         } else if (progress.hasWarnings()) {
             setExitStatus(2, "plan warnings", false);
         }
+    }
+
+    public Integer getExitOverride() {
+        return exitOverride;
+    }
+
+    public void setExitOverride(Integer exitOverride) {
+        this.exitOverride = exitOverride;
     }
 
     private static URI createUri(String source) {


### PR DESCRIPTION
## Overview
As per title.

I've not updated the help as I think the logical place to document this is here: https://www.zaproxy.org/docs/automate/automation-framework/#exit-value

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
