### PR TITLE
No longer support Java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17, 19]
+        java: [17, 19]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}

--- a/.github/workflows/crowdin-upload-files.yml
+++ b/.github/workflows/crowdin-upload-files.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
     - name: Upload Files
       env:
         CROWDIN_AUTH_TOKEN: ${{ secrets.ZAPBOT_CROWDIN_TOKEN }}

--- a/.github/workflows/prepare-release-add-on.yml
+++ b/.github/workflows/prepare-release-add-on.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
     - name: Prepare Release and Create Pull Request
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}

--- a/.github/workflows/release-add-on.yml
+++ b/.github/workflows/release-add-on.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: 17
     - name: Generate Release State
       run: ./gradlew :addOns:generateReleaseStateLastCommit
     - name: Build and Release Add-On

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ allprojects {
         }
 
         java {
-            val javaVersion = JavaVersion.VERSION_11
+            val javaVersion = JavaVersion.VERSION_17
             sourceCompatibility = javaVersion
             targetCompatibility = javaVersion
         }


### PR DESCRIPTION
## Overview
No longer support Java 11

## Related Issues

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
