### PR TITLE
Comparable response sqli

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -19,9 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
-import difflib.Delta;
-import difflib.DiffUtils;
-import difflib.Patch;
 import java.io.IOException;
 import java.net.SocketException;
 import java.net.URLDecoder;
@@ -30,7 +27,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -47,6 +43,7 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.PolicyTag;
+import org.zaproxy.addon.commonlib.http.ComparableResponse;
 import org.zaproxy.zap.extension.authentication.ExtensionAuthentication;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.Tech;
@@ -911,8 +908,8 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
             return; // Something went wrong, no point continuing
         }
 
-        mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
-        mResBodyNormalStripped = this.stripOff(mResBodyNormalUnstripped, origParamValue);
+        final ComparableResponse normalResponse =
+                new ComparableResponse(refreshedmessage, origParamValue);
 
         if (!sqlInjectionFoundForUrl
                 && doExpressionBased
@@ -939,6 +936,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
                     String modifiedParamValueConfirmForAdd = String.valueOf(paramPlusThree) + "-2";
                     // Do the attack for ADD variant
                     expressionBasedAttack(
+                            normalResponse,
                             param,
                             origParamValue,
                             modifiedParamValueForAdd,
@@ -964,6 +962,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
                                 String.valueOf(paramMultFour) + "/2";
                         // Do the attack for MULT variant
                         expressionBasedAttack(
+                                normalResponse,
                                 param,
                                 origParamValue,
                                 modifiedParamValueForMult,
@@ -1055,8 +1054,8 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
             return; // Something went wrong, no point continuing
         }
 
-        mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
-        mResBodyNormalStripped = this.stripOff(mResBodyNormalUnstripped, origParamValue);
+        final ComparableResponse normalResponse =
+                new ComparableResponse(refreshedmessage, origParamValue);
 
         // try each of the AND syntax values in turn.
         // Which one is successful will depend on the column type of the table/view column into
@@ -1093,113 +1092,138 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
             }
             countBooleanBasedRequests++;
 
-            String resBodyANDTrueUnstripped = msg2.getResponseBody().toString();
-            String resBodyANDTrueStripped =
-                    stripOffOriginalAndAttackParam(
-                            resBodyANDTrueUnstripped, origParamValue, sqlBooleanAndTrueValue);
+            final ComparableResponse andTrueResponse =
+                    new ComparableResponse(msg2, sqlBooleanAndTrueValue);
 
-            // set up two little arrays to ease the work of checking the unstripped output, and
-            // then the stripped output
-            String normalBodyOutput[] = {mResBodyNormalUnstripped, mResBodyNormalStripped};
-            String andTrueBodyOutput[] = {resBodyANDTrueUnstripped, resBodyANDTrueStripped};
-            boolean strippedOutput[] = {false, true};
+            if (isStop()) {
+                LOGGER.debug("Stopping the scan due to a user request");
+                return;
+            }
 
-            for (int booleanStrippedUnstrippedIndex = 0;
-                    booleanStrippedUnstrippedIndex < 2;
-                    booleanStrippedUnstrippedIndex++) {
-                if (isStop()) {
-                    LOGGER.debug("Stopping the scan due to a user request");
-                    return;
-                }
+            // if the results of the "AND 1=1" match the original query, we may be onto something.
+            if (compareResponses(normalResponse, andTrueResponse) == 1) {
+                LOGGER.debug(
+                        "Check 2, response for AND TRUE condition [{}] matched (refreshed) original results for {}",
+                        sqlBooleanAndTrueValue,
+                        refreshedmessage.getRequestHeader().getURI());
+                // so they match. Was it a fluke? See if we get the same result by tacking on "AND 1
+                // = 2" to the original
+                HttpMessage msg2_and_false = getNewMsg();
 
-                // if the results of the "AND 1=1" match the original query (using either the
-                // stripped or unstripped versions), we may be onto something.
-                if (andTrueBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
-                                normalBodyOutput[booleanStrippedUnstrippedIndex])
-                        == 0) {
+                setParameter(msg2_and_false, param, sqlBooleanAndFalseValue);
+
+                try {
+                    sendAndReceive(msg2_and_false, false); // do not follow redirects
+                } catch (SocketException ex) {
                     LOGGER.debug(
-                            "Check 2, {} html output for AND TRUE condition [{}] matched (refreshed) original results for {}",
-                            (strippedOutput[booleanStrippedUnstrippedIndex]
-                                    ? "STRIPPED"
-                                    : "UNSTRIPPED"),
-                            sqlBooleanAndTrueValue,
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg2_and_false.getRequestHeader().getURI());
+                    continue; // Something went wrong, continue on to the next item in the
+                    // loop
+                }
+                countBooleanBasedRequests++;
+
+                final ComparableResponse andFalseResponse =
+                        new ComparableResponse(msg2_and_false, sqlBooleanAndFalseValue);
+
+                if (compareResponses(normalResponse, andFalseResponse) < 1) {
+                    LOGGER.debug(
+                            "Check 2, response output for AND FALSE condition [{}] differed from (refreshed) original results for {}",
+                            sqlBooleanAndFalseValue,
                             refreshedmessage.getRequestHeader().getURI());
-                    // so they match. Was it a fluke? See if we get the same result by tacking
-                    // on "AND 1 = 2" to the original
-                    HttpMessage msg2_and_false = getNewMsg();
 
-                    setParameter(msg2_and_false, param, sqlBooleanAndFalseValue);
+                    // it's different (suggesting that the "AND 1 = 2" appended on gave
+                    // different results because it restricted the data set to nothing
+                    // Likely a SQL Injection. Raise it
+                    String extraInfo =
+                            Constant.messages.getString(
+                                            MESSAGE_PREFIX + "alert.booleanbased.extrainfo",
+                                            sqlBooleanAndTrueValue,
+                                            sqlBooleanAndFalseValue)
+                                    + "\n"
+                                    + Constant.messages.getString(
+                                            MESSAGE_PREFIX
+                                                    + "alert.booleanbased.extrainfo.dataexists");
 
+                    // raise the alert, and save the attack string for the "Authentication
+                    // Bypass" alert, if necessary
+                    sqlInjectionAttack = sqlBooleanAndTrueValue;
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(sqlInjectionAttack)
+                            .setOtherInfo(extraInfo)
+                            .setMessage(msg2)
+                            .raise();
+
+                    sqlInjectionFoundForUrl = true;
+
+                    break; // No further need to loop through SQL_AND
+
+                } else {
+                    // the results of the always false condition are the same as for the
+                    // original unmodified parameter
+                    // this could be because there was *no* data returned for the original
+                    // unmodified parameter
+                    // so consider the effect of adding comments to both the always true
+                    // condition, and the always false condition
+                    // the first value to try..
+                    // ZAP: Removed getURLDecode()
+                    String orValue = origParamValue + SQL_LOGIC_OR_TRUE[i];
+
+                    // this is where that comment comes in handy: if the RDBMS supports
+                    // one-line comments, add one in to attempt to ensure that the
+                    // condition becomes one that is effectively always true, returning ALL
+                    // data (or as much as possible), allowing us to pinpoint the SQL
+                    // Injection
+                    LOGGER.debug(
+                            "Check 2 , response for AND FALSE condition [{}] SAME as (refreshed) original results for {} ### (forcing OR TRUE check)",
+                            sqlBooleanAndFalseValue,
+                            refreshedmessage.getRequestHeader().getURI());
+                    HttpMessage msg2_or_true = getNewMsg();
+                    setParameter(msg2_or_true, param, orValue);
                     try {
-                        sendAndReceive(msg2_and_false, false); // do not follow redirects
+                        sendAndReceive(msg2_or_true, false); // do not follow redirects
                     } catch (SocketException ex) {
                         LOGGER.debug(
                                 "Caught {} {} when accessing: {}",
                                 ex.getClass().getName(),
                                 ex.getMessage(),
-                                msg2_and_false.getRequestHeader().getURI());
-                        continue; // Something went wrong, continue on to the next item in the
-                        // loop
+                                msg2_or_true.getRequestHeader().getURI());
+                        continue; // Something went wrong, continue on to the next item in
+                        // the loop
                     }
                     countBooleanBasedRequests++;
 
-                    String resBodyANDFalseUnstripped = msg2_and_false.getResponseBody().toString();
-                    String resBodyANDFalseStripped =
-                            stripOffOriginalAndAttackParam(
-                                    resBodyANDFalseUnstripped,
-                                    origParamValue,
-                                    sqlBooleanAndFalseValue);
+                    final ComparableResponse orTrueResponse =
+                            new ComparableResponse(msg2_or_true, orValue);
 
-                    String andFalseBodyOutput[] = {
-                        resBodyANDFalseUnstripped, resBodyANDFalseStripped
-                    };
-
-                    // which AND False output should we compare? the stripped or the unstripped
-                    // version?
-                    // depends on which one we used to get to here.. use the same as that..
-
-                    // build an always false AND query.  Result should be different to prove the
-                    // SQL works.
-                    if (andFalseBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
-                                    normalBodyOutput[booleanStrippedUnstrippedIndex])
-                            != 0) {
+                    if (compareResponses(normalResponse, orTrueResponse) < 1) {
                         LOGGER.debug(
-                                "Check 2, {} html output for AND FALSE condition [{}] differed from (refreshed) original results for {}",
-                                (strippedOutput[booleanStrippedUnstrippedIndex]
-                                        ? "STRIPPED"
-                                        : "UNSTRIPPED"),
-                                sqlBooleanAndFalseValue,
+                                "Check 2, response for OR TRUE condition [{}] different to (refreshed) original results for {}",
+                                orValue,
                                 refreshedmessage.getRequestHeader().getURI());
 
-                        // it's different (suggesting that the "AND 1 = 2" appended on gave
-                        // different results because it restricted the data set to nothing
+                        // it's different (suggesting that the "OR 1 = 1" appended on gave
+                        // different results because it broadened the data set from nothing
+                        // to something
                         // Likely a SQL Injection. Raise it
-                        String extraInfo = null;
-                        if (strippedOutput[booleanStrippedUnstrippedIndex]) {
-                            extraInfo =
-                                    Constant.messages.getString(
-                                            MESSAGE_PREFIX + "alert.booleanbased.extrainfo",
-                                            sqlBooleanAndTrueValue,
-                                            sqlBooleanAndFalseValue,
-                                            "");
-                        } else {
-                            extraInfo =
-                                    Constant.messages.getString(
-                                            MESSAGE_PREFIX + "alert.booleanbased.extrainfo",
-                                            sqlBooleanAndTrueValue,
-                                            sqlBooleanAndFalseValue,
-                                            "NOT ");
-                        }
-                        extraInfo =
-                                extraInfo
+                        String extraInfo =
+                                Constant.messages.getString(
+                                                MESSAGE_PREFIX + "alert.booleanbased.extrainfo",
+                                                sqlBooleanAndTrueValue,
+                                                orValue,
+                                                "")
                                         + "\n"
                                         + Constant.messages.getString(
                                                 MESSAGE_PREFIX
-                                                        + "alert.booleanbased.extrainfo.dataexists");
+                                                        + "alert.booleanbased.extrainfo.datanotexists");
 
-                        // raise the alert, and save the attack string for the "Authentication
-                        // Bypass" alert, if necessary
-                        sqlInjectionAttack = sqlBooleanAndTrueValue;
+                        // raise the alert, and save the attack string for the
+                        // "Authentication Bypass" alert, if necessary
+                        sqlInjectionAttack = orValue;
                         newAlert()
                                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                                 .setParam(param)
@@ -1209,167 +1233,24 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
                                 .raise();
 
                         sqlInjectionFoundForUrl = true;
+                        // booleanBasedSqlInjectionFoundForParam = true;  //causes us to
+                        // skip past the other entries in SQL_AND.  Only one will expose a
+                        // vuln for a given param, since the database column is of only 1
+                        // type
 
-                        break; // No further need to loop through SQL_AND
-
-                    } else {
-                        // the results of the always false condition are the same as for the
-                        // original unmodified parameter
-                        // this could be because there was *no* data returned for the original
-                        // unmodified parameter
-                        // so consider the effect of adding comments to both the always true
-                        // condition, and the always false condition
-                        // the first value to try..
-                        // ZAP: Removed getURLDecode()
-                        String orValue = origParamValue + SQL_LOGIC_OR_TRUE[i];
-
-                        // this is where that comment comes in handy: if the RDBMS supports
-                        // one-line comments, add one in to attempt to ensure that the
-                        // condition becomes one that is effectively always true, returning ALL
-                        // data (or as much as possible), allowing us to pinpoint the SQL
-                        // Injection
-                        LOGGER.debug(
-                                "Check 2 , {} html output for AND FALSE condition [{}] SAME as (refreshed) original results for {} ### (forcing OR TRUE check)",
-                                (strippedOutput[booleanStrippedUnstrippedIndex]
-                                        ? "STRIPPED"
-                                        : "UNSTRIPPED"),
-                                sqlBooleanAndFalseValue,
-                                refreshedmessage.getRequestHeader().getURI());
-                        HttpMessage msg2_or_true = getNewMsg();
-                        setParameter(msg2_or_true, param, orValue);
-                        try {
-                            sendAndReceive(msg2_or_true, false); // do not follow redirects
-                        } catch (SocketException ex) {
-                            LOGGER.debug(
-                                    "Caught {} {} when accessing: {}",
-                                    ex.getClass().getName(),
-                                    ex.getMessage(),
-                                    msg2_or_true.getRequestHeader().getURI());
-                            continue; // Something went wrong, continue on to the next item in
-                            // the loop
-                        }
-                        countBooleanBasedRequests++;
-
-                        String resBodyORTrueUnstripped = msg2_or_true.getResponseBody().toString();
-                        String resBodyORTrueStripped =
-                                stripOffOriginalAndAttackParam(
-                                        resBodyORTrueUnstripped, origParamValue, orValue);
-
-                        String orTrueBodyOutput[] = {
-                            resBodyORTrueUnstripped, resBodyORTrueStripped
-                        };
-
-                        int compareOrToOriginal =
-                                orTrueBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
-                                        normalBodyOutput[booleanStrippedUnstrippedIndex]);
-                        if (compareOrToOriginal != 0) {
-                            LOGGER.debug(
-                                    "Check 2, {} html output for OR TRUE condition [{}] different to (refreshed) original results for {}",
-                                    (strippedOutput[booleanStrippedUnstrippedIndex]
-                                            ? "STRIPPED"
-                                            : "UNSTRIPPED"),
-                                    orValue,
-                                    refreshedmessage.getRequestHeader().getURI());
-
-                            // it's different (suggesting that the "OR 1 = 1" appended on gave
-                            // different results because it broadened the data set from nothing
-                            // to something
-                            // Likely a SQL Injection. Raise it
-                            String extraInfo = null;
-                            if (strippedOutput[booleanStrippedUnstrippedIndex]) {
-                                extraInfo =
-                                        Constant.messages.getString(
-                                                MESSAGE_PREFIX + "alert.booleanbased.extrainfo",
-                                                sqlBooleanAndTrueValue,
-                                                orValue,
-                                                "");
-                            } else {
-                                extraInfo =
-                                        Constant.messages.getString(
-                                                MESSAGE_PREFIX + "alert.booleanbased.extrainfo",
-                                                sqlBooleanAndTrueValue,
-                                                orValue,
-                                                "NOT ");
-                            }
-                            extraInfo =
-                                    extraInfo
-                                            + "\n"
-                                            + Constant.messages.getString(
-                                                    MESSAGE_PREFIX
-                                                            + "alert.booleanbased.extrainfo.datanotexists");
-
-                            // raise the alert, and save the attack string for the
-                            // "Authentication Bypass" alert, if necessary
-                            sqlInjectionAttack = orValue;
-                            newAlert()
-                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setParam(param)
-                                    .setAttack(sqlInjectionAttack)
-                                    .setOtherInfo(extraInfo)
-                                    .setMessage(msg2)
-                                    .raise();
-
-                            sqlInjectionFoundForUrl = true;
-                            // booleanBasedSqlInjectionFoundForParam = true;  //causes us to
-                            // skip past the other entries in SQL_AND.  Only one will expose a
-                            // vuln for a given param, since the database column is of only 1
-                            // type
-
-                            break;
-                        }
+                        break;
                     }
-                } // if the results of the "AND 1=1" match the original query, we may be onto
-                // something.
-                else {
-                    // the results of the "AND 1=1" do NOT match the original query, for
-                    // whatever reason (no sql injection, or the web page is not stable)
-                    if (this.debugEnabled) {
-                        LOGGER.debug(
-                                "Check 2, {} html output for AND condition [{}] does NOT match the (refreshed) original results for {}",
-                                (strippedOutput[booleanStrippedUnstrippedIndex]
-                                        ? "STRIPPED"
-                                        : "UNSTRIPPED"),
-                                sqlBooleanAndTrueValue,
-                                refreshedmessage.getRequestHeader().getURI());
-                        Patch<String> diffpatch =
-                                DiffUtils.diff(
-                                        new LinkedList<>(
-                                                Arrays.asList(
-                                                        normalBodyOutput[
-                                                                booleanStrippedUnstrippedIndex]
-                                                                .split("\\n"))),
-                                        new LinkedList<>(
-                                                Arrays.asList(
-                                                        andTrueBodyOutput[
-                                                                booleanStrippedUnstrippedIndex]
-                                                                .split("\\n"))));
-
-                        // and convert the list of patches to a String, joining using a newline
-                        StringBuilder tempDiff = new StringBuilder(250);
-                        for (Delta<String> delta : diffpatch.getDeltas()) {
-                            String changeType = null;
-                            if (delta.getType() == Delta.TYPE.CHANGE) {
-                                changeType = "Changed Text";
-                            } else if (delta.getType() == Delta.TYPE.DELETE) {
-                                changeType = "Deleted Text";
-                            } else if (delta.getType() == Delta.TYPE.INSERT) {
-                                changeType = "Inserted text";
-                            } else {
-                                changeType = "Unknown change type [" + delta.getType() + "]";
-                            }
-
-                            tempDiff.append("\n(" + changeType + ")\n"); // blank line before
-                            tempDiff.append(
-                                    "Output for Unmodified parameter: "
-                                            + delta.getOriginal()
-                                            + "\n");
-                            tempDiff.append(
-                                    "Output for   modified parameter: "
-                                            + delta.getRevised()
-                                            + "\n");
-                        }
-                        LOGGER.debug("DIFFS: {}", tempDiff);
-                    }
+                }
+            } // if the results of the "AND 1=1" match the original query, we may be onto
+            // something.
+            else {
+                // the results of the "AND 1=1" do NOT match the original query, for
+                // whatever reason (no sql injection, or the web page is not stable)
+                if (this.debugEnabled) {
+                    LOGGER.debug(
+                            "Check 2, response for AND condition [{}] does NOT match the (refreshed) original results for {}",
+                            sqlBooleanAndTrueValue,
+                            refreshedmessage.getRequestHeader().getURI());
                 }
             }
         }
@@ -1834,6 +1715,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
     }
 
     private void expressionBasedAttack(
+            ComparableResponse normalResponse,
             String param,
             String originalParam,
             String modifiedParamValue,
@@ -1856,19 +1738,16 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
         }
         countExpressionBasedRequests++;
 
-        String modifiedExpressionOutputUnstripped = msg.getResponseBody().toString();
-        String modifiedExpressionOutputStripped =
-                stripOffOriginalAndAttackParam(
-                        modifiedExpressionOutputUnstripped, originalParam, modifiedParamValue);
-        String normalBodyOutputStripped = stripOff(mResBodyNormalStripped, modifiedParamValue);
+        final ComparableResponse modifiedExpressionResponse =
+                new ComparableResponse(msg, modifiedParamValue);
 
         if (!sqlInjectionFoundForUrl && countExpressionBasedRequests < doExpressionMaxRequests) {
             // if the results of the modified request match the original query, we may be onto
             // something.
 
-            if (modifiedExpressionOutputStripped.compareTo(normalBodyOutputStripped) == 0) {
+            if (compareResponses(normalResponse, modifiedExpressionResponse) == 1) {
                 LOGGER.debug(
-                        "Check 4, STRIPPED html output for modified expression parameter [{}] matched (refreshed) original results for {}",
+                        "Check 4, response for modified expression parameter [{}] matched (refreshed) original results for {}",
                         modifiedParamValue,
                         refreshedmessage.getRequestHeader().getURI());
                 // confirm that a different parameter value generates different output, to minimise
@@ -1892,17 +1771,10 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
                 }
                 countExpressionBasedRequests++;
 
-                String confirmExpressionOutputUnstripped = msgConfirm.getResponseBody().toString();
-                String confirmExpressionOutputStripped =
-                        stripOffOriginalAndAttackParam(
-                                confirmExpressionOutputUnstripped,
-                                originalParam,
-                                modifiedParamValueConfirm);
+                final ComparableResponse confirmExpressionResponse =
+                        new ComparableResponse(msgConfirm, modifiedParamValueConfirm);
 
-                normalBodyOutputStripped =
-                        stripOff(mResBodyNormalStripped, modifiedParamValueConfirm);
-
-                if (confirmExpressionOutputStripped.compareTo(normalBodyOutputStripped) != 0) {
+                if (compareResponses(normalResponse, confirmExpressionResponse) < 1) {
                     // the confirm query did not return the same results.  This means that arbitrary
                     // queries are not all producing the same page output.
                     // this means the fact we earlier reproduced the original page output with a
@@ -1934,6 +1806,33 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
                 return;
             }
         }
+    }
+
+    /**
+     * 0 means very different and 1 very similar. Note that this is the opposite from most compareTo
+     * implementations but it matches the behavior of the compareWith function and heuristics in
+     * {@code ComparableResponse}
+     */
+    private float compareResponses(ComparableResponse one, ComparableResponse two) {
+        return responseBodyHeuristic(one, two);
+    }
+
+    /**
+     * Checks the response bodies of two requests for an exact match after stripping off the input
+     * parameters from both requests
+     */
+    private float responseBodyHeuristic(ComparableResponse one, ComparableResponse two) {
+        final String stripped1 =
+                stripOffOriginalAndAttackParam(
+                        one.getBody(), one.getValueSent(), two.getValueSent());
+        final String stripped2 =
+                stripOffOriginalAndAttackParam(
+                        two.getBody(), one.getValueSent(), two.getValueSent());
+        if (stripped1.compareTo(stripped2) == 0) {
+            return 1;
+        }
+
+        return 0;
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -93,8 +93,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
 
     private String sqlInjectionAttack = null;
     private HttpMessage refreshedmessage = null;
-    private String mResBodyNormalUnstripped = null;
-    private String mResBodyNormalStripped = null;
     // what do we do at each attack strength?
     // (some SQL Injection vulns would be picked up by multiple types of checks, and we skip out
     // after the first alert for a URL)
@@ -128,7 +126,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
      * maximise SQL errors Note that we do separate runs for each family of characters, in case one
      * family are filtered out, the others might still get past
      */
-    private static final String[] SQL_CHECK_ERR = {"'", "\"", ";", "'(", ")", "(", "NULL", "'\""};
+    static final String[] SQL_CHECK_ERR = {"'", "\"", ";", "'(", ")", "(", "NULL", "'\""};
 
     /**
      * A collection of RDBMS with its error message fragments and {@code Tech}.
@@ -457,7 +455,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
      * generic UNION statements. Hoping these will cause a specific error message that we will
      * recognise
      */
-    private static String[] SQL_UNION_APPENDAGES = {
+    static String[] SQL_UNION_APPENDAGES = {
         " UNION ALL select NULL" + SQL_ONE_LINE_COMMENT,
         "' UNION ALL select NULL" + SQL_ONE_LINE_COMMENT,
         "\" UNION ALL select NULL" + SQL_ONE_LINE_COMMENT,
@@ -650,8 +648,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
         sqlInjectionFoundForUrl = false;
         sqlInjectionAttack = null;
         refreshedmessage = null;
-        mResBodyNormalUnstripped = null;
-        mResBodyNormalStripped = null;
 
         try {
             // reinitialise the count for each type of request, for each parameter.  We will be
@@ -1293,6 +1289,8 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
             countBooleanBasedRequests++;
 
             String resBodyORTrueUnstripped = msg2.getResponseBody().toString();
+            String mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
+            String mResBodyNormalStripped = this.stripOff(mResBodyNormalUnstripped, origParamValue);
 
             // if the results of the "OR 1=1" exceed the original query (unstripped, by more
             // than a 20% size difference, say), we may be onto something.
@@ -1408,6 +1406,9 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
             }
             countUnionBasedRequests++;
 
+            String mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
+            String mResBodyNormalStripped = this.stripOff(mResBodyNormalUnstripped, origParamValue);
+
             // now check the results.. look first for UNION specific error messages in the
             // output that were not there in the original output
             // and failing that, look for generic RDBMS specific error messages
@@ -1476,8 +1477,8 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
             return; // Something went wrong, no point continuing
         }
 
-        mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
-        mResBodyNormalStripped = this.stripOff(mResBodyNormalUnstripped, origParamValue);
+        String mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
+        String mResBodyNormalStripped = this.stripOff(mResBodyNormalUnstripped, origParamValue);
 
         if (!sqlInjectionFoundForUrl
                 && doOrderByBased

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -411,7 +411,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
      * *not* in the last where clause in a SQL query so as a result, the rest of the query needs to
      * be closed off with the comment.
      */
-    private static final String[] SQL_LOGIC_AND_TRUE = {
+    static final String[] SQL_LOGIC_AND_TRUE = {
         " AND 1=1" + SQL_ONE_LINE_COMMENT,
         "' AND '1'='1'" + SQL_ONE_LINE_COMMENT,
         "\" AND \"1\"=\"1\"" + SQL_ONE_LINE_COMMENT,
@@ -424,7 +424,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
     };
 
     /** always false statement for comparison in boolean based SQL injection check */
-    private static final String[] SQL_LOGIC_AND_FALSE = {
+    static final String[] SQL_LOGIC_AND_FALSE = {
         " AND 1=2" + SQL_ONE_LINE_COMMENT,
         "' AND '1'='2'" + SQL_ONE_LINE_COMMENT,
         "\" AND \"1\"=\"2\"" + SQL_ONE_LINE_COMMENT,
@@ -441,7 +441,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
      * injection check Note that, if necessary, the code also tries a variant with the one-line
      * comment " -- " appended to the end.
      */
-    private static final String[] SQL_LOGIC_OR_TRUE = {
+    static final String[] SQL_LOGIC_OR_TRUE = {
         " OR 1=1" + SQL_ONE_LINE_COMMENT,
         "' OR '1'='1'" + SQL_ONE_LINE_COMMENT,
         "\" OR \"1\"=\"1\"" + SQL_ONE_LINE_COMMENT,
@@ -573,7 +573,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
             doExpressionBased = true;
             doExpressionMaxRequests = 8;
             doBooleanBased = true;
-            doBooleanMaxRequests = 6;
+            doBooleanMaxRequests = 6; // will not run all the LIKE attacks.. these are done at high
             doUnionBased = true;
             doUnionMaxRequests = 5;
             doOrderByBased = false;
@@ -586,8 +586,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
             doExpressionBased = true;
             doExpressionMaxRequests = 16;
             doBooleanBased = true;
-            doBooleanMaxRequests =
-                    20; // will not run all the LIKE attacks.. these are done at insane..
+            doBooleanMaxRequests = 20;
             doUnionBased = true;
             doUnionMaxRequests = 10;
             doOrderByBased = true;
@@ -1873,7 +1872,18 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin
         return result;
     }
 
-    /** Replace body by stripping off pattern strings. */
+    /**
+     * Replace body by stripping off pattern strings.
+     *
+     * <p>Stripping both the originalPattern and attackPattern prevents false negatives when the
+     * originalPattern is always part of the response.
+     *
+     * <p>For example: there is a website about cats and the response body is always "This is a page
+     * about cats. You submitted {value}". If the originalPattern is "cats", the stripped response
+     * is "This is a page about . You submitted ". When an attack payload is sent, such as "cats AND
+     * 1=1" if only the attackPattern is stripped, the stripped response becomes "This is a page
+     * about cats. You submitted ". So the original "cats" value needs to be stripped as well.
+     */
     protected String stripOffOriginalAndAttackParam(
             String body, String originalPattern, String attackPattern) {
         String result = this.stripOff(this.stripOff(body, attackPattern), originalPattern);


### PR DESCRIPTION
## Overview

Start using ComparableResponse for expression based and boolean based sql injection response comparisons. Use a custom comparison function that is very close to the previous comparison*. The reasoning for this is to not couple this refactor to new logic that risks introducing false positives/negatives. I'll send separate PRs for adding some heuristics that handle existing false positive cases that I know of and it should be easy for any ZAP contributor to make further improvements to the heuristics.

This change is on top of https://github.com/zaproxy/zap-extensions/pull/5867 and https://github.com/zaproxy/zap-extensions/pull/5797 which add unit tests to ensure the existing behavior is not broken. After those are merged, I'll rebase, squash, and signoff the final commit here.

* the previous logic is checking the response bodies for an exact match either stripped of input parameters or unstripped. As far as I can tell, only stripped needs to be checked. The strip function is deterministic so if the unstripped match, then the stripped have to match too. i.e. if `unstripped1 == unstripped2` then `strip(unstripped1, param1, param2) == strip(unstripped2, param1, param2)` the 3 inputs to the strip function are exactly the same in both cases so the results must be the same too.

## Related Issues

https://github.com/zaproxy/zaproxy/issues/8652

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
