### PR TITLE
ascanrules: sqli heuristic to fix 3xx redirect false positives

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - SQL Injection scan rule to treat a 500 response to an SQLi attack as a likely vulnerability.
+- Use location header in sql injection response comparisons (Issue 8651)
 
 ## [71] - 2025-03-04
 ### Fixed


### PR DESCRIPTION
## Overview
Fix the sql injection false positive case described in https://github.com/zaproxy/zaproxy/issues/8651. The short summary is that the expression based test sends 3 requests: normal, modified, and confirm. A sql injection is suspected if normal and modified return the same response, but confirm returns a different response. The response comparison logic looks only at the response body. In the case of 3xx redirects the bodies can be exactly the same when the location headers are different. This change adds a heuristic for checking the location headers and treating different 3xx redirects as different responses, even when the bodies are the same.

This change is built on top of https://github.com/zaproxy/zap-extensions/pull/5974. Once that one is done I'll rebase, squash, and sign-off the resulting commit.

## Related Issues

Fix zaproxy/zaproxy#8651.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
