### PR TITLE
automation: apply object to object in order

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Method to allow the user to set the exit code via a script.
 
 ### Changed
+- Maintenance changes.
 - Updated automation framework documentation and templates for `activeScan` job to reflect changes to the default value of threadPerHost parameter
 - Update help for the "requestor" job.
 - Update help to indicate that job order is important (Issue 8675).

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -29,12 +29,14 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -352,7 +354,10 @@ public class JobUtils {
         }
 
         try {
-            Method[] methods = srcObject.getClass().getMethods();
+            Method[] methods =
+                    Stream.of(srcObject.getClass().getMethods())
+                            .sorted(Comparator.comparing(Method::getName))
+                            .toArray(Method[]::new);
             for (Method m : methods) {
                 String getterName = m.getName();
 

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InOrder;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -128,6 +130,22 @@ class JobUtilsUnitTest extends TestUtils {
         // Then
         assertThat(dest.getValueString(), is(nullValue()));
         assertThat(dest.isBool(), is(nullValue()));
+    }
+
+    @Test
+    void shouldApplyObjectToObjectInExpectedOrder() {
+        // Given
+        Data source = new Data("A", Boolean.TRUE);
+        Data dest = mock(Data.class);
+        InOrder inOrder = inOrder(dest);
+        AutomationProgress progress = mock(AutomationProgress.class);
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.replaceVars(any())).willAnswer(invocation -> invocation.getArgument(0));
+        // When
+        JobUtils.applyObjectToObject(source, dest, "name", new String[] {}, progress, env);
+        // Then
+        inOrder.verify(dest).setValueString("A");
+        inOrder.verify(dest).setBool(Boolean.TRUE);
     }
 
     @Test


### PR DESCRIPTION
Apply the object's data always in a specific order to allow to verify that the changes are applied properly (e.g. restoring original values).