### PR TITLE
formhandler: Help Fix

### DIFF
--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Depend on Common Library add-on, to provide the default/custom values to the other add-ons (Issue 8016).
 
+### Fixed
+- Fixed an issue in the help which may cause images to be displayed inline impacting the flow of the text.
+
 ## [6.6.0] - 2024-05-07
 ### Changed
 - Update minimum ZAP version to 2.15.0.

--- a/addOns/formhandler/src/main/javahelp/org/zaproxy/zap/extension/formhandler/resources/help/contents/FormHandlerHelp.html
+++ b/addOns/formhandler/src/main/javahelp/org/zaproxy/zap/extension/formhandler/resources/help/contents/FormHandlerHelp.html
@@ -31,8 +31,8 @@
 			<p>
 				The Value Generator can be configured thought ZAP's Options. Selecting the Value Generator tab will display a table 
 				with all existing inputs that are currently defined. An example is shown below.
-			</p>
-			<img src="../contents/images/formHandlerTable.PNG" alt="Image Not Available"/>
+			</p><br>
+			<img src="../contents/images/formHandlerTable.PNG" alt="A screenshot of the Value Generator's main table"/>
 
 		<H3>Adding a New Field</H3>
 			<p>
@@ -40,7 +40,7 @@
 				for the user to provide field information.
 			</p>
 
-			<img src="../contents/images/formHandlerAddDialog.PNG" alt="Image Not Available"/>
+			<img src="../contents/images/formHandlerAddDialog.PNG" alt="A screenshot of the Value Generator's add dialog"/>
 
 			<p>
 				Please take note of the following when adding a new field:
@@ -60,15 +60,15 @@
 			<p>
 				The add-on allows the user to modify the values and names of existing fields. This can be done 
 				by selecting the field that you wish to modify and clicking on the <b>Modify</b> button.
-			</p>
-			<img src="../contents/images/formHandlerModDialog.PNG" alt="Image Not Available"/>
+			</p><br>
+			<img src="../contents/images/formHandlerModDialog.PNG" alt="A screenshot of the Value Generator's modify dialog"/>
 
 			<p>
 				When modifying a field the user is constrained by the same rules as creating a new one. The most
 				common constraint when modifying a field is that the name cannot be the same as an existing field.
 				(i.e. No duplicate fields)
-			<p>
- 
+			</p>
+
 		<H3>Removing Fields</H3>
 			<p>
 				The user can remove fields at any time. To do so simply select the field that you wish to remove and 


### PR DESCRIPTION
Fix images being shown inline with text:
![image](https://github.com/user-attachments/assets/44900f58-6922-4c86-9d9a-bbb8838bfd2a)

It seems GitHub.dev trimmed trailing white spaces, I'll get that fixed.
