### PR TITLE
reports: Fix Report Job dialog not resolving correct directory when relative path is used

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update automation job help.
 - Fields with default or missing values are omitted for the `report` job in saved Automation Framework plans.
+- Fixed ReportJobDialog not resolving correct directory when relative path is used on ReportDir
 
 ## [0.34.0] - 2024-10-07
 ### Changed

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -182,12 +182,9 @@ public class ReportJob extends AutomationJob {
 
         File file;
         String reportDir = getParameters().getReportDir();
-        if (reportDir != null && reportDir.length() > 0) {
-            File dir = JobUtils.getFile(reportDir, getPlan());
-            file = new File(dir, fileName);
-        } else {
-            file = JobUtils.getFile(fileName, getPlan());
-        }
+        File dir = resolveReportDirAsFile(reportDir, fileName);
+        file = new File(dir, fileName);
+
         reportData.setTitle(this.getParameters().getReportTitle());
         reportData.setDescription(this.getParameters().getReportDescription());
         reportData.setContexts(env.getContexts());
@@ -272,6 +269,16 @@ public class ReportJob extends AutomationJob {
             progress.error(
                     Constant.messages.getString(
                             "reports.automation.error.generate", this.getName(), e.getMessage()));
+        }
+    }
+
+    // Resolves the report directory (can be relative or absolute) as a File.
+    // defaults to reportfile´s directory when reportDir parameter is empty
+    public File resolveReportDirAsFile(String reportDir, String fileName) {
+        if (reportDir != null && reportDir.length() > 0) {
+            return JobUtils.getFile(reportDir, getPlan());
+        } else {
+            return JobUtils.getFile(fileName, getPlan()).getParentFile();
         }
     }
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
@@ -109,11 +109,8 @@ public class ReportJobDialog extends StandardFieldsDialog {
         this.addTextField(TAB_SCOPE, FIELD_REPORT_NAME, params.getReportFile());
 
         String dirName = params.getReportDir();
-        File dir = null;
+        File dir = job.resolveReportDirAsFile(dirName, params.getReportFile());
 
-        if (!StringUtils.isEmpty(dirName)) {
-            dir = new File(dirName);
-        }
         this.addFileSelectField(
                 TAB_SCOPE, FIELD_REPORT_DIR, dir, JFileChooser.DIRECTORIES_ONLY, null);
         if (!StringUtils.isEmpty(dirName) && JobUtils.containsVars(dirName)) {


### PR DESCRIPTION
## Overview
When using relative paths (as recommended https://www.zaproxy.org/docs/desktop/addons/automation-framework/#file-paths) in `report`-job of automation plan the UI component does not resolve correct directory and throws an error if one tries to save the plan with UI.

I fixed this by adding new public method for resolving the report directory and used it in ReportJobDialog.

![image](https://github.com/user-attachments/assets/d67602fd-fe7c-427d-8542-6e1b2d555aba)


## Related Issues
N/A

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
