### PR TITLE
Update Gradle add-on plugin and reset releases

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     jacoco
     id("org.cyclonedx.bom") version "1.8.2" apply false
     id("org.rm3l.datanucleus-gradle-plugin") version "2.0.0" apply false
-    id("org.zaproxy.add-on") version "0.11.0" apply false
+    id("org.zaproxy.add-on") version "0.12.0" apply false
     id("org.zaproxy.crowdin") version "0.4.0" apply false
     id("me.champeau.gradle.japicmp") version "0.4.3" apply false
 }

--- a/addOns/webdrivers/webdriverlinux/gradle.properties
+++ b/addOns/webdrivers/webdriverlinux/gradle.properties
@@ -1,2 +1,2 @@
 version=116
-release=true
+release=false

--- a/addOns/webdrivers/webdrivermacos/gradle.properties
+++ b/addOns/webdrivers/webdrivermacos/gradle.properties
@@ -1,2 +1,2 @@
 version=116
-release=true
+release=false

--- a/addOns/webdrivers/webdriverwindows/gradle.properties
+++ b/addOns/webdrivers/webdriverwindows/gradle.properties
@@ -1,2 +1,2 @@
 version=116
-release=true
+release=false


### PR DESCRIPTION
Update the plugin to support newer Java versions.
Reset release state of failed releases to be restarted later.