### PR TITLE
automation: Preserve Rule ID zero

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow to choose one thread for the `activeScan` job through the GUI.
 - Active Scan jobs will once again use the default policy if neither a policy nor a policyDefinition has been set.
 - Bug in job alert tests related to alert matching.
+- Active scan rule ID 0 (Directory Browsing) will be included in the plan (yaml) when saved (Issue 8746).
 
 ## [0.43.0] - 2024-10-07
 ### Fixed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationPlan.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationPlan.java
@@ -306,15 +306,18 @@ public class AutomationPlan {
                 data.addJob(job.getData());
             }
 
-            FilterProvider filters =
-                    new SimpleFilterProvider()
-                            .addFilter(
-                                    DefaultPropertyFilter.FILTER_ID, new DefaultPropertyFilter());
-            writer.println(YAML_OBJECT_MAPPER.writer(filters).writeValueAsString(data));
+            writer.println(writeObjectAsString(data));
         }
         this.changed = false;
         AutomationEventPublisher.publishEvent(AutomationEventPublisher.PLAN_SAVED, this, null);
         return true;
+    }
+
+    public static String writeObjectAsString(Object obj) throws JsonProcessingException {
+        FilterProvider filters =
+                new SimpleFilterProvider()
+                        .addFilter(DefaultPropertyFilter.FILTER_ID, new DefaultPropertyFilter());
+        return YAML_OBJECT_MAPPER.writer(filters).writeValueAsString(obj);
     }
 
     public static class Data {

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PolicyDefinition.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PolicyDefinition.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.automation.jobs;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -230,7 +231,9 @@ public class PolicyDefinition extends AutomationData {
     @Getter
     @Setter
     public static class Rule extends AutomationData {
+        @JsonInclude(JsonInclude.Include.ALWAYS)
         private int id;
+
         private String name;
         private String threshold;
         private String strength;

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PolicyDefinitionUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PolicyDefinitionUnitTest.java
@@ -19,12 +19,14 @@
  */
 package org.zaproxy.addon.automation.jobs;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -49,6 +51,7 @@ import org.parosproxy.paros.core.scanner.PluginFactory;
 import org.parosproxy.paros.core.scanner.PluginFactoryTestHelper;
 import org.parosproxy.paros.core.scanner.PluginTestHelper;
 import org.yaml.snakeyaml.Yaml;
+import org.zaproxy.addon.automation.AutomationPlan;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.addon.automation.jobs.PolicyDefinition.Rule;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
@@ -348,5 +351,21 @@ class PolicyDefinitionUnitTest {
         assertThat(progress.hasErrors(), is(equalTo(false)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(policyDefinition.getScanPolicy("test", progress), is(nullValue()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 50000, 99999})
+    void shouldAlwaysIncludeIdWhenSerializingARule(int id) throws JsonProcessingException {
+        // Given
+        Rule rule =
+                new Rule(
+                        id,
+                        "Test Rule",
+                        AttackStrength.MEDIUM.name(),
+                        AlertThreshold.MEDIUM.name());
+        // When
+        String ruleYaml = AutomationPlan.writeObjectAsString(rule);
+        // Then
+        assertThat(ruleYaml, containsString("id: " + id));
     }
 }


### PR DESCRIPTION
## Overview
- Set Jackson to always include the Rule ID.
- CHANGELOG add fix note.
- UnitTest to ensure rule ID is serialized as expected.

## Related Issues
- Fixes zaproxy/zaproxy#8746

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
