### PR TITLE
network: remove debug print

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -270,7 +270,6 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
             }
         }
 
-        System.err.println(updateLoggers);
         if (updateLoggers) {
             ctx.updateLoggers();
         }


### PR DESCRIPTION
Remove the debug print that was left out in a previous change.