### PR TITLE
automation: Fix Active Scan Policy job Rule add/modify Dialog sizing/display

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Active Scan jobs will once again use the default policy if neither a policy nor a policyDefinition has been set.
 - Bug in job alert tests related to alert matching.
 - Active scan rule ID 0 (Directory Browsing) will be included in the plan (yaml) when saved (Issue 8746).
+- Sizing/display of the Active Scan Policy job rule add/modify dialogs.
 
 ## [0.43.0] - 2024-10-07
 ### Fixed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAscanRuleDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAscanRuleDialog.java
@@ -60,6 +60,7 @@ public class AddAscanRuleDialog extends StandardFieldsDialog {
     public AddAscanRuleDialog(
             AscanRulesTableModel model, PolicyDefinition.Rule rule, int tableIndex)
             throws ConfigurationException {
+        // This dimension will not make a difference, pack is called below
         super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(300, 150));
         this.rule = rule;
         this.model = model;
@@ -108,6 +109,7 @@ public class AddAscanRuleDialog extends StandardFieldsDialog {
         this.addComboField(STRENGTH_PARAM, allstrengths, strengthName);
 
         this.addPadding();
+        pack();
     }
 
     @Override


### PR DESCRIPTION
Prevent the dialog(s) from being initially displayed smaller than their contents.