### PR TITLE
QuickStart: Fix AJAX Spider options

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - An exception that prevented the look and feel from changing completely.
+- Issues setting the AJAX Spider options.
 
 ## [50] - 2024-09-24
 ### Changed

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
@@ -111,6 +111,12 @@ public class AjaxSpiderExplorer implements PlugableSpider {
     @Override
     public void startScan(URI uri) {
         int selInd = this.getSelectComboBox().getSelectedIndex();
+
+        // Save the settings for next time
+        QuickStartParam qsParam = extension.getExtQuickStart().getQuickStartParam();
+        qsParam.setAjaxSpiderSelection(((Select) selectComboBox.getSelectedItem()).name());
+        qsParam.setAjaxSpiderDefaultBrowser(browserComboBox.getSelectedItem().toString());
+
         if (selInd == Select.NEVER.getIndex()) {
             ZAP.getEventBus().unregisterConsumer(eventConsumer);
             return;
@@ -180,13 +186,6 @@ public class AjaxSpiderExplorer implements PlugableSpider {
         if (selectComboBox == null) {
             selectComboBox = new JComboBox<>();
             Stream.of(Select.values()).forEach(s -> selectComboBox.addItem(s));
-            selectComboBox.addActionListener(
-                    e ->
-                            extension
-                                    .getExtQuickStart()
-                                    .getQuickStartParam()
-                                    .setAjaxSpiderSelection(
-                                            ((Select) selectComboBox.getSelectedItem()).name()));
         }
         return selectComboBox;
     }
@@ -198,13 +197,6 @@ public class AjaxSpiderExplorer implements PlugableSpider {
                     extension.getExtSelenium().createProvidedBrowsersComboBoxModel();
             model.setIncludeUnconfigured(false);
             browserComboBox.setModel(model);
-            browserComboBox.addActionListener(
-                    e ->
-                            extension
-                                    .getExtQuickStart()
-                                    .getQuickStartParam()
-                                    .setAjaxSpiderDefaultBrowser(
-                                            browserComboBox.getSelectedItem().toString()));
 
             String defaultBrowserId = Browser.FIREFOX_HEADLESS.getId();
             Optional<ProvidedBrowserUI> defaultItem =


### PR DESCRIPTION
## Overview
The QuickStart AJAX Spider options should be persisted between restarts, but there were 2 problems.
1. Changing the AJAX Spider run option caused an config event to be raised which meant that if a URL was specified it might get cleared.
2. The selected browser was never set as it was always changed back to firefox-headless when the dialog was initialised

This PR fixes those problems.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
