### PR TITLE
websocket: fix duplicated New Context menu item

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.16.0.
 
+### Fixed
+- Correct location/function of New Context context menu item.
+
 ## [31] - 2024-05-07
 ### Added
 - Support for menu weights (Issue 8369)

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketContextMenu.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketContextMenu.java
@@ -54,8 +54,10 @@ public class PopupIncludeWebSocketContextMenu extends PopupMenuItemContextInclud
     }
 
     @Override
-    protected ExtensionPopupMenuItem createPopupIncludeInContextMenu() {
-        return new PopupIncludeWebSocketInContextMenu();
+    protected ExtensionPopupMenuItem createPopupIncludeInContextMenu(int weight) {
+        PopupIncludeWebSocketInContextMenu menu = new PopupIncludeWebSocketInContextMenu();
+        menu.setWeight(weight);
+        return menu;
     }
 
     @Override


### PR DESCRIPTION
Override the "new" method that makes use of weights to return the proper menu item implementation, which corrects both the location it appears in and its functionality.
Remove the "old" method as it's no longer used/needed.