### PR TITLE
replacer: do not warn for `deleteAllRules`

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Typo in automation job help.
+- Address misleading warning `Unrecognised parameter` for `deleteAllRules` (Issue 8764).
 
 ### Changed
 - Update minimum ZAP version to 2.16.0.

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/automation/ReplacerJob.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/automation/ReplacerJob.java
@@ -74,6 +74,16 @@ public class ReplacerJob extends AutomationJob {
     }
 
     @Override
+    public boolean applyCustomParameter(String name, String value) {
+        if ("deleteAllRules".equals(name)) {
+            // Applied when the job is executed.
+            return true;
+        }
+
+        return super.applyCustomParameter(name, value);
+    }
+
+    @Override
     public void verifyParameters(AutomationProgress progress) {
         Map<?, ?> jobData = this.getJobData();
         if (jobData == null) {

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/automation/ReplacerJobUnitTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/automation/ReplacerJobUnitTest.java
@@ -97,7 +97,7 @@ class ReplacerJobUnitTest extends TestUtils {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void shouldApplyParameterDeleteAllRules(boolean value) {
+    void shouldVerifyAndApplyParameterDeleteAllRules(boolean value) {
         // Given
         ReplacerJob job =
                 createReplacerJob(
@@ -111,6 +111,27 @@ class ReplacerJobUnitTest extends TestUtils {
         assertThat(progress.hasErrors(), is(equalTo(false)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(job.getData().getParameters().getDeleteAllRules(), is(equalTo(value)));
+    }
+
+    @Test
+    void shouldApplyParameters() {
+        // Given
+        ReplacerJob job =
+                createReplacerJob(
+                        """
+                        parameters:
+                          deleteAllRules: true
+                        rules: []
+                        """);
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        job.applyParameters(progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        // Nothing else to check, they are applied at the same time as they are verified.
     }
 
     @Test


### PR DESCRIPTION
Handle the `deleteAllRules` when applying the custom parameters to prevent the warning that the parameter is unrecognised.

Fix zaproxy/zaproxy#8764.