### PR TITLE
 Alert help should link to the alert pages

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommonActiveScanRuleInfo.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommonActiveScanRuleInfo.java
@@ -28,6 +28,8 @@ public interface CommonActiveScanRuleInfo {
     }
 
     default String getHelpLink(int id) {
+
+        Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90020/">90020</a>.
         return "https://www.zaproxy.org/docs/desktop/addons/active-scan-rules/#id-" + id;
     }
 }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommonActiveScanRuleInfo.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommonActiveScanRuleInfo.java
@@ -29,7 +29,7 @@ public interface CommonActiveScanRuleInfo {
 
     default String getHelpLink(int id) {
 
-        Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90020/">90020</a>.
+        Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90020/">90020</a>
         return "https://www.zaproxy.org/docs/desktop/addons/active-scan-rules/#id-" + id;
     }
 }

--- a/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/internal/vulns/vulnerabilities.xml
+++ b/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/internal/vulns/vulnerabilities.xml
@@ -986,7 +986,17 @@ There are two main types of processes that require validation: flow control and 
 "Flow control" refers to multi-step processes that require each step to be performed in a specific order by the user. When an attacker performs the step incorrectly or out of order, the access controls may be bypassed and an application integrity error may occur. Examples of multi-step processes include wire transfer, password recovery, purchase checkout, and account sign-up.
 
 "Business logic" refers to the context in which a process will execute as governed by the business requirements. Exploiting a business logic weakness requires knowledge of the business; if no knowledge is needed to exploit it, then most likely it isn't a business logic flaw. Due to this, typical security measures such as scans and code review will not find this class of weakness. One approach to testing is offered by OWASP in their Testing Guide.</desc>
-	<solution></solution>
+	<solution>Make sure that all operations within a multi-step process are either performed entirely or not at all. If one step fails, the changes made must be canceled. Fuzzing inputs is a good way to test for anomalies and to verify the results after the flow completes.
+
+		Make sure the correct order of steps in the flow is enforced and that the order cannot be changed or bypassed by the user.
+
+		Developers and testers must have a solid understanding of the domain that the application serves.
+
+		Do not rely on implicit assumptions about how users or different application parts will behave.
+
+		Identify all references to other code that interacts with each component and evaluate the possible side-effects if a malicious actor manipulates these dependencies in unexpected ways.
+
+		Maintain clear code, design documents, and data flow diagrams for all transactions and workflows, noting any assumptions made at each stage and what the expected behavior is.</solution>
 	<reference>https://owasp.org/www-community/vulnerabilities/Business_logic_vulnerability</reference>
 	<reference>https://cwe.mitre.org/data/definitions/840.html</reference>
 </vuln_item_wasc_40>

--- a/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/internal/vulns/vulnerabilities.xml
+++ b/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/internal/vulns/vulnerabilities.xml
@@ -986,8 +986,8 @@ There are two main types of processes that require validation: flow control and 
 "Flow control" refers to multi-step processes that require each step to be performed in a specific order by the user. When an attacker performs the step incorrectly or out of order, the access controls may be bypassed and an application integrity error may occur. Examples of multi-step processes include wire transfer, password recovery, purchase checkout, and account sign-up.
 
 "Business logic" refers to the context in which a process will execute as governed by the business requirements. Exploiting a business logic weakness requires knowledge of the business; if no knowledge is needed to exploit it, then most likely it isn't a business logic flaw. Due to this, typical security measures such as scans and code review will not find this class of weakness. One approach to testing is offered by OWASP in their Testing Guide.</desc>
-	<solution>Make sure that all operations within a multi-step process are either performed entirely or not at all. If one step fails, the changes made must be canceled. Fuzzing inputs is a good way to test for anomalies and to verify the results after the flow completes.
-
+	<solution>Make sure that all operations within a multi-step process are either performed entirely or not at all.
+		If one step fails, the changes made must be canceled. Fuzzing inputs is a good way to test for anomalies and to verify the results after the flow completes.
 		Make sure the correct order of steps in the flow is enforced and that the order cannot be changed or bypassed by the user.
 
 		Developers and testers must have a solid understanding of the domain that the application serves.
@@ -996,7 +996,8 @@ There are two main types of processes that require validation: flow control and 
 
 		Identify all references to other code that interacts with each component and evaluate the possible side-effects if a malicious actor manipulates these dependencies in unexpected ways.
 
-		Maintain clear code, design documents, and data flow diagrams for all transactions and workflows, noting any assumptions made at each stage and what the expected behavior is.</solution>
+		Maintain clear code, design documents, and data flow diagrams for all transactions and workflows, noting any assumptions made at each stage and what the expected behavior is.
+	</solution>
 	<reference>https://owasp.org/www-community/vulnerabilities/Business_logic_vulnerability</reference>
 	<reference>https://cwe.mitre.org/data/definitions/840.html</reference>
 </vuln_item_wasc_40>

--- a/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/internal/vulns/vulnerabilities.xml
+++ b/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/internal/vulns/vulnerabilities.xml
@@ -835,7 +835,7 @@ Even if you make a mistake in your validation (such as forgetting one out of 100
 Routing Detours are a type of "Man in the Middle" attack where Intermediaries can be injected or "hijacked" to route sensitive messages to an outside location. Routing information (either in the HTTP header or in WS-Routing header) can be modified en route and traces of the routing can be removed from the header and message such that the receiving application none the wiser that a routing detour has occurred. The header and the insertion of header objects is often less protected than the message; this is due to the fact that the header is used as a catch all for metadata about the transaction such as authentication, routing, formatting, schema, canonicalization, namespaces, etc. Also, many processes may be involved in adding to/processing the header of an XML document. In many implementations the routing info can come from an external web service (using WS-Referral for example) that provides the specific routing for the transaction.
 
 WS-Addressing is a newer standard published by the W3C to provide routing functionality to SOAP messages. One of the key differences between WS-Routing and WS-Addressing is that WS-Addressing only provides the next location in the route. While little research has been done into the susceptibility of WS-Addressing to Routing Detour Attack, some research suggests that WS-Addressing is vulnerable to Routing Detour as well.</desc>
-	<solution>Always fully authenticate both ends of any communications channel.
+	<solution>Always fully authenticate both ends of any communications channel, and Use SSL for connections between all parties with mutual authentication.
 
 Adhere to the principle of complete mediation.
 
@@ -915,7 +915,8 @@ If an attacker submits a Server-side Include statement, he may have the ability 
 	<solution>Disable SSI execution on pages that do not require it. For pages requiring SSI ensure that you perform the following checks
 - Only enable the SSI directives that are needed for this page and disable all others.
 - HTML entity encode user supplied data before passing it to a page with SSI execution permissions.
-- Use SUExec to have the page execute as the owner of the file instead of the web server user.</solution>
+- Use SUExec to have the page execute as the owner of the file instead of the web server user.
+- A list of specifically approved values should be implemented for input validation. If that's not possible, only short alphanumeric strings should be allowed. Any input containing other types of data, including any potential SSI metacharacters, must be rejected.</solution>
 	<reference>https://owasp.org/www-community/attacks/Server-Side_Includes_(SSI)_Injection</reference>
 </vuln_item_wasc_36>
 
@@ -967,7 +968,7 @@ Many open redirect problems occur because the programmer assumed that certain in
 	<desc>XPath Injection is an attack technique used to exploit applications that construct XPath (XML Path Language) queries from user-supplied input to query or navigate XML documents. It can be used directly by an application to query an XML document, as part of a larger operation such as applying an XSLT transformation to an XML document, or applying an XQuery to an XML document. The syntax of XPath bears some resemblance to an SQL query, and indeed, it is possible to form SQL-like queries on an XML document using XPath.
 
 If an application uses run-time XPath query construction, embedding unsafe user input into the query, it may be possible for the attacker to inject data into the query such that the newly formed query will be parsed in a way differing from the programmer's intention.</desc>
-	<solution>Use parameterized XPath queries (e.g. using XQuery). This will help ensure separation between data plane and control plane.
+	<solution>Use parameterized XPath queries (e.g. using XQuery). This will help ensure separation between data plane and control plane. At the very least, input containing any XPath metacharacters such as " ' / @ = * [ ] ( and ) should be rejected.
 
 Properly validate user input. Reject data where appropriate, filter where appropriate and escape where appropriate. Make sure input that will be used in XPath queries is safe in that context.</solution>
 	<reference>https://owasp.org/www-community/attacks/XPATH_Injection</reference>


### PR DESCRIPTION
Proposed solution:  The Alert help should link to the alert pages using a standard format. Suggestion is to include a link immediately after the alert heading