### PR TITLE
commonlib: handle no input when providing values

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Policy tags for use with scan rules and the new Scan Policies add-on.
 
+### Fixed
+- Be more lenient with the input used for providing values, to prevent exceptions.
+
 ## [1.28.0] - 2024-09-24
 ### Changed
 - Maintenance changes.

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/DefaultValueProvider.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/DefaultValueProvider.java
@@ -23,8 +23,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import net.htmlparser.jericho.FormControlType;
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Default implementation of the {@link ValueProvider}.
@@ -36,13 +36,14 @@ import org.apache.commons.httpclient.URI;
  */
 public class DefaultValueProvider implements ValueProvider {
 
+    static final String CONTROL_TYPE_ATTRIBUTE = "Control Type";
+
     private static final String ATTR_TYPE = "type";
     private static final String DEFAULT_NUMBER_VALUE = "1";
-    private static final String DEFAULT_TEXT_VALUE =
-            org.parosproxy.paros.Constant.PROGRAM_NAME_SHORT;
-    private static final String DEFAULT_PASS_VALUE = DEFAULT_TEXT_VALUE;
-    private static final String DEFAULT_FILE_VALUE = "test_file.txt";
-    private static final String DEFAULT_EMPTY_VALUE = "";
+    static final String DEFAULT_TEXT_VALUE = org.parosproxy.paros.Constant.PROGRAM_NAME_SHORT;
+    static final String DEFAULT_PASS_VALUE = DEFAULT_TEXT_VALUE;
+    static final String DEFAULT_FILE_VALUE = "test_file.txt";
+    static final String DEFAULT_EMPTY_VALUE = "";
 
     private Date defaultDate;
 
@@ -90,12 +91,16 @@ public class DefaultValueProvider implements ValueProvider {
             Map<String, String> envAttributes,
             Map<String, String> fieldAttributes) {
 
-        // If there is a default value provided, return it
-        if (!defaultValue.isEmpty()) {
+        if (StringUtils.isNotEmpty(defaultValue)) {
             return defaultValue;
         }
 
-        if (fieldAttributes.get("Control Type").equalsIgnoreCase(FormControlType.TEXT.toString())) {
+        if (fieldAttributes == null) {
+            return DEFAULT_EMPTY_VALUE;
+        }
+
+        String controlType = fieldAttributes.get(CONTROL_TYPE_ATTRIBUTE);
+        if ("TEXT".equalsIgnoreCase(controlType)) {
             // Converted FormControlType to String to allow for case insensitive comparison
             // If the control type was reduced to a TEXT type by the Jericho library, check the
             // HTML5 type and use proper values
@@ -150,13 +155,9 @@ public class DefaultValueProvider implements ValueProvider {
                 SimpleDateFormat format = new SimpleDateFormat("yyyy-'W'ww");
                 return format.format(getDefaultDate());
             }
-        } else if (fieldAttributes
-                .get("Control Type")
-                .equalsIgnoreCase(FormControlType.PASSWORD.toString())) {
+        } else if ("PASSWORD".equalsIgnoreCase(controlType)) {
             return DEFAULT_PASS_VALUE;
-        } else if (fieldAttributes
-                .get("Control Type")
-                .equalsIgnoreCase(FormControlType.FILE.toString())) {
+        } else if ("FILE".equalsIgnoreCase(controlType)) {
             return DEFAULT_FILE_VALUE;
         }
         return DEFAULT_EMPTY_VALUE;

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/DefaultValueProviderUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/DefaultValueProviderUnitTest.java
@@ -1,0 +1,105 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Unit test for {@link DefaultValueProvider}. */
+class DefaultValueProviderUnitTest {
+
+    private DefaultValueProvider provider;
+
+    @BeforeEach
+    void setup() {
+        provider = new DefaultValueProvider();
+    }
+
+    @Test
+    void shouldGetValueWithNoInput() {
+        // Given / When
+        String value = provider.getValue(null, null, null, null, null, null, null);
+        // Then
+        assertThat(value, is(equalTo(DefaultValueProvider.DEFAULT_EMPTY_VALUE)));
+    }
+
+    @Test
+    void shouldGetValueFromDefaultValue() {
+        // Given
+        String defaultValue = "Default Value";
+        // When
+        String value = provider.getValue(null, null, null, defaultValue, null, null, null);
+        // Then
+        assertThat(value, is(equalTo(defaultValue)));
+    }
+
+    @Test
+    void shouldGetValueWithoutControlType() {
+        // Given
+        Map<String, String> fieldAttributes = Map.of();
+        // When
+        String value = provider.getValue(null, null, null, null, null, null, fieldAttributes);
+        // Then
+        assertThat(value, is(equalTo(DefaultValueProvider.DEFAULT_EMPTY_VALUE)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text", "TEXT", "Text"})
+    void shouldGetValueForSimpleTextControlType(String type) {
+        // Given
+        Map<String, String> fieldAttributes =
+                Map.of(DefaultValueProvider.CONTROL_TYPE_ATTRIBUTE, type);
+        // When
+        String value = provider.getValue(null, null, null, null, null, null, fieldAttributes);
+        // Then
+        assertThat(value, is(equalTo(DefaultValueProvider.DEFAULT_TEXT_VALUE)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"password", "PASSWORD", "Password"})
+    void shouldGetValueForPasswordControlType(String type) {
+        // Given
+        Map<String, String> fieldAttributes =
+                Map.of(DefaultValueProvider.CONTROL_TYPE_ATTRIBUTE, type);
+        // When
+        String value = provider.getValue(null, null, null, null, null, null, fieldAttributes);
+        // Then
+        assertThat(value, is(equalTo(DefaultValueProvider.DEFAULT_PASS_VALUE)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"file", "FILE", "File"})
+    void shouldGetValueForFileControlType(String type) {
+        // Given
+        Map<String, String> fieldAttributes =
+                Map.of(DefaultValueProvider.CONTROL_TYPE_ATTRIBUTE, type);
+        // When
+        String value = provider.getValue(null, null, null, null, null, null, fieldAttributes);
+        // Then
+        assertThat(value, is(equalTo(DefaultValueProvider.DEFAULT_FILE_VALUE)));
+    }
+}


### PR DESCRIPTION
Rework the input checks to prevent NullPointerException since not all callers have all values.
Remove unneeded dependency on Jericho classes by inlining values.