### PR TITLE
Revert some add-ons back to 2.15 and Java 11

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -121,12 +121,20 @@ subprojects {
 
     group = "org.zaproxy.addon"
 
+    val java11AddOns = setOf("commonlib", "domxss", "network", "retire", "selenium")
+
     java {
         // Compile with appropriate Java version when building ZAP releases.
         if (System.getenv("ZAP_RELEASE") != null) {
             toolchain {
                 languageVersion.set(JavaLanguageVersion.of(System.getenv("ZAP_JAVA_VERSION")))
             }
+        }
+
+        if (java11AddOns.contains(name)) {
+            val javaVersion = JavaVersion.VERSION_11
+            sourceCompatibility = javaVersion
+            targetCompatibility = javaVersion
         }
     }
 
@@ -163,7 +171,7 @@ subprojects {
 
     val zapGav = "org.zaproxy:zap:2.16.0-SNAPSHOT"
     dependencies {
-        "zap"(zapGav)
+        "zap"(if (java11AddOns.contains(name)) "org.zaproxy:zap:2.15.0" else zapGav)
     }
 
     val apiGenClasspath = configurations.detachedConfiguration(dependencies.create(zapGav))
@@ -174,7 +182,7 @@ subprojects {
         )
 
         manifest {
-            zapVersion.set("2.16.0")
+            zapVersion.set(if (java11AddOns.contains(name)) "2.15.0" else "2.16.0")
 
             changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
             repo.set("https://github.com/zaproxy/zap-extensions/")
@@ -182,7 +190,7 @@ subprojects {
 
         apiClientGen {
             classpath.run {
-                setFrom(apiGenClasspath)
+                setFrom("org.zaproxy:zap:2.15.0")
                 from(configurations.named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME))
                 from(tasks.named(JavaPlugin.JAR_TASK_NAME))
             }

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.16.0.
 - Dependency updates.
 - Let the Value Generator add-on provide the custom values through this add-on (Issue 8016).
 

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.16.0.
 - Address deprecation warnings with newer Selenium version (4.27).
 - Include the whole HTTP message in the raised alerts.
 - Include the steps to reproduce the DOM XSS in the other info of the alert.

--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.16.0.
 - Configure the logging to prevent verbose log messages when using BC JSSE provider.
 - Improve error handling on client's unknown CA TLS alert.
 - Report available TLS providers when failed to query the TLS/SSL protocol versions.

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - An issue that was resulting in False Positives.
 
 ### Changed
-- Update minimum ZAP version to 2.16.0.
 - The scan rule now uses a more specific CWE (Issue 8732).
 
 ## [0.42.0] - 2024-11-25

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.16.0.
 - Update Selenium to version 4.27.0.
 - Use WebDriver BiDi with Firefox.
 

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -18,8 +18,14 @@ tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs = options.compilerArgs + "-Xlint:-processing"
 }
 
+java {
+    val javaVersion = JavaVersion.VERSION_11
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+}
+
 dependencies {
-    compileOnly("org.zaproxy:zap:2.16.0-SNAPSHOT")
+    compileOnly("org.zaproxy:zap:2.15.0")
     implementation(project(":addOns:network"))
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 


### PR DESCRIPTION
Change the add-ons that should be released for 2.15:
 - `commonlib`
 - `domxss`
 - `network`
 - `retire`
 - `selenium`