### PR TITLE
Client: Use dev mode

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -175,7 +175,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
             extensionHook.getHookView().addWorkPanel(getClientDetailsPanel());
             extensionHook.getHookView().addStatusPanel(getClientHistoryPanel());
 
-            if (Constant.isDevBuild()) {
+            if (Constant.isDevMode()) {
                 // Not for release .. yet ;)
                 extensionHook.getHookMenu().addToolsMenuItem(getMenuItemCustomScan());
                 extensionHook
@@ -746,7 +746,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
     }
 
     private void addScanToUi(final ClientSpider scan) {
-        if (!Constant.isDevBuild()) {
+        if (!Constant.isDevMode()) {
             return;
         }
 
@@ -768,7 +768,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
             spiderScanController.reset();
 
             if (hasView()) {
-                if (Constant.isDevBuild()) {
+                if (Constant.isDevMode()) {
                     getClientSpiderPanel().reset();
                 }
                 if (spiderDialog != null) {
@@ -779,14 +779,14 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
 
         @Override
         public void sessionChanged(final Session session) {
-            if (hasView() && Constant.isDevBuild()) {
+            if (hasView() && Constant.isDevMode()) {
                 ThreadUtils.invokeAndWaitHandled(getClientSpiderPanel()::reset);
             }
         }
 
         @Override
         public void sessionScopeChanged(Session session) {
-            if (hasView() && Constant.isDevBuild()) {
+            if (hasView() && Constant.isDevMode()) {
                 getClientSpiderPanel().sessionScopeChanged(session);
             }
         }
@@ -798,7 +798,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
             }
 
             if (hasView()) {
-                if (Constant.isDevBuild()) {
+                if (Constant.isDevMode()) {
                     getClientSpiderPanel().sessionModeChanged(mode);
                 }
                 getMenuItemCustomScan().setEnabled(!Mode.safe.equals(mode));

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ui/PopupMenuClientAttack.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ui/PopupMenuClientAttack.java
@@ -43,7 +43,7 @@ public class PopupMenuClientAttack extends ExtensionPopupMenu {
             JTree tree = (JTree) invoker;
             if (ClientMapPanel.CLIENT_TREE_NAME.equals(tree.getName())) {
                 removeAll();
-                if (Constant.isDevBuild()) {
+                if (Constant.isDevMode()) {
                     // Not for release .. yet ;)
                     add(new PopupClientSpider(clientMapPanel));
                     List<ClientNode> nodes = clientMapPanel.getSelectedNodes();


### PR DESCRIPTION
## Overview
With this change the spider will be enabled when the `-dev`option is used.

## Related Issues

## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
