### PR TITLE
automation: fix typo in test class name

### DIFF
--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtensionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtensionAutomationUnitTest.java
@@ -67,7 +67,8 @@ import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-class ExtentionAutomationUnitTest extends TestUtils {
+/** Unit test for {@link ExtensionAutomation}. */
+class ExtensionAutomationUnitTest extends TestUtils {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
 


### PR DESCRIPTION
Rename the class to "Extension".