### PR TITLE
pscanrules: Ignore JavaScript Files while scanning for timestamps on High threshold

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Application Error Disclosure
     - Information Disclosure - Suspicious Comments
     - Username Hash Found
-- Updated Timestamp Disclosure Scan Rule to skip JavaScript files when Alert Threshold is set to High.
+- Updated Timestamp Disclosure Scan Rule to skip JavaScript files when Alert Threshold is set to High (Issue 8380).
 
 ## [61] - 2024-09-24
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Application Error Disclosure
     - Information Disclosure - Suspicious Comments
     - Username Hash Found
-- Updated Timestamp Disclosure Scan Rule to skip Javascript files when Alert Threshold is set to High
+- Updated Timestamp Disclosure Scan Rule to skip JavaScript files when Alert Threshold is set to High.
 
 ## [61] - 2024-09-24
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - The Absence of Anti-CSRF Tokens scan rule now only considers forms with GET method at Low Threshold. (Forms submitted via GET, not forms delivered via GET.)
+- Updated Timestamp Disclosure Scan Rule to skip JavaScript files when Alert Threshold is set to High (Issue 8380).
 
 ### Changed
 - Replace usage of CWE-200 for the following rules (Issue 8712):
@@ -32,7 +33,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Application Error Disclosure
     - Information Disclosure - Suspicious Comments
     - Username Hash Found
-- Updated Timestamp Disclosure Scan Rule to skip JavaScript files when Alert Threshold is set to High (Issue 8380).
 
 ## [61] - 2024-09-24
 ### Changed

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Application Error Disclosure
     - Information Disclosure - Suspicious Comments
     - Username Hash Found
+- Updated Timestamp Disclosure Scan Rule to skip Javascript files when Alert Threshold is set to High
 
 ## [61] - 2024-09-24
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -123,11 +123,10 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (ResourceIdentificationUtils.isFont(msg)) {
+        if (ResourceIdentificationUtils.isFont(msg) || ResourceIdentificationUtils.isJavaScript(msg)) {
             return;
         }
         LOGGER.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI());
-
         List<HttpHeaderField> responseparts = new ArrayList<>();
         msg.getResponseHeader().getHeaders().stream()
                 .filter(header -> !containsIgnoreCase(RESPONSE_HEADERS_TO_IGNORE, header.getName()))

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -123,13 +123,12 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (ResourceIdentificationUtils.isFont(msg)) {
+        if (ResourceIdentificationUtils.isFont(msg)
+                || (this.getAlertThreshold().equals(AlertThreshold.HIGH)
+                        && ResourceIdentificationUtils.isJavaScript(msg))) {
             return;
         }
-        if (this.getAlertThreshold() == AlertThreshold.HIGH && ResourceIdentificationUtils.isJavaScript(msg)){
-           LOGGER.debug("Skipping Javascript files from TimestampDisclosureScanRule as alert threshold is set to High");
-           return;
-        }
+
         LOGGER.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI());
         List<HttpHeaderField> responseparts = new ArrayList<>();
         msg.getResponseHeader().getHeaders().stream()

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -123,9 +123,12 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (ResourceIdentificationUtils.isFont(msg)
-                || ResourceIdentificationUtils.isJavaScript(msg)) {
+        if (ResourceIdentificationUtils.isFont(msg)) {
             return;
+        }
+        if (this.getAlertThreshold() == AlertThreshold.HIGH && ResourceIdentificationUtils.isJavaScript(msg)){
+           LOGGER.debug("Skipping Javascript files from TimestampDisclosureScanRule as alert threshold is set to High");
+           return;
         }
         LOGGER.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI());
         List<HttpHeaderField> responseparts = new ArrayList<>();

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -123,7 +123,8 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (ResourceIdentificationUtils.isFont(msg) || ResourceIdentificationUtils.isJavaScript(msg)) {
+        if (ResourceIdentificationUtils.isFont(msg)
+                || ResourceIdentificationUtils.isJavaScript(msg)) {
             return;
         }
         LOGGER.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI());

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -129,7 +129,6 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
             return;
         }
 
-        LOGGER.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI());
         List<HttpHeaderField> responseparts = new ArrayList<>();
         msg.getResponseHeader().getHeaders().stream()
                 .filter(header -> !containsIgnoreCase(RESPONSE_HEADERS_TO_IGNORE, header.getName()))

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -129,6 +129,8 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
             return;
         }
 
+        LOGGER.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI());
+
         List<HttpHeaderField> responseparts = new ArrayList<>();
         msg.getResponseHeader().getHeaders().stream()
                 .filter(header -> !containsIgnoreCase(RESPONSE_HEADERS_TO_IGNORE, header.getName()))

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -477,6 +477,7 @@ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10035/">10035</a>.
 <H2 id="id-10096">Timestamp Disclosure</H2>
 A timestamp was disclosed by the application/web server.<br>
 At HIGH threshold this rule does not alert on potential timestamps that are not within a range of plus or minus one year.<br>
+At HIGH threshold this rule ignores timestamps in JavaScript files.<br>
 At MEDIUM threshold this rule does not alert on potential timestamps beyond 10 years.<br>
 At all thresholds, this rule will not alert on timestamps beyond the Y2038 epoch edge.<br>
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -503,7 +503,7 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
     }
 
     @Test
-    void shouldNotRaiseAlertOnTimeStampInJavascriptFilesAtHighThreshold() throws Exception {
+    void shouldNotRaiseAlertOnTimeStampInJavaScriptFilesAtHighThreshold() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -520,7 +520,7 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
     @EnumSource(
             value = AlertThreshold.class,
             names = {"MEDIUM", "LOW"})
-    void shouldRaiseAlertBelowHighThresholdOnTimeStampInJavascriptFiles(AlertThreshold threshold)
+    void shouldRaiseAlertBelowHighThresholdOnTimeStampInJavaScriptFiles(AlertThreshold threshold)
             throws URIException {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -503,8 +503,7 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
     }
 
     @Test
-    void shouldNotRaiseAlertOnTimeStampInJavascriptFilesAtHighThreshold()
-            throws Exception {
+    void shouldNotRaiseAlertOnTimeStampInJavascriptFilesAtHighThreshold() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -518,7 +517,8 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
     }
 
     @ParameterizedTest
-    @EnumSource(value = AlertThreshold.class,
+    @EnumSource(
+            value = AlertThreshold.class,
             names = {"MEDIUM", "LOW"})
     void shouldRaiseAlertBelowHighThresholdOnTimeStampInJavascriptFiles(AlertThreshold threshold)
             throws URIException {

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -502,13 +502,18 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
         assertEquals(0, alertsRaised.size());
     }
 
-    @Test
-    void shouldNotRaiseAlertOnTimeStampInJavaScriptFilesAtHighThreshold() throws Exception {
-        // Given
+    private static HttpMessage createJavaScriptReponseWithTimeStamp() throws URIException {
         Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
         HttpMessage msg = createMessage(strTestDate);
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "javascript");
+        return msg;
+    }
+
+    @Test
+    void shouldNotRaiseAlertOnTimeStampInJavaScriptFilesAtHighThreshold() throws Exception {
+        // Given
+        HttpMessage msg = createJavaScriptReponseWithTimeStamp();
         rule.setAlertThreshold(AlertThreshold.HIGH);
         // When
         scanHttpResponseReceive(msg);
@@ -523,10 +528,7 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
     void shouldRaiseAlertBelowHighThresholdOnTimeStampInJavaScriptFiles(AlertThreshold threshold)
             throws URIException {
         // Given
-        Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
-        String strTestDate = String.valueOf(testDate.getEpochSecond());
-        HttpMessage msg = createMessage(strTestDate);
-        msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "javascript");
+        HttpMessage msg = createJavaScriptReponseWithTimeStamp();
         rule.setAlertThreshold(threshold);
         // When
         scanHttpResponseReceive(msg);

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -501,6 +501,22 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
         assertEquals(0, alertsRaised.size());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"javascript"})
+    void shouldNotRaiseAlertOnTimeStampInJavascriptFilesAtHighThreshold(String type)
+            throws Exception {
+        // Given
+        Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
+        String strTestDate = String.valueOf(testDate.getEpochSecond());
+        HttpMessage msg = createMessage(strTestDate);
+        msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, type);
+        rule.setAlertThreshold(AlertThreshold.HIGH);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(0, alertsRaised.size());
+    }
+
     private static HttpMessage createMessage(String timestamp) throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));


### PR DESCRIPTION
Passive scan rule identifies timestamps falsely in js files ending up in false positives. Timestamps in JS files can't happen so they should be ignored.

fixes zaproxy/zaproxy#8380