### PR TITLE
client: limit spider scope and use own proxies

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -91,6 +91,7 @@ import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.selenium.ProfileManager;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ScanEventPublisher;
 import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.users.User;
@@ -700,10 +701,14 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
         return StringUtils.abbreviateMiddle(displayName, "..", 30);
     }
 
-    public int startScan(String url, ClientOptions options, User user)
+    public int startScan(
+            String url, ClientOptions options, Context context, User user, boolean subtreeOnly)
             throws URIException, NullPointerException {
         return this.startScan(
-                abbreviateDisplayName(url), null, user, new Object[] {new URI(url, true), options});
+                abbreviateDisplayName(url),
+                null,
+                user,
+                new Object[] {new URI(url, true), options, context, subtreeOnly});
     }
 
     public int startScan(

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderDialog.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderDialog.java
@@ -128,15 +128,14 @@ public class ClientSpiderDialog extends StandardFieldsDialog {
             this.addUrlSelectField(0, FIELD_START, url, true, false);
         }
 
+        this.addComboField(0, FIELD_CONTEXT, new String[] {}, "");
+        List<String> ctxNames = new ArrayList<>();
+        ctxNames.add("");
+        Session session = Model.getSingleton().getSession();
+        session.getContexts().forEach(context -> ctxNames.add(context.getName()));
+        this.setComboFields(FIELD_CONTEXT, ctxNames, "");
+
         if (extUserMgmt != null) {
-            this.addComboField(0, FIELD_CONTEXT, new String[] {}, "");
-
-            List<String> ctxNames = new ArrayList<>();
-            ctxNames.add("");
-            Session session = Model.getSingleton().getSession();
-            session.getContexts().forEach(context -> ctxNames.add(context.getName()));
-
-            this.setComboFields(FIELD_CONTEXT, ctxNames, "");
             this.addComboField(0, FIELD_USER, new String[] {}, "");
 
             this.addFieldListener(FIELD_CONTEXT, e -> setUsers());
@@ -183,7 +182,7 @@ public class ClientSpiderDialog extends StandardFieldsDialog {
 
     private Context getSelectedContext() {
         String ctxName = this.getStringValue(FIELD_CONTEXT);
-        if (this.extUserMgmt != null && !this.isEmptyField(FIELD_CONTEXT)) {
+        if (!this.isEmptyField(FIELD_CONTEXT)) {
             Session session = Model.getSingleton().getSession();
             return session.getContext(ctxName);
         }
@@ -369,7 +368,12 @@ public class ClientSpiderDialog extends StandardFieldsDialog {
 
         User user = this.getSelectedUser();
         try {
-            this.extension.startScan(getStartUrl(), clientParams, user);
+            this.extension.startScan(
+                    getStartUrl(),
+                    clientParams,
+                    getSelectedContext(),
+                    user,
+                    subtreeOnlyPreviousCheckedState);
         } catch (Exception e) {
             // Should not happen as we will already have checked the URL
             LOGGER.debug("Failed to start client spider", e);

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderPanel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderPanel.java
@@ -56,6 +56,7 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
 
     private static final TaskTableModel EMPTY_ACTIONS_TABLE_MODEL = new TaskTableModel();
     private static final UrlTableModel EMPTY_URL_TABLE_MODEL = new UrlTableModel();
+    private static final MessagesTableModel EMPTY_MESSAGES_TABLE_MODEL = new MessagesTableModel();
 
     public static final String PANEL_NAME = "ClientPanel";
 
@@ -70,7 +71,9 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
     private JScrollPane addedNodesTableScrollPane;
     private JLabel addedCountNameLabel;
     private JLabel addedCountValueLabel;
+    private JLabel countCrawledUrlsLabel;
     private ZapTable tasksTable;
+    private ZapTable messagesTable;
     private JScrollPane tasksTableScrollPane;
 
     private ExtensionClientIntegration extension;
@@ -97,6 +100,10 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
             tabbedPane.addTab(
                     Constant.messages.getString("client.spider.panel.tab.tasks"),
                     getTasksTableScrollPane());
+            messagesTable = new MessagesTable(EMPTY_MESSAGES_TABLE_MODEL);
+            tabbedPane.addTab(
+                    Constant.messages.getString("client.spider.panel.tab.messages"),
+                    new JScrollPane(messagesTable));
             tabbedPane.setSelectedIndex(0);
 
             mainPanel.add(tabbedPane);
@@ -188,6 +195,12 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
     protected int addToolBarElements(JToolBar toolBar, Location location, int gridX) {
         if (ScanPanel2.Location.afterProgressBar == location) {
             toolBar.add(new JToolBar.Separator(), getGBC(gridX++, 0));
+            toolBar.add(
+                    new JLabel(Constant.messages.getString("client.spider.toolbar.urls.label")),
+                    getGBC(gridX++, 0));
+            countCrawledUrlsLabel = new JLabel(ZERO_REQUESTS_LABEL_TEXT);
+            toolBar.add(countCrawledUrlsLabel, getGBC(gridX++, 0));
+            toolBar.add(new JToolBar.Separator(), getGBC(gridX++, 0));
             toolBar.add(getAddedCountNameLabel(), getGBC(gridX++, 0));
             toolBar.add(getAddedCountValueLabel(), getGBC(gridX++, 0));
 
@@ -202,8 +215,10 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
         if (sc != null) {
             this.getAddedCountValueLabel()
                     .setText(Integer.toString(sc.getAddedNodesTableModel().getRowCount()));
+            countCrawledUrlsLabel.setText(Integer.toString(sc.getCountCrawledUrls()));
         } else {
             this.getAddedCountValueLabel().setText(ZERO_REQUESTS_LABEL_TEXT);
+            countCrawledUrlsLabel.setText(ZERO_REQUESTS_LABEL_TEXT);
         }
     }
 
@@ -216,9 +231,11 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
         if (scanner != null) {
             getAddedNodesTable().setModel(scanner.getAddedNodesTableModel());
             getTasksTable().setModel(scanner.getActionsTableModel());
+            messagesTable.setModel(scanner.getMessagesTableModel());
         } else {
             getAddedNodesTable().setModel(EMPTY_URL_TABLE_MODEL);
             getTasksTable().setModel(EMPTY_ACTIONS_TABLE_MODEL);
+            messagesTable.setModel(EMPTY_MESSAGES_TABLE_MODEL);
         }
         this.updateAddedCount();
     }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderTask.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderTask.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
 
 public class ClientSpiderTask implements Runnable {
 
@@ -53,7 +54,6 @@ public class ClientSpiderTask implements Runnable {
     private ClientSpider clientSpider;
     private List<SpiderAction> actions;
     private int timeout;
-    private WebDriver wd;
     @Getter private Status status;
     @Getter private String error;
 
@@ -93,8 +93,10 @@ public class ClientSpiderTask implements Runnable {
         long startTime = System.currentTimeMillis();
         this.status = Status.RUNNING;
         this.clientSpider.taskStateChange(this);
+        WebDriverProcess wdp = null;
         try {
-            wd = this.clientSpider.getWebDriver();
+            wdp = this.clientSpider.getWebDriverProcess();
+            WebDriver wd = wdp.getWebDriver();
             startTime = System.currentTimeMillis();
             wd.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(this.timeout));
             actions.forEach(e -> e.run(wd));
@@ -107,8 +109,8 @@ public class ClientSpiderTask implements Runnable {
             this.error = e.getMessage();
             this.clientSpider.taskStateChange(this);
         }
-        if (wd != null) {
-            this.clientSpider.returnWebDriver(wd);
+        if (wdp != null) {
+            this.clientSpider.returnWebDriverProcess(wdp);
         }
         LOGGER.debug(
                 "Task {} completed {} in {} secs",

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/HttpPrefixUriValidator.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/HttpPrefixUriValidator.java
@@ -1,0 +1,345 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import java.util.Arrays;
+import java.util.Locale;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A {@code URI} validator based on a HTTP or HTTPS {@code URI}.
+ *
+ * <p>The {@code URI}s are required to start with the {@code URI} (the prefix) to be considered
+ * valid.
+ *
+ * @see #isValid(URI)
+ */
+class HttpPrefixUriValidator {
+
+    private static final Logger LOGGER = LogManager.getLogger(HttpPrefixUriValidator.class);
+
+    /** The normalised form of HTTP scheme, that is, all letters lowercase. */
+    private static final String HTTP_SCHEME = "http";
+
+    /** The normalised form of HTTPS scheme, that is, all letters lowercase. */
+    private static final String HTTPS_SCHEME = "https";
+
+    /** The port number that indicates that a port is the default of a scheme. */
+    private static final int DEFAULT_PORT = -1;
+
+    /**
+     * The port number that indicates that a port is of an unknown scheme (that is, non HTTP and
+     * HTTPS).
+     */
+    private static final int UNKNOWN_PORT = -2;
+
+    /** The default port number of HTTP scheme. */
+    private static final int DEFAULT_HTTP_PORT = 80;
+
+    /** The default port number of HTTPS scheme. */
+    private static final int DEFAULT_HTTPS_PORT = 443;
+
+    /** The scheme used for filtering. Never {@code null}. */
+    private final String scheme;
+
+    /** The host used for filtering. Never {@code null}. */
+    private final String host;
+
+    /** The port used for filtering. */
+    private final int port;
+
+    /** The path used for filtering. Might be {@code null}. */
+    private final char[] path;
+
+    /**
+     * Constructs a {@code HttpPrefixFetchFilter} using the given {@code URI} as prefix.
+     *
+     * <p>The user info, query component and fragment of the given {@code URI} are discarded. The
+     * scheme and domain comparisons are done in a case insensitive way while the path component
+     * comparison is case sensitive.
+     *
+     * @param prefix the {@code URI} that will be used as prefix
+     * @throws IllegalArgumentException if any of the following conditions is {@code true}:
+     *     <ul>
+     *       <li>The given {@code prefix} is {@code null};
+     *       <li>The given {@code prefix} has {@code null} scheme;
+     *       <li>The scheme of the given {@code prefix} is not HTTP or HTTPS;
+     *       <li>The given {@code prefix} has {@code null} host;
+     *       <li>The given {@code prefix} has malformed host.
+     *     </ul>
+     */
+    public HttpPrefixUriValidator(URI prefix) {
+        if (prefix == null) {
+            throw new IllegalArgumentException("Parameter prefix must not be null.");
+        }
+
+        char[] rawScheme = prefix.getRawScheme();
+        if (rawScheme == null) {
+            throw new IllegalArgumentException("Parameter prefix must have a scheme.");
+        }
+        String normalisedScheme = normalisedScheme(rawScheme);
+        if (!isHttpOrHttps(normalisedScheme)) {
+            throw new IllegalArgumentException("The prefix's scheme must be HTTP or HTTPS.");
+        }
+        scheme = normalisedScheme;
+
+        if (prefix.getRawHost() == null) {
+            throw new IllegalArgumentException("Parameter prefix must have a host.");
+        }
+        try {
+            host = normalisedHost(prefix);
+        } catch (URIException e) {
+            throw new IllegalArgumentException("Failed to obtain the host from the prefix:", e);
+        }
+
+        port = normalisedPort(scheme, prefix.getPort());
+        path = prefix.getRawPath();
+    }
+
+    /**
+     * Returns the normalised form of the given {@code scheme}.
+     *
+     * <p>The normalisation process consists in converting the scheme to lowercase, if {@code null}
+     * it is returned an empty {@code String}.
+     *
+     * @param scheme the scheme that will be normalised
+     * @return a {@code String} with the host scheme, never {@code null}
+     * @see URI#getRawScheme()
+     */
+    private static String normalisedScheme(char[] scheme) {
+        if (scheme == null) {
+            return "";
+        }
+        return new String(scheme).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTP or HTTPS.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTP or HTTPS, {@code false} otherwise
+     */
+    private static boolean isHttpOrHttps(String scheme) {
+        return isHttp(scheme) || isHttps(scheme);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTP.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTP, {@code false} otherwise
+     */
+    private static boolean isHttp(String scheme) {
+        return HTTP_SCHEME.equals(scheme);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTPS.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTPS, {@code false} otherwise
+     */
+    private static boolean isHttps(String scheme) {
+        return HTTPS_SCHEME.equals(scheme);
+    }
+
+    /**
+     * Returns the normalised form of the host of the given {@code uri}.
+     *
+     * <p>The normalisation process consists in converting the host to lowercase, if {@code null} it
+     * is returned an empty {@code String}.
+     *
+     * @param uri the URI whose host will be extracted and normalised
+     * @return a {@code String} with the host normalised, never {@code null}
+     * @throws URIException if the host of the given {@code uri} is malformed
+     */
+    private static String normalisedHost(URI uri) throws URIException {
+        if (uri.getRawHost() == null) {
+            return "";
+        }
+        return uri.getHost().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Returns the normalised form of the given {@code port}, based on the given {@code scheme}.
+     *
+     * <p>If the port is non-default (as given by {@link #DEFAULT_PORT}), it's immediately returned.
+     * Otherwise, for schemes HTTP and HTTPS it's returned 80 and 443, respectively, for any other
+     * scheme it's returned {@link #UNKNOWN_PORT}.
+     *
+     * @param scheme the (normalised) scheme of the URI where the port was defined
+     * @param port the port to normalise
+     * @return the normalised port
+     * @see #normalisedScheme(char[])
+     * @see URI#getPort()
+     */
+    private static int normalisedPort(String scheme, int port) {
+        if (port != DEFAULT_PORT) {
+            return port;
+        }
+
+        if (isHttp(scheme)) {
+            return DEFAULT_HTTP_PORT;
+        }
+
+        if (isHttps(scheme)) {
+            return DEFAULT_HTTPS_PORT;
+        }
+
+        return UNKNOWN_PORT;
+    }
+
+    /**
+     * Gets the prefix normalised, as it is used to filter the {@code URI}s.
+     *
+     * @return a {@code String} with the prefix normalised
+     * @see #isValid(URI)
+     */
+    public String getNormalisedPrefix() {
+        StringBuilder strBuilder = new StringBuilder();
+        strBuilder.append(scheme).append("://").append(host);
+        if (!isDefaultHttpOrHttpsPort(scheme, port)) {
+            strBuilder.append(':').append(port);
+        }
+        if (path != null) {
+            strBuilder.append(path);
+        }
+        return strBuilder.toString();
+    }
+
+    public static String getNormalisedPrefix(String uri) {
+        if (uri == null) {
+            throw new IllegalArgumentException("Parameter uri must not be null.");
+        }
+
+        try {
+            return new HttpPrefixUriValidator(new URI(uri, true)).getNormalisedPrefix();
+        } catch (URIException e) {
+            LOGGER.warn("Failed to normalise prefix:", e);
+        }
+        return uri;
+    }
+
+    /**
+     * Tells whether or not the given {@code port} is the default for the given {@code scheme}.
+     *
+     * <p>The method returns always {@code false} for non HTTP or HTTPS schemes.
+     *
+     * @param scheme the scheme of a URI, might be {@code null}
+     * @param port the port of a URI
+     * @return {@code true} if the {@code port} is the default for the given {@code scheme}, {@code
+     *     false} otherwise
+     */
+    private static boolean isDefaultHttpOrHttpsPort(String scheme, int port) {
+        if (port == DEFAULT_HTTP_PORT && isHttp(scheme)) {
+            return true;
+        }
+        if (port == DEFAULT_HTTPS_PORT && isHttps(scheme)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given URI is valid, by starting or not with the defined prefix.
+     *
+     * @param uri the uri to be validated
+     * @return {@code true} if valid, that is, the {@code uri} starts with the {@code prefix},
+     *     {@code false} otherwise
+     */
+    public boolean isValid(URI uri) {
+        if (uri == null) {
+            return false;
+        }
+
+        String otherScheme = normalisedScheme(uri.getRawScheme());
+        if (port != normalisedPort(otherScheme, uri.getPort())) {
+            return false;
+        }
+
+        if (!scheme.equals(otherScheme)) {
+            return false;
+        }
+
+        if (!hasSameHost(uri)) {
+            return false;
+        }
+
+        if (!startsWith(uri.getRawPath(), path)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Tells whether or not the given {@code uri} has the same host as required by this prefix.
+     *
+     * <p>For malformed hosts it returns always {@code false}.
+     *
+     * @param uri the {@code URI} whose host will be checked
+     * @return {@code true} if the host is same, {@code false} otherwise
+     */
+    private boolean hasSameHost(URI uri) {
+        try {
+            return host.equals(normalisedHost(uri));
+        } catch (URIException e) {
+            LOGGER.warn("Failed to normalise host: {}", Arrays.toString(uri.getRawHost()), e);
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given {@code array} starts with the given {@code prefix}.
+     *
+     * <p>The {@code prefix} might be {@code null} in which case it's considered that the {@code
+     * array} starts with the prefix.
+     *
+     * @param array the array that will be tested if starts with the prefix, might be {@code null}
+     * @param prefix the array used as prefix, might be {@code null}
+     * @return {@code true} if the {@code array} starts with the {@code prefix}, {@code false}
+     *     otherwise
+     */
+    private static boolean startsWith(char[] array, char[] prefix) {
+        if (prefix == null) {
+            return true;
+        }
+
+        if (array == null) {
+            return false;
+        }
+
+        int length = prefix.length;
+        if (array.length < length) {
+            return false;
+        }
+
+        for (int i = 0; i < length; i++) {
+            if (prefix[i] != array[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/MessagesTable.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/MessagesTable.java
@@ -1,0 +1,151 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import java.awt.Component;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.SortOrder;
+import javax.swing.table.TableModel;
+import org.jdesktop.swingx.decorator.AbstractHighlighter;
+import org.jdesktop.swingx.decorator.ComponentAdapter;
+import org.jdesktop.swingx.renderer.DefaultTableRenderer;
+import org.jdesktop.swingx.renderer.IconAware;
+import org.jdesktop.swingx.renderer.IconValues;
+import org.jdesktop.swingx.renderer.MappedValue;
+import org.jdesktop.swingx.renderer.StringValues;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.zaproxy.addon.client.spider.ClientSpider.ResourceState;
+import org.zaproxy.addon.client.spider.MessagesTableModel.ProcessedCellItem;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.table.HistoryReferencesTable;
+
+@SuppressWarnings("serial")
+public class MessagesTable extends HistoryReferencesTable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String RESULTS_TABLE_NAME = "ClientSpiderMessagesTable";
+
+    private final ExtensionHistory extensionHistory;
+
+    public MessagesTable(MessagesTableModel model) {
+        super(model);
+
+        setName(RESULTS_TABLE_NAME);
+
+        setAutoCreateColumnsFromModel(false);
+
+        getColumnExt(0)
+                .setCellRenderer(
+                        new DefaultTableRenderer(
+                                new MappedValue(StringValues.EMPTY, IconValues.NONE),
+                                JLabel.CENTER));
+        getColumnExt(0).setHighlighters(new ProcessedCellItemIconHighlighter(0));
+
+        getColumnExt(Constant.messages.getString("view.href.table.header.timestamp.response"))
+                .setVisible(false);
+        getColumnExt(Constant.messages.getString("view.href.table.header.size.requestheader"))
+                .setVisible(false);
+        getColumnExt(Constant.messages.getString("view.href.table.header.size.requestbody"))
+                .setVisible(false);
+
+        extensionHistory =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+    }
+
+    @Override
+    public void setModel(TableModel dataModel) {
+        // Keep the same column sorted when model is changed
+        int sortedcolumnIndex = getSortedColumnIndex();
+        SortOrder sortOrder = getSortOrder(sortedcolumnIndex);
+        super.setModel(dataModel);
+        if (sortedcolumnIndex != -1) {
+            setSortOrder(sortedcolumnIndex, sortOrder);
+        }
+    }
+
+    @Override
+    protected HistoryReference getHistoryReferenceAtViewRow(int row) {
+        HistoryReference historyReference = super.getHistoryReferenceAtViewRow(row);
+        if (historyReference == null) {
+            return null;
+        }
+
+        if (extensionHistory == null
+                || extensionHistory.getHistoryReference(historyReference.getHistoryId()) == null) {
+            // Associated message was deleted in the meantime.
+            return null;
+        }
+
+        return historyReference;
+    }
+
+    private static class ProcessedCellItemIconHighlighter extends AbstractHighlighter {
+
+        private static final ImageIcon ALLOWED_ICON =
+                DisplayUtils.getScaledIcon(
+                        MessagesTable.class.getResource("/resource/icon/16/152.png"));
+
+        private static final ImageIcon NOT_ALLOWED_ICON =
+                DisplayUtils.getScaledIcon(
+                        MessagesTable.class.getResource("/resource/icon/16/149.png"));
+
+        private final int columnIndex;
+
+        public ProcessedCellItemIconHighlighter(final int columnIndex) {
+            this.columnIndex = columnIndex;
+        }
+
+        @Override
+        protected Component doHighlight(Component component, ComponentAdapter adapter) {
+            ProcessedCellItem cell = (ProcessedCellItem) adapter.getValue(columnIndex);
+
+            boolean allowed = cell.getState() == ResourceState.ALLOWED;
+            Icon icon = getIcon(allowed);
+            if (component instanceof IconAware) {
+                ((IconAware) component).setIcon(icon);
+            } else if (component instanceof JLabel) {
+                ((JLabel) component).setIcon(icon);
+            }
+
+            if (component instanceof JLabel) {
+                ((JLabel) component).setText(allowed ? "" : cell.getLabel());
+            }
+
+            return component;
+        }
+
+        private static Icon getIcon(boolean allowed) {
+            return allowed ? ALLOWED_ICON : NOT_ALLOWED_ICON;
+        }
+
+        // Method/JavaDoc copied from
+        // org.jdesktop.swingx.decorator.IconHighlighter#canHighlight(Component, ComponentAdapter)
+        @Override
+        protected boolean canHighlight(final Component component, final ComponentAdapter adapter) {
+            return component instanceof IconAware || component instanceof JLabel;
+        }
+    }
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/MessagesTableModel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/MessagesTableModel.java
@@ -1,0 +1,364 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import java.awt.EventQueue;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.event.TableModelEvent;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.zaproxy.addon.client.spider.ClientSpider.ResourceState;
+import org.zaproxy.zap.ZAP;
+import org.zaproxy.zap.eventBus.Event;
+import org.zaproxy.zap.eventBus.EventConsumer;
+import org.zaproxy.zap.extension.alert.AlertEventPublisher;
+import org.zaproxy.zap.view.table.AbstractCustomColumnHistoryReferencesTableModel;
+import org.zaproxy.zap.view.table.AbstractHistoryReferencesTableEntry;
+import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
+
+@SuppressWarnings("serial")
+public class MessagesTableModel
+        extends AbstractCustomColumnHistoryReferencesTableModel<MessagesTableModel.TableEntry> {
+
+    private static final long serialVersionUID = 4949104995571034494L;
+
+    private static final Column[] COLUMNS =
+            new Column[] {
+                Column.CUSTOM,
+                Column.HREF_ID,
+                Column.REQUEST_TIMESTAMP,
+                Column.RESPONSE_TIMESTAMP,
+                Column.METHOD,
+                Column.URL,
+                Column.STATUS_CODE,
+                Column.STATUS_REASON,
+                Column.RTT,
+                Column.SIZE_REQUEST_HEADER,
+                Column.SIZE_REQUEST_BODY,
+                Column.SIZE_RESPONSE_HEADER,
+                Column.SIZE_RESPONSE_BODY,
+                Column.HIGHEST_ALERT,
+                Column.NOTE,
+                Column.TAGS
+            };
+
+    private static final String[] CUSTOM_COLUMN_NAMES = {
+        Constant.messages.getString("client.spider.panel.table.header.state")
+    };
+
+    private static final EnumMap<ResourceState, ProcessedCellItem> statesMap;
+
+    private final ExtensionHistory extensionHistory;
+    private AlertEventConsumer alertEventConsumer;
+
+    private List<TableEntry> resources;
+    private Map<Integer, Integer> idsToRows;
+
+    static {
+        statesMap = new EnumMap<>(ResourceState.class);
+        addState(statesMap, ResourceState.ALLOWED, "allowed");
+        addState(statesMap, ResourceState.EXCLUDED, "excluded");
+        addState(statesMap, ResourceState.IO_ERROR, "ioerror");
+        addState(statesMap, ResourceState.OUT_OF_CONTEXT, "outofcontext");
+        addState(statesMap, ResourceState.OUT_OF_HOST, "outofhost");
+        addState(statesMap, ResourceState.OUT_OF_SUBTREE, "outofsubtree");
+    }
+
+    public MessagesTableModel() {
+        super(COLUMNS);
+
+        resources = new ArrayList<>();
+        idsToRows = new HashMap<>();
+
+        alertEventConsumer = new AlertEventConsumer();
+        extensionHistory =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+        ZAP.getEventBus()
+                .registerConsumer(
+                        alertEventConsumer, AlertEventPublisher.getPublisher().getPublisherName());
+    }
+
+    private static void addState(
+            Map<ResourceState, ProcessedCellItem> map, ResourceState state, String i18nName) {
+        map.put(
+                state,
+                new ProcessedCellItem(
+                        state,
+                        Constant.messages.getString("client.spider.panel.table.cell." + i18nName)));
+    }
+
+    public void addHistoryReference(HistoryReference historyReference, ResourceState state) {
+        HistoryReference latestHistoryReference = historyReference;
+        if (extensionHistory != null) {
+            latestHistoryReference =
+                    extensionHistory.getHistoryReference(historyReference.getHistoryId());
+        }
+        final TableEntry entry = new TableEntry(latestHistoryReference, state);
+        EventQueue.invokeLater(
+                () -> {
+                    final int row = resources.size();
+                    idsToRows.put(entry.getHistoryId(), Integer.valueOf(row));
+                    resources.add(entry);
+                    fireTableRowsInserted(row, row);
+                });
+    }
+
+    void unload() {
+        if (alertEventConsumer != null) {
+            ZAP.getEventBus()
+                    .unregisterConsumer(
+                            alertEventConsumer,
+                            AlertEventPublisher.getPublisher().getPublisherName());
+            alertEventConsumer = null;
+        }
+    }
+
+    @Override
+    public void addEntry(TableEntry entry) {}
+
+    @Override
+    public void refreshEntryRow(int historyReferenceId) {
+        final DefaultHistoryReferencesTableEntry entry = getEntryWithHistoryId(historyReferenceId);
+
+        if (entry != null) {
+            int rowIndex = getEntryRowIndex(historyReferenceId);
+            getEntryWithHistoryId(historyReferenceId).refreshCachedValues();
+
+            fireTableRowsUpdated(rowIndex, rowIndex);
+        }
+    }
+
+    @Override
+    public void removeEntry(int historyReferenceId) {}
+
+    @Override
+    public TableEntry getEntry(int rowIndex) {
+        return resources.get(rowIndex);
+    }
+
+    @Override
+    public TableEntry getEntryWithHistoryId(int historyReferenceId) {
+        final int row = getEntryRowIndex(historyReferenceId);
+        if (row != -1) {
+            return resources.get(row);
+        }
+        return null;
+    }
+
+    @Override
+    public int getEntryRowIndex(int historyReferenceId) {
+        final Integer row = idsToRows.get(Integer.valueOf(historyReferenceId));
+        if (row != null) {
+            return row.intValue();
+        }
+        return -1;
+    }
+
+    @Override
+    public void clear() {
+        resources = new ArrayList<>();
+        idsToRows = new HashMap<>();
+        fireTableDataChanged();
+    }
+
+    @Override
+    public int getRowCount() {
+        return resources.size();
+    }
+
+    @Override
+    protected Class<?> getColumnClass(Column column) {
+        return AbstractHistoryReferencesTableEntry.getColumnClass(column);
+    }
+
+    @Override
+    protected Object getPrototypeValue(Column column) {
+        return AbstractHistoryReferencesTableEntry.getPrototypeValue(column);
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        if (columnIndex == -1) {
+            return getEntry(rowIndex);
+        }
+        return super.getValueAt(rowIndex, columnIndex);
+    }
+
+    @Override
+    protected Object getCustomValueAt(TableEntry entry, int columnIndex) {
+        if (getCustomColumnIndex(columnIndex) == 0) {
+            return statesMap.get(entry.getResourceState());
+        }
+        return null;
+    }
+
+    @Override
+    protected String getCustomColumnName(int columnIndex) {
+        return CUSTOM_COLUMN_NAMES[getCustomColumnIndex(columnIndex)];
+    }
+
+    @Override
+    protected Class<?> getCustomColumnClass(int columnIndex) {
+        if (getCustomColumnIndex(columnIndex) == 0) {
+            return ProcessedCellItem.class;
+        }
+        return null;
+    }
+
+    @Override
+    protected Object getCustomPrototypeValue(int columnIndex) {
+        if (getCustomColumnIndex(columnIndex) == 0) {
+            return "Out Of Context";
+        }
+        return null;
+    }
+
+    static class TableEntry extends DefaultHistoryReferencesTableEntry {
+
+        private final ResourceState state;
+
+        public TableEntry(HistoryReference historyReference, ResourceState state) {
+            super(historyReference, COLUMNS);
+            this.state = state;
+        }
+
+        public ResourceState getResourceState() {
+            return state;
+        }
+    }
+
+    private class AlertEventConsumer implements EventConsumer {
+
+        @Override
+        public void eventReceived(Event event) {
+            switch (event.getEventType()) {
+                case AlertEventPublisher.ALERT_ADDED_EVENT:
+                case AlertEventPublisher.ALERT_CHANGED_EVENT:
+                case AlertEventPublisher.ALERT_REMOVED_EVENT:
+                    refreshEntry(
+                            Integer.valueOf(
+                                    event.getParameters()
+                                            .get(AlertEventPublisher.HISTORY_REFERENCE_ID)));
+                    break;
+                case AlertEventPublisher.ALL_ALERTS_REMOVED_EVENT:
+                    refreshEntries();
+                    break;
+                default:
+            }
+        }
+
+        private void refreshEntry(final int id) {
+            if (EventQueue.isDispatchThread()) {
+                refreshEntryRow(id);
+                return;
+            }
+
+            EventQueue.invokeLater(() -> refreshEntry(id));
+        }
+
+        private void refreshEntries() {
+            if (EventQueue.isDispatchThread()) {
+                refreshEntryRows();
+                return;
+            }
+
+            EventQueue.invokeLater(this::refreshEntries);
+        }
+
+        public void refreshEntryRows() {
+            if (getRowCount() == 0) {
+                return;
+            }
+
+            for (int i = 0; i < getRowCount(); i++) {
+                getEntry(i).refreshCachedValues();
+            }
+
+            fireTableChanged(
+                    new TableModelEvent(
+                            MessagesTableModel.this,
+                            0,
+                            getRowCount() - 1,
+                            getColumnIndex(Column.HIGHEST_ALERT),
+                            TableModelEvent.UPDATE));
+        }
+    }
+
+    static class ProcessedCellItem implements Comparable<ProcessedCellItem> {
+
+        private final ResourceState state;
+        private final String label;
+
+        public ProcessedCellItem(ResourceState state, String label) {
+            this.state = state;
+            this.label = label;
+        }
+
+        public ResourceState getState() {
+            return state;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 + state.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            ProcessedCellItem other = (ProcessedCellItem) obj;
+            if (state != other.state) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int compareTo(ProcessedCellItem other) {
+            if (other == null) {
+                return 1;
+            }
+            return state.compareTo(other.state);
+        }
+    }
+}

--- a/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
+++ b/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
@@ -92,13 +92,22 @@ client.scandialog.title = Client Spider
 
 client.spider.menu.tools.label = Client Spider
 client.spider.options.title = Client Options
+client.spider.outofscope.response = (403 Forbidden) Out of Client Spider scope
 client.spider.panel.tab.addednodes = Added Nodes
+client.spider.panel.tab.messages = Messages
 client.spider.panel.tab.tasks = Tasks
 client.spider.panel.tab.urls = URLs
 
 client.spider.panel.table.action.click = Click
 client.spider.panel.table.action.get = Get
 client.spider.panel.table.action.submit = submit
+
+client.spider.panel.table.cell.allowed = Allowed
+client.spider.panel.table.cell.excluded = Excluded
+client.spider.panel.table.cell.ioerror = I/O Error
+client.spider.panel.table.cell.outofcontext = Out of Context
+client.spider.panel.table.cell.outofhost = Out of Host
+client.spider.panel.table.cell.outofsubtree = Out of Subtree
 
 client.spider.panel.table.details.button = Button: {0}
 client.spider.panel.table.details.link = Link: {0} {1}
@@ -107,6 +116,7 @@ client.spider.panel.table.header.action = Action
 client.spider.panel.table.header.details = Details
 client.spider.panel.table.header.error = Error
 client.spider.panel.table.header.id = ID
+client.spider.panel.table.header.state = State
 client.spider.panel.table.header.status = Status
 client.spider.panel.table.header.uri = URI
 
@@ -129,6 +139,7 @@ client.spider.toolbar.button.stop = Stop Spider
 client.spider.toolbar.button.unpause = Resume Spider
 client.spider.toolbar.progress.label = Progress:
 client.spider.toolbar.progress.select = --Select Scan--
+client.spider.toolbar.urls.label = Crawled URLs:
 
 client.tree.popup.attack = Attack
 client.tree.popup.browser = Open in Browser...

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ExtensionClientIntegrationUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ExtensionClientIntegrationUnitTest.java
@@ -152,7 +152,8 @@ class ExtensionClientIntegrationUnitTest {
 
         try {
             // When
-            int spiderId = extClient.startScan("https://www.example.com", options, null);
+            int spiderId =
+                    extClient.startScan("https://www.example.com", options, null, null, false);
             ClientSpider spider = extClient.getScan(spiderId);
             boolean isRunning = spider.isRunning();
             spider.stopScan();


### PR DESCRIPTION
Limit to context, subtree, or target preventing any accesses outside the selected spider scope.
Use own proxies when spidering instead of the main one, to limit the scope and allow later to track the requests of each action.