### PR TITLE
client: prevent ZAP dirs usage/init in tests

### DIFF
--- a/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
@@ -295,8 +295,6 @@ class ClientMapUnitTest {
         assertThat(root.getChildAt(0).getChildAt(2).getChildCount(), is(1));
         assertThat(
                 root.getChildAt(0).getChildAt(2).getChildAt(0).getUserObject().getName(), is("#"));
-        System.out.println(root.getChildAt(0).getChildAt(2).getChildAt(0).getUserObject().getUrl());
-        System.out.println("https://www.example.com/?p2=v3&p1=v4#/");
         assertThat(
                 root.getChildAt(0).getChildAt(2).getChildAt(0).getUserObject().getUrl(),
                 is("https://www.example.com/?p2=v3&p1=v4#"));

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/UrlTableModelUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/UrlTableModelUnitTest.java
@@ -23,21 +23,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 
-import java.util.Locale;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.parosproxy.paros.Constant;
-import org.zaproxy.zap.utils.I18N;
+import org.zaproxy.addon.client.ExtensionClientIntegration;
+import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link UrlTableModel}. */
-class UrlTableModelUnitTest {
+class UrlTableModelUnitTest extends TestUtils {
 
     private UrlTableModel model;
 
     @BeforeAll
     static void setupAll() {
-        Constant.messages = new I18N(Locale.ROOT);
+        mockMessages(new ExtensionClientIntegration());
     }
 
     @BeforeEach

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/zest/ExtensionClientZestTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/zest/ExtensionClientZestTest.java
@@ -45,7 +45,7 @@ class ExtensionClientZestTest {
     void setUp() {
         extensionLoader =
                 mock(ExtensionLoader.class, withSettings().strictness(Strictness.LENIENT));
-        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        Control.initSingletonForTesting(mock(Model.class), extensionLoader);
 
         ExtensionZest extensionZest = mock(ExtensionZest.class);
         given(extensionLoader.getExtension(ExtensionZest.class)).willReturn(extensionZest);


### PR DESCRIPTION
Mock some classes to prevent the usage/init of the ZAP dirs.
Remove some sys outs.
