### PR TITLE
domxss: handle XPath failure

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.16.0.
 
+### Fixed
+- Handle exceptions while obtaining the XPath of an element.
+
 ## [20] - 2024-12-23
 ### Changed
 - Address deprecation warnings with newer Selenium version (4.27).

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -701,7 +701,12 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
 
     private static String getXPath(WebElement element) {
         StringBuilder strBuilder = new StringBuilder(100);
-        insertXPath(element, strBuilder);
+        try {
+            insertXPath(element, strBuilder);
+        } catch (Exception e) {
+            LOGGER.debug("Failed to obtain full XPath: {}", e.getMessage());
+            strBuilder.insert(0, Constant.messages.getString("domxss.step.partial.xpath"));
+        }
         return strBuilder.toString();
     }
 

--- a/addOns/domxss/src/main/resources/org/zaproxy/zap/extension/domxss/resources/Messages.properties
+++ b/addOns/domxss/src/main/resources/org/zaproxy/zap/extension/domxss/resources/Messages.properties
@@ -6,4 +6,5 @@ domxss.step.access = Access: {0}
 domxss.step.click = Click element: {0}
 domxss.step.input = Write to {0} the value: {1}
 domxss.step.intro = The following steps were done to trigger the DOM XSS:
+domxss.step.partial.xpath = (partial XPath)
 domxss.step.payload = With {0} as: {1}


### PR DESCRIPTION
Catch exceptions that might happen if any of the elements is no longer available while obtaining the XPath of an element.