### PR TITLE
automation: prevent ZAP home usage in tests

### DIFF
--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
@@ -1192,7 +1192,7 @@ class AutomationEnvironmentUnitTest {
         given(extensionLoader.getExtension(ExtensionNetwork.class)).willReturn(extNetwork);
         ArgumentCaptor<HttpProxy> proxyCaptor = ArgumentCaptor.forClass(HttpProxy.class);
 
-        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        Control.initSingletonForTesting(mock(Model.class), extensionLoader);
 
         // When
         AutomationEnvironment env = new AutomationEnvironment(contextData, progress);
@@ -1240,7 +1240,7 @@ class AutomationEnvironmentUnitTest {
         given(extensionLoader.getExtension(ExtensionNetwork.class)).willReturn(extNetwork);
         ArgumentCaptor<HttpProxy> proxyCaptor = ArgumentCaptor.forClass(HttpProxy.class);
 
-        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        Control.initSingletonForTesting(mock(Model.class), extensionLoader);
 
         // When
         AutomationEnvironment env = new AutomationEnvironment(contextData, progress);
@@ -1289,7 +1289,7 @@ class AutomationEnvironmentUnitTest {
         given(extensionLoader.getExtension(ExtensionNetwork.class)).willReturn(extNetwork);
         ArgumentCaptor<HttpProxy> proxyCaptor = ArgumentCaptor.forClass(HttpProxy.class);
 
-        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        Control.initSingletonForTesting(mock(Model.class), extensionLoader);
 
         // When
         AutomationEnvironment env = new AutomationEnvironment(contextData, progress);


### PR DESCRIPTION
Mock the `Model` to prevent access/usage of the default ZAP home which would/could lead to concurrent accesses and cause the tests to fail as the home cannot be shared.