### PR TITLE
Remove double dots in skipped messages

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Server Side Template Injection (Blind)
   - XML External Entity Attack
 - Cloud Metadata Attack scan rule is improved to support GCP, Azure, and OCI.
+- Remove double dot in skipped message of a scan rule that uses the Active Scan OAST service.
 
 ### Fixed
 - A situation where the Server-Side Template Injection (SSTI) scan rule might result in false positives related to the Go payloads (Issue 8622).

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -101,7 +101,7 @@ ascanrules.log4shell.cve45046.name = Log4Shell (CVE-2021-45046)
 ascanrules.log4shell.cve45046.refs = https://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-45046
 ascanrules.log4shell.cve45046.soln = Upgrade Log4j2 to version 2.17.1 or newer.
 ascanrules.log4shell.name = Log4Shell
-ascanrules.log4shell.skipped = no Active Scan OAST service is selected.
+ascanrules.log4shell.skipped = no Active Scan OAST service is selected
 
 ascanrules.name = Active Scan Rules
 

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The following scan rules now use more specific CWE IDs:
     - Proxy Disclosure (Issue 8713)
     - Possible Username Enumeration (Issue 8715)
+- Remove double dot in skipped message of scan rules that use the Active Scan OAST service.
 
 ### Fixed
 - Address exception when scanning a message without path with Possible Username Enumeration scan rule.

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -123,7 +123,7 @@ ascanbeta.noanticsrftokens.desc = No Anti-CSRF tokens were found in a HTML submi
 ascanbeta.noanticsrftokens.name = Absence of Anti-CSRF Tokens
 
 ascanbeta.oobxss.name = Out of Band XSS
-ascanbeta.oobxss.skipped = no Active Scan OAST service is selected.
+ascanbeta.oobxss.skipped = no Active Scan OAST service is selected
 
 ascanbeta.proxydisclosure.attack = TRACE, OPTIONS methods with 'Max-Forwards' header. TRACK method.
 ascanbeta.proxydisclosure.desc = {0} proxy server(s) were detected or fingerprinted. This information helps a potential attacker to determine\n- A list of targets for an attack against the application.\n - Potential vulnerabilities on the proxy servers that service the application.\n - The presence or absence of any proxy-based components that might cause attacks against the application to be detected, prevented, or mitigated.
@@ -232,13 +232,13 @@ ascanbeta.ssrf.desc = The web server receives a remote address and retrieves the
 ascanbeta.ssrf.name = Server Side Request Forgery
 ascanbeta.ssrf.otherinfo.canaryinbody = The canary token from the out-of-band service was found in the response body.
 ascanbeta.ssrf.refs = https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
-ascanbeta.ssrf.skipped = no Active Scan OAST service is selected.
+ascanbeta.ssrf.skipped = no Active Scan OAST service is selected
 ascanbeta.ssrf.soln = Do not accept remote addresses as request parameters, and if you must, ensure that they are validated against an allow-list of expected values.
 
 ascanbeta.text4shell.desc = Apache Commons Text prior to 1.10.0 allows RCE when applied to untrusted input due to insecure interpolation defaults.Apache Commons Text performs variable interpolation, allowing properties to be dynamically evaluated and expanded.The application has been shown to initial contact with remote servers via variable interpolation and may well be vulnerable to Remote Code Execution (RCE).
 ascanbeta.text4shell.name = Text4shell (CVE-2022-42889)
 ascanbeta.text4shell.refs = https://nvd.nist.gov/vuln/detail/CVE-2022-42889\nhttps://securitylab.github.com/advisories/GHSL-2022-018_Apache_Commons_Text/
-ascanbeta.text4shell.skipped = no Active Scan OAST service is selected.
+ascanbeta.text4shell.skipped = no Active Scan OAST service is selected
 ascanbeta.text4shell.soln = Upgrade Apache Commons Text prior to version 1.10.0 or newer.
 
 ascanbeta.usernameenumeration.alert.attack = Manipulate [{0}] field: [{1}] and monitor the output


### PR DESCRIPTION
Remove the dot from the messages as the main message already has one.