### PR TITLE
scripts: Fix NPE in `ScriptSynchronizerUtils`

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Correct auto-complete suggestions for parameters of Passive Rules.
+- Some script errors were not being propagated to the output correctly.
 
 ## [45.7.0] - 2024-10-07
 ### Fixed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptSynchronizerUtils.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptSynchronizerUtils.java
@@ -44,8 +44,9 @@ class ScriptSynchronizerUtils {
                 // Python and Kotlin scripts throw this exception when the method is not implemented
                 return null;
             } catch (Exception e) {
-                if ("groovy.lang.MissingMethodException"
-                        .equals(e.getCause().getClass().getCanonicalName())) {
+                if (e.getCause() != null
+                        && "groovy.lang.MissingMethodException"
+                                .equals(e.getCause().getClass().getCanonicalName())) {
                     // Groovy scripts throw this exception when the method is not implemented
                     return null;
                 }


### PR DESCRIPTION
## Overview
`org.graalvm.polyglot.PolyglotException#getCause()` returns `null` which results in an NPE.

While the error was being handled outside, the cause of the actual Exception was lost and the NPE was logged to the output instead.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title