### PR TITLE
custompayloads: Fix accidental substitution of CONST and literal

### DIFF
--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParam.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParam.java
@@ -89,7 +89,7 @@ public class CustomPayloadsParam extends VersionedAbstractParam {
 
     private void loadPayloadsFromConfig(HierarchicalConfiguration rootConfig) {
         List<HierarchicalConfiguration> categories =
-                rootConfig.configurationsAt("custompayloads.categories.");
+                rootConfig.configurationsAt(ALL_CATEGORIES_KEY);
         payloadCategories = new HashMap<>();
         for (HierarchicalConfiguration category : categories) {
             List<HierarchicalConfiguration> fields = category.configurationsAt("payloads.payload");

--- a/addOns/custompayloads/src/test/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParamUnitTest.java
+++ b/addOns/custompayloads/src/test/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParamUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.custompayloads;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -39,6 +40,8 @@ class CustomPayloadsParamUnitTest {
 
     private static CustomPayloadsParam param;
     private ZapXmlConfiguration configuration;
+
+    private static CustomPayload testPayload = new CustomPayload(true, "foo", "bar");
 
     @BeforeEach
     void setUp() {
@@ -97,15 +100,17 @@ class CustomPayloadsParamUnitTest {
                 (int) configuration.getProperty("custompayloads[@version]"),
                 is(greaterThanOrEqualTo(1)));
         assertThat(configuration.getProperty(configKey + "id"), is(nullValue()));
-        assertThat(configuration.getBoolean(configKey + "enabled"), is(equalTo(true)));
-        assertThat(configuration.getProperty(configKey + "payload"), is(equalTo("bar")));
+        assertThat(param.getCategoriesNames(), hasItem("foo"));
+        assertThat(param.getPayloads().size(), is(equalTo(1)));
+        CustomPayload payload = param.getPayloads().get(0);
+        assertThat(payload.getCategory(), is(equalTo(testPayload.getCategory())));
+        assertThat(payload.getPayload(), is(equalTo(testPayload.getPayload())));
     }
 
     private static ZapXmlConfiguration createUnversionedConfig() {
         ZapXmlConfiguration testConfig = new ZapXmlConfiguration();
 
         Map<String, PayloadCategory> payloadCategories = new HashMap<>();
-        CustomPayload testPayload = new CustomPayload(true, "foo", "bar");
         payloadCategories.put(
                 testPayload.getCategory(),
                 new PayloadCategory(testPayload.getCategory(), List.of(), List.of(testPayload)));


### PR DESCRIPTION
## Overview
Fix accidental substitution of CONST and literal

## Related Issues
Follow-up to: https://github.com/zaproxy/zap-extensions/pull/5853

## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
