### PR TITLE
custompayloads: Don't save or load payloads with nameless category

### DIFF
--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add help button to Options panel and add further detailed Help content.
 
+### Fixed
+- The add-on will no longer attempt to save or load Payloads for which there is no Category.
+
 ## [0.13.0] - 2023-11-10
 ### Changed
 - Update minimum ZAP version to 2.14.0.

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsMultipleOptionsTablePanel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsMultipleOptionsTablePanel.java
@@ -200,4 +200,12 @@ public class CustomPayloadsMultipleOptionsTablePanel
 
         return false;
     }
+
+    @Override
+    public void setComponentEnabled(boolean enabled) {
+        super.setComponentEnabled(enabled);
+        resetButton.setEnabled(enabled);
+        addMissingDefaultsButton.setEnabled(enabled);
+        fileButton.setEnabled(enabled);
+    }
 }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsOptionsPanel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsOptionsPanel.java
@@ -31,6 +31,9 @@ public class CustomPayloadsOptionsPanel extends AbstractParamPanel {
     private static final long serialVersionUID = 1L;
     private static final String OPTIONS_TITLE =
             Constant.messages.getString("custompayloads.options.title");
+    private static final String OPTIONS_TITLE_DISABLED =
+            Constant.messages.getString("custompayloads.options.dialog.disabled");
+    private JLabel titleLabel;
     CustomPayloadsMultipleOptionsTablePanel tablePanel;
     CustomPayloadMultipleOptionsTableModel tableModel;
 
@@ -46,7 +49,8 @@ public class CustomPayloadsOptionsPanel extends AbstractParamPanel {
         gbc.anchor = GridBagConstraints.LINE_START;
         gbc.fill = GridBagConstraints.BOTH;
 
-        this.add(new JLabel(OPTIONS_TITLE), gbc);
+        titleLabel = new JLabel(OPTIONS_TITLE);
+        this.add(titleLabel, gbc);
         gbc.weighty = 1.0;
         this.add(tablePanel, gbc);
     }
@@ -55,6 +59,13 @@ public class CustomPayloadsOptionsPanel extends AbstractParamPanel {
     public void initParam(Object obj) {
         OptionsParam optionsParam = (OptionsParam) obj;
         CustomPayloadsParam param = optionsParam.getParamSet(CustomPayloadsParam.class);
+        if (param.getCategoriesNames().isEmpty()) {
+            tablePanel.setComponentEnabled(false);
+            titleLabel.setText(OPTIONS_TITLE_DISABLED);
+        } else {
+            tablePanel.setComponentEnabled(true);
+            titleLabel.setText(OPTIONS_TITLE);
+        }
         tableModel.clear();
         tableModel.addModels(param.getPayloads());
         tableModel.setDefaultPayloads(param.getDefaultPayloads());

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParam.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParam.java
@@ -94,6 +94,9 @@ public class CustomPayloadsParam extends VersionedAbstractParam {
         for (HierarchicalConfiguration category : categories) {
             List<HierarchicalConfiguration> fields = category.configurationsAt("payloads.payload");
             String cat = category.getString(CATEGORY_NAME_KEY);
+            if (cat == null) {
+                continue;
+            }
             List<CustomPayload> payloads = new ArrayList<>();
             for (HierarchicalConfiguration sub : fields) {
                 boolean isEnabled = sub.getBoolean(PAYLOAD_ENABLED_KEY);

--- a/addOns/custompayloads/src/main/resources/org/zaproxy/zap/extension/custompayloads/resources/Messages.properties
+++ b/addOns/custompayloads/src/main/resources/org/zaproxy/zap/extension/custompayloads/resources/Messages.properties
@@ -36,6 +36,7 @@ custompayloads.options.dialog.addMultiplePayload.error.title = Error Adding Payl
 custompayloads.options.dialog.addMultiplePayload.selectFile.button.name = Select File
 custompayloads.options.dialog.addMultiplePayload.title = Add Multiple Payloads
 custompayloads.options.dialog.category = Category
+custompayloads.options.dialog.disabled = Disabled: There are no add-ons/rules installed which use this functionality.
 custompayloads.options.dialog.enabled = Enabled
 custompayloads.options.dialog.payload = Payload
 custompayloads.options.dialog.remove.button.cancel = Cancel

--- a/addOns/custompayloads/src/test/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParamUnitTest.java
+++ b/addOns/custompayloads/src/test/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParamUnitTest.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.custompayloads;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -86,6 +87,18 @@ class CustomPayloadsParamUnitTest {
                 (int) configuration.getProperty("custompayloads[@version]"),
                 is(greaterThanOrEqualTo(1)));
         assertThat(configuration.getProperty(configKey), is(nullValue()));
+    }
+
+    @Test
+    void shouldNotLoadPayloadWithNamelessCategory() {
+        // Given
+        configuration = createUnversionedConfig();
+        configuration.clearProperty("custompayloads.categories.category[@name]");
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getCategoriesNames(), is(empty()));
+        assertThat(param.getPayloads(), is(empty()));
     }
 
     @Test


### PR DESCRIPTION
## Overview
The add-on will no longer attempt to save or load Payloads for which there is no Category.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
