### PR TITLE
custompayloads: Ensure file is readable for multi payload import

### DIFF
--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -8,12 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.16.0.
 - Maintenance changes.
 - The superfluous/unused ID element of the custom payloads has been removed from the GUI and config.
+- Now depends on the Common Library add-on.
 
 ### Added
 - Add help button to Options panel and add further detailed Help content.
 
 ### Fixed
 - The add-on will no longer attempt to save or load Payloads for which there is no Category.
+- Ensure file is selected, exists, and is readable when attempting to import multiple payloads.
 
 ## [0.13.0] - 2023-11-10
 ### Changed

--- a/addOns/custompayloads/custompayloads.gradle.kts
+++ b/addOns/custompayloads/custompayloads.gradle.kts
@@ -9,6 +9,14 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/custom-payloads/")
+
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">= 1.17.0 & < 2.0.0")
+                }
+            }
+        }
     }
 
     apiClientGen {
@@ -18,5 +26,7 @@ zapAddOn {
 }
 
 dependencies {
+    zapAddOn("commonlib")
+
     testImplementation(project(":testutils"))
 }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomMultiplePayloadDialog.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomMultiplePayloadDialog.java
@@ -24,6 +24,7 @@ import java.io.File;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.commonlib.ui.ReadableFileChooser;
 import org.zaproxy.zap.utils.DisplayUtils;
 
 public class CustomMultiplePayloadDialog extends AbstractColumnDialog<CustomPayload> {
@@ -50,13 +51,19 @@ public class CustomMultiplePayloadDialog extends AbstractColumnDialog<CustomPayl
         this.addFileButtonListener(fileButton);
     }
 
+    @Override
+    public String validateFields() {
+        return multiplePayload == null
+                ? Constant.messages.getString(
+                        "custompayloads.options.dialog.addMultiplePayload.file.error.text")
+                : null;
+    }
+
     public void addFileButtonListener(JButton fileButton) {
         fileButton.addActionListener(
                 e -> {
-                    JFileChooser chooser = new JFileChooser();
-                    int result = chooser.showOpenDialog(this);
-
-                    if (result == JFileChooser.APPROVE_OPTION) {
+                    JFileChooser chooser = new ReadableFileChooser();
+                    if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
                         multiplePayload = chooser.getSelectedFile();
                     }
                 });

--- a/addOns/custompayloads/src/main/resources/org/zaproxy/zap/extension/custompayloads/resources/Messages.properties
+++ b/addOns/custompayloads/src/main/resources/org/zaproxy/zap/extension/custompayloads/resources/Messages.properties
@@ -33,6 +33,7 @@ custompayloads.options.dialog.addMultiplePayload.addPayload.button.name = Add Mu
 custompayloads.options.dialog.addMultiplePayload.duplicates.checkbox.label = Prevent Duplicates
 custompayloads.options.dialog.addMultiplePayload.error.text = An error occurred while importing the payloads:\n{0}
 custompayloads.options.dialog.addMultiplePayload.error.title = Error Adding Payloads
+custompayloads.options.dialog.addMultiplePayload.file.error.text = Please select a file to import.
 custompayloads.options.dialog.addMultiplePayload.selectFile.button.name = Select File
 custompayloads.options.dialog.addMultiplePayload.title = Add Multiple Payloads
 custompayloads.options.dialog.category = Category


### PR DESCRIPTION
## Overview
A fix to ensure that the file being imported is readable.

## Related Issues
N/A
![image](https://github.com/user-attachments/assets/e680f046-b336-43d6-8099-1bce97eec709)
![image](https://github.com/user-attachments/assets/1eb02e6f-2eb0-4305-a260-685ec3de2113)

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
