### PR TITLE
Exclude Log4j 2 from runtime classpath of add-ons

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -150,6 +150,11 @@ subprojects {
             exclude(group = "org.apache.logging.log4j", module = "log4j-1.2-api")
         }
 
+        "runtimeClasspath" {
+            exclude(group = "org.apache.logging.log4j", module = "log4j-core")
+            exclude(group = "org.apache.logging.log4j", module = "log4j-api")
+        }
+
         val zapAddOn by creating
 
         "compileOnly" {

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Import HAR entry sent and elapsed time.
 - Duplicate or missing "Save URLs..." entries in the Export menu.
 - The "Save All URLs..." export option was saving only the selected URLs.
+- Correct bundled dependencies to avoid conflicts with core logging libraries.
 
 ## [0.12.0] - 2024-10-07
 ### Changed

--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -68,10 +68,7 @@ dependencies {
     implementation("io.netty:netty-codec-http2:$nettyVersion")
 
     hc("org.apache.httpcomponents.client5:httpclient5:5.2.1")
-    implementation(libs.log4j.slf4j) {
-        // Provided by ZAP.
-        exclude(group = "org.apache.logging.log4j")
-    }
+    implementation(libs.log4j.slf4j)
 
     val bcVersion = "1.77"
     val bcJava = "jdk18on"

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -82,10 +82,7 @@ dependencies {
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
-    implementation(libs.log4j.slf4j2) {
-        // Provided by ZAP.
-        exclude(group = "org.apache.logging.log4j")
-    }
+    implementation(libs.log4j.slf4j2)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(libs.log4j.core)

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -59,10 +59,7 @@ dependencies {
 
     implementation("org.thymeleaf:thymeleaf:3.1.2.RELEASE")
     implementation("org.xhtmlrenderer:flying-saucer-pdf:9.3.1")
-    implementation(libs.log4j.slf4j2) {
-        // Provided by ZAP.
-        exclude(group = "org.apache.logging.log4j")
-    }
+    implementation(libs.log4j.slf4j2)
 
     testImplementation(project(":addOns:sequence"))
     testImplementation(project(":testutils"))

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -41,10 +41,7 @@ dependencies {
     var seleniumVersion = "4.27.0"
     selenium("org.seleniumhq.selenium:selenium-java:$seleniumVersion")
     selenium("org.seleniumhq.selenium:htmlunit3-driver:$seleniumVersion")
-    implementation(libs.log4j.slf4j) {
-        // Provided by ZAP.
-        exclude(group = "org.apache.logging.log4j")
-    }
+    implementation(libs.log4j.slf4j)
 
     zapAddOn("commonlib")
     zapAddOn("network")

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -61,10 +61,7 @@ dependencies {
     implementation("com.predic8:soa-model-core:2.0.1")
     implementation("com.sun.xml.messaging.saaj:saaj-impl:3.0.0")
     implementation("jakarta.xml.soap:jakarta.xml.soap-api:3.0.0")
-    implementation(libs.log4j.slf4j) {
-        // Provided by ZAP.
-        exclude(group = "org.apache.logging.log4j")
-    }
+    implementation(libs.log4j.slf4j)
 
     testImplementation(project(":testutils"))
 }


### PR DESCRIPTION
Prevent the inclusion of the Log4j 2 API and implementation as those are already included by core and would cause conflicts making add-ons to not use the same classes/configs as core.
Remove now redundant local exclusions.


---
This was reported for exim and, after double checking the dependencies of all add-ons, that's the only one affected.