### PR TITLE
client: handle URLs without hostname in spider

### DIFF
--- a/addOns/client/client.gradle.kts
+++ b/addOns/client/client.gradle.kts
@@ -64,4 +64,5 @@ dependencies {
     zapAddOn("zest")
 
     testImplementation(project(":testutils"))
+    testImplementation(libs.log4j.core)
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -422,6 +422,11 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
             return false;
         }
 
+        char[] host = uri.getRawHost();
+        if (host == null) {
+            return true;
+        }
+
         return checkResourceState(uri, new String(uri.getRawHost())) == ResourceState.ALLOWED;
     }
 


### PR DESCRIPTION
Correctly handle URLs without hostname when checking if they are in scope for the spider.