### PR TITLE
client: address concurrency issues with tasks

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -495,22 +495,17 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
                 });
     }
 
-    public void taskStateChange(final ClientSpiderTask task) {
-        ThreadUtils.invokeLater(
-                () ->
-                        tasksModel.updateTaskState(
-                                task.getId(), task.getStatus().toString(), task.getError()));
+    void taskStateChange(final ClientSpiderTask task) {
+        tasksModel.updateTaskState(task.getId(), task.getStatus().toString(), task.getError());
     }
 
     private void addTaskToTasksModel(final ClientSpiderTask task, String url) {
-        ThreadUtils.invokeLater(
-                () ->
-                        tasksModel.addTask(
-                                task.getId(),
-                                task.getDisplayName(),
-                                url,
-                                task.getDetailsString(),
-                                task.getStatus().toString()));
+        tasksModel.addTask(
+                task.getId(),
+                task.getDisplayName(),
+                url,
+                task.getDetailsString(),
+                task.getStatus().toString());
     }
 
     protected void setRedirect(String originalUrl, String redirectedUrl) {


### PR DESCRIPTION
Sync the access internally in the task model to, regardless of how ZAP is run, prevent concurrency issues which would lead to some tasks going missing while they were being added to the list of tasks which would later lead to exceptions as the tasks were not present in the model.
Only report model changes if there's a view.