### PR TITLE
network: set local address to request header

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Set the local address where (e.g. server, proxy) the request header was received.
+
 ### Changed
 - Update minimum ZAP version to 2.16.0.
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/CommonMessagePropertiesHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/CommonMessagePropertiesHandler.java
@@ -32,6 +32,8 @@ import org.zaproxy.addon.network.internal.ChannelAttributes;
  * <ul>
  *   <li>The sender address, obtained from the channel attribute {@link
  *       ChannelAttributes#REMOTE_ADDRESS}.
+ *   <li>The local address, obtained from the channel attribute {@link
+ *       ChannelAttributes#LOCAL_ADDRESS}.
  * </ul>
  */
 @Sharable
@@ -61,6 +63,9 @@ public class CommonMessagePropertiesHandler extends SimpleChannelInboundHandler<
         if (remoteAddress != null) {
             msg.getRequestHeader().setSenderAddress(remoteAddress.getAddress());
         }
+
+        msg.getRequestHeader()
+                .setLocalAddress(ctx.channel().attr(ChannelAttributes.LOCAL_ADDRESS).get());
 
         ctx.fireChannelRead(msg);
     }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/CommonMessagePropertiesHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/CommonMessagePropertiesHandlerUnitTest.java
@@ -37,12 +37,15 @@ class CommonMessagePropertiesHandlerUnitTest {
     private static final InetSocketAddress SENDER_ADDRESS =
             new InetSocketAddress("127.0.0.1", 1234);
 
+    private static final InetSocketAddress LOCAL_ADDRESS = new InetSocketAddress("127.0.0.1", 4321);
+
     protected EmbeddedChannel channel;
 
     @BeforeEach
     void setUp() {
         channel = new EmbeddedChannel(CommonMessagePropertiesHandler.getInstance());
         channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(SENDER_ADDRESS);
+        channel.attr(ChannelAttributes.LOCAL_ADDRESS).set(LOCAL_ADDRESS);
     }
 
     @Test
@@ -68,6 +71,32 @@ class CommonMessagePropertiesHandlerUnitTest {
         written(msg);
         // Then
         assertThat(msg.getRequestHeader().getSenderAddress(), is(nullValue()));
+        assertThat(msg.getUserObject(), is(nullValue()));
+        assertChannelState(msg);
+    }
+
+    @Test
+    void shouldSetLocalAddress() {
+        // Given
+        InetSocketAddress address = new InetSocketAddress("127.0.0.2", 12345);
+        channel.attr(ChannelAttributes.LOCAL_ADDRESS).set(address);
+        HttpMessage msg = new HttpMessage();
+        // When
+        written(msg);
+        // Then
+        assertThat(msg.getRequestHeader().getLocalAddress(), is(equalTo(address)));
+        assertChannelState(msg);
+    }
+
+    @Test
+    void shouldNotSetLocalAddressIfNotPresent() {
+        // Given
+        channel.attr(ChannelAttributes.LOCAL_ADDRESS).set(null);
+        HttpMessage msg = new HttpMessage();
+        // When
+        written(msg);
+        // Then
+        assertThat(msg.getRequestHeader().getLocalAddress(), is(nullValue()));
         assertThat(msg.getUserObject(), is(nullValue()));
         assertChannelState(msg);
     }


### PR DESCRIPTION
Set the address where (e.g. server, proxy) the request header was received.