### PR TITLE
client: adjust thread accesses

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
@@ -38,7 +38,6 @@ import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiResponse;
 import org.zaproxy.zap.extension.api.ApiResponseElement;
-import org.zaproxy.zap.utils.ThreadUtils;
 
 public class ClientIntegrationAPI extends ApiImplementor {
     private static final String PREFIX = "client";
@@ -92,27 +91,21 @@ public class ClientIntegrationAPI extends ApiImplementor {
         if (url instanceof String) {
             String urlStr = (String) url;
             if (!ExtensionClientIntegration.isApiUrl(urlStr)) {
-                ThreadUtils.invokeAndWaitHandled(
-                        () -> {
-                            ClientNode node =
-                                    this.extension.getOrAddClientNode(urlStr, false, false);
-                            ClientSideComponent component = new ClientSideComponent(json);
-                            extension.addComponentToNode(node, component);
-                            if (component.isStorageEvent()) {
-                                String storageUrl = node.getSite() + component.getTypeForDisplay();
-                                extension.addComponentToNode(
-                                        this.extension.getOrAddClientNode(storageUrl, false, true),
-                                        component);
-                            }
-                        });
+                ClientNode node = this.extension.getOrAddClientNode(urlStr, false, false);
+                ClientSideComponent component = new ClientSideComponent(json);
+                extension.addComponentToNode(node, component);
+                if (component.isStorageEvent()) {
+                    String storageUrl = node.getSite() + component.getTypeForDisplay();
+                    extension.addComponentToNode(
+                            this.extension.getOrAddClientNode(storageUrl, false, true), component);
+                }
             }
         } else {
             LOGGER.debug("Not got url:(: {}", url);
         }
         Object href = json.get("href");
         if (href instanceof String && ((String) href).toLowerCase(Locale.ROOT).startsWith("http")) {
-            ThreadUtils.invokeAndWaitHandled(
-                    () -> this.extension.getOrAddClientNode((String) href, false, false));
+            extension.getOrAddClientNode((String) href, false, false);
         }
     }
 
@@ -121,7 +114,7 @@ public class ClientIntegrationAPI extends ApiImplementor {
         if (event.getUrl() == null || !ExtensionClientIntegration.isApiUrl(event.getUrl())) {
             this.extension.addReportedObject(event);
             if (event.getUrl() != null) {
-                ThreadUtils.invokeAndWaitHandled(() -> this.extension.setVisited(event.getUrl()));
+                extension.setVisited(event.getUrl());
             }
         }
     }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -471,8 +471,12 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
         getClientDetailsPanel().setClientNode(node);
     }
 
-    public void clientNodeChanged(ClientNode node) {
-        this.clientTree.nodeChanged(node);
+    private void clientNodeChanged(ClientNode node) {
+        if (!hasView()) {
+            return;
+        }
+
+        ThreadUtils.invokeAndWaitHandled(() -> clientTree.nodeChanged(node));
     }
 
     public boolean addComponentToNode(ClientNode node, ClientSideComponent component) {


### PR DESCRIPTION
Reduce the work done in the EDT as much of it does not need to happen there.
Sync addition of the tasks as well to ensure the check done on removal takes into account the tasks that might have been being added/executed at the same time.
Also, remove sync on WebDriver retrieval since that's already synced internally.
Rework the task model to make the ID/row match in all cases, it was still possible for the ID/row to be interleaved enough that later would lead to index out of bound exceptions.