### PR TITLE
webdrivers: update ZAP to 2.16

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.16.0.
 
 ## [118] - 2025-01-08
 ### Changed

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.16.0.
 
 ## [118] - 2025-01-08
 ### Changed

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -80,8 +80,6 @@ subprojects {
         sourceSets["main"].output.dir(mapOf("builtBy" to downloadTasks), webdriversDir)
 
         zapAddOn {
-            zapVersion.set("2.15.0")
-
             manifest {
                 files.from(webdriversDir)
             }

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.16.0.
 
 ## [118] - 2025-01-08
 ### Changed


### PR DESCRIPTION
The next releases will be for 2.16.