### PR TITLE
reports: use own stats key if no resource message

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update automation job help.
 - Fields with default or missing values are omitted for the `report` job in saved Automation Framework plans.
 
+### Fixed
+- Do not log an error when the statistics do not have a resource message (Issue 8788).
+
 ## [0.34.0] - 2024-10-07
 ### Changed
 - Checkmarx rebrand.

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportHelper.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportHelper.java
@@ -38,6 +38,8 @@ import org.zaproxy.zap.utils.XMLStringUtil;
 
 public class ReportHelper {
 
+    private static final String STATS_RESOURCE_PREFIX = ExtensionReports.PREFIX + ".report.";
+
     public static String getRiskString(int risk) {
         return Constant.messages.getString(ExtensionReports.PREFIX + ".report.risk." + risk);
     }
@@ -48,7 +50,11 @@ public class ReportHelper {
     }
 
     public static String getStatisticsString(String statsKey) {
-        return Constant.messages.getString(ExtensionReports.PREFIX + ".report." + statsKey);
+        String resourceKey = STATS_RESOURCE_PREFIX + statsKey;
+        if (Constant.messages.containsKey(resourceKey)) {
+            return Constant.messages.getString(resourceKey);
+        }
+        return statsKey;
     }
 
     public static String getHostForSite(String site) {

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportHelperUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportHelperUnitTest.java
@@ -20,13 +20,18 @@
 package org.zaproxy.addon.reports;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.zap.extension.alert.AlertNode;
+import org.zaproxy.zap.utils.I18N;
 
 class ReportHelperUnitTest {
 
@@ -163,6 +168,33 @@ class ReportHelperUnitTest {
         assertThat(ex1sql2Alerts.size(), is(0));
         assertThat(ex2sql2Alerts.size(), is(0));
         assertThat(ex3sql2Alerts.size(), is(1));
+    }
+
+    @Test
+    void shouldGetStatisticsString() throws Exception {
+        // Given
+        Constant.messages = mock(I18N.class);
+        String statsKey = "some.stats.key";
+        String resourceKey = "reports.report." + statsKey;
+        given(Constant.messages.containsKey(resourceKey)).willReturn(true);
+        String expectedString = "Statistic Xyz";
+        given(Constant.messages.getString(resourceKey)).willReturn(expectedString);
+        // When
+        String string = ReportHelper.getStatisticsString(statsKey);
+        // Then
+        assertThat(string, is(equalTo(expectedString)));
+    }
+
+    @Test
+    void shouldGetStatsKeyForMissingStatisticsString() throws Exception {
+        // Given
+        Constant.messages = mock(I18N.class);
+        String statsKey = "some.stats.key";
+        given(Constant.messages.containsKey("reports.report." + statsKey)).willReturn(false);
+        // When
+        String string = ReportHelper.getStatisticsString(statsKey);
+        // Then
+        assertThat(string, is(equalTo(statsKey)));
     }
 
     AlertNode newAlertNode(int risk, String name, String url) {


### PR DESCRIPTION
Use the own stats key when the stats do not have a resource message, instead of letting core log an error that it's missing.

Fix zaproxy/zaproxy#8788.