### PR TITLE
Remove usage of ZAP snapshot

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -166,7 +166,7 @@ subprojects {
         }
     }
 
-    val zapGav = "org.zaproxy:zap:2.16.0-SNAPSHOT"
+    val zapGav = "org.zaproxy:zap:2.16.0"
     dependencies {
         "zap"(zapGav)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,9 +28,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
     }
 
     spotless {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -19,7 +19,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.16.0-SNAPSHOT")
+    compileOnly("org.zaproxy:zap:2.16.0")
     implementation(project(":addOns:network"))
     implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 


### PR DESCRIPTION
Use the main release which is already available.