### PR TITLE
automation: correct job config in the help

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Address malformed HTML in the help.
+- Correct default value of `threadPerHost` property of the `activeScan-config` job's help.
 
 ## [0.44.0] - 2025-01-09
 ### Added

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascanconfig.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascanconfig.html
@@ -21,7 +21,7 @@ This job configures the active scanner, for custom active scans (e.g. Sequence).
       defaultPolicy:                       # String: The name of the default scan policy to use, default: Default Policy
       handleAntiCSRFTokens:                # Bool: If set then automatically handle anti CSRF tokens, default: false
       injectPluginIdInHeader:              # Bool: If set then the relevant rule ID will be injected into the X-ZAP-Scan-ID header of each request, default: false
-      threadPerHost:                       # Int: The max number of threads per host, default: 2
+      threadPerHost:                       # Int: The max number of threads per host, default: 2 * Number of available processor cores
     inputVectors:                          # The input vectors used during the active scan.
       urlQueryStringAndDataDrivenNodes:    # Configures the scanning of query parameters and DDNs.
          enabled:                          # Bool: If query parameters and DDNs scanning should be enabled. Default: true


### PR DESCRIPTION
Add missing text to configuration of `threadPerHost`.