### PR TITLE
ascanrulesBeta: Address ReDoS in Insecure HTTP Methods rule

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Replace usage of CWE-200 for the Insecure HTTP Method scan rule (Issue 8714).
 
+### Fixed
+- Address potential/theoretical reDoS issue in the Insecure HTTP Method scan rule.
+
 ## [57] - 2025-01-15
 ### Changed
 - Update minimum ZAP version to 2.16.0.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
@@ -149,7 +149,7 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin
             String thirdpartyHost = "www.google.com";
             int thirdpartyPort = 80;
             Pattern thirdPartyContentPattern =
-                    Pattern.compile("<title.*Google.*/title>", Pattern.CASE_INSENSITIVE);
+                    Pattern.compile("<title.*{1,10}Google.{1,25}/title>", Pattern.CASE_INSENSITIVE);
 
             // send an OPTIONS message, and see what the server reports. Do
             // not try any methods not listed in those results.


### PR DESCRIPTION
## Overview
- CHANGELOG > Add fix note.
- InsecureHttpMethodScanRule > Adjust regex pattern for Google title elements. There's no reason to look for unlimited length character strings. It is doubtful that google would produce content that might cause a ReDoS, but limiting the regex is "safest".

## Related Issues
https://github.com/zaproxy/zap-extensions/security/code-scanning/89

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
