### PR TITLE
client: fix concurrency issue with components

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fix concurrency issue with page components which could lead to exceptions in the GUI.
 
 ## [0.10.0] - 2025-01-10
 ### Changed

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientSideDetails.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientSideDetails.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.client.internal;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
@@ -32,7 +33,7 @@ public class ClientSideDetails {
     private boolean storage;
     private boolean redirect;
 
-    private Set<ClientSideComponent> components = new HashSet<>();
+    private Set<ClientSideComponent> components = Collections.synchronizedSet(new HashSet<>());
 
     public ClientSideDetails(String name, String url, boolean visited, boolean storage) {
         this.name = name;


### PR DESCRIPTION
Make the components in `ClientSideDetails` synchronized as multiple components can be added at the same time which could lead to inconsistent state in the set and later lead to exceptions.

---
Found in https://github.com/zaproxy/zap-extensions/pull/6040#issuecomment-2593380551.