### PR TITLE
selenium: allow to log browser's `console.log`

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Allow to log browser's `console.log`, done at DEBUG level with the name `org.zaproxy.webdriver`.
 
+### Changed
+- Use WebDriver BiDi with Chrome.
 
 ## [15.32.0] - 2025-01-10
 ### Changed


### PR DESCRIPTION
Add handler to Chrome and Firefox and log DEBUG those messages.
Use WebDriver BiDi with Chrome, which is required for the above.