### PR TITLE
pscan: fix exception while generating the API

### DIFF
--- a/addOns/pscan/CHANGELOG.md
+++ b/addOns/pscan/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Correct help configuration to work with any language.
+- Maintenance changes.
 
 ### Fixed
 - Fix broken link the help page.

--- a/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/PassiveScanApi.java
+++ b/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/PassiveScanApi.java
@@ -106,8 +106,10 @@ public class PassiveScanApi extends ApiImplementor {
         this.addApiView(new ApiView(VIEW_SCANNERS));
         ApiView currentRule = new ApiView(VIEW_CURRENT_RULE);
         currentRule.setDeprecated(true);
-        currentRule.setDeprecatedDescription(
-                Constant.messages.getString("pscan.api.view.currentRule.deprecated"));
+        if (Constant.messages != null) {
+            currentRule.setDeprecatedDescription(
+                    Constant.messages.getString("pscan.api.view.currentRule.deprecated"));
+        }
         this.addApiView(currentRule);
         this.addApiView(new ApiView(VIEW_CURRENT_TASKS));
         this.addApiView(new ApiView(VIEW_MAX_ALERTS_PER_RULE));


### PR DESCRIPTION
Check if the `messages` exists when creating the API as it will not at that point when the API clients are being generated.