### PR TITLE
authhelper: ignore non-displayed fields in BBA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Ignore non-displayed fields when selecting the user name and password.
 
 ## [0.17.0] - 2025-01-09
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
@@ -143,7 +144,7 @@ public class AuthUtils {
 
     static WebElement getUserField(List<WebElement> inputElements) {
         List<WebElement> filteredList =
-                inputElements.stream()
+                displayed(inputElements)
                         .filter(
                                 elem ->
                                         "text".equalsIgnoreCase(elem.getDomAttribute("type"))
@@ -180,6 +181,10 @@ public class AuthUtils {
         return null;
     }
 
+    private static Stream<WebElement> displayed(List<WebElement> elements) {
+        return elements.stream().filter(WebElement::isDisplayed);
+    }
+
     static boolean attributeContains(WebElement we, String attribute, String[] strings) {
         String att = we.getDomAttribute(attribute);
         if (att == null) {
@@ -195,12 +200,10 @@ public class AuthUtils {
     }
 
     static WebElement getPasswordField(List<WebElement> inputElements) {
-        for (WebElement element : inputElements) {
-            if ("password".equalsIgnoreCase(element.getDomAttribute("type"))) {
-                return element;
-            }
-        }
-        return null;
+        return displayed(inputElements)
+                .filter(element -> "password".equalsIgnoreCase(element.getDomAttribute("type")))
+                .findFirst()
+                .orElse(null);
     }
 
     /**

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.Setter;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -109,6 +110,30 @@ class AuthUtilsUnitTest extends TestUtils {
         // Then
         assertThat(field, is(notNullValue()));
         assertThat(field.getDomAttribute("type"), is(equalTo("text")));
+    }
+
+    @Test
+    void shouldReturnUserTextFieldIgnoringNonDisplayedFields() throws Exception {
+        // Given
+        List<WebElement> inputElements = new ArrayList<>();
+        // Registration form, not displayed.
+        TestWebElement inputField = new TestWebElement("input", "text");
+        inputField.setDisplayed(false);
+        inputElements.add(inputField);
+        inputField = new TestWebElement("input", "password");
+        inputField.setDisplayed(false);
+        inputElements.add(inputField);
+        // Login form, displayed.
+        inputElements.add(new TestWebElement("input", "text"));
+        inputElements.add(new TestWebElement("input", "password"));
+
+        // When
+        WebElement field = AuthUtils.getUserField(inputElements);
+
+        // Then
+        assertThat(field, is(notNullValue()));
+        assertThat(field.getDomAttribute("type"), is(equalTo("text")));
+        assertThat(field.isDisplayed(), is(equalTo(true)));
     }
 
     @Test
@@ -190,6 +215,30 @@ class AuthUtilsUnitTest extends TestUtils {
         // Then
         assertThat(field, is(notNullValue()));
         assertThat(field.getDomAttribute("type"), is(equalTo("password")));
+    }
+
+    @Test
+    void shouldReturnPasswordFieldIgnoringNonDisplayedFields() throws Exception {
+        // Given
+        List<WebElement> inputElements = new ArrayList<>();
+        // Registration form, not displayed.
+        TestWebElement inputField = new TestWebElement("input", "email");
+        inputField.setDisplayed(false);
+        inputElements.add(inputField);
+        inputField = new TestWebElement("input", "password");
+        inputField.setDisplayed(false);
+        inputElements.add(inputField);
+        // Login form, displayed.
+        inputElements.add(new TestWebElement("input", "email"));
+        inputElements.add(new TestWebElement("input", "password"));
+
+        // When
+        WebElement field = AuthUtils.getPasswordField(inputElements);
+
+        // Then
+        assertThat(field, is(notNullValue()));
+        assertThat(field.getDomAttribute("type"), is(equalTo("password")));
+        assertThat(field.isDisplayed(), is(equalTo(true)));
     }
 
     @Test
@@ -631,6 +680,7 @@ class AuthUtilsUnitTest extends TestUtils {
         private String type;
         private String id;
         private String name;
+        @Setter private boolean displayed = true;
 
         TestWebElement(String tag, String type) {
             this.tag = tag;
@@ -712,7 +762,7 @@ class AuthUtilsUnitTest extends TestUtils {
 
         @Override
         public boolean isDisplayed() {
-            return false;
+            return displayed;
         }
 
         @Override


### PR DESCRIPTION
Fields that are not displayed can't be interacted with thus unlikely to be the user name and password fields that the user would have to fill to login.