### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Use ZAP for launching Firefox and Chrome.
+- Update Zest library to 0.23.0:
+  - Update Selenium to version 4.28.0.
+  - Update minimum Java version to 17.
 
 ## [48.0.0] - 2025-01-10
 ### Added

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -49,9 +49,10 @@ dependencies {
     zapAddOn("scripts")
     zapAddOn("selenium")
 
-    api("org.zaproxy:zest:0.22.0") {
+    api("org.zaproxy:zest:0.23.0") {
         // Provided by commonlib add-on.
-        exclude(group = "com.fasterxml.jackson")
+        exclude(group = "com.fasterxml.jackson.core")
+        exclude(group = "com.fasterxml.jackson.dataformat")
         // Provided by Selenium add-on.
         exclude(group = "org.seleniumhq.selenium")
         // Provided by ZAP.


### PR DESCRIPTION
Update Zest library to 0.23.0:
 - Update Selenium to version 4.28.0.
 - Update minimum Java version to 17.