### PR TITLE
client: Fix browser recording on launch

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Extension not enabled when launched from ZAP.
+- Browser recording not enabled when launched from ZAP recorder.
 
 ## [0.11.0] - 2025-01-17
 ### Fixed

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
@@ -81,7 +81,9 @@ public class ClientIntegrationAPI extends ApiImplementor {
         return callbackUrl;
     }
 
-    private void handleReportObject(JSONObject json) {
+    private void handleReportObject(String jsonStr) {
+        LOGGER.debug("Got object: {}", jsonStr);
+        JSONObject json = JSONObject.fromObject(jsonStr);
         ReportedElement rnode = new ReportedElement(json);
         if (!"A".equals(rnode.getNodeName())) {
             // Dont add links - they flood the table
@@ -109,7 +111,9 @@ public class ClientIntegrationAPI extends ApiImplementor {
         }
     }
 
-    private void handleReportEvent(JSONObject json) {
+    private void handleReportEvent(String jsonStr) {
+        LOGGER.debug("Got event: {}", jsonStr);
+        JSONObject json = JSONObject.fromObject(jsonStr);
         ReportedEvent event = new ReportedEvent(json);
         if (event.getUrl() == null || !ExtensionClientIntegration.isApiUrl(event.getUrl())) {
             this.extension.addReportedObject(event);
@@ -121,43 +125,25 @@ public class ClientIntegrationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        JSONObject json;
-        switch (name) {
-            case ACTION_REPORT_OBJECT:
-                String objJson = this.getParam(params, PARAM_OBJECT_JSON, "");
-                LOGGER.debug("Got object: {}", objJson);
-                json = JSONObject.fromObject(objJson);
-                handleReportObject(json);
-                break;
+        try {
+            switch (name) {
+                case ACTION_REPORT_OBJECT -> handleReportObject(
+                        this.getParam(params, PARAM_OBJECT_JSON, ""));
 
-            case ACTION_REPORT_EVENT:
-                String eventJson = this.getParam(params, PARAM_EVENT_JSON, "");
-                LOGGER.debug("Got event: {}", eventJson);
-                json = JSONObject.fromObject(eventJson);
-                handleReportEvent(json);
-                break;
+                case ACTION_REPORT_EVENT -> handleReportEvent(
+                        this.getParam(params, PARAM_EVENT_JSON, ""));
 
-            case ACTION_REPORT_ZEST_STATEMENT:
-                String statementJson = this.getParam(params, PARAM_STATEMENT_JSON, "");
-                LOGGER.debug("Got script: {}", statementJson);
-                try {
-                    this.extension.addZestStatement(statementJson);
-                } catch (Exception e) {
-                    LOGGER.debug(e);
-                }
-                break;
-            case ACTION_REPORT_ZEST_SCRIPT:
-                String scriptJson = this.getParam(params, PARAM_SCRIPT_JSON, "");
-                LOGGER.debug("Got script: {}", scriptJson);
-                try {
-                    this.extension.addZestStatement(scriptJson);
-                } catch (Exception e) {
-                    LOGGER.debug(e);
-                }
-                break;
-
-            default:
-                throw new ApiException(ApiException.Type.BAD_ACTION);
+                case ACTION_REPORT_ZEST_STATEMENT -> this.extension.addZestStatement(
+                        this.getParam(params, PARAM_STATEMENT_JSON, ""));
+                case ACTION_REPORT_ZEST_SCRIPT -> this.extension.addZestStatement(
+                        this.getParam(params, PARAM_SCRIPT_JSON, ""));
+                default -> throw new ApiException(ApiException.Type.BAD_ACTION);
+            }
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR);
         }
 
         return ApiResponseElement.OK;
@@ -174,43 +160,30 @@ public class ClientIntegrationAPI extends ApiImplementor {
         return str;
     }
 
-    static JSONObject decodeParam(String body, String param) {
-        String str = decodeParamString(body, param);
-        return JSONObject.fromObject(str);
-    }
-
     @Override
     public String handleCallBack(HttpMessage msg) throws ApiException {
         if (HttpRequestHeader.POST.equals(msg.getRequestHeader().getMethod())) {
             String body = msg.getRequestBody().toString();
 
             if (body.startsWith(PARAM_OBJECT_JSON + "=")) {
-                JSONObject json = decodeParam(body, PARAM_OBJECT_JSON);
-                LOGGER.debug("Got object: {}", json);
-                handleReportObject(json);
-
+                handleReportObject(decodeParamString(body, PARAM_OBJECT_JSON));
             } else if (body.startsWith(PARAM_EVENT_JSON)) {
-                JSONObject json = decodeParam(body, PARAM_EVENT_JSON);
-                LOGGER.debug("Got event: {}", json);
-                handleReportEvent(json);
+                handleReportEvent(decodeParamString(body, PARAM_EVENT_JSON));
             } else if (body.startsWith(PARAM_STATEMENT_JSON)) {
                 try {
                     this.extension.addZestStatement(decodeParamString(body, PARAM_STATEMENT_JSON));
                 } catch (Exception e) {
-                    LOGGER.debug(e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             } else if (body.startsWith(PARAM_SCRIPT_JSON)) {
                 try {
                     this.extension.addZestStatement(decodeParamString(body, PARAM_SCRIPT_JSON));
                 } catch (Exception e) {
-                    LOGGER.debug(e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
-
-        } else {
-            // Will be accessed via a GET as part of the browser ext initiation
-            msg.setResponseBody(ApiResponseElement.OK.toJSON().toString());
         }
+        // Will be accessed via a GET as part of the browser ext initiation
         return "";
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -675,7 +675,9 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
     }
 
     void addZestStatement(String stmt) throws Exception {
+        LOGGER.debug("Got zest statement: {}", stmt);
         if (clientHandler == null) {
+            LOGGER.debug("Ignoring zest statement as no clientHandler");
             return;
         }
         clientHandler.addZestStatement(stmt);

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/RedirectScript.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/RedirectScript.java
@@ -35,15 +35,23 @@ public class RedirectScript implements BrowserHook {
 
     @Override
     public void browserLaunched(SeleniumScriptUtils ssutils) {
-        String zapurl = api.getCallbackUrl();
+        StringBuilder sb = new StringBuilder();
+        String apiurl = api.getCallbackUrl();
+        sb.append(apiurl);
+        if (apiurl.contains("?")) {
+            sb.append('&');
+        } else {
+            sb.append('?');
+        }
+        sb.append("zapenable=true");
+        if (ssutils.getRequester() == ZEST_CLIENT_RECORDER_INITIATOR) {
+            sb.append("&zaprecord=true");
+        }
+        String zapurl = sb.toString();
         ssutils.getWebDriver().get(zapurl);
         JavascriptExecutor jsExecutor = (JavascriptExecutor) ssutils.getWebDriver();
-        jsExecutor.executeScript("localStorage.setItem('localzapurl', '" + zapurl + "')");
-        if (ssutils.getRequester() == ZEST_CLIENT_RECORDER_INITIATOR) {
-            jsExecutor.executeScript("localStorage.setItem('localzapenable',false)");
-        }
-
-        // This statement make sure that the ZAP browser extension is configured properly
+        jsExecutor.executeScript("localStorage.setItem('localzapurl', '" + apiurl + "')");
+        // The second refresh seems to be needed sometimes - could be a browser timing issue?
         ssutils.getWebDriver().get(zapurl);
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/RedirectScriptUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/RedirectScriptUnitTest.java
@@ -36,9 +36,6 @@ import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 /** Unit test for {@link RedirectScript}. */
 class RedirectScriptUnitTest {
 
-    private static final String DISABLE_CLIENT_SCRIPT =
-            "localStorage.setItem('localzapenable',false)";
-
     private TestWebDriver wd;
     private SeleniumScriptUtils ssutils;
     private ClientIntegrationAPI api;
@@ -63,7 +60,7 @@ class RedirectScriptUnitTest {
         // When
         script.browserLaunched(ssutils);
         // Then
-        verify(wd, times(0)).executeScript(DISABLE_CLIENT_SCRIPT);
+        verify(wd, times(2)).get("callback-url?zapenable=true");
     }
 
     @Test
@@ -73,7 +70,7 @@ class RedirectScriptUnitTest {
         // When
         script.browserLaunched(ssutils);
         // Then
-        verify(wd).executeScript(DISABLE_CLIENT_SCRIPT);
+        verify(wd, times(2)).get("callback-url?zapenable=true&zaprecord=true");
     }
 
     private interface TestWebDriver extends WebDriver, JavascriptExecutor {}

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Firefox to recorder.
+
+### Changed
+- Record script order to be alphabetical.
+
 ### Fixed
 - Record Client Submit statement.
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -24,6 +24,7 @@ import java.awt.Frame;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
@@ -64,6 +65,11 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
     private static final String ERROR_CLIENT = "zest.dialog.script.error.client";
     private static final String THREAD_PREFIX = "ZAP-client-browser-";
 
+    private static List<String> BROWSERS =
+            List.of(
+                    ExtensionSelenium.getName(Browser.FIREFOX),
+                    ExtensionSelenium.getName(Browser.CHROME));
+
     private int threadId = 1;
     private static final Logger LOGGER = LogManager.getLogger(ZestRecordScriptDialog.class);
 
@@ -86,7 +92,7 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
         this.addTextField(0, FIELD_TITLE, "");
         this.addComboField(0, FIELD_TYPE, this.getScriptTypes(), "", false);
         this.addComboField(0, FIELD_RECORD, this.getRecordTypes(), "", false);
-        this.addComboField(0, FIELD_BROWSER, getBrowsers(), "", false);
+        this.addComboField(0, FIELD_BROWSER, BROWSERS, "", false);
 
         this.addNodeSelectField(0, FIELD_CLIENT_NODE, node, true, false);
 
@@ -146,6 +152,8 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
                 list.add(Constant.messages.getString(st.getI18nKey()));
             }
         }
+        // Alphabetic order best, and it just so happens Auth scripts will appear at the top
+        Collections.sort(list);
 
         return list;
     }
@@ -170,16 +178,6 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
     private boolean isServerSide() {
         return this.getStringValue(FIELD_RECORD)
                 .equals(Constant.messages.getString("zest.dialog.script.record.type.server"));
-    }
-
-    private List<String> getBrowsers() {
-        List<String> browsers = new ArrayList<>();
-        // String firefox = Browser.FIREFOX.getId();
-        String chrome = Browser.CHROME.getId();
-
-        // browsers.add(Character.toUpperCase(firefox.charAt(0)) + firefox.substring(1));
-        browsers.add(Character.toUpperCase(chrome.charAt(0)) + chrome.substring(1));
-        return browsers;
     }
 
     private List<String> getSites() {


### PR DESCRIPTION
## Overview
Record a client Zest script via the recorder. Your chosen browser will launch but the ext will not start recording - you have to do that manually.
This PR fixes that.
Note that it looks like when the recorder is started in this way then it does not put in the initial Window Launch statement. 
Will need to investigate that, but its likely to be a bug in the browser extension..

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
