### PR TITLE
authhelper: use single field for user name in BBA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Ignore non-displayed fields when selecting the user name and password.
+- Use single displayed field for user name, e.g. multi step login.
 
 ## [0.17.0] - 2025-01-09
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -36,7 +36,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
@@ -143,15 +142,24 @@ public class AuthUtils {
     }
 
     static WebElement getUserField(List<WebElement> inputElements) {
-        List<WebElement> filteredList =
-                displayed(inputElements)
+        List<WebElement> filteredList = displayed(inputElements).toList();
+        if (filteredList.size() == 1) {
+            LOGGER.debug(
+                    "Choosing only displayed field: name={} id={}",
+                    filteredList.get(0).getDomAttribute("name"),
+                    filteredList.get(0).getDomAttribute("id"));
+            return filteredList.get(0);
+        }
+
+        filteredList =
+                filteredList.stream()
                         .filter(
                                 elem ->
                                         "text".equalsIgnoreCase(elem.getDomAttribute("type"))
                                                 || "email"
                                                         .equalsIgnoreCase(
                                                                 elem.getDomAttribute("type")))
-                        .collect(Collectors.toList());
+                        .toList();
 
         if (!filteredList.isEmpty()) {
             if (filteredList.size() > 1) {

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -137,6 +137,42 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldReturnSingleFieldAsUserField() throws Exception {
+        // Given
+        List<WebElement> inputElements = new ArrayList<>();
+        // Starting form with just username with custom input type.
+        inputElements.add(new TestWebElement("input", "customtype"));
+
+        // When
+        WebElement field = AuthUtils.getUserField(inputElements);
+
+        // Then
+        assertThat(field, is(notNullValue()));
+        assertThat(field.getDomAttribute("type"), is(equalTo("customtype")));
+        assertThat(field.isDisplayed(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldReturnDisplayedSingleFieldAsUserField() throws Exception {
+        // Given
+        List<WebElement> inputElements = new ArrayList<>();
+        // Some other form, not displayed.
+        TestWebElement inputField = new TestWebElement("input", "text");
+        inputField.setDisplayed(false);
+        inputElements.add(inputField);
+        // Starting form with just username with custom input type, displayed.
+        inputElements.add(new TestWebElement("input", "customtype"));
+
+        // When
+        WebElement field = AuthUtils.getUserField(inputElements);
+
+        // Then
+        assertThat(field, is(notNullValue()));
+        assertThat(field.getDomAttribute("type"), is(equalTo("customtype")));
+        assertThat(field.isDisplayed(), is(equalTo(true)));
+    }
+
+    @Test
     void shouldReturnUserEmailField() throws Exception {
         // Given
         List<WebElement> inputElements = new ArrayList<>();


### PR DESCRIPTION
Skip further filtering when the login page has a single displayed field, as in that case it should be the user name.