### PR TITLE
pscan: Clarify that passiveScan-wait is based on minutes

### DIFF
--- a/addOns/pscan/CHANGELOG.md
+++ b/addOns/pscan/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Correct help configuration to work with any language.
 - Maintenance changes.
+- Clarified passiveScan-wait > maxDuration documentation.
 
 ### Fixed
 - Fix broken link the help page.

--- a/addOns/pscan/src/main/javahelp/org/zaproxy/addon/pscan/help/contents/job-pscanwait.html
+++ b/addOns/pscan/src/main/javahelp/org/zaproxy/addon/pscan/help/contents/job-pscanwait.html
@@ -20,7 +20,7 @@ It is covered in the video: <a href="https://youtu.be/hcftgjz_Vgc">ZAP Chat 12 A
 <pre>
   - type: passiveScan-wait             # Passive scan wait for the passive scanner to finish
     parameters:
-      maxDuration: 5                   # Int: The max time to wait for the passive scanner, default: 0 unlimited
+      maxDuration: 5                   # Int: The max time in minutes to wait for the passive scanner, default: 0 unlimited
 </pre>
 
 <H2>Job Data</H2>

--- a/addOns/pscan/src/main/resources/org/zaproxy/addon/pscan/automation/jobs/passiveScan-wait-max.yaml
+++ b/addOns/pscan/src/main/resources/org/zaproxy/addon/pscan/automation/jobs/passiveScan-wait-max.yaml
@@ -1,6 +1,6 @@
   - type: passiveScan-wait             # Passive scan wait for the passive scanner to finish
     parameters:
-      maxDuration: 5                   # Int: The max time to wait for the passive scanner, default: 0 unlimited
+      maxDuration: 5                   # Int: The max time in minutes to wait for the passive scanner, default: 0 unlimited
     tests:
       - name: 'test one'                       # Name of the test, optional
         type: alert                            # Specifies that the test is of type 'alert'

--- a/addOns/pscan/src/main/resources/org/zaproxy/addon/pscan/automation/jobs/passiveScan-wait-min.yaml
+++ b/addOns/pscan/src/main/resources/org/zaproxy/addon/pscan/automation/jobs/passiveScan-wait-min.yaml
@@ -1,6 +1,6 @@
   - type: passiveScan-wait             # Passive scan wait for the passive scanner to finish
     parameters:
-      maxDuration: 5                   # Int: The max time to wait for the passive scanner, default: 0 unlimited
+      maxDuration: 5                   # Int: The max time in minutes to wait for the passive scanner, default: 0 unlimited
     tests:
       - name: 'test one'                       # Name of the test, optional
         type: alert                            # Specifies that the test is of type 'alert'


### PR DESCRIPTION
## Overview
Clarify that passiveScan-wait is based on minutes, as discussed via slack.
https://github.com/zaproxy/zap-extensions/blob/1845b961d43f2a13e63b2a7c8326aa690aa05619/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/automation/jobs/PassiveScanWaitJob.java#L80

## Related Issues
n/a

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [n/a] Write tests
- [n/a] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
