### PR TITLE
dev: add link depending on localStorage

### DIFF
--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Link which is only shown if a localStorage item is set, for testing in browser spider authentication.
+
 ### Changed
 - Update minimum ZAP version to 2.16.0.
 

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieDir.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieDir.java
@@ -36,5 +36,6 @@ public class SimpleJsonCookieDir extends TestAuthDirectory {
         this.addPage(new SimpleJsonCookieProtectedPage(server, "page1.html"));
         this.addPage(new SimpleJsonCookieProtectedPage(server, "page2.html"));
         this.addPage(new SimpleJsonCookieProtectedPage(server, "page3.html"));
+        this.addPage(new SimpleJsonCookieProtectedPage(server, "s3cr3t.html"));
     }
 }

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/index.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/index.html
@@ -33,7 +33,10 @@
 		<li>username = test@test.com
 		<li>password = password123
 	</ul>
-	The verification URL returns JSON with the username and a 200 response if valid, otherwise a 403 response.
+	The verification URL returns JSON with the username and a 200 response if valid, otherwise a 403 response.<br>
+	On a successfull login it will set a local storage item called zapSecret.<br>
+	If zapSecret is set then page3 will add a link to a page based on the secret name.<br>
+	Spiders that authenticate in separate browsers should not be able to find the "secret" page.
 	
 </div>
 <script>
@@ -54,6 +57,7 @@ function submitform() {
 	        var json = JSON.parse(xhr.responseText);
 	        
 	        if (json.result === "OK") {
+	        	localStorage.setItem("zapSecret", "s3c" + "r3t");
 	        	window.location.replace("home.html");
 	        } else {
 	        	const h3 = document.createElement("h3");

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/page3.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/page3.html
@@ -5,9 +5,22 @@
 	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
-<div class="roundContainer">
+<div class="roundContainer" id="div1">
 	<h1>Page 3</H1>
-	Protected by creds so that it can be used to test authenticated spidering.
+	Protected by creds so that it can be used to test authenticated spidering.<p>
+	Will also include a link to a hidden page, but only if a specific localStorage item has been set during login.<p>
 </div>
+<script>
+let zapSecret = localStorage.getItem("zapSecret");
+if (zapSecret) {
+  let a = document.createElement('a');
+  let link = document.createTextNode("Link only present if logged in");
+  a.appendChild(link);
+  a.title = "Link only present if logged in";
+  a.href = zapSecret + ".html";
+  document.getElementById("div1").appendChild(a);
+}
+</script>
+
 </body>
 </html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/s3cr3t.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/simple-json-cookie/s3cr3t.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Secret Page</H1>
+	Protected by creds and a localStorage item so that it can be used to test authenticated spidering.
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Overview
Added a link which is only shown if a localStorage item is set, for testing in browser spider authentication.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
