### PR TITLE
authhelper: restore DOM property check in BBA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Ignore non-displayed fields when selecting the user name and password.
 - Use single displayed field for user name, e.g. multi step login.
 
+### Fixed
+- Input fields that do not explicitly declare their type were no longer being chosen by the Browser Based Authentication.
+
 ## [0.17.0] - 2025-01-09
 ### Changed
 - Update minimum ZAP version to 2.16.0.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -144,21 +144,19 @@ public class AuthUtils {
     static WebElement getUserField(List<WebElement> inputElements) {
         List<WebElement> filteredList = displayed(inputElements).toList();
         if (filteredList.size() == 1) {
-            LOGGER.debug(
-                    "Choosing only displayed field: name={} id={}",
-                    filteredList.get(0).getDomAttribute("name"),
-                    filteredList.get(0).getDomAttribute("id"));
-            return filteredList.get(0);
+            WebElement element = filteredList.get(0);
+            logFieldElement("Choosing only displayed", element);
+            return element;
         }
 
         filteredList =
                 filteredList.stream()
                         .filter(
-                                elem ->
-                                        "text".equalsIgnoreCase(elem.getDomAttribute("type"))
-                                                || "email"
-                                                        .equalsIgnoreCase(
-                                                                elem.getDomAttribute("type")))
+                                elem -> {
+                                    String type = getAttribute(elem, "type");
+                                    return "text".equalsIgnoreCase(type)
+                                            || "email".equalsIgnoreCase(type);
+                                })
                         .toList();
 
         if (!filteredList.isEmpty()) {
@@ -168,25 +166,34 @@ public class AuthUtils {
                 for (WebElement we : filteredList) {
                     if (attributeContains(we, "id", USERNAME_FIELD_INDICATORS)
                             || attributeContains(we, "name", USERNAME_FIELD_INDICATORS)) {
-                        LOGGER.debug(
-                                "Choosing 'best' user field: name={} id={}",
-                                we.getDomAttribute("name"),
-                                we.getDomAttribute("id"));
+                        logFieldElement("Choosing 'best' user", we);
                         return we;
                     }
-                    LOGGER.debug(
-                            "Not yet choosing user field: name={} id={}",
-                            we.getDomAttribute("name"),
-                            we.getDomAttribute("id"));
+                    logFieldElement("Not yet choosing user", we);
                 }
             }
-            LOGGER.debug(
-                    "Choosing first user field: name={} id={}",
-                    filteredList.get(0).getDomAttribute("name"),
-                    filteredList.get(0).getDomAttribute("id"));
-            return filteredList.get(0);
+
+            WebElement element = filteredList.get(0);
+            logFieldElement("Choosing first user", element);
+            return element;
         }
         return null;
+    }
+
+    private static void logFieldElement(String prefix, WebElement element) {
+        LOGGER.debug(
+                "{} field: name={} id={}",
+                prefix,
+                getAttribute(element, "name"),
+                getAttribute(element, "id"));
+    }
+
+    private static String getAttribute(WebElement element, String name) {
+        String value = element.getDomAttribute(name);
+        if (value != null) {
+            return value;
+        }
+        return element.getDomProperty(name);
     }
 
     private static Stream<WebElement> displayed(List<WebElement> elements) {
@@ -194,7 +201,7 @@ public class AuthUtils {
     }
 
     static boolean attributeContains(WebElement we, String attribute, String[] strings) {
-        String att = we.getDomAttribute(attribute);
+        String att = getAttribute(we, attribute);
         if (att == null) {
             return false;
         }
@@ -209,7 +216,7 @@ public class AuthUtils {
 
     static WebElement getPasswordField(List<WebElement> inputElements) {
         return displayed(inputElements)
-                .filter(element -> "password".equalsIgnoreCase(element.getDomAttribute("type")))
+                .filter(element -> "password".equalsIgnoreCase(getAttribute(element, "type")))
                 .findFirst()
                 .orElse(null);
     }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Setter;
 import org.apache.commons.httpclient.URI;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -102,6 +103,24 @@ class AuthUtilsUnitTest extends TestUtils {
         List<WebElement> inputElements = new ArrayList<>();
         inputElements.add(new TestWebElement("input", "password"));
         inputElements.add(new TestWebElement("input", "text"));
+        inputElements.add(new TestWebElement("input", "checkbox"));
+
+        // When
+        WebElement field = AuthUtils.getUserField(inputElements);
+
+        // Then
+        assertThat(field, is(notNullValue()));
+        assertThat(field.getDomAttribute("type"), is(equalTo("text")));
+    }
+
+    @Test
+    void shouldReturnUserTextFieldByDomProperty() throws Exception {
+        // Given
+        List<WebElement> inputElements = new ArrayList<>();
+        inputElements.add(new TestWebElement("input", "password"));
+        TestWebElement inputField = new TestWebElement("input", "text");
+        inputField.setUseDomProperty(true);
+        inputElements.add(inputField);
         inputElements.add(new TestWebElement("input", "checkbox"));
 
         // When
@@ -244,6 +263,24 @@ class AuthUtilsUnitTest extends TestUtils {
         inputElements.add(new TestWebElement("input", "email"));
         inputElements.add(new TestWebElement("input", "checkbox"));
         inputElements.add(new TestWebElement("input", "password"));
+
+        // When
+        WebElement field = AuthUtils.getPasswordField(inputElements);
+
+        // Then
+        assertThat(field, is(notNullValue()));
+        assertThat(field.getDomAttribute("type"), is(equalTo("password")));
+    }
+
+    @Test
+    void shouldReturnPasswordFieldByDomProperty() throws Exception {
+        // Given
+        List<WebElement> inputElements = new ArrayList<>();
+        inputElements.add(new TestWebElement("input", "email"));
+        inputElements.add(new TestWebElement("input", "checkbox"));
+        TestWebElement inputField = new TestWebElement("input", "password");
+        inputField.setUseDomProperty(true);
+        inputElements.add(inputField);
 
         // When
         WebElement field = AuthUtils.getPasswordField(inputElements);
@@ -717,6 +754,8 @@ class AuthUtilsUnitTest extends TestUtils {
         private String id;
         private String name;
         @Setter private boolean displayed = true;
+        @Setter private boolean useDomAttribute = true;
+        @Setter private boolean useDomProperty;
 
         TestWebElement(String tag, String type) {
             this.tag = tag;
@@ -753,6 +792,13 @@ class AuthUtilsUnitTest extends TestUtils {
 
         @Override
         public String getDomAttribute(String name) {
+            if (useDomAttribute) {
+                return getAttributeImpl(name);
+            }
+            return null;
+        }
+
+        private String getAttributeImpl(String name) {
             switch (name) {
                 case "id":
                     return id;
@@ -763,6 +809,14 @@ class AuthUtilsUnitTest extends TestUtils {
                 default:
                     return null;
             }
+        }
+
+        @Override
+        public @Nullable String getDomProperty(String name) {
+            if (useDomProperty) {
+                return getAttributeImpl(name);
+            }
+            return null;
         }
 
         @Override


### PR DESCRIPTION
Use both DOM attributes and properties when checking the fields.
A previous deprecation warn was addressed by checking only the DOM attributes which inadvertently broke wanted behaviour (e.g. user name fields that don't have the type declared as a DOM attribute).
Extract method to log (potential) user fields.
