### PR TITLE
pscanrules: CSP-Exclude plugin-types, report-uri, and sandbox from Wildcard Alert

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - X-Backend-Server Header Information Leak
     - X-ChromeLogger-Data (XCOLD) Header Information Leak
     - X-Debug-Token Information Leak
+- Removed lack of "report-uri" or "plugin-types" from "CSP: Wildcard Directive" alerts when missing. plugin-types is deprecated and report-uri has no impact for this issue. (Issue 8700)
 
 ## [62] - 2025-01-10
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,16 +71,16 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
 
     // Per:
     // https://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources as of 20200618
+    // 20250131 "base-uri" is not included. Per MDN if it isn't specified then the <base> value is
+    // used, if no base value then location.href "plugin-types" is not included, the directive has
+    // been deprecated. "report-uri" is not included as it has no literal impact. "sandbox" does not
+    // fallback, but excluding it does not necessarily make anything 'more' vulnerable, it's use
+    // simply allows more detailed control of what embedded content can do.
     private static final List<String> DIRECTIVES_WITHOUT_FALLBACK =
-            Arrays.asList(
-                    "base-uri",
-                    "form-action",
-                    "frame-ancestors",
-                    "plugin-types",
-                    "report-uri",
-                    "sandbox");
+            List.of("form-action", "frame-ancestors");
+
     private static final List<String> ALLOWED_DIRECTIVES =
-            Arrays.asList(
+            List.of(
                     // TODO: Remove once https://github.com/shapesecurity/salvation/issues/232 is
                     // addressed
                     "require-trusted-types-for", "trusted-types");


### PR DESCRIPTION
## Overview
Removed lack of "report-uri" or "plugin-types" from "CSP: Wildcard Directive" alerts when missing. plugin-types is deprecated and report-uri has no impact for this issue. 

- Update Change log.
- Tweak code.
- Clean code: Switch Arrays.asList to List.of

## Related Issues
- zaproxy/zaproxy#8700

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
