### PR TITLE
authhelper: reset demo mode always

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for Client Script Authentication when used in conjunction with the Ajax Spider add-on.
 - Add support for custom authentication steps in Browser Based Authentication.
 
+### Fixed
+- Reset always the state of the demo mode in the Authentication Tester dialogue.
+
 ## [0.18.0] - 2025-01-27
 ### Changed
 - Ignore non-displayed fields when selecting the user name and password.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
@@ -246,6 +246,7 @@ public class AuthTestDialog extends StandardFieldsDialog {
 
     private void authenticate() {
         StatsListener statsListener = null;
+        boolean demoMode = getBoolValue(DEMO_LABEL);
         try {
             this.diagnosticField.setText("");
             ext.enableAuthDiagCollector(true);
@@ -305,7 +306,7 @@ public class AuthTestDialog extends StandardFieldsDialog {
             } catch (Exception e) {
                 // Ignore - not yet supported so will default to "poll"
             }
-            if (this.getBoolValue(DEMO_LABEL)) {
+            if (demoMode) {
                 AuthUtils.setDemoMode(true);
             }
 
@@ -419,7 +420,7 @@ public class AuthTestDialog extends StandardFieldsDialog {
             if (statsListener != null) {
                 Stats.removeListener(statsListener);
             }
-            if (this.getBoolValue(DEMO_LABEL)) {
+            if (demoMode) {
                 AuthUtils.setDemoMode(false);
             }
             ext.enableAuthDiagCollector(false);


### PR DESCRIPTION
Cache the value to ensure that the state of demo mode is reset always, it was possible for the mode to be kept enabled if the user disabled it before the test finished.