### PR TITLE
automation: correctly load numeric passwords

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Fixed
+- Correctly load numeric user passwords.
 - Address malformed HTML in the help.
 - Correct default value of `threadPerHost` property of the `activeScan-config` job's help.
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ContextWrapper.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ContextWrapper.java
@@ -198,6 +198,7 @@ public class ContextWrapper {
                                                 "automation.error.context.baduser", userObj));
                             } else {
                                 UserData ud = new UserData();
+                                forceCredentialsStringType(userObj);
                                 JobUtils.applyParamsToObject(
                                         (LinkedHashMap<?, ?>) userObj, ud, "users", null, progress);
                                 if (env.getUser(ud.getName()) != null) {
@@ -230,6 +231,21 @@ public class ContextWrapper {
         if (data.getUrls().isEmpty()) {
             progress.error(
                     Constant.messages.getString("automation.error.context.nourl", contextData));
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void forceCredentialsStringType(Object userObj) {
+        Object credentials = ((LinkedHashMap) userObj).get("credentials");
+        if (credentials instanceof LinkedHashMap) {
+            ((LinkedHashMap) credentials)
+                    .replaceAll(
+                            (k, v) -> {
+                                if (v instanceof Number) {
+                                    return v.toString();
+                                }
+                                return v;
+                            });
         }
     }
 


### PR DESCRIPTION
Make the credentials of the expected type to prevent class cast exceptions.