### PR TITLE
pscanrulesAlpha: Replace usage of CWE-200

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.16.0.
 - Maintenance changes.
+- Replace usage of CWE-200 for the Base64 Disclosure scan rule (Issue 8730).
 
 ## [43] - 2024-09-02
 ### Changed

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -325,7 +325,7 @@ public class Base64Disclosure extends PluginPassiveScanner implements CommonPass
         return newAlert()
                 .setRisk(Alert.RISK_INFO)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setCweId(200) // Information Exposure,
+                .setCweId(319) // CWE-319: Cleartext Transmission of Sensitive Information
                 .setWascId(13) // Information Leakage
                 .setAlertRef(getPluginId() + alertRef);
     }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64DisclosureUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64DisclosureUnitTest.java
@@ -105,12 +105,15 @@ class Base64DisclosureUnitTest extends PassiveScannerTest<Base64Disclosure> {
         assertThat(vsAlert.getName(), is(equalTo("ASP.NET ViewState Disclosure")));
         assertThat(vsAlert.getRisk(), is(equalTo(Alert.RISK_INFO)));
         assertThat(vsAlert.getAlertRef(), is(equalTo("10094-1")));
+        assertThat(vsAlert.getCweId(), is(equalTo(319)));
         assertThat(maclessAlert.getName(), is(equalTo("ASP.NET ViewState Integrity")));
         assertThat(maclessAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(maclessAlert.getAlertRef(), is(equalTo("10094-2")));
+        assertThat(maclessAlert.getCweId(), is(equalTo(642)));
         assertThat(base64Alert.getName(), is(equalTo("Base64 Disclosure")));
         assertThat(base64Alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
         assertThat(base64Alert.getAlertRef(), is(equalTo("10094-3")));
+        assertThat(base64Alert.getCweId(), is(equalTo(319)));
     }
 
     private static HttpMessage createMessage() throws Exception {


### PR DESCRIPTION
## Overview
- Add change note.
- Tweak CWE value in rule.
- Assert value in unit test.

## Related Issues
- Fixes zaproxy/zaproxy#8730

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
