### PR TITLE
postman: correct header deserialization

### DIFF
--- a/addOns/postman/CHANGELOG.md
+++ b/addOns/postman/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct deserialization of headers.
 
 ## [0.5.0] - 2025-01-10
 ### Changed

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/deserializers/ObjectDeserializer.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/deserializers/ObjectDeserializer.java
@@ -31,7 +31,9 @@ import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.type.LogicalType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import java.io.IOException;
+import org.zaproxy.addon.postman.PostmanParser;
 
 /**
  * A custom JSON deserializer to ignore properties of an object when its signature doesn't match,
@@ -48,7 +50,11 @@ public class ObjectDeserializer extends JsonDeserializer<Object> implements Cont
 
     public ObjectDeserializer(Class<? extends Object> targetClass) {
         this.targetClass = targetClass;
-        this.mapper = new ObjectMapper();
+        this.mapper =
+                new ObjectMapper()
+                        .setTypeFactory(
+                                TypeFactory.defaultInstance()
+                                        .withClassLoader(PostmanParser.class.getClassLoader()));
         configureMapper();
     }
 


### PR DESCRIPTION
Use the class loader of the add-on when deserializing the headers, otherwise it would fail to find the classes of the add-on.