### PR TITLE
authhelper: BBA Don't attempt to set auth message null if handler null

### DIFF
--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -267,7 +267,9 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
                 AuthenticationCredentials credentials,
                 User user)
                 throws UnsupportedAuthenticationCredentialsException {
-            handler.resetAuthMsg();
+            if (handler != null) {
+                handler.resetAuthMsg();
+            }
             if (this.loginPageWait > 0) {
                 AuthUtils.setTimeToWaitMs(TimeUnit.SECONDS.toMillis(loginPageWait));
             }


### PR DESCRIPTION
## Overview
BBA & CSA Don't attempt to set handler null if already null

## Related Issues
Addresses recent workflow failures: https://github.com/zaproxy/zaproxy/actions/runs/13104643180

## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
