### PR TITLE
pscanrulesBeta: address typo in test method name

### DIFF
--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InPageBannerInfoLeakScanRuleUnitTest.java
@@ -160,7 +160,7 @@ class InPageBannerInfoLeakScanRuleUnitTest
     }
 
     @Test
-    void shouldReturnExmpectedNumberOfExmapleAlerts() {
+    void shouldReturnExpectedNumberOfExampleAlerts() {
         // Given / When
         List<Alert> alerts = rule.getExampleAlerts();
         // Then


### PR DESCRIPTION
Address typos in Expected and Example.