### PR TITLE
scripts: Remove unnecessary custom param handling

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Remove unnecessary custom parameter handling.
 
 ## [45.8.0] - 2025-01-10
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ScriptJob.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ScriptJob.java
@@ -45,7 +45,6 @@ public class ScriptJob extends AutomationJob {
 
     public static final String JOB_NAME = "script";
     public static final String PARAM_ACTION = "action";
-    public static final String PARAM_SCRIPT_NAME = "scriptName";
     protected static final Map<String, Function<ScriptJobParameters, ScriptAction>> ACTIONS =
             new HashMap<String, Function<ScriptJobParameters, ScriptAction>>() {
                 private static final long serialVersionUID = 1L;
@@ -144,14 +143,6 @@ public class ScriptJob extends AutomationJob {
     @Override
     public ScriptJobParameters getParameters() {
         return parameters;
-    }
-
-    @Override
-    public Map<String, String> getCustomConfigParameters() {
-        Map<String, String> map = super.getCustomConfigParameters();
-        map.put(PARAM_ACTION, "");
-        map.put(PARAM_SCRIPT_NAME, "");
-        return map;
     }
 
     @Override

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/ScriptJobUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/ScriptJobUnitTest.java
@@ -45,8 +45,10 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -1278,6 +1280,16 @@ class ScriptJobUnitTest extends TestUtils {
         assertThat(progress.hasErrors(), is(equalTo(false)));
         verify(extScript).setEnabled(scriptWrapper, false);
         assertThat(progress.hasWarnings(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotHaveCustomParameters() {
+        // Given
+        ScriptJob job = new ScriptJob();
+        // When
+        Map<String, String> custParams = job.getCustomConfigParameters();
+        // Then
+        assertThat(custParams, is(equalTo(Collections.EMPTY_MAP)));
     }
 
     private ScriptJob setJobData(ScriptJob job, String yamlStr) {


### PR DESCRIPTION
## Overview
- CHANGELOG > Added fix note.
- ScriptJob > Remove unnecessary constant and overridden getCustomConfigParameters method.
- ScriptJobUnitTest > Add test asserting there are no custom config params.

Note the issue only occurs when -autogenconf is used.
-autogenmin, -autogenmax both use the expected key value, saving a un-configured script job doesn't include any params, and saving a configured script job uses the expected key value.

## Related Issues
- zaproxy/zaproxy#8844

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
