### PR TITLE
client: add API for the spider

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Add API endpoints for the Client Spider.
 
 ## [0.14.0] - 2025-03-04
 ### Added

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -72,6 +72,7 @@ import org.zaproxy.addon.client.pscan.ClientPassiveScanHelper;
 import org.zaproxy.addon.client.pscan.OptionsPassiveScan;
 import org.zaproxy.addon.client.spider.AuthenticationHandler;
 import org.zaproxy.addon.client.spider.ClientSpider;
+import org.zaproxy.addon.client.spider.ClientSpiderApi;
 import org.zaproxy.addon.client.spider.ClientSpiderDialog;
 import org.zaproxy.addon.client.spider.ClientSpiderPanel;
 import org.zaproxy.addon.client.spider.PopupMenuSpider;
@@ -196,6 +197,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
         extensionHook.addSessionListener(new SessionChangedListenerImpl());
         extensionHook.addOptionsParamSet(getClientParam());
         extensionHook.addApiImplementor(this.api);
+        extensionHook.addApiImplementor(new ClientSpiderApi(this));
         extensionHook.addSessionListener(new SessionChangeListener());
 
         if (hasView()) {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderApi.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderApi.java
@@ -1,0 +1,262 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import java.util.List;
+import net.sf.json.JSONObject;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.SiteNode;
+import org.zaproxy.addon.client.ClientOptions;
+import org.zaproxy.addon.client.ExtensionClientIntegration;
+import org.zaproxy.zap.extension.api.ApiAction;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiException.Type;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
+import org.zaproxy.zap.extension.api.ApiView;
+import org.zaproxy.zap.extension.selenium.Browser;
+import org.zaproxy.zap.extension.users.ExtensionUserManagement;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.users.User;
+import org.zaproxy.zap.utils.ApiUtils;
+
+public class ClientSpiderApi extends ApiImplementor {
+
+    private static final Logger LOGGER = LogManager.getLogger(ClientSpiderApi.class);
+
+    private static final String PREFIX = "clientSpider";
+    private static final String I18N_PREFIX = "client." + PREFIX;
+
+    private static final String ACTION_START_SCAN = "scan";
+    private static final String ACTION_STOP_SCAN = "stop";
+
+    private static final String VIEW_STATUS = "status";
+
+    private static final String PARAM_BROWSER = "browser";
+    private static final String PARAM_CONTEXT_NAME = "contextName";
+    private static final String PARAM_SCAN_ID = "scanId";
+    private static final String PARAM_SUBTREE_ONLY = "subtreeOnly";
+    private static final String PARAM_URL = "url";
+    private static final String PARAM_USER_NAME = "userName";
+
+    private final ExtensionClientIntegration extension;
+
+    public ClientSpiderApi() {
+        this(null);
+    }
+
+    public ClientSpiderApi(ExtensionClientIntegration extension) {
+        this.extension = extension;
+
+        addApiAction(
+                new ApiAction(
+                        ACTION_START_SCAN,
+                        null,
+                        List.of(
+                                PARAM_BROWSER,
+                                PARAM_URL,
+                                PARAM_CONTEXT_NAME,
+                                PARAM_USER_NAME,
+                                PARAM_SUBTREE_ONLY)));
+
+        addApiAction(new ApiAction(ACTION_STOP_SCAN, List.of(PARAM_SCAN_ID)));
+
+        addApiView(new ApiView(VIEW_STATUS, List.of(PARAM_SCAN_ID)));
+    }
+
+    @Override
+    protected String getI18nPrefix() {
+        return I18N_PREFIX;
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
+        LOGGER.debug("Request for handleApiAction: {} (params: {})", name, params);
+
+        switch (name) {
+            case ACTION_START_SCAN:
+                return startScan(name, params);
+
+            case ACTION_STOP_SCAN:
+                extension.stopScan(getClientSpider(params).getScanId());
+                return ApiResponseElement.OK;
+
+            default:
+                throw new ApiException(ApiException.Type.BAD_ACTION);
+        }
+    }
+
+    private ApiResponse startScan(String name, JSONObject params) throws ApiException {
+        String url = ApiUtils.getOptionalStringParam(params, PARAM_URL);
+
+        Context context = null;
+        if (params.containsKey(PARAM_CONTEXT_NAME)) {
+            String contextName = params.getString(PARAM_CONTEXT_NAME);
+            if (!contextName.isEmpty()) {
+                context = ApiUtils.getContextByName(contextName);
+            }
+        }
+
+        boolean validateUrl = true;
+        if (url == null || url.isEmpty()) {
+            url = getContextUrl(context);
+            validateUrl = false;
+        } else if (context != null && !context.isInContext(url)) {
+            throw new ApiException(Type.URL_NOT_IN_CONTEXT, PARAM_URL);
+        }
+
+        if (validateUrl) {
+            validateUrl(url);
+        }
+
+        validateMode(url, context, validateUrl);
+
+        ClientOptions options = extension.getClientParam().clone();
+        options.setBrowserId(getBrowser(params));
+
+        User user = getUser(params, context);
+
+        try {
+            int scanId =
+                    extension.startScan(
+                            url,
+                            options,
+                            context,
+                            user,
+                            getParam(params, PARAM_SUBTREE_ONLY, false));
+            return new ApiResponseElement(name, Integer.toString(scanId));
+        } catch (Exception e) {
+            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
+        }
+    }
+
+    private static String getContextUrl(Context context) throws ApiException {
+        if (context == null || !context.hasNodesInContextFromSiteTree()) {
+            throw new ApiException(Type.MISSING_PARAMETER, PARAM_URL);
+        }
+
+        List<SiteNode> nodes = context.getNodesInContextFromSiteTree();
+        if (nodes.isEmpty()) {
+            throw new ApiException(Type.MISSING_PARAMETER, PARAM_URL);
+        }
+
+        return nodes.get(0).getHistoryReference().getURI().getEscapedURIReference();
+    }
+
+    private static void validateUrl(String url) throws ApiException {
+        try {
+            String scheme = new URI(url, true).getScheme();
+            if (scheme == null
+                    || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+                throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL);
+            }
+        } catch (URIException e) {
+            throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL, e);
+        }
+    }
+
+    private static void validateMode(String url, Context context, boolean validateUrl)
+            throws ApiException {
+        switch (Control.getSingleton().getMode()) {
+            case safe:
+                throw new ApiException(ApiException.Type.MODE_VIOLATION);
+
+            case protect:
+                if ((validateUrl && !Model.getSingleton().getSession().isInScope(url))
+                        || (context != null && !context.isInScope())) {
+                    throw new ApiException(ApiException.Type.MODE_VIOLATION);
+                }
+                break;
+
+            case attack, standard:
+            default:
+                break;
+        }
+    }
+
+    private static String getBrowser(JSONObject params) throws ApiException {
+        String browserId = params.optString(PARAM_BROWSER);
+        if (browserId.isEmpty()) {
+            return Browser.FIREFOX_HEADLESS.getId();
+        }
+
+        Browser browser = Browser.getBrowserWithIdNoFailSafe(browserId);
+        if (browser == null) {
+            throw new ApiException(Type.ILLEGAL_PARAMETER, PARAM_BROWSER);
+        }
+        return browser.getId();
+    }
+
+    private static User getUser(JSONObject params, Context context) throws ApiException {
+        String userName = params.optString(PARAM_USER_NAME);
+        if (userName.isEmpty()) {
+            return null;
+        }
+
+        if (context == null) {
+            throw new ApiException(Type.MISSING_PARAMETER, PARAM_CONTEXT_NAME);
+        }
+
+        ExtensionUserManagement usersExtension =
+                Control.getSingleton()
+                        .getExtensionLoader()
+                        .getExtension(ExtensionUserManagement.class);
+        if (usersExtension == null) {
+            throw new ApiException(Type.NO_IMPLEMENTOR, ExtensionUserManagement.NAME);
+        }
+        return usersExtension.getContextUserAuthManager(context.getId()).getUsers().stream()
+                .filter(e -> userName.equals(e.getName()))
+                .findFirst()
+                .orElseThrow(() -> new ApiException(Type.USER_NOT_FOUND, PARAM_USER_NAME));
+    }
+
+    @Override
+    public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
+
+        switch (name) {
+            case VIEW_STATUS:
+                ClientSpider scan = getClientSpider(params);
+                int progress = scan.isStopped() ? 100 : scan.getProgress();
+                return new ApiResponseElement(name, Integer.toString(progress));
+
+            default:
+                throw new ApiException(ApiException.Type.BAD_VIEW);
+        }
+    }
+
+    private ClientSpider getClientSpider(JSONObject params) throws ApiException {
+        ClientSpider scan = extension.getScan(ApiUtils.getIntParam(params, PARAM_SCAN_ID));
+        if (scan == null) {
+            throw new ApiException(Type.ILLEGAL_PARAMETER, PARAM_SCAN_ID);
+        }
+        return scan;
+    }
+}

--- a/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
+++ b/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
@@ -27,6 +27,18 @@ client.automation.dialog.summary = Default
 client.automation.dialog.tab.params = Scope
 client.automation.name = Client Spider Automation
 
+client.clientSpider.api.action.scan = Starts a client spider scan.
+client.clientSpider.api.action.scan.param.browser = The ID of the browser. See Selenium documentation for valid IDs.
+client.clientSpider.api.action.scan.param.contextName = The name of the context.
+client.clientSpider.api.action.scan.param.subtreeOnly = true to spider only under the subtree, false otherwise.
+client.clientSpider.api.action.scan.param.url = The URL from where to start the spider.
+client.clientSpider.api.action.scan.param.userName = The name of the user.
+client.clientSpider.api.action.stop = Stops a client spider scan.
+client.clientSpider.api.action.stop.param.scanId = The ID of the client spider.
+client.clientSpider.api.desc = Allows to manage the Client Spider.
+client.clientSpider.api.view.status = Gets the status of a client spider scan.
+client.clientSpider.api.view.status.param.scanId = The ID of the client spider.
+
 client.components.table.header.form = Form ID
 client.components.table.header.href = HREF
 client.components.table.header.id = ID

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderApiUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderApiUnitTest.java
@@ -1,0 +1,183 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.client.ExtensionClientIntegration;
+import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.api.API.RequestType;
+import org.zaproxy.zap.extension.api.ApiElement;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiParameter;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link ClientSpiderApi}. */
+class ClientSpiderApiUnitTest extends TestUtils {
+
+    private ClientSpiderApi clientSpiderAPI;
+
+    @BeforeEach
+    void setUp() {
+        mockMessages(new ExtensionClientIntegration());
+
+        clientSpiderAPI = new ClientSpiderApi();
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        Constant.messages = null;
+    }
+
+    @Test
+    void shouldHavePrefix() {
+        // Given / When
+        String prefix = clientSpiderAPI.getPrefix();
+        // Then
+        assertThat(prefix, is(equalTo("clientSpider")));
+    }
+
+    @Test
+    void shouldAddApiElements() {
+        // Given / When
+        clientSpiderAPI = new ClientSpiderApi();
+        // Then
+        assertThat(clientSpiderAPI.getApiActions(), hasSize(2));
+        assertThat(clientSpiderAPI.getApiViews(), hasSize(1));
+        assertThat(clientSpiderAPI.getApiOthers(), hasSize(0));
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"unknown", "something"})
+    void shouldThrowApiExceptionForUnknownAction(String name) {
+        // Given
+        JSONObject params = new JSONObject();
+        // When
+        ApiException exception =
+                assertThrows(
+                        ApiException.class, () -> clientSpiderAPI.handleApiAction(name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_ACTION)));
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"unknown", "something"})
+    void shouldThrowApiExceptionForUnknownOther(String name) {
+        // Given
+        HttpMessage message = new HttpMessage();
+        JSONObject params = new JSONObject();
+        // When
+        ApiException exception =
+                assertThrows(
+                        ApiException.class,
+                        () -> clientSpiderAPI.handleApiOther(message, name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_OTHER)));
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"unknown", "something"})
+    void shouldThrowApiExceptionForUnknownView(String name) {
+        // Given
+        JSONObject params = new JSONObject();
+        // When
+        ApiException exception =
+                assertThrows(ApiException.class, () -> clientSpiderAPI.handleApiView(name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_VIEW)));
+    }
+
+    @Test
+    void shouldHaveDescriptionsForAllApiElements() {
+        clientSpiderAPI = new ClientSpiderApi();
+        List<String> missingKeys = new ArrayList<>();
+        List<String> missingDescriptions = new ArrayList<>();
+        checkKey(clientSpiderAPI.getDescriptionKey(), missingKeys, missingDescriptions);
+        checkApiElements(
+                clientSpiderAPI,
+                clientSpiderAPI.getApiActions(),
+                API.RequestType.action,
+                missingKeys,
+                missingDescriptions);
+        checkApiElements(
+                clientSpiderAPI,
+                clientSpiderAPI.getApiOthers(),
+                API.RequestType.other,
+                missingKeys,
+                missingDescriptions);
+        checkApiElements(
+                clientSpiderAPI,
+                clientSpiderAPI.getApiViews(),
+                API.RequestType.view,
+                missingKeys,
+                missingDescriptions);
+        assertThat(missingKeys, is(empty()));
+        assertThat(missingDescriptions, is(empty()));
+    }
+
+    private static void checkKey(String key, List<String> missingKeys, List<String> missingDescs) {
+        if (!Constant.messages.containsKey(key)) {
+            missingKeys.add(key);
+        } else if (Constant.messages.getString(key).isBlank()) {
+            missingDescs.add(key);
+        }
+    }
+
+    private static void checkApiElements(
+            ApiImplementor api,
+            List<? extends ApiElement> elements,
+            RequestType type,
+            List<String> missingKeys,
+            List<String> missingDescriptions) {
+        elements.sort((a, b) -> a.getName().compareTo(b.getName()));
+        for (ApiElement element : elements) {
+            assertThat(
+                    "API " + type + " element: " + api.getPrefix() + "/" + element.getName(),
+                    element.getDescriptionTag(),
+                    is(not(emptyString())));
+            checkKey(element.getDescriptionTag(), missingKeys, missingDescriptions);
+            element.getParameters().stream()
+                    .map(ApiParameter::getDescriptionKey)
+                    .forEach(key -> checkKey(key, missingKeys, missingDescriptions));
+        }
+    }
+}


### PR DESCRIPTION
## Overview
Add the new spider(Client Spider) to the API. 
Actions: start scan /  stop scan
Views: view status

## Related Issues
Specify any related issues or pull requests by linking to them.

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
