### PR TITLE
client: fix pscan counter

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct Client Passive Scan Queue counter, which could be showing one when none left.
 
 ## [0.13.0] - 2025-02-04
 ### Added

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -613,8 +613,13 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
     }
 
     private void decPscanCount() {
-        if (hasView() && this.pscanStatus.getScanCount() > 0) {
-            ThreadUtils.invokeLater(pscanStatus::decScanCount);
+        if (hasView()) {
+            ThreadUtils.invokeLater(
+                    () -> {
+                        if (pscanStatus.getScanCount() > 0) {
+                            pscanStatus.decScanCount();
+                        }
+                    });
         }
     }
 


### PR DESCRIPTION
Execute the count check also in the EDT to avoid concurrency issues, which could leave the counter showing one when none left to scan.