### PR TITLE
pscan: init options in extension's init method

### DIFF
--- a/addOns/pscan/CHANGELOG.md
+++ b/addOns/pscan/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Allow add-ons to obtain (empty) tags before the extension is fully initialised to prevent exceptions.
 
 ## [0.2.0] - 2025-02-12
 ### Added

--- a/addOns/pscan/gradle.properties
+++ b/addOns/pscan/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.0
+version=0.2.1
 release=false
 zap.maven.publish=true
 zap.maven.pom.inceptionyear=2024

--- a/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/ExtensionPassiveScan2.java
+++ b/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/ExtensionPassiveScan2.java
@@ -177,6 +177,8 @@ public class ExtensionPassiveScan2 extends ExtensionAdaptor {
 
     @Override
     public void init() {
+        options = new PassiveScannerOptions();
+
         setScanRuleManager(scanRuleManagerProxy);
         setPassiveController(passiveControllerProxy);
 
@@ -263,7 +265,6 @@ public class ExtensionPassiveScan2 extends ExtensionAdaptor {
 
     @Override
     public void hook(ExtensionHook extensionHook) {
-        options = new PassiveScannerOptions();
         extensionHook.addOptionsParamSet(options);
 
         if (hasView()) {

--- a/addOns/pscan/src/test/java/org/zaproxy/addon/pscan/ExtensionPassiveScan2UnitTest.java
+++ b/addOns/pscan/src/test/java/org/zaproxy/addon/pscan/ExtensionPassiveScan2UnitTest.java
@@ -20,13 +20,20 @@
 package org.zaproxy.addon.pscan;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link ExtensionPassiveScan2}. */
@@ -53,5 +60,18 @@ class ExtensionPassiveScan2UnitTest extends TestUtils {
     @Test
     void shouldHaveDescription() {
         assertThat(extension.getDescription(), is(not(emptyString())));
+    }
+
+    @Test
+    void shouldGetEmptyTagsAfterInit() {
+        // Given
+        ExtensionLoader extensionLoader = mock(ExtensionLoader.class);
+        when(extensionLoader.getExtension(ExtensionPassiveScan.class))
+                .thenReturn(mock(ExtensionPassiveScan.class));
+        Control.initSingletonForTesting(mock(Model.class), extensionLoader);
+        // When
+        extension.init();
+        // Then
+        assertThat(extension.getAutoTaggingTags(), is(empty()));
     }
 }


### PR DESCRIPTION
That prevents exceptions if any extension tries to get the tags before the extension is fully initialised.