### PR TITLE
ascanrulesBeta: include exception message in log

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Replace usage of CWE-200 for the Insecure HTTP Method scan rule (Issue 8714).
+- Include exception message of failed attacks in the Server Side Request Forgery scan rule.
 
 ### Fixed
 - Address potential/theoretical reDoS issue in the Insecure HTTP Method scan rule.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SsrfScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SsrfScanRule.java
@@ -143,7 +143,7 @@ public class SsrfScanRule extends AbstractAppParamPlugin implements CommonActive
                 scanWithExternalOastService(param);
             }
         } catch (Exception e) {
-            LOGGER.warn("Could not perform SSRF Attack.");
+            LOGGER.warn("Could not perform SSRF Attack: {}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
Include the exception message to hopefully allow to know what went wrong when scanning for SSRF.