### PR TITLE
network: keep properties mutable on conn close

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Ensure message properties are kept mutable even in case of connection close.
 
 ## [0.20.0] - 2025-01-09
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -26,7 +26,6 @@ import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -542,7 +541,9 @@ public class HttpSenderApache
         }
 
         if (!connection.isOpen()) {
-            message.setUserObject(Collections.singletonMap("connection.closed", Boolean.TRUE));
+            Map<String, Object> newProperties = new HashMap<>();
+            newProperties.put("connection.closed", Boolean.TRUE);
+            message.setUserObject(newProperties);
             return;
         }
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
@@ -962,9 +963,11 @@ class HttpSenderImplUnitTest {
             assertThat(message.getResponseHeader().toString(), is(equalTo(responseHeader)));
             assertThat(message.getResponseBody().toString(), is(equalTo("")));
             assertThat(message.getUserObject(), is(instanceOf(Map.class)));
-            assertThat(
-                    (Map<?, ?>) message.getUserObject(),
-                    hasEntry("connection.closed", Boolean.TRUE));
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> properties = (Map<Object, Object>) message.getUserObject();
+            assertThat(properties, hasEntry("connection.closed", Boolean.TRUE));
+            // Should be mutable.
+            assertDoesNotThrow(() -> properties.put("Something", "Value"));
         }
 
         @ParameterizedTest


### PR DESCRIPTION
Ensure message properties are kept mutable even in case of connection close as the message might be resent with new properties.