### PR TITLE
ascanruels: Address SAST (Sonar) findings in SQLi Rule

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [70] - 2025-01-09
 ### Changed


### PR DESCRIPTION
## Overview
- CHANGELOG > Add maint note.
- SqlInjectScanRule
    - Replace Arrays.asList with inline array declarations with List.of().
    - Change enum names to full caps.
    - Change static access to constants in abstract classes to use the base class.
    - Reduce newlines in some comment blocks.
    - Combine nested ifs.
    - Remove unnecessary return statement.
    - Extract a method for boolean based extra info. (Reduce repetition of string literal/code).
    - Correct array declarations (square brackets on type not name).
    - Extract constants for two multi-occurrence string literals.
    - Move counter from within loop to loop declaration.

## Related Issues
n/a

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
