### PR TITLE
authhelper: correct API param handling in BBA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correctly read the API parameters when setting up Browser Based Authentication.
 
 ## [0.22.0] - 2025-02-12
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -384,9 +384,10 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
 
         @Override
         public ApiResponse getApiResponseRepresentation() {
-            Map<String, String> values = new HashMap<>();
+            Map<String, Object> values = new HashMap<>();
             values.put(PARAM_LOGIN_PAGE_URL, loginPageUrl);
             values.put(PARAM_BROWSER_ID, browserId);
+            values.put(PARAM_LOGIN_PAGE_WAIT, loginPageWait);
             return new AuthMethodApiResponseRepresentation<>(values);
         }
 
@@ -625,17 +626,19 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
                     method.setLoginPageUrl(
                             ApiUtils.getNonEmptyStringParam(params, PARAM_LOGIN_PAGE_URL));
 
-                    String browserId = ApiUtils.getOptionalStringParam(null, PARAM_BROWSER_ID);
+                    String browserId = ApiUtils.getOptionalStringParam(params, PARAM_BROWSER_ID);
                     if (!StringUtils.isEmpty(browserId)) {
                         method.setBrowserId(browserId);
                     }
 
                     String loginPageWaitStr =
-                            ApiUtils.getOptionalStringParam(null, PARAM_LOGIN_PAGE_WAIT);
+                            ApiUtils.getOptionalStringParam(params, PARAM_LOGIN_PAGE_WAIT);
                     if (!StringUtils.isEmpty(loginPageWaitStr)) {
                         method.setLoginPageWait(Integer.parseInt(loginPageWaitStr));
                     }
 
+                } catch (ApiException e) {
+                    throw e;
                 } catch (Exception e) {
                     throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                 }


### PR DESCRIPTION
Properly read the API parameters when configuring the BBA.
Include the `loginPageWait` in the API response.
Re-throw the API exceptions which provide more/better details of the error.