### PR TITLE
pscanrules: Re-map rules attributed to CWE-200

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - The Absence of Anti-CSRF Tokens scan rule now only considers forms with GET method at Low Threshold. (Forms submitted via GET, not forms delivered via GET.)
 
+### Changed
+- Replace usage of CWE-200 for the following rules (Issue 8712):
+    - Application Error Disclosure (Issue 8716)
+    - HTTP Server Response Header
+    - Hash Disclosure
+    - Information Disclosure - Debug Error Messages
+    - Information Disclosure - Sensitive Information in HTTP Referrer Header
+    - Information Disclosure - Sensitive Information in URL
+    - Information Disclosure - Suspicious Comments
+    - Private IP Disclosure
+    - Server Leaks Information via "X-Powered-By" HTTP Response Header
+    - Session ID in URL Rewrite
+    - Timestamp Disclosure
+    - X-Backend-Server Header Information Leak
+    - X-ChromeLogger-Data (XCOLD) Header Information Leak
+    - X-Debug-Token Information Leak
+
 ## [62] - 2025-01-10
 ### Changed
 - Update minimum ZAP version to 2.16.0.

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -188,7 +188,8 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
-                .setCweId(200)
+                // CWE-550: Server-generated Error Message Containing Sensitive Information
+                .setCweId(550)
                 .setWascId(13);
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRule.java
@@ -272,7 +272,9 @@ public class HashDisclosureScanRule extends PluginPassiveScanner
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(200) // Information Exposure,
+                // CWE-497: Exposure of Sensitive System Information to an Unauthorized Control
+                // Sphere
+                .setCweId(497)
                 .setWascId(13); // Information Leakage
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
@@ -182,7 +182,9 @@ public class InfoPrivateAddressDisclosureScanRule extends PluginPassiveScanner
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(200) // CWE Id 200 - Information Exposure
+                // CWE-497: Exposure of Sensitive System Information to an Unauthorized Control
+                // Sphere
+                .setCweId(497)
                 .setWascId(13); // WASC Id - Info leakage
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
@@ -340,7 +340,7 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setParam(param)
                 .setEvidence(evidence)
-                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setCweId(598) // CWE-598: Use of GET Request Method With Sensitive Query Strings
                 .setWascId(13) // WASC Id - Info leakage
                 .setAlertRef(getPluginId() + alertRef);
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
@@ -80,7 +80,7 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
-                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setCweId(1295) // CWE-1295: Debug Messages Revealing Unnecessary Information
                 .setWascId(13); // WASC Id - Info leakage
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
@@ -112,7 +112,7 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner
                 .setOtherInfo(other)
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
-                .setCweId(200) // CWE Id 200 - Information Exposure)
+                .setCweId(598) // CWE-598: Use of GET Request Method With Sensitive Query Strings
                 .setWascId(13); // WASC Id - Info leakage
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
@@ -129,7 +129,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner
                 .setRisk(Alert.RISK_INFO)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
-                .setCweId(200) // CWE Id 200 - Information Exposure
+                .setCweId(598) // CWE-598: Use of GET Request Method With Sensitive Query Strings
                 .setWascId(13) // WASC Id - Info leakage
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setOtherInfo(other)

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
@@ -193,8 +193,9 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setOtherInfo(detail)
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
-                .setCweId(200) // CWE Id 200 - Information Exposure)
-                .setWascId(13) // WASC Id - Info leakage)
+                // CWE-615: Inclusion of Sensitive Information in Source Code Comments
+                .setCweId(615)
+                .setWascId(13) // WASC Id - Info leakage
                 .setEvidence(evidence);
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRule.java
@@ -104,7 +104,9 @@ public class ServerHeaderInfoLeakScanRule extends PluginPassiveScanner
                 .setReference(
                         Constant.messages.getString("pscanrules.serverheaderinfoleak.general.refs"))
                 .setEvidence(directive)
-                .setCweId(200)
+                // CWE-497: Exposure of Sensitive System Information to an Unauthorized Control
+                // Sphere
+                .setCweId(497)
                 .setWascId(13);
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -198,7 +198,9 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(evidence)
-                .setCweId(200) // CWE Id 200 - Information Exposure
+                // CWE-497: Exposure of Sensitive System Information to an Unauthorized Control
+                // Sphere
+                .setCweId(497)
                 .setWascId(13); // WASC Id - Info leakage
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRule.java
@@ -70,7 +70,9 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setEvidence(evidence)
-                .setCweId(200)
+                // CWE-497: Exposure of Sensitive System Information to an Unauthorized Control
+                // Sphere
+                .setCweId(497)
                 .setWascId(13);
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRule.java
@@ -110,7 +110,7 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(xcldField)
-                .setCweId(200)
+                .setCweId(532) // CWE-532: Insertion of Sensitive Information into Log File
                 .setWascId(13);
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
@@ -130,7 +130,7 @@ public class XDebugTokenScanRule extends PluginPassiveScanner implements CommonP
     }
 
     public int getCweId() {
-        return 200; // CWE Id 200 - Information Exposure
+        return 489; // CWE-489: Active Debug Code
     }
 
     public int getWascId() {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
@@ -114,7 +114,9 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
                 .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
                 .setEvidence(alertEvidence)
-                .setCweId(200) // CWE Id 200 - Information Exposure
+                // CWE-497: Exposure of Sensitive System Information to an Unauthorized Control
+                // Sphere
+                .setCweId(497)
                 .setWascId(13); // WASC Id - Info leakage
     }
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
@@ -117,7 +117,7 @@ class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<ApplicationErr
         // Then
         assertThat(alerts.size(), is(equalTo(1)));
         assertThat(tags.size(), is(equalTo(6)));
-        assertThat(tags, hasKey("CWE-200"));
+        assertThat(tags, hasKey("CWE-550"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_ERRH_01_ERR.getTag()));
@@ -125,6 +125,7 @@ class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<ApplicationErr
         assertThat(tags, hasKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getCweId(), is(equalTo(550)));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/HashDisclosureScanRuleUnitTest.java
@@ -183,6 +183,7 @@ class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDisclosureSc
         List<Alert> alerts = rule.getExampleAlerts();
         // Then
         assertThat(alerts.size(), is(equalTo(1)));
+        assertThat(alerts.get(0).getCweId(), is(equalTo(497)));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRuleUnitTest.java
@@ -80,6 +80,7 @@ class InfoPrivateAddressDisclosureScanRuleUnitTest
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_LOW)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getCweId(), is(equalTo(497)));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRuleUnitTest.java
@@ -113,6 +113,7 @@ class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSessionIdU
         assertThat(alert1.getConfidence(), is(equalTo(Alert.CONFIDENCE_HIGH)));
         assertThat(alert1.getParam(), is(equalTo("jsessionid")));
         assertThat(alert1.getEvidence(), is(equalTo("1A530637289A03B07199A44E8D531427")));
+        assertThat(alert1.getCweId(), is(equalTo(598)));
         assertThat(alert1.getAlertRef(), is(equalTo(rule.getPluginId() + "-1")));
 
         Alert alert2 = alerts.get(1);
@@ -120,12 +121,14 @@ class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSessionIdU
         assertThat(alert2.getConfidence(), is(equalTo(Alert.CONFIDENCE_HIGH)));
         assertThat(
                 alert2.getEvidence(), is(equalTo("jsessionid=1A530637289A03B07199A44E8D531427")));
+        assertThat(alert1.getCweId(), is(equalTo(598)));
         assertThat(alert2.getAlertRef(), is(equalTo(rule.getPluginId() + "-2")));
 
         Alert alert3 = alerts.get(2);
         assertThat(alert3.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
         assertThat(alert3.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
         assertThat(alert3.getEvidence(), is(equalTo("www.example.org")));
+        assertThat(alert1.getCweId(), is(equalTo(598)));
         assertThat(alert3.getAlertRef(), is(equalTo(rule.getPluginId() + "-3")));
     }
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRuleUnitTest.java
@@ -123,6 +123,7 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
         Alert alert = alerts.get(0);
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_LOW)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getCweId(), is(equalTo(1295)));
     }
 
     @Test
@@ -157,7 +158,6 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
         assertThat(alert.getUri(), equalTo(URI));
         assertThat(alert.getRisk(), equalTo(Alert.RISK_LOW));
         assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
-        assertThat(alert.getCweId(), equalTo(200));
         assertThat(alert.getWascId(), equalTo(13));
         assertThat(alert.getEvidence(), equalTo(debugError));
     }
@@ -175,7 +175,6 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
         expectedAlerts++;
         assertThat(alertsRaised.size(), equalTo(expectedAlerts));
         Alert alert = alertsRaised.get(expectedAlerts - 1);
-        assertThat(alert.getCweId(), equalTo(200));
         assertThat(alert.getWascId(), equalTo(13));
         assertThat(alert.getEvidence(), equalTo(DEFAULT_ERROR_MESSAGE));
 
@@ -189,7 +188,6 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
         expectedAlerts++;
         assertThat(alertsRaised.size(), equalTo(expectedAlerts));
         alert = alertsRaised.get(expectedAlerts - 1);
-        assertThat(alert.getCweId(), equalTo(200));
         assertThat(alert.getWascId(), equalTo(13));
         assertThat(alert.getEvidence(), equalTo(DEFAULT_ERROR_MESSAGE.toLowerCase()));
 
@@ -203,7 +201,6 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
         expectedAlerts++;
         assertThat(alertsRaised.size(), equalTo(expectedAlerts));
         alert = alertsRaised.get(expectedAlerts - 1);
-        assertThat(alert.getCweId(), equalTo(200));
         assertThat(alert.getWascId(), equalTo(13));
         assertThat(alert.getEvidence(), equalTo(DEFAULT_ERROR_MESSAGE.toUpperCase()));
     }
@@ -290,7 +287,6 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(200));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(13));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo(DEFAULT_ERROR_MESSAGE));
     }
@@ -310,7 +306,6 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
         expectedAlerts++;
         assertThat(alertsRaised.size(), equalTo(expectedAlerts));
         Alert alert = alertsRaised.get(expectedAlerts - 1);
-        assertThat(alert.getCweId(), equalTo(200));
         assertThat(alert.getWascId(), equalTo(13));
         assertThat(alert.getEvidence(), equalTo(DEFAULT_ERROR_MESSAGE));
 
@@ -347,7 +342,6 @@ class InformationDisclosureDebugErrorsScanRuleUnitTest
         expectedAlerts++;
         assertThat(alertsRaised.size(), equalTo(expectedAlerts));
         alert = alertsRaised.get(expectedAlerts - 1);
-        assertThat(alert.getCweId(), equalTo(200));
         assertThat(alert.getWascId(), equalTo(13));
         assertThat(alert.getEvidence(), equalTo(debugError));
     }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRuleUnitTest.java
@@ -114,6 +114,7 @@ class InformationDisclosureInUrlScanRuleUnitTest
         Alert alert = alerts.get(0);
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getCweId(), is(equalTo(598)));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRuleUnitTest.java
@@ -116,6 +116,7 @@ class InformationDisclosureReferrerScanRuleUnitTest
         Alert alert = alerts.get(0);
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getCweId(), is(equalTo(598)));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
@@ -350,9 +350,10 @@ class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
                                         "\\bFIXME\\b",
                                         "<!-- FixMe: cookie: root=true; Secure -->"))));
         assertThat(alert.getEvidence(), is(equalTo("FixMe")));
+        assertThat(alert.getCweId(), is(equalTo(615)));
         Map<String, String> tags = alert.getTags();
         assertThat(tags.size(), is(equalTo(5)));
-        assertThat(tags, hasKey("CWE-200"));
+        assertThat(tags, hasKey("CWE-615"));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()));
         assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getTag()));

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ServerHeaderInfoLeakScanRuleUnitTest.java
@@ -156,6 +156,8 @@ class ServerHeaderInfoLeakScanRuleUnitTest
         assertThat(alerts.size(), is(equalTo(2)));
         assertThat(countLows, is(equalTo(1L)));
         assertThat(countInfos, is(equalTo(1L)));
+        assertThat(alerts.get(0).getCweId(), is(equalTo(497)));
+        assertThat(alerts.get(1).getCweId(), is(equalTo(497)));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -81,6 +81,7 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
         Alert alert = alerts.get(0);
         assertThat(alert.getName(), is(equalTo("Timestamp Disclosure - Unix")));
         assertThat(alert.getParam(), is(equalTo("registeredAt")));
+        assertThat(alert.getCweId(), is(equalTo(497)));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XBackendServerInformationLeakScanRuleUnitTest.java
@@ -111,6 +111,7 @@ class XBackendServerInformationLeakScanRuleUnitTest
         Alert alert = alerts.get(0);
         assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
         assertThat(alert.getEvidence(), equalTo(HEADER_VALUE));
+        assertThat(alert.getCweId(), is(equalTo(497)));
         assertThat(
                 alert.getSolution(), equalTo(Constant.messages.getString(MESSAGE_PREFIX + "soln")));
         assertThat(

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
@@ -166,7 +166,8 @@ class XChromeLoggerDataInfoLeakScanRuleUnitTest
         Map<String, String> tags1 = alert.getTags();
         assertThat(tags1.size(), is(equalTo(4)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_HIGH)));
-        assertThat(tags1, hasKey("CWE-200"));
+        assertThat(alert.getCweId(), is(equalTo(532)));
+        assertThat(tags1, hasKey("CWE-532"));
         assertThat(
                 tags1.containsKey(CommonAlertTag.OWASP_2017_A03_DATA_EXPOSED.getTag()),
                 is(equalTo(true)));

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRuleUnitTest.java
@@ -56,7 +56,7 @@ class XDebugTokenScanRuleUnitTest extends PassiveScannerTest<XDebugTokenScanRule
         int wasc = rule.getWascId();
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(cwe, is(equalTo(200)));
+        assertThat(cwe, is(equalTo(489)));
         assertThat(wasc, is(equalTo(13)));
         assertThat(tags.size(), is(equalTo(3)));
         assertThat(

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRuleUnitTest.java
@@ -79,6 +79,7 @@ class XPoweredByHeaderInfoLeakScanRuleUnitTest
         Alert alert = alerts.get(0);
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_LOW)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getCweId(), is(equalTo(497)));
     }
 
     @Test


### PR DESCRIPTION
## Overview
- Update CHANGELOG, rules, and tests.

## Related Issues
- Fixes zaproxy/zaproxy#8729
- Fixes zaproxy/zaproxy#8728
- Fixes zaproxy/zaproxy#8727
- Fixes zaproxy/zaproxy#8726
- Fixes zaproxy/zaproxy#8725
- Fixes zaproxy/zaproxy#8724
- Fixes zaproxy/zaproxy#8723
- Fixes zaproxy/zaproxy#8722
- Fixes zaproxy/zaproxy#8721
- Fixes zaproxy/zaproxy#8720
- Fixes zaproxy/zaproxy#8719
- Fixes zaproxy/zaproxy#8718
- Fixes zaproxy/zaproxy#8717
- Fixes zaproxy/zaproxy#8716
- Fixes zaproxy/zaproxy#8712


## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
