### PR TITLE
authhelper: prefer form related fields in BBA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Prefer form related fields in Browser Based Authentication for the selection of username field.
+
 ### Fixed
 - Correctly read the API parameters when setting up Browser Based Authentication.
 

--- a/addOns/authhelper/authhelper.gradle.kts
+++ b/addOns/authhelper/authhelper.gradle.kts
@@ -96,5 +96,6 @@ dependencies {
         exclude(group = "commons-codec", module = "commons-codec")
     }
 
+    testImplementation("io.github.bonigarcia:selenium-jupiter:5.1.1")
     testImplementation(project(":testutils"))
 }


### PR DESCRIPTION
Prefer the fields that are under the same form as the password field as that should increase the likelihood of choosing the right username field.