### PR TITLE
authhelper: tweak the auth report keys

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Prefer form related fields in Browser Based Authentication for the selection of username field.
+- Tweaked the auth report summary keys.
 
 ### Fixed
 - Correctly read the API parameters when setting up Browser Based Authentication.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/ExtensionAuthhelperReport.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/ExtensionAuthhelperReport.java
@@ -106,7 +106,7 @@ public class ExtensionAuthhelperReport extends ExtensionAdaptor {
                 pass,
                 "auth.summary." + key,
                 Constant.messages.getString(
-                        "authhelper.authreport." + key + (pass ? ".pass" : ".fail")));
+                        "authhelper.authreport.summary." + key + (pass ? ".pass" : ".fail")));
     }
 
     private static Context getFirstAuthConfiguredContext(ReportData reportData) {
@@ -156,7 +156,7 @@ public class ExtensionAuthhelperReport extends ExtensionAdaptor {
 
                     addSummaryItem(
                             ard,
-                            "summary.auth",
+                            "auth",
                             inMemoryStats.getStat(hostname, AuthenticationHelper.AUTH_SUCCESS_STATS)
                                     != null);
 
@@ -168,8 +168,8 @@ public class ExtensionAuthhelperReport extends ExtensionAdaptor {
                                         hostname, AuthUtils.AUTH_BROWSER_PASSED_STATS);
 
                         if (passedCount != null) {
-                            addSummaryItem(ard, "summary.username", true);
-                            addSummaryItem(ard, "summary.password", true);
+                            addSummaryItem(ard, "username", true);
+                            addSummaryItem(ard, "password", true);
                         } else {
                             Long noUserCount =
                                     inMemoryStats.getStat(
@@ -178,8 +178,8 @@ public class ExtensionAuthhelperReport extends ExtensionAdaptor {
                                     inMemoryStats.getStat(
                                             hostname, AuthUtils.AUTH_NO_PASSWORD_FIELD_STATS);
 
-                            addSummaryItem(ard, "summary.username", noUserCount != null);
-                            addSummaryItem(ard, "summary.password", noPwdCount != null);
+                            addSummaryItem(ard, "username", noUserCount != null);
+                            addSummaryItem(ard, "password", noPwdCount != null);
                         }
                     }
 
@@ -194,19 +194,19 @@ public class ExtensionAuthhelperReport extends ExtensionAdaptor {
                 }
 
             } else {
-                addSummaryItem(ard, "summary.stats", false);
+                addSummaryItem(ard, "stats", false);
             }
 
             addSummaryItem(
                     ard,
-                    "summary.session",
+                    "session",
                     !(authContext.getSessionManagementMethod()
                             instanceof
                             AutoDetectSessionManagementMethodType
                                     .AutoDetectSessionManagementMethod));
             addSummaryItem(
                     ard,
-                    "summary.verif",
+                    "verif",
                     !(AuthCheckingStrategy.AUTO_DETECT.equals(
                             authContext.getAuthenticationMethod().getAuthCheckingStrategy())));
 

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
@@ -41,46 +41,57 @@
 	<table>
 		<tr>
 			<th align="left">Key</th>
+			<th align="left">Passed</th>
 			<th align="left">Description</th>
 		</tr>
 		<tr>
-			<td>auth.auth.fail</td>
+			<td>auth.summary.auth</td>
+			<td>false</td>
 			<td>Authentication failed</td>
 		</tr>
 		<tr>
-			<td>auth.auth.pass</td>
+			<td>auth.summary.auth</td>
+			<td>true</td>
 			<td>Authentication appeared to work</td>
 		</tr>
 		<tr>
-			<td>auth.password.fail</td>
+			<td>auth.summary.password</td>
+			<td>false</td>
 			<td>Password field not identified</td>
 		</tr>
 		<tr>
-			<td>auth.password.pass</td>
+			<td>auth.summary.password</td>
+			<td>true</td>
 			<td>Password field identified</td>
 		</tr>
 		<tr>
-			<td>auth.session.fail</td>
+			<td>auth.summary.session</td>
+			<td>false</td>
 			<td>Session Handling not identified</td>
 		</tr>
 		<tr>
-			<td>auth.session.pass</td>
+			<td>auth.summary.session</td>
+			<td>true</td>
 			<td>Session Handling identified</td>
 		</tr>
 		<tr>
-			<td>auth.username.fail</td>
+			<td>auth.summary.username</td>
+			<td>false</td>
 			<td>Username field not identified</td>
 		</tr>
 		<tr>
-			<td>auth.username.pass</td>
+			<td>auth.summary.username</td>
+			<td>true</td>
 			<td>Username field identified</td>
 		</tr>
 		<tr>
-			<td>auth.verif.fail</td>
+			<td>auth.summary.verif</td>
+			<td>false</td>
 			<td>Verification URL not identified</td>
 		</tr>
 		<tr>
-			<td>auth.verif.pass</td>
+			<td>auth.summary.verif</td>
+			<td>true</td>
 			<td>Verification URL identified</td>
 		</tr>
 	</table>


### PR DESCRIPTION
## Overview
Removed the incorrect `summary.summary` part and the pass?fail extensions.

## Related Issues

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
