### PR TITLE
reports: update method call in JSON plus report

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Include correct alert instances in Traditional JSON Report with requests and responses (Issue 8861).
 
 ## [0.36.0] - 2025-02-12
-
+### Changed
+- Allow multiple add-ons to provide report data.
 
 ## [0.35.0] - 2025-01-10
 ### Added

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
@@ -8,7 +8,7 @@
             "@host": "[(${helper.legacyEscapeText(helper.getHostForSite(site), true)})]",
             "@port": "[(${helper.getPortForSite(site)})]",
             "@ssl": "[(${helper.isSslSite(site)})]",
-            "alerts": [ [#th:block th:each="alert, alertState: ${helper.getAlertsForSite(alertTree, site)}" th:with="instances=${helper.getAlertInstancesForSite(alertTree, site, alert.pluginId)}"]
+            "alerts": [ [#th:block th:each="alert, alertState: ${helper.getAlertsForSite(alertTree, site)}" th:with="instances=${helper.getAlertInstancesForSite(alertTree, site, alert.name, alert.risk)}"]
                 {
                     "pluginid": "[(${alert.pluginId})]",
                     "alertRef": "[(${alert.alertRef})]",


### PR DESCRIPTION
Use the non-deprecated method to obtain the alert instances as the other method might return incorrect alerts.
Mention the change done in the previous version (it had no entries).

Fix zaproxy/zaproxy#8861.