### PR TITLE
authhelper: Tweak auth report escaping

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Correctly read the API parameters when setting up Browser Based Authentication.
+- Tweaked auth report output to ensure that values are properly escaped.
 
 ## [0.22.0] - 2025-02-12
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/ExtensionAuthhelperReport.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/ExtensionAuthhelperReport.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -215,11 +214,7 @@ public class ExtensionAuthhelperReport extends ExtensionAdaptor {
             env.addContext(authContext);
             AutomationPlan plan = new AutomationPlan(env, new ArrayList<>(), progress);
             try {
-                if (reportData.getTemplateName().endsWith("-json")) {
-                    ard.setAfEnv(StringEscapeUtils.escapeJson(plan.toYaml()));
-                } else {
-                    ard.setAfEnv(plan.toYaml());
-                }
+                ard.setAfEnv(plan.toYaml());
             } catch (IOException e) {
                 LOGGER.error(e.getMessage(), e);
             }

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
@@ -120,22 +120,22 @@
 	,"summaryItems": [
 		{
 			"description": "Username field identified",
-			"passed": "true",
+			"passed": true,
 			"key": "auth.summary.username"
 		},
 		{
 			"description": "Password field identified",
-			"passed": "true",
+			"passed": true,
 			"key": "auth.summary.password"
 		},
 		{
 			"description": "Session Handling identified",
-			"passed": "true",
+			"passed": true,
 			"key": "auth.summary.session"
 		},
 		{
 			"description": "Verification URL identified",
-			"passed": "true",
+			"passed": true,
 			"key": "auth.summary.verif"
 		}
 	]
@@ -144,72 +144,72 @@
 		{
 			"key": "stats.auth.browser.foundfields",
 			"scope": "site",
-			"value": "1"
+			"value": 1
 		},
 		{
 			"key": "stats.auth.browser.passed",
 			"scope": "site",
-			"value": "1"
+			"value": 1
 		},
 		{
 			"key": "stats.auth.configure.session.header",
 			"scope": "global",
-			"value": "1"
+			"value": 1
 		},
 		{
 			"key": "stats.auth.configure.verification",
 			"scope": "global",
-			"value": "1"
+			"value": 1
 		},
 		{
 			"key": "stats.auth.detect.auth.json",
 			"scope": "global",
-			"value": "5"
+			"value": 5
 		},
 		{
 			"key": "stats.auth.detect.session.accesstoken",
 			"scope": "global",
-			"value": "5"
+			"value": 5
 		},
 		{
 			"key": "stats.auth.detect.session.authorization",
 			"scope": "global",
-			"value": "1"
+			"value": 1
 		},
 		{
 			"key": "stats.auth.detect.session.token",
 			"scope": "global",
-			"value": "7"
+			"value": 7
 		},
 		{
 			"key": "stats.auth.session.set.header",
 			"scope": "global",
-			"value": "20"
+			"value": 20
 		},
 		{
 			"key": "stats.auth.sessiontoken.accesstoken",
 			"scope": "site",
-			"value": "9"
+			"value": 9
 		},
 		{
 			"key": "stats.auth.sessiontoken.token",
 			"scope": "site",
-			"value": "6"
+			"value": 6
 		},
 		{
 			"key": "stats.auth.sessiontokens.max",
 			"scope": "global",
-			"value": "2"
+			"value": 2
 		},
 		{
 			"key": "stats.auth.state.loggedin",
 			"scope": "site",
-			"value": "2"
+			"value": 2
 		},
 		{
 			"key": "stats.auth.success",
 			"scope": "site",
-			"value": "1"
+			"value": 1
 		}
 	]
 }

--- a/addOns/authhelper/src/main/zapHomeFiles/reports/auth-report-json/report.json
+++ b/addOns/authhelper/src/main/zapHomeFiles/reports/auth-report-json/report.json
@@ -6,21 +6,21 @@
 	[#th:block th:if="${reportData.isIncludeSection('summary')}"]
 	,"summaryItems": [[#th:block th:each="sumItem, sumState: ${rptData.getSummaryItems()}"][#th:block th:if="${! sumState.first}"],[/th:block]
 		{
-			"description": "[(${sumItem.description})]",
-			"passed": "[(${sumItem.passed})]",
-			"key": "[(${sumItem.key})]"
+			"description": [[${sumItem.description}]],
+			"passed": [[${sumItem.passed}]],
+			"key": [[${sumItem.key}]]
 		}[/th:block]
 	]
 	[/th:block]
 	[#th:block th:if="${reportData.isIncludeSection('afenv')}"]
-	,"afEnv": "[(${rptData.getAfEnv()})]"
+	,"afEnv": [[${rptData.getAfEnv()}]]
 	[/th:block]
 	[#th:block th:if="${reportData.isIncludeSection('statistics')}"]
 	,"statistics": [[#th:block th:each="statItem, statState: ${rptData.getStatistics()}"][#th:block th:if="${! statState.first}"],[/th:block]
 		{
-			"key": "[(${statItem.key})]",
-			"scope": "[(${statItem.scope})]",
-			"value": "[(${statItem.value})]"
+			"key": [[${statItem.key}]],
+			"scope": [[${statItem.scope}]],
+			"value": [[${statItem.value}]]
 		}[/th:block]
 	]
 	[/th:block]


### PR DESCRIPTION
## Overview
Ensure output is escaped as expected. Booleans without quotes, strings with inner quotes escaped etc.

## Related Issues
n/a

Note: Some of these tests fail on windows, likely due to line ending differences. But work fine via git bash/gradle.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
