### PR TITLE
pscanrules: Refactor `CookieLooselyScopedScanRule` to align with the latest RFC standards

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Fixed
-- Refactored CookieLooselyScopedScanRule to comply with the latest RFC standards and streamline the loosely scoped cookie check (Issue 8863).
+- Refactored Loosely Scoped Cookie to comply with the latest RFC standards and streamline the loosely scoped cookie check (Issue 8863).
 - The Absence of Anti-CSRF Tokens scan rule now only considers forms with GET method at Low Threshold. (Forms submitted via GET, not forms delivered via GET.)
 - The Information Disclosure - Suspicious Comments scan rule:
     - Should now be less false positive prone on JavaScript findings (Issues 6622 & 6736).

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Fixed
+- Refactored CookieLooselyScopedScanRule to comply with the latest RFC standards and streamline the loosely scoped cookie check (Issue 8863).
 - The Absence of Anti-CSRF Tokens scan rule now only considers forms with GET method at Low Threshold. (Forms submitted via GET, not forms delivered via GET.)
 - The Information Disclosure - Suspicious Comments scan rule:
     - Should now be less false positive prone on JavaScript findings (Issues 6622 & 6736).

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -89,7 +89,9 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner
 
         // No problem here since by default the cookie is
         // scoped to the origin, not including subdomains
-        if (cookieDomain == null || cookieDomain.isEmpty()) return false;
+        if (cookieDomain == null || cookieDomain.isEmpty()) {
+            return false;
+        }
 
         cookieDomain = cookieDomain.toLowerCase();
         originDomain = originDomain.toLowerCase();

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -70,7 +70,7 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner
             }
         }
 
-        // raise alert if have found any loosely scoped cookies
+        // raise an alert if any loosely scoped cookies were found
         if (!looselyScopedCookies.isEmpty()) {
             buildAlert(host, looselyScopedCookies).raise();
         }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -78,7 +78,9 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner
 
     /*
      * Determines whether the specified cookie is loosely scoped by
-     * checking its Domain attribute value against the origin domain.
+     * checking its Domain attribute value against the origin domain
+     *
+     * Compliant with RFC 6265 (https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3).
      */
     private static boolean isLooselyScopedCookie(HttpCookie cookie, String originDomain) {
         // preconditions

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -33,12 +33,6 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.CookieUtils;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-/**
- * A port from a Watcher passive scanner (http://websecuritytool.codeplex.com/) rule {@code
- * CasabaSecurity.Web.Watcher.Checks.CheckPasvCookieLooselyScope}
- *
- * <p>http://websecuritytool.codeplex.com/SourceControl/changeset/view/17f2e3ded58f#Watcher%20Check%20Library%2fCheck.Pasv.Cookie.LooselyScoped.cs
- */
 public class CookieLooselyScopedScanRule extends PluginPassiveScanner
         implements CommonPassiveScanRuleInfo {
 
@@ -77,87 +71,47 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner
         }
 
         // raise alert if have found any loosely scoped cookies
-        if (looselyScopedCookies.size() > 0) {
+        if (!looselyScopedCookies.isEmpty()) {
             buildAlert(host, looselyScopedCookies).raise();
         }
     }
 
     /*
      * Determines whether the specified cookie is loosely scoped by
-     * checking it's Domain attribute value against the host
+     * checking its Domain attribute value against the origin domain.
      */
-    private static boolean isLooselyScopedCookie(HttpCookie cookie, String host) {
+    private static boolean isLooselyScopedCookie(HttpCookie cookie, String originDomain) {
         // preconditions
         assert cookie != null;
-        assert host != null;
+        assert originDomain != null;
 
         String cookieDomain = cookie.getDomain();
 
-        // if Domain attribute hasn't been specified, the cookie
-        // is scoped with the response host
-        if (cookieDomain == null || cookieDomain.isEmpty()) {
+        // No problem here since by default the cookie is
+        // scoped to the origin, not including subdomains
+        if (cookieDomain == null || cookieDomain.isEmpty()) return false;
+
+        cookieDomain = cookieDomain.toLowerCase();
+        originDomain = originDomain.toLowerCase();
+
+        // If the cookie domain starts with a leading dot,
+        // remove it as per RFC (ignore the dot)
+        if (cookieDomain.startsWith(".")) {
+            cookieDomain = cookieDomain.substring(1);
+        }
+
+        // According to the RFC, the cookie domain must either be the same as
+        // the origin domain or a higher-order domain. Therefore, if the cookieDomain
+        // is more specific (lower order) than the originDomain, the cookie is invalid
+        // and cannot be considered loosely scoped.
+        if (cookieDomain.equals(originDomain) || cookieDomain.length() > originDomain.length()) {
             return false;
         }
 
-        // Split cookie domain into sub-domains
-        String[] cookieDomains = cookie.getDomain().split("\\.");
-        // Split host FQDN into sub-domains
-        String[] hostDomains = host.split("\\.");
-
-        boolean isFromTheSameDomain = isCookieAndHostHaveTheSameDomain(cookieDomains, hostDomains);
-        if (!isFromTheSameDomain) {
-            return true;
-        }
-        // if cookie domain doesn't start with '.', and the domain is
-        // not a second-level domain (example.com), the cookie Domain and
-        // host values should match exactly
-        if (!cookieDomain.startsWith(".") && cookieDomains.length >= 2 && !isFromTheSameDomain) {
-            return !cookieDomain.equals(host);
-        }
-
-        // otherwise, remove the '.' and compare the result with the host
-        if (cookieDomains.length != 2) {
-            cookieDomains = cookieDomain.substring(1).split("\\.");
-        }
-
-        // loosely scoped domain name should have fewer sub-domains
-        if (cookieDomains.length == 0 || cookieDomains.length >= hostDomains.length) {
-            return false;
-        }
-
-        // and those sub-domains should match the right most sub-domains of the
-        // origin domain name
-        for (int i = 1; i <= cookieDomains.length; i++) {
-            if (!cookieDomains[cookieDomains.length - i].equalsIgnoreCase(
-                    hostDomains[hostDomains.length - i])) {
-                return false;
-            }
-        }
-
-        // so, the right-most domains matched, the cookie is loosely scoped
-        return true;
-    }
-
-    private static boolean isCookieAndHostHaveTheSameDomain(
-            String[] cookieDomains, String[] hostDomains) {
-        if (cookieDomains == null
-                || hostDomains == null
-                || cookieDomains[0].equalsIgnoreCase("null")
-                || hostDomains[0].equalsIgnoreCase(
-                        "null")) { // this happens  when we don't have any host domain
-            return true;
-        }
-        if (!cookieDomains[cookieDomains.length - 1].equalsIgnoreCase(
-                hostDomains[hostDomains.length - 1])) {
-            return false;
-        }
-        if (cookieDomains.length < 2
-                || hostDomains.length < 2
-                || !cookieDomains[cookieDomains.length - 2].equalsIgnoreCase(
-                        hostDomains[hostDomains.length - 2])) {
-            return false;
-        }
-        return true;
+        // If the cookie domain is a higher-order domain
+        // (cookieDomain is "example.com", originDomain is "sub.example.com")
+        // it is considered loosely scoped
+        return originDomain.endsWith("." + cookieDomain);
     }
 
     private AlertBuilder buildAlert(String host, List<HttpCookie> looselyScopedCookies) {

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help_it_IT/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help_it_IT/contents/pscanrules.html
@@ -136,7 +136,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10010/">10010</a>.
 
 <h2 id="id-90033">Cookie - Loosely Scoped</h2>
-Cookies can be scoped by domain or path. This check is only concerned with domain scope. The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. <code>www.nottrusted.com</code>, or loosely scoped to a parent domain e.g. <code>nottrusted.com</code>. In the latter case, any subdomain of <code>nottrusted.com</code> can access the cookie. Loosely scoped cookies are common in mega-applications like <code>google.com</code> and <code>live.com</code>.
+Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. <code>www.nottrusted.com</code>, or loosely scoped to a parent domain e.g. <code>nottrusted.com</code>. In the latter case, any subdomain of <code>nottrusted.com</code> can access the cookie. Loosely scoped cookies are common in mega-applications like <code>google.com</code> and <code>live.com</code>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java">CookieLooselyScopedScanRule.java</a>
 <br>

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help_it_IT/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help_it_IT/contents/pscanrules.html
@@ -136,7 +136,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10010/">10010</a>.
 
 <h2 id="id-90033">Cookie - Loosely Scoped</h2>
-Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. <code>www.nottrusted.com</code>, or loosely scoped to a parent domain e.g. <code>nottrusted.com</code>. In the latter case, any subdomain of <code>nottrusted.com</code> can access the cookie. Loosely scoped cookies are common in mega-applications like <code>google.com</code> and <code>live.com</code>.
+Cookies can be scoped by domain or path. This check is only concerned with domain scope. The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. <code>www.nottrusted.com</code>, or loosely scoped to a parent domain e.g. <code>nottrusted.com</code>. In the latter case, any subdomain of <code>nottrusted.com</code> can access the cookie. Loosely scoped cookies are common in mega-applications like <code>google.com</code> and <code>live.com</code>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java">CookieLooselyScopedScanRule.java</a>
 <br>

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
@@ -155,7 +155,7 @@ class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLoose
     }
 
     @Test
-    void shouldRaiseAlertIfHostDomainIsDifferentFromCookieDomain() throws Exception {
+    void shouldNotRaiseAlertIfHostDomainIsDifferentFromCookieDomain() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://dev.test.org HTTP/1.1");
@@ -166,7 +166,7 @@ class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLoose
         scanHttpResponseReceive(msg);
 
         // Then
-        assertThat(alertsRaised.size(), is(1));
+        assertThat(alertsRaised.size(), is(0));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
@@ -243,6 +243,34 @@ class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLoose
     }
 
     @Test
+    void shouldNotRaiseAlertForExactMatchIgnoringLeadingDot() throws Exception {
+        // Given
+        HttpMessage msg = createBasicMessage();
+        msg.setRequestHeader("GET http://test.com HTTP/1.1");
+        msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=.test.com;");
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    void shouldRaiseAlertForNestedSubdomainIfCookieDomainIsHigherOrder() throws Exception {
+        // Given
+        HttpMessage msg = createBasicMessage();
+        msg.setRequestHeader("GET http://deep.sub.example.com HTTP/1.1");
+        msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=example.com;");
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+    }
+
+    @Test
     void shouldScanCookieDomainWithJustTld() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();


### PR DESCRIPTION
This PR addresses the issue reported in the `zaproxy` project ([CookieLooselyScoped scan rule Incorrect logic and outdated RFC standard #8863](https://github.com/zaproxy/zaproxy/issues/8863))

Fix zaproxy/zaproxy#8863.