### PR TITLE
authhelper: verification detection improvements

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Prefer form related fields in Browser Based Authentication for the selection of username field.
 - Tweaked the auth report summary keys.
+- Only check URLs and methods once for being good verification requests.
+- Added API support to the browser based auth method proxy.
 
 ### Fixed
 - Correctly read the API parameters when setting up Browser Based Authentication.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -89,13 +89,9 @@ public class AuthenticationDiagnostics implements AutoCloseable {
                     @Override
                     public void onHttpResponseReceive(
                             HttpMessage msg, int initiator, HttpSender sender) {
-                        if (msg.getResponseHeader().isImage()
-                                || !(msg.getResponseHeader().isHtml()
-                                        || msg.getResponseHeader().isJson()
-                                        || msg.getResponseHeader().isXml())) {
+                        if (!AuthUtils.isRelevantToAuth(msg)) {
                             return;
                         }
-
                         addMessageToStep(msg);
                     }
 

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -66,13 +66,13 @@ import org.zaproxy.addon.authhelper.internal.ClientSideHandler;
 import org.zaproxy.addon.authhelper.internal.StepsPanel;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.network.internal.client.apachev5.HttpSenderContextApache;
+import org.zaproxy.addon.network.server.HttpServerConfig;
 import org.zaproxy.addon.network.server.Server;
 import org.zaproxy.zap.authentication.AbstractAuthenticationMethodOptionsPanel;
 import org.zaproxy.zap.authentication.AbstractCredentialsOptionsPanel;
 import org.zaproxy.zap.authentication.AuthenticationCredentials;
 import org.zaproxy.zap.authentication.AuthenticationHelper;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
-import org.zaproxy.zap.authentication.AuthenticationMethod.UnsupportedAuthenticationCredentialsException;
 import org.zaproxy.zap.authentication.AuthenticationMethodType;
 import org.zaproxy.zap.authentication.UsernamePasswordAuthenticationCredentials;
 import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
@@ -144,7 +144,13 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
         if (proxy == null) {
             ExtensionNetwork extNet = AuthUtils.getExtension(ExtensionNetwork.class);
             handler = new ClientSideHandler(context);
-            proxy = extNet.createHttpProxy(getHttpSender(), handler);
+            proxy =
+                    extNet.createHttpServer(
+                            HttpServerConfig.builder()
+                                    .setHttpMessageHandler(handler)
+                                    .setHttpSender(getHttpSender())
+                                    .setServeZapApi(true)
+                                    .build());
         }
         return proxy;
     }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationDetectionScanRule.java
@@ -53,11 +53,7 @@ public class VerificationDetectionScanRule extends PluginPassiveScanner {
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
-        if (msg.getResponseHeader().isImage()
-                || !(msg.getResponseHeader().isHtml()
-                        || msg.getResponseHeader().isJson()
-                        || msg.getResponseHeader().isXml())) {
-            // An "image/svg+xml" will look like XML
+        if (!AuthUtils.isRelevantToAuth(msg)) {
             return;
         }
 

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ClientSideHandler.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ClientSideHandler.java
@@ -64,7 +64,11 @@ public final class ClientSideHandler implements HttpMessageHandler {
 
         AuthenticationHelper.addAuthMessageToHistory(msg);
 
-        if (isPost(msg) && context.isIncluded(msg.getRequestHeader().getURI().toString())) {
+        if (!context.isIncluded(msg.getRequestHeader().getURI().toString())) {
+            return;
+        }
+
+        if (isPost(msg)) {
             // Record the last in scope POST as a fallback
             fallbackMsg = msg;
         }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -51,6 +51,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.OutputType;
@@ -758,6 +760,41 @@ class AuthUtilsUnitTest extends TestUtils {
         // Then
         assertThat(st1, is(notNullValue()));
         assertThat(st2, is(nullValue()));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "text/html; charset=utf-8, true",
+        "multipart/form-data; boundary=ExampleBoundaryString, true",
+        "application/x-www-form-urlencoded, true",
+        "application/json, true",
+        "application/xhtml+xml, true",
+        "application/xml, true",
+        "text/xml, true",
+        "application/x-font-ttf, false",
+        "text/css, false",
+        "text/javascript; charset=utf-8, false",
+        "image/gif, false",
+        "image/svg+xml, false",
+    })
+    void shouldReportIfRelevantToAuth(String contentType, String result) throws Exception {
+        // Given
+        HttpMessage msg =
+                new HttpMessage(
+                        new HttpRequestHeader(
+                                HttpRequestHeader.GET,
+                                new URI("https://www.example.com", true),
+                                HttpHeader.HTTP11),
+                        new HttpRequestBody(),
+                        new HttpResponseHeader(),
+                        new HttpResponseBody());
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, contentType);
+
+        // When
+        boolean res = AuthUtils.isRelevantToAuth(msg);
+
+        // Then
+        assertThat(res, is(equalTo(Boolean.parseBoolean(result))));
     }
 
     static class BrowserTest extends TestUtils {


### PR DESCRIPTION
## Overview
- Only check URLs and methods once for being good verification requests.
- Added API support to the browser based auth method proxy.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
