### PR TITLE
selenium: update Selenium library

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update Selenium to version 4.28.1.
+- Update Selenium to version 4.29.0.
 
 ## [15.33.0] - 2025-01-23
 ### Added

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -38,9 +38,9 @@ zapAddOn {
 dependencies {
     compileOnly(libs.log4j.core)
 
-    var seleniumVersion = "4.28.1"
+    var seleniumVersion = "4.29.0"
     selenium("org.seleniumhq.selenium:selenium-java:$seleniumVersion")
-    selenium("org.seleniumhq.selenium:htmlunit3-driver:4.28.0")
+    selenium("org.seleniumhq.selenium:htmlunit3-driver:$seleniumVersion")
     implementation(libs.log4j.slf4j)
 
     zapAddOn("commonlib")

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -1079,11 +1079,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
             case FIREFOX:
             case FIREFOX_HEADLESS:
                 FirefoxOptions firefoxOptions = new FirefoxOptions();
-                // Use WebDriver BiDi
                 firefoxOptions.setCapability(BIDI_CAPABILITIY, true);
-                // Force the use of just BiDi, should not be required once Selenium stops
-                // adding the preference https://github.com/SeleniumHQ/selenium/issues/14885
-                firefoxOptions.addPreference("remote.active-protocols", "1");
                 setCommonOptions(firefoxOptions, proxyAddress, proxyPort);
 
                 String binaryPath =


### PR DESCRIPTION
Update Selenium library to version 4.29.0.
Remove workarounds no longer needed.