### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update Zest library to 0.24.0:
+  - Update Selenium to version 4.29.0.
+  - Remove workaround that was now causing exceptions.
 
 ## [48.3.0] - 2025-02-07
 ### Changed

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     zapAddOn("scripts")
     zapAddOn("selenium")
 
-    api("org.zaproxy:zest:0.23.0") {
+    api("org.zaproxy:zest:0.24.0") {
         // Provided by commonlib add-on.
         exclude(group = "com.fasterxml.jackson.core")
         exclude(group = "com.fasterxml.jackson.dataformat")


### PR DESCRIPTION
Update Zest library to 0.24.0:
 - Update Selenium to version 4.29.0.
 - Remove workaround that was now causing exceptions.