### PR TITLE
authhelper: Add Reset Button

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - If authentication fails then try to find a likely looking login link.
 - Persist diagnostics to the session and include it in the Authentication Report (JSON) for Client Script and Browser Based Authentication methods.
+- A reset button.
 
 ### Changed
 - Prefer form related fields in Browser Based Authentication for the selection of username field.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthhelperParam.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthhelperParam.java
@@ -27,6 +27,8 @@ import org.zaproxy.zap.extension.selenium.Browser;
 
 public class AuthhelperParam extends AbstractParam {
 
+    public static final int DEFAULT_WAIT = 2;
+    public static final Browser DEFAULT_BROWSER = Browser.FIREFOX;
     private static final String AUTO_KEY = "authhelper";
 
     private static final String LOGIN_URL_KEY = AUTO_KEY + ".loginurl";
@@ -40,7 +42,7 @@ public class AuthhelperParam extends AbstractParam {
     private String loginUrl;
     private String username;
     private String browser;
-    private int wait = 2;
+    private int wait = DEFAULT_WAIT;
     private boolean demoMode;
     private boolean recordDiagnostics;
     private List<AuthenticationStep> steps = List.of();
@@ -51,8 +53,8 @@ public class AuthhelperParam extends AbstractParam {
     protected void parse() {
         this.loginUrl = this.getString(LOGIN_URL_KEY, "");
         this.username = this.getString(USERNAME_KEY, null);
-        this.browser = this.getString(BROWSER_KEY, Browser.FIREFOX.getId());
-        this.wait = getInteger(WAIT_KEY, 2);
+        this.browser = this.getString(BROWSER_KEY, DEFAULT_BROWSER.getId());
+        this.wait = getInteger(WAIT_KEY, DEFAULT_WAIT);
         this.demoMode = getBoolean(DEMO_MODE_KEY, false);
         this.recordDiagnostics = getBoolean(RECORD_DIAGNOSTICS_KEY, false);
 

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-tester.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-tester.html
@@ -45,6 +45,9 @@ the session handling or find a suitable verification URL.
 This just adds 2 second delays between filling in each field and before submitting the form.
 It has no other effect than making it easier to see what is going on when a non-headless browser is used.
 
+<H3>Reset Button</H3>
+The reset button allows you to reset all the fields on the Test tab, and disable all Steps in the Steps tab (steps are only disabled not removed as recreating them might be tedious).
+
 <H2>Results Panel</H2>
 
 The results panel show the progress and what has been identified. All elements need to be identified in order for 

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -70,6 +70,7 @@ authhelper.auth.method.diags.zest.interaction = Element Interaction
 authhelper.auth.method.diags.zest.open = Browser Opened
 
 authhelper.auth.test.dialog.button.copy = Copy
+authhelper.auth.test.dialog.button.reset = Reset
 
 authhelper.auth.test.dialog.button.save = Test
 


### PR DESCRIPTION
## Overview
- auth-tester.html > Added description of the Reset button.
- AuthhelperParam > Added constant for the default browser and wait value.
- AuthTestDialog > Added Reset button and functionality. (Added pack call to the dialog so that it is sized/displayed more appropriately.)
- CHANGELOG > Added note.
- Messages.properties > Added supporting KVP.

## Related Issues
N/A

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
