### PR TITLE
authhelper: SAST (SonarLint) Fixes

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Warn when the recorded script used with Client Script Based Authentication does not launch a browser.
 - Updated to depend on Zest add-on 48.6.0.
+- Maintenance changes.
 
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollector.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollector.java
@@ -234,8 +234,8 @@ public class AuthDiagnosticCollector implements HttpSenderListener {
         JSONObject sanObj = new JSONObject();
         for (Object key : jsonObject.keySet()) {
             Object val = jsonObject.get(key);
-            if (val instanceof String) {
-                sanObj.put(key, getSanitizedToken((String) val));
+            if (val instanceof String valStr) {
+                sanObj.put(key, getSanitizedToken(valStr));
             } else {
                 sanObj.put(key, val);
             }
@@ -244,17 +244,17 @@ public class AuthDiagnosticCollector implements HttpSenderListener {
     }
 
     protected Object sanitiseJson(Object obj) {
-        if (obj instanceof JSONObject) {
-            return sanitiseJson((JSONObject) obj);
-        } else if (obj instanceof JSONArray) {
+        if (obj instanceof JSONObject jObj) {
+            return sanitiseJson(jObj);
+        } else if (obj instanceof JSONArray jArr) {
             JSONArray sanArr = new JSONArray();
-            Object[] oa = ((JSONArray) obj).toArray();
+            Object[] oa = jArr.toArray();
             for (int i = 0; i < oa.length; i++) {
                 sanArr.add(sanitiseJson(oa[i]));
             }
             return sanArr;
-        } else if (obj instanceof String) {
-            return getSanitizedToken((String) obj);
+        } else if (obj instanceof String objStr) {
+            return getSanitizedToken(objStr);
 
         } else {
             return obj;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
@@ -172,11 +172,10 @@ public class AuthTestDialog extends StandardFieldsDialog {
         JButton copyButton =
                 new JButton(Constant.messages.getString("authhelper.auth.test.dialog.button.copy"));
         copyButton.addActionListener(
-                l -> {
-                    Toolkit.getDefaultToolkit()
-                            .getSystemClipboard()
-                            .setContents(new StringSelection(diagnosticField.getText()), null);
-                });
+                l ->
+                        Toolkit.getDefaultToolkit()
+                                .getSystemClipboard()
+                                .setContents(new StringSelection(diagnosticField.getText()), null));
 
         buttonPanel.add(new JLabel(), LayoutHelper.getGBC(0, 0, 1, 0.3D));
         buttonPanel.add(copyButton, LayoutHelper.getGBC(1, 0, 1, 0.3D));
@@ -445,7 +444,7 @@ public class AuthTestDialog extends StandardFieldsDialog {
         }
     }
 
-    private void setTotp(
+    private static void setTotp(
             List<AuthenticationStep> steps, UsernamePasswordAuthenticationCredentials credentials) {
         if (!TotpSupport.isTotpInCore()) {
             return;
@@ -469,7 +468,8 @@ public class AuthTestDialog extends StandardFieldsDialog {
         TotpSupport.setTotpData(totpData, credentials);
     }
 
-    private void reloadAuthenticationMethod(AuthenticationMethod am) throws ConfigurationException {
+    private static void reloadAuthenticationMethod(AuthenticationMethod am)
+            throws ConfigurationException {
         // OK, this does look weird, but it is the easiest way to actually get
         // the session management data loaded :/
         AuthenticationMethodType type = am.getType();
@@ -478,7 +478,7 @@ public class AuthTestDialog extends StandardFieldsDialog {
         type.importData(config, am);
     }
 
-    private void reloadSessionManagementMethod(SessionManagementMethod smm)
+    private static void reloadSessionManagementMethod(SessionManagementMethod smm)
             throws ConfigurationException {
         // OK, this does look weird, but it is the easiest way to actually get
         // the session management data loaded :/
@@ -529,7 +529,7 @@ public class AuthTestDialog extends StandardFieldsDialog {
     @Override
     public void save() {
         resetResultsPanel();
-        Thread t = new Thread(() -> authenticate(), "ZAP-auth-tester");
+        Thread t = new Thread(this::authenticate, "ZAP-auth-tester");
         t.start();
         // Save the values for next time
         this.saveDetails();

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDetectionScanRule.java
@@ -249,25 +249,23 @@ public class AuthenticationDetectionScanRule extends PluginPassiveScanner {
     }
 
     void extractJsonStrings(JSON json, String parent, TreeSet<HtmlParameter> params) {
-        if (json instanceof JSONObject) {
-            JSONObject jsonObject = (JSONObject) json;
-            for (Object key : jsonObject.keySet()) {
-                Object obj = jsonObject.get(key);
-                if (obj instanceof JSONObject) {
-                    extractJsonStrings(
-                            (JSONObject) obj, normalisedKey(parent, (String) key), params);
-                } else if (obj instanceof String) {
+        if (json instanceof JSONObject jObj) {
+            for (Object key : jObj.keySet()) {
+                Object obj = jObj.get(key);
+                if (obj instanceof JSONObject jObj2) {
+                    extractJsonStrings(jObj2, normalisedKey(parent, (String) key), params);
+                } else if (obj instanceof String objStr) {
                     params.add(
                             new HtmlParameter(
                                     HtmlParameter.Type.form,
                                     normalisedKey(parent, (String) key),
-                                    (String) obj));
+                                    objStr));
                 }
             }
-        } else if (json instanceof JSONArray) {
-            Object[] oa = ((JSONArray) json).toArray();
+        } else if (json instanceof JSONArray jArr) {
+            Object[] oa = jArr.toArray();
             for (int i = 0; i < oa.length; i++) {
-                extractJsonStrings((JSONArray) json, parent + "[" + i + "]", params);
+                extractJsonStrings(jArr, parent + "[" + i + "]", params);
             }
         }
     }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -216,7 +216,7 @@ public class AuthenticationDiagnostics implements AutoCloseable {
         createStep();
     }
 
-    private <T> void processStorage(JavascriptExecutor je, DiagnosticBrowserStorageItem.Type type) {
+    private void processStorage(JavascriptExecutor je, DiagnosticBrowserStorageItem.Type type) {
         @SuppressWarnings("unchecked")
         List<Map<String, String>> storage =
                 (List<Map<String, String>>) je.executeScript(type.getScript());
@@ -238,7 +238,7 @@ public class AuthenticationDiagnostics implements AutoCloseable {
                 .forEach(currentStep.getBrowserStorageItems()::add);
     }
 
-    private DiagnosticWebElement createDiagnosticWebElement(
+    private static DiagnosticWebElement createDiagnosticWebElement(
             WebDriver wd, List<WebElement> forms, WebElement element) {
         if (element == null) {
             return null;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationRequestDetails.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationRequestDetails.java
@@ -29,7 +29,7 @@ public class AuthenticationRequestDetails {
     public enum AuthDataType {
         FORM,
         JSON
-    };
+    }
 
     private final URI uri;
     private final HtmlParameter userParam;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AutoDetectSessionManagementMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AutoDetectSessionManagementMethodType.java
@@ -92,9 +92,10 @@ public class AutoDetectSessionManagementMethodType extends SessionManagementMeth
 
         @Override
         public boolean equals(Object obj) {
-            if (obj == null) return false;
-            if (getClass() != obj.getClass()) return false;
-            return true;
+            if (obj == null) {
+                return false;
+            }
+            return getClass() == obj.getClass();
         }
 
         @Override

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -158,10 +158,10 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
             HttpSender temp = getHttpSender();
             Object obj = MethodUtils.invokeMethod(temp, true, "getContext");
 
-            if (obj instanceof HttpSenderContextApache) {
+            if (obj instanceof HttpSenderContextApache hsca) {
                 return FieldUtils.readField(
                         HttpSenderContextApache.class.getDeclaredField("localCookieStore"),
-                        (HttpSenderContextApache) obj,
+                        hsca,
                         true);
             }
         } catch (Exception e) {
@@ -370,7 +370,7 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
                         user.setAuthenticatedSession(session);
                     }
 
-                    AuthUtils.checkLoginLinkVerification(httpSender, user, session, loginPageUrl);
+                    AuthUtils.checkLoginLinkVerification(httpSender, user, loginPageUrl);
 
                     if (this.isAuthenticated(authMsg, user, true)) {
                         diags.recordStep(
@@ -712,43 +712,36 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
 
             // Add behaviour for Node Select dialog
             selectButton.addActionListener(
-                    new java.awt.event.ActionListener() {
-                        @Override
-                        public void actionPerformed(java.awt.event.ActionEvent e) {
-                            NodeSelectDialog nsd =
-                                    new NodeSelectDialog(View.getSingleton().getMainFrame());
-                            // Try to pre-select the node according to what has been inserted in the
-                            // fields
-                            SiteNode node = null;
-                            if (loginUrlField.getText().trim().length() > 0)
-                                try {
-                                    node =
-                                            Model.getSingleton()
-                                                    .getSession()
-                                                    .getSiteTree()
-                                                    .findNode(
-                                                            new URI(
-                                                                    loginUrlField.getText(),
-                                                                    false));
-                                } catch (Exception e2) {
-                                    // Ignore. It means we could not properly get a node for the
-                                    // existing
-                                    // value and does not have any harmful effects
-                                }
+                    e -> {
+                        NodeSelectDialog nsd =
+                                new NodeSelectDialog(View.getSingleton().getMainFrame());
+                        // Try to pre-select the node according to what has been inserted in the
+                        // fields
+                        SiteNode node = null;
+                        if (!loginUrlField.getText().trim().isEmpty())
+                            try {
+                                node =
+                                        Model.getSingleton()
+                                                .getSession()
+                                                .getSiteTree()
+                                                .findNode(new URI(loginUrlField.getText(), false));
+                            } catch (Exception e2) {
+                                // Ignore. It means we could not properly get a node for the
+                                // existing value and does not have any harmful effects
+                            }
 
-                            // Show the dialog and wait for input
-                            node = nsd.showDialog(node);
-                            if (node != null && node.getHistoryReference() != null) {
-                                try {
-                                    LOGGER.debug(
-                                            "Selected Browser Based Auth Login URL via dialog: {}",
-                                            node.getHistoryReference().getURI());
+                        // Show the dialog and wait for input
+                        node = nsd.showDialog(node);
+                        if (node != null && node.getHistoryReference() != null) {
+                            try {
+                                LOGGER.debug(
+                                        "Selected Browser Based Auth Login URL via dialog: {}",
+                                        node.getHistoryReference().getURI());
 
-                                    loginUrlField.setText(
-                                            node.getHistoryReference().getURI().toString());
-                                } catch (Exception e1) {
-                                    LOGGER.error(e1.getMessage(), e1);
-                                }
+                                loginUrlField.setText(
+                                        node.getHistoryReference().getURI().toString());
+                            } catch (Exception e1) {
+                                LOGGER.error(e1.getMessage(), e1);
                             }
                         }
                     });

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -466,10 +466,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                 user.setAuthenticatedSession(session);
 
                 AuthUtils.checkLoginLinkVerification(
-                        getHttpSender(),
-                        user,
-                        session,
-                        authMsg.getRequestHeader().getURI().toString());
+                        getHttpSender(), user, authMsg.getRequestHeader().getURI().toString());
 
                 if (this.isAuthenticated(authMsg, user, true)) {
                     // Let the user know it worked

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ExtensionAuthhelper.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ExtensionAuthhelper.java
@@ -288,7 +288,7 @@ public class ExtensionAuthhelper extends ExtensionAdaptor {
         return parameter;
     }
 
-    private void updateContextAuth(
+    private static void updateContextAuth(
             Context context, AuthenticationRequestDetails ard, HttpMessage msg) {
 
         PostBasedAuthenticationMethodType methodType;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
@@ -204,8 +204,7 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
         @Override
         public void processMessageToMatchSession(HttpMessage message, WebSession session)
                 throws UnsupportedWebSessionException {
-            if (session instanceof HttpHeaderBasedSession) {
-                HttpHeaderBasedSession hbSession = (HttpHeaderBasedSession) session;
+            if (session instanceof HttpHeaderBasedSession hbSession) {
                 LOGGER.debug(
                         "processMessageToMatchSession {} # headers {} ",
                         message.getRequestHeader().getURI(),
@@ -239,9 +238,7 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
 
                 Context context = Model.getSingleton().getSession().getContext(contextId);
                 AuthenticationMethod am = context.getAuthenticationMethod();
-                if (am instanceof BrowserBasedAuthenticationMethod) {
-                    BrowserBasedAuthenticationMethod bbam = (BrowserBasedAuthenticationMethod) am;
-
+                if (am instanceof BrowserBasedAuthenticationMethod bbam) {
                     try {
                         Method method =
                                 LegacyUtils.class.getMethod(
@@ -286,9 +283,10 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
 
         @Override
         public boolean equals(Object obj) {
-            if (obj == null) return false;
-            if (getClass() != obj.getClass()) return false;
-            return true;
+            if (obj == null) {
+                return false;
+            }
+            return getClass() == obj.getClass();
         }
 
         @Override

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementPanel.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementPanel.java
@@ -77,7 +77,7 @@ public class HeaderBasedSessionManagementPanel extends Panel {
                         STD_INSETS));
     }
 
-    private GridBagConstraints getGBC(int x, int y) {
+    private static GridBagConstraints getGBC(int x, int y) {
         return LayoutHelper.getGBC(
                 x,
                 y,
@@ -158,11 +158,11 @@ public class HeaderBasedSessionManagementPanel extends Panel {
         clearFields();
 
         for (Pair<String, String> header : headers) {
-            Pair<ZapTextField, ZapTextField> fields = getNextFields();
-            fields.first.setText(header.first);
-            fields.first.discardAllEdits();
-            fields.second.setText(header.second);
-            fields.second.discardAllEdits();
+            Pair<ZapTextField, ZapTextField> hdrFields = getNextFields();
+            hdrFields.first.setText(header.first);
+            hdrFields.first.discardAllEdits();
+            hdrFields.second.setText(header.second);
+            hdrFields.second.discardAllEdits();
         }
         // There should always be another blank row
         getNextFields();

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -153,7 +153,7 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                 LOGGER.debug(
                         "Failed to find source of session management tokens in {}:",
                         msg.getRequestHeader().getURI());
-                requestTokens.forEach((st) -> LOGGER.debug("Missed token {}", st.getToken()));
+                requestTokens.forEach(st -> LOGGER.debug("Missed token {}", st.getToken()));
             }
         }
     }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationRequestDetails.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationRequestDetails.java
@@ -49,7 +49,7 @@ public class VerificationRequestDetails {
         this.token = null;
     }
 
-    private String urlEncode(String str) {
+    private static String urlEncode(String str) {
         try {
             return URLEncoder.encode(str, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationStep.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationStep.java
@@ -278,7 +278,7 @@ public class AuthenticationStep
             }
 
             try {
-                int value = Integer.valueOf(newStep.getTimeout());
+                int value = newStep.getTimeout();
                 if (value <= 0) {
                     return ValidationResult.INVALID_TIMEOUT;
                 }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ClientSideHandler.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ClientSideHandler.java
@@ -66,8 +66,8 @@ public final class ClientSideHandler implements HttpMessageHandler {
     public ClientSideHandler(User user) {
         this.user = user;
         if (user.getAuthenticationCredentials()
-                instanceof UsernamePasswordAuthenticationCredentials authCreds) {
-            this.authCreds = authCreds;
+                instanceof UsernamePasswordAuthenticationCredentials authCred) {
+            this.authCreds = authCred;
         }
     }
 

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/StepsPanel.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/StepsPanel.java
@@ -84,7 +84,7 @@ public class StepsPanel {
         return stepsModel.getElements();
     }
 
-    private <T> AuthenticationStep showAddDialogue(
+    private AuthenticationStep showAddDialogue(
             AbstractMultipleOptionsBaseTableModel<AuthenticationStep> model) {
         if (addDialog == null) {
             addDialog = new DialogAddStep(parent);
@@ -99,7 +99,7 @@ public class StepsPanel {
         return elem;
     }
 
-    private <T> AuthenticationStep showModifyDialogue(
+    private AuthenticationStep showModifyDialogue(
             AbstractMultipleOptionsBaseTableModel<AuthenticationStep> model, AuthenticationStep e) {
         if (modifyDialog == null) {
             modifyDialog = new DialogModifyStep(parent);
@@ -311,8 +311,8 @@ public class StepsPanel {
 
         @Override
         public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
-            if (getEffectiveColumnIndex(columnIndex) == 0 && aValue instanceof Boolean) {
-                steps.get(rowIndex).setEnabled(((Boolean) aValue).booleanValue());
+            if (getEffectiveColumnIndex(columnIndex) == 0 && aValue instanceof Boolean val) {
+                steps.get(rowIndex).setEnabled(val.booleanValue());
                 fireTableCellUpdated(rowIndex, columnIndex);
             }
         }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollectorUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollectorUnitTest.java
@@ -56,7 +56,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     Session session;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         adc = new AuthDiagnosticCollector();
         sb = new StringBuilder();
         adc.setCollector(str -> sb.append(str));
@@ -97,7 +97,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldNotLogMsgIfDisabled() throws Exception {
+    void shouldNotLogMsgIfDisabled() {
         // Given / When
         adc.onHttpResponseReceive(new HttpMessage(), 1, null);
 
@@ -163,7 +163,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldAppendCookies() throws Exception {
+    void shouldAppendCookies() {
         // Given
         List<HttpCookie> cookies = new ArrayList<>();
         cookies.add(new HttpCookie("name", "someValue"));
@@ -189,9 +189,9 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldAppendStructuredData() throws Exception {
+    void shouldAppendStructuredData() {
         // Given
-        StringBuilder sb = new StringBuilder();
+        StringBuilder builder = new StringBuilder();
         HttpRequestHeader header = new HttpRequestHeader();
         HttpRequestBody body = new HttpRequestBody();
 
@@ -200,11 +200,11 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
                 "[{\"user\":\"test@test.com\",\"password\":\"password123\"},{\"xxx\":\"yyy\"}]");
 
         // When
-        adc.appendPostData(new HttpMessage(header, body), true, sb);
+        adc.appendPostData(new HttpMessage(header, body), true, builder);
 
         // Then
         assertThat(
-                sb.toString(),
+                builder.toString(),
                 is(
                         equalTo(
                                 "\n[{\"user\":\"sanitizedtoken0\",\"password\":\"sanitizedtoken1\"},{\"xxx\":\"sanitizedtoken2\"}]\n")));
@@ -213,7 +213,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     @Test
     void shouldAppendPostData() throws Exception {
         // Given
-        StringBuilder sb = new StringBuilder();
+        StringBuilder builder = new StringBuilder();
         HttpRequestHeader header = new HttpRequestHeader();
         HttpRequestBody body = new HttpRequestBody();
 
@@ -223,10 +223,10 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         body.setBody("aaa=bbb&ccc=ddd");
 
         // When
-        adc.appendPostData(new HttpMessage(header, body), true, sb);
+        adc.appendPostData(new HttpMessage(header, body), true, builder);
 
         // Then
-        assertThat(sb.toString(), is(equalTo("\naaa=sanitizedtoken0&ccc=sanitizedtoken1&\n")));
+        assertThat(builder.toString(), is(equalTo("\naaa=sanitizedtoken0&ccc=sanitizedtoken1&\n")));
     }
 
     @Test
@@ -234,7 +234,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         // Given
         adc.setUsername("test@example.org");
         adc.setPassword("mySuperSecretPassword");
-        StringBuilder sb = new StringBuilder();
+        StringBuilder builder = new StringBuilder();
         HttpRequestHeader header = new HttpRequestHeader();
         HttpRequestBody body = new HttpRequestBody();
 
@@ -244,15 +244,16 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         body.setBody("user=test@example.org&pass=mySuperSecretPassword");
 
         // When
-        adc.appendPostData(new HttpMessage(header, body), true, sb);
+        adc.appendPostData(new HttpMessage(header, body), true, builder);
 
         // Then
         assertThat(
-                sb.toString(), is(equalTo("\npass=F4keP4ssw0rd&user=FakeUserName@example.com&\n")));
+                builder.toString(),
+                is(equalTo("\npass=F4keP4ssw0rd&user=FakeUserName@example.com&\n")));
     }
 
     @Test
-    void shouldNotAppendNonJsonData() throws Exception {
+    void shouldNotAppendNonJsonData() {
         // Given
         HttpRequestHeader header = new HttpRequestHeader();
         HttpRequestBody body = new HttpRequestBody();
@@ -269,7 +270,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldAppendExactHeaders() throws Exception {
+    void shouldAppendExactHeaders() {
         // Given
         HttpHeader header = new HttpRequestHeader();
 
@@ -285,7 +286,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldAppendSanitisedHeaders() throws Exception {
+    void shouldAppendSanitisedHeaders() {
         // Given
         HttpHeader header = new HttpRequestHeader();
 
@@ -303,7 +304,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnSanitisedSimpleJsonObject() throws Exception {
+    void shouldReturnSanitisedSimpleJsonObject() {
         // Given
         String jsonStr = "{\"user\":\"test@test.com\",\"password\":\"password123\"}";
         JSONObject json = JSONObject.fromObject(jsonStr);
@@ -318,7 +319,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnSanitisedSimpleJsonArray() throws Exception {
+    void shouldReturnSanitisedSimpleJsonArray() {
         // Given
         String jsonStr = "[{\"user\":\"test@test.com\",\"password\":\"password123\"}]";
         JSONArray json = JSONArray.fromObject(jsonStr);

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -117,7 +117,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnUserTextField() throws Exception {
+    void shouldReturnUserTextField() {
         // Given
         List<WebElement> inputElements = new ArrayList<>();
         inputElements.add(new TestWebElement("input", "password"));
@@ -175,7 +175,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnSingleFieldAsUserField() throws Exception {
+    void shouldReturnSingleFieldAsUserField() {
         // Given
         List<WebElement> inputElements = new ArrayList<>();
         // Starting form with just username with custom input type.
@@ -211,7 +211,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnUserEmailField() throws Exception {
+    void shouldReturnUserEmailField() {
         // Given
         List<WebElement> inputElements = new ArrayList<>();
         inputElements.add(new TestWebElement("input", "password"));
@@ -227,7 +227,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnUserEmailFieldById() throws Exception {
+    void shouldReturnUserEmailFieldById() {
         // Given
         List<WebElement> inputElements = new ArrayList<>();
         inputElements.add(new TestWebElement("input", "password"));
@@ -244,7 +244,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnUserEmailFieldByName() throws Exception {
+    void shouldReturnUserEmailFieldByName() {
         // Given
         List<WebElement> inputElements = new ArrayList<>();
         inputElements.add(new TestWebElement("input", "password"));
@@ -261,7 +261,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnNoUserField() throws Exception {
+    void shouldReturnNoUserField() {
         // Given
         List<WebElement> inputElements = new ArrayList<>();
         inputElements.add(new TestWebElement("input", "password"));
@@ -276,7 +276,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnPasswordField() throws Exception {
+    void shouldReturnPasswordField() {
         // Given
         List<WebElement> inputElements = new ArrayList<>();
         inputElements.add(new TestWebElement("input", "email"));
@@ -334,7 +334,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnNoPasswordField() throws Exception {
+    void shouldReturnNoPasswordField() {
         // Given
         List<WebElement> inputElements = new ArrayList<>();
         inputElements.add(new TestWebElement("input", "email"));
@@ -428,10 +428,11 @@ class AuthUtilsUnitTest extends TestUtils {
         HttpMessage msg =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET / HTTP/1.1\r\n"
-                                        + "Header1: Value1\r\n"
-                                        + "Header2: Value2\r\n"
-                                        + "Host: example.com\r\n\r\n"),
+                                """
+                                GET / HTTP/1.1\r
+                                Header1: Value1\r
+                                Header2: Value2\r
+                                Host: example.com\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader("HTTP/1.1 200 OK\r\n"),
                         new HttpResponseBody("Response Body"));
@@ -450,9 +451,10 @@ class AuthUtilsUnitTest extends TestUtils {
                         new HttpRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
-                                "HTTP/1.1 200 OK\r\n"
-                                        + "Header1: Value1\r\n"
-                                        + "Header2: Value2\r\n"),
+                                """
+                                HTTP/1.1 200 OK\r
+                                Header1: Value1\r
+                                Header2: Value2\r\n"""),
                         new HttpResponseBody("Response Body"));
         // When
         Map<String, SessionToken> tokens = AuthUtils.getAllTokens(msg, false);
@@ -492,17 +494,18 @@ class AuthUtilsUnitTest extends TestUtils {
                         new HttpResponseHeader(
                                 "HTTP/1.1 200 OK\r\n" + "Content-Type: application/json"),
                         new HttpResponseBody(
-                                "{'wrapper1': {\n"
-                                        + "  'att1': 'val1',\n"
-                                        + "  'att2': 'val2',\n"
-                                        + "  'wrapper2': {\n"
-                                        + "    'att1': 'val3',\n"
-                                        + "    'array': [\n"
-                                        + "      {'att1': 'val4', 'att2': 'val5'},\n"
-                                        + "      {'att3': 'val6', 'att4': 'val7'}\n"
-                                        + "    ]\n"
-                                        + "  }\n"
-                                        + "}}"));
+                                """
+                                {"wrapper1": {
+                                  "att1": "val1",
+                                  "att2": "val2",
+                                  "wrapper2": {
+                                    "att1": "val3",
+                                    "array": [
+                                      {"att1": "val4", "att2": "val5"},
+                                      {"att3": "val6", "att4": "val7"}
+                                    ]
+                                  }
+                                }}"""));
         // When
         Map<String, SessionToken> tokens = AuthUtils.getAllTokens(msg, false);
 
@@ -528,9 +531,10 @@ class AuthUtilsUnitTest extends TestUtils {
         HttpMessage msg =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET https://example.com/ HTTP/1.1\r\n"
-                                        + "Host: example.com\r\n"
-                                        + "Cookie: aaa=bbb\r\n\r\n"),
+                                """
+                                GET https://example.com/ HTTP/1.1\r
+                                Host: example.com\r
+                                Cookie: aaa=bbb\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
                                 "HTTP/1.1 200 OK\r\n" + "Set-Cookie: ccc=ddd; HttpOnly; Secure"),
@@ -553,9 +557,10 @@ class AuthUtilsUnitTest extends TestUtils {
         HttpMessage msg =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET https://example.com/ HTTP/1.1\r\n"
-                                        + "Host: example.com\r\n"
-                                        + "Cookie: aaa=bbb\r\n\r\n"),
+                                """
+                                GET https://example.com/ HTTP/1.1\r
+                                Host: example.com\r
+                                Cookie: aaa=bbb\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
                                 "HTTP/1.1 200 OK\r\n" + "Set-Cookie: ccc=ddd; HttpOnly; Secure"),
@@ -759,7 +764,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnNoSessionToken() throws Exception {
+    void shouldReturnNoSessionToken() {
         // Given
         AuthUtils.recordSessionToken(
                 new SessionToken(SessionToken.HEADER_SOURCE, HttpHeader.AUTHORIZATION, "456"));
@@ -770,7 +775,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReturnSessionToken() throws Exception {
+    void shouldReturnSessionToken() {
         // Given
         AuthUtils.recordSessionToken(
                 new SessionToken(SessionToken.HEADER_SOURCE, "Header1", "123"));
@@ -788,7 +793,7 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldRemoveSessionToken() throws Exception {
+    void shouldRemoveSessionToken() {
         // Given
         AuthUtils.recordSessionToken(
                 new SessionToken(SessionToken.HEADER_SOURCE, "Header1", "123"));

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodTypeUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodTypeUnitTest.java
@@ -73,7 +73,7 @@ class HeaderBasedSessionManagementMethodTypeUnitTest extends TestUtils {
     private static final String VALUE_5 = "v{%script:sc_var%}-{%url:test%}";
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         mockMessages(new ExtensionAuthhelper());
         envVars = new HashMap<>();
         HeaderBasedSessionManagementMethod.replaceEnvVarsForTesting(envVars);
@@ -81,7 +81,7 @@ class HeaderBasedSessionManagementMethodTypeUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReplaceSimpleTokens() throws Exception {
+    void shouldReplaceSimpleTokens() {
         // Given
         String baseString = "Prefix{%token1%}middle{%token2%}Postfix";
         Map<String, SessionToken> map = new HashMap<>();
@@ -95,7 +95,7 @@ class HeaderBasedSessionManagementMethodTypeUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldLeaveMissingTokens() throws Exception {
+    void shouldLeaveMissingTokens() {
         // Given
         String baseString = "Prefix{%token1%}middle{%token2%}Postfix";
         Map<String, SessionToken> map = new HashMap<>();
@@ -108,7 +108,7 @@ class HeaderBasedSessionManagementMethodTypeUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReplaceRecordedToken() throws Exception {
+    void shouldReplaceRecordedToken() {
         // Given
         String baseString = "Prefix{%token1%}Postfix";
         Map<String, SessionToken> map = new HashMap<>();
@@ -126,28 +126,31 @@ class HeaderBasedSessionManagementMethodTypeUnitTest extends TestUtils {
         HttpMessage msg =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET https://example.com/?att1=val1&att2=val2 HTTP/1.1\r\n"
-                                        + "Header1: Value1\r\n"
-                                        + "Header2: Value2\r\n"
-                                        + "Host: example.com\r\n\r\n"),
+                                """
+                                GET https://example.com/?att1=val1&att2=val2 HTTP/1.1\r
+                                Header1: Value1\r
+                                Header2: Value2\r
+                                Host: example.com\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
-                                "HTTP/1.1 200 OK\r\n"
-                                        + "Header3: Value3\r\n"
-                                        + "Header4: Value4\r\n"
-                                        + "Content-Type: application/json"),
+                                """
+                                HTTP/1.1 200 OK\r
+                                Header3: Value3\r
+                                Header4: Value4\r
+                                Content-Type: application/json"""),
                         new HttpResponseBody(
-                                "{'wrapper1': {\n"
-                                        + "  'att1': 'val1',\n"
-                                        + "  'att2': 'val2',\n"
-                                        + "  'wrapper2': {\n"
-                                        + "    'att1': 'val3',\n"
-                                        + "    'array': [\n"
-                                        + "      {'att1': 'val4'},\n"
-                                        + "      {'att3': 'val6', 'att4': 'val7'}\n"
-                                        + "    ]\n"
-                                        + "  }\n"
-                                        + "}}"));
+                                """
+                                {"wrapper1": {
+                                  "att1": "val1",
+                                  "att2": "val2",
+                                  "wrapper2": {
+                                    "att1": "val3",
+                                    "array": [
+                                      {"att1": "val4"},
+                                      {"att3": "val6", "att4": "val7"}
+                                    ]
+                                  }
+                                }}"""));
         envVars.put("envvar1", "envvalue1");
         envVars.put("envvar2", "envvalue2");
         ScriptVars.setGlobalVar("scriptvar1", "scriptvalue1");
@@ -199,10 +202,11 @@ class HeaderBasedSessionManagementMethodTypeUnitTest extends TestUtils {
         HttpMessage msg =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET / HTTP/1.1\r\n"
-                                        + "Header1: Value1\r\n"
-                                        + "Header2: Value2\r\n"
-                                        + "Host: example.com\r\n\r\n"),
+                                """
+                                GET / HTTP/1.1\r
+                                Header1: Value1\r
+                                Header2: Value2\r
+                                Host: example.com\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader("HTTP/1.1 200 OK\r\n"),
                         new HttpResponseBody("Response Body"));

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/LoginLinkDetectorUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/LoginLinkDetectorUnitTest.java
@@ -45,7 +45,7 @@ import org.openqa.selenium.WebElement;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.testutils.TestUtils;
 
-public class LoginLinkDetectorUnitTest extends TestUtils {
+class LoginLinkDetectorUnitTest extends TestUtils {
 
     @RegisterExtension static SeleniumJupiter seleniumJupiter = new SeleniumJupiter();
 

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/VerificationRequestDetailsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/VerificationRequestDetailsUnitTest.java
@@ -55,7 +55,7 @@ class VerificationRequestDetailsUnitTest extends TestUtils {
     private ContextUserAuthManager cuam;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() {
         extensionLoader =
                 mock(ExtensionLoader.class, withSettings().strictness(Strictness.LENIENT));
         context = mock(Context.class);
@@ -76,10 +76,11 @@ class VerificationRequestDetailsUnitTest extends TestUtils {
         HttpMessage msg =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET / HTTP/1.1\r\n"
-                                        + "Header1: Value1\r\n"
-                                        + "Header2: Value2\r\n"
-                                        + "Host: example.com\r\n\r\n"),
+                                """
+                                GET / HTTP/1.1\r
+                                Header1: Value1\r
+                                Header2: Value2\r
+                                Host: example.com\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader("HTTP/1.1 404 OK\r\n"),
                         new HttpResponseBody(body));
@@ -108,12 +109,13 @@ class VerificationRequestDetailsUnitTest extends TestUtils {
         HttpMessage msg =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET / HTTP/1.1\r\n"
-                                        + "Header1: Value1\r\n"
-                                        + "Host: example.com\r\n\r\n"),
+                                """
+                                GET / HTTP/1.1\r
+                                Header1: Value1\r
+                                Host: example.com\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
-                                "HTTP/1.1 200 OK\r\n" + "Content-Type: application/json\r\n"),
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"),
                         new HttpResponseBody(body));
         List<User> users = new ArrayList<>();
         users.add(new User(1, username));
@@ -143,12 +145,13 @@ class VerificationRequestDetailsUnitTest extends TestUtils {
         HttpMessage msg =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET / HTTP/1.1\r\n"
-                                        + "Header1: Value1\r\n"
-                                        + "Host: example.com\r\n\r\n"),
+                                """
+                                GET / HTTP/1.1\r
+                                Header1: Value1\r
+                                Host: example.com\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
-                                "HTTP/1.1 200 OK\r\n" + "Content-Type: application/json\r\n"),
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"),
                         new HttpResponseBody(body));
         List<User> users = new ArrayList<>();
         User user = new User(1, "test");
@@ -261,14 +264,14 @@ class VerificationRequestDetailsUnitTest extends TestUtils {
                         new HttpRequestHeader("GET / HTTP/1.1\r\n"),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
-                                "HTTP/1.1 200 OK\r\n" + "Content-Type: application/text\r\n"),
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/text\r\n"),
                         new HttpResponseBody(stdBody));
         HttpMessage msg2 =
                 new HttpMessage(
                         new HttpRequestHeader("GET / HTTP/1.1\r\n"),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
-                                "HTTP/1.1 200 OK\r\n" + "Content-Type: application/json\r\n"),
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"),
                         new HttpResponseBody(jsnBody));
 
         // When
@@ -294,12 +297,13 @@ class VerificationRequestDetailsUnitTest extends TestUtils {
         HttpMessage msg1 =
                 new HttpMessage(
                         new HttpRequestHeader(
-                                "GET / HTTP/1.1\r\n"
-                                        + "Header1: Value1\r\n"
-                                        + "Host: example.com\r\n\r\n"),
+                                """
+                                GET / HTTP/1.1\r
+                                Header1: Value1\r
+                                Host: example.com\r\n\r\n"""),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
-                                "HTTP/1.1 200 OK\r\n" + "Content-Type: application/json\r\n"),
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"),
                         new HttpResponseBody(body1));
 
         HttpMessage msg2 =
@@ -307,7 +311,7 @@ class VerificationRequestDetailsUnitTest extends TestUtils {
                         new HttpRequestHeader("GET / HTTP/1.1\r\n"),
                         new HttpRequestBody("Request Body"),
                         new HttpResponseHeader(
-                                "HTTP/1.1 200 OK\r\n" + "Content-Type: application/json\r\n"),
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"),
                         new HttpResponseBody(body2));
 
         // When

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/internal/ClientSideHandlerUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/internal/ClientSideHandlerUnitTest.java
@@ -61,7 +61,7 @@ import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.Pair;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class ClientSideHandlerUnitTest extends TestUtils {
+class ClientSideHandlerUnitTest extends TestUtils {
 
     private static final String TEST_USERNAME = "test@example.org.com";
     private static final String TEST_PASSWORD = "mySuperSecretPassword";
@@ -82,7 +82,7 @@ public class ClientSideHandlerUnitTest extends TestUtils {
     private static final String SESSION_TOKEN1 = "1234567890123456789012345678901234567890";
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         mockMessages(new ExtensionAuthhelper());
         given(model.getSession()).willReturn(session);
         context = new Context(session, 0);
@@ -118,7 +118,7 @@ public class ClientSideHandlerUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldExtractKeyValuePairs() throws Exception {
+    void shouldExtractKeyValuePairs() {
         // Given / When
         List<Pair<String, String>> tokens =
                 ClientSideHandler.extractKeyValuePairs(

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/report/ExtensionAuthhelperReportUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/report/ExtensionAuthhelperReportUnitTest.java
@@ -68,7 +68,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 class ExtensionAuthhelperReportUnitTest extends TestUtils {
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         mockMessages(new ExtensionAuthhelper());
 
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
@@ -81,7 +81,7 @@ class ExtensionAuthhelperReportUnitTest extends TestUtils {
         Constant.PROGRAM_VERSION = "Test Build";
     }
 
-    private ReportData getGenericReportData(String templateName) {
+    private static ReportData getGenericReportData(String templateName) {
         ReportData reportData = new ReportData(templateName);
         reportData.setTitle("Test Title");
         reportData.setDescription("Test Description");
@@ -314,7 +314,7 @@ class ExtensionAuthhelperReportUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldIgnoreNonAuthReport() throws Exception {
+    void shouldIgnoreNonAuthReport() {
         // Given
         ExtensionAuthhelperReport.AuthReportDataHandler dataHandler =
                 new ExtensionAuthhelperReport.AuthReportDataHandler();
@@ -328,7 +328,7 @@ class ExtensionAuthhelperReportUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldNotErrorIfNoContexts() throws Exception {
+    void shouldNotErrorIfNoContexts() {
         // Given
         ExtensionAuthhelperReport.AuthReportDataHandler dataHandler =
                 new ExtensionAuthhelperReport.AuthReportDataHandler();
@@ -346,7 +346,7 @@ class ExtensionAuthhelperReportUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReportPassingCase() throws Exception {
+    void shouldReportPassingCase() {
         // Given
         String site = "https://www.example.com";
         ExtensionAuthhelperReport.AuthReportDataHandler dataHandler =
@@ -398,7 +398,7 @@ class ExtensionAuthhelperReportUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReportFailingCase() throws Exception {
+    void shouldReportFailingCase() {
         // Given
         String site = "https://www.example.com";
         ExtensionAuthhelperReport.AuthReportDataHandler dataHandler =


### PR DESCRIPTION
## Overview
Address minor code issues identified by SAST (sonarlint):
- Use variable assignment from isntanceof checks avoiding subsequent casts.
- Return conditions more directly.
- Remove unnecessary curly braces.
- Remove unnecessary semi-colon.
- Use method references vs lambda where possible.
- Combine sequential ifs where possible.
- Remove unnecessary toString() calls.
- Remove unnecessary parameterization where diamond is fine.
- Use super references where the distinction helps.
- Use curly braces consistently.
- Remove unnecessary found brackets in lambda use.
- Remove unnecessary throw Exception declarations in Unit Tests.
- Name some local variables no not "hide" other class variables.
- Use String text blocks vs concatenation where possible.
- Remove public declarations from Unit Test class or methods where unnecessary.
- Remove unnecessary string concatenation.
- Declare methods static where possible/practical.
- Switch single parameter for loops to while where practical.
- Remove unnecessary throws declarations on methods.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
