### PR TITLE
authhelper: Use page with login links for verification

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - If authentication fails then try to find a likely looking login link.
 - Persist diagnostics to the session and include it in the Authentication Report (JSON) for Client Script and Browser Based Authentication methods.
 - A reset button.
+- Checks to try to find a verification URL with a login link, if nothing better has been found.
 
 ### Changed
 - Prefer form related fields in Browser Based Authentication for the selection of username field.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -372,6 +372,8 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
                         user.setAuthenticatedSession(session);
                     }
 
+                    AuthUtils.checkLoginLinkVerification(httpSender, user, session, loginPageUrl);
+
                     if (this.isAuthenticated(authMsg, user, true)) {
                         diags.recordStep(
                                 authMsg,

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -386,6 +386,12 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                 WebSession session = sessionManagementMethod.extractWebSession(authMsg);
                 user.setAuthenticatedSession(session);
 
+                AuthUtils.checkLoginLinkVerification(
+                        getHttpSender(),
+                        user,
+                        session,
+                        authMsg.getRequestHeader().getURI().toString());
+
                 if (this.isAuthenticated(authMsg, user, true)) {
                     // Let the user know it worked
                     AuthenticationHelper.notifyOutputAuthSuccessful(authMsg);

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/LoginLinkDetector.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/LoginLinkDetector.java
@@ -21,6 +21,9 @@ package org.zaproxy.addon.authhelper;
 
 import java.util.List;
 import java.util.Locale;
+import net.htmlparser.jericho.Element;
+import net.htmlparser.jericho.HTMLElementName;
+import net.htmlparser.jericho.Source;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -46,6 +49,28 @@ public class LoginLinkDetector {
 
     private static boolean elementContainsText(WebElement element, List<String> searchTexts) {
         String txt = element.getText().toLowerCase(Locale.ROOT);
+        return searchTexts.stream().anyMatch(txt::contains);
+    }
+
+    public static List<Element> getLoginLinks(Source src, List<String> loginLabels) {
+        // Try finding links first
+        List<Element> loginLinks = findElementsByTagAndLabels(src, HTMLElementName.A, loginLabels);
+        if (!loginLinks.isEmpty()) {
+            return loginLinks;
+        }
+        // If no links found, try buttons
+        return findElementsByTagAndLabels(src, HTMLElementName.BUTTON, loginLabels);
+    }
+
+    private static List<Element> findElementsByTagAndLabels(
+            Source src, String tag, List<String> labels) {
+        return src.getAllElements(tag).stream()
+                .filter(element -> elementContainsText(element, labels))
+                .toList();
+    }
+
+    private static boolean elementContainsText(Element element, List<String> searchTexts) {
+        String txt = element.getTextExtractor().toString().toLowerCase(Locale.ROOT);
         return searchTexts.stream().anyMatch(txt::contains);
     }
 }


### PR DESCRIPTION
## Overview
Try to find a verification URL with a login link on it.
This is when verification has been set to autodetect and we've not found any suitable URLs so far.
It is likely to work better for more traditional apps as it currently only check HTML responses.

Ready for review but set WIP in case we want to make sure the itests are working before we merge it and potentially cause other problems?

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
