### PR TITLE
reports: Fix Theme handling

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- Themes are once again properly taken into account when generating reports (Issue 8854).
+
 ### Added
 - Allow report data to be cleaned up after the report generation.
 - Allow reports to read HTTP messages through the report helper.

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
@@ -436,7 +436,7 @@ public class ReportDialog extends StandardFieldsDialog {
         reportData.setDescription(this.getStringValue(FIELD_DESCRIPTION));
         reportData.setContexts(this.getContextsSelector().getSelectedValuesList());
         reportData.setSites(this.getSitesSelector().getSelectedValuesList());
-        reportData.setTheme(template.getThemeForName(getStringValue(FIELD_TEMPLATE)));
+        reportData.setTheme(template.getThemeForName(getStringValue(FIELD_THEME)));
         if (reportData.getSites().isEmpty()) {
             // None selected so add all
             reportData.setSites(ExtensionReports.getSites());


### PR DESCRIPTION
## Overview
- CHANGELOG > Add a fix note.
- ReportDIalog > Ensure the correct constant is used when getting the theme details.

## Related Issues
- Fixes zaproxy/zaproxy38854

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
