### PR TITLE
automation: Handle FP alerts in Exit Status

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow to use variables for the TOTP data.
 - Allow to enable diagnostics for Client Script and Browser Based Authentication methods.
 
+### Fixed
+- Ensure that the Exit Status job accounts for False Positive alerts (Issue 8875).
+
 ## [0.47.0] - 2025-02-12
 ### Added
 - Method to get the YAML representation of a plan.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ExitStatusJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ExitStatusJob.java
@@ -81,6 +81,9 @@ public class ExitStatusJob extends AutomationJob {
         try {
             for (JobResultData data : progress.getAllJobResultData()) {
                 for (Alert alert : data.getAllAlertData()) {
+                    if (alert.getConfidence() == Alert.CONFIDENCE_FALSE_POSITIVE) {
+                        continue;
+                    }
                     if (errorRisk != null && errorRisk <= alert.getRisk()) {
                         progress.error(
                                 Constant.messages.getString(


### PR DESCRIPTION
## Overview
- CHANGELOG > Add fix note.
- ExitStatusJob > Exclude FP alerts when looping to establish exit code.
- ExitStatusJobUnitTest > Add test to assert the behavior.

## Related Issues
- Fixes zaproxy/zaproxy#8875

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
