### PR TITLE
ascanrules: External Redirect scan rule to regenerate anti CSRF tokens

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- External Redirect scan rule to regenerate anti CSRF tokens.
 
 ## [70] - 2025-01-09
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
@@ -233,7 +233,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin
             try {
                 // Send the request and retrieve the response
                 // Be careful: we haven't to follow redirect
-                sendAndReceive(testMsg, false, false);
+                sendAndReceive(testMsg, false);
 
                 String payloadScheme =
                         StringUtils.containsIgnoreCase(payload, HttpHeader.HTTPS)


### PR DESCRIPTION
## Overview
As per title - it looks like this might have been a mistake back in 2014
https://github.com/zaproxy/zap-extensions/commit/4ba378a5dd75c464dc7da287c450fda31b6b919e

Tested manually - looks too hard to add unit tests?

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
