### PR TITLE
pscanrules: Separate Alert for CSP directives without fallback

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The CSP scan rule now treats Wildcard directives separately from those which are undefined but have no fallback (Issue 8700).
 
 ## [63] - 2025-03-04
 ### Fixed

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -115,11 +115,13 @@ pscanrules.csp.malformed.otherinfo = A non-ASCII character was encountered while
 pscanrules.csp.meta.bad.directive.desc = The policy specified via meta element contains either or both the sandbox or frame-ancestors directive, which are not permitted inside meta CSP definitions.
 pscanrules.csp.meta.bad.directive.name = Meta Policy Invalid Directive
 pscanrules.csp.name = CSP
+pscanrules.csp.nofallback.desc = The Content Security Policy fails to define one of the directives that has no fallback. Missing/excluding them is the same as allowing anything.
+pscanrules.csp.nofallback.name = Failure to Define Directive with No Fallback
+pscanrules.csp.nofallback.otherinfo = The directive(s): {0} is/are among the directives that do not fallback to default-src.
 pscanrules.csp.notices.errors = Errors:
 pscanrules.csp.notices.infoitems = Info Items:
 pscanrules.csp.notices.name = Notices
 pscanrules.csp.notices.warnings = Warnings:
-pscanrules.csp.otherinfo.extended = \n\nThe directive(s): {0} are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.
 pscanrules.csp.refs = https://www.w3.org/TR/CSP/\nhttps://caniuse.com/#search=content+security+policy\nhttps://content-security-policy.com/\nhttps://github.com/HtmlUnit/htmlunit-csp\nhttps://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
 pscanrules.csp.scriptsrc.unsafe.eval.name = script-src unsafe-eval
 pscanrules.csp.scriptsrc.unsafe.eval.otherinfo = script-src includes unsafe-eval.


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- ContentSecurityPolicyScanRule > Adjust handling for directives without fallback.
- ContentSecurityPolicyScanRuleUnitTest > Updated to conform to the new handling.
- Messages.properties > Updated with supporting KVPs and changes.

## Related Issues
- Fixes zaproxy/zaproxy#8700

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
