### PR TITLE
authhelper: add diag post data + initial auto-detect unit tests

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Document custom steps for Browser Based Authentication.
+- Sanitized post data to auth diagnostics.
 
 ### Changed
 - Add any session related cookies which are not being tracked.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
@@ -256,8 +256,12 @@ public class AuthTestDialog extends StandardFieldsDialog {
         StatsListener statsListener = null;
         boolean demoMode = getBoolValue(DEMO_LABEL);
         try {
+            String username = this.getStringValue(USERNAME_LABEL);
+            String password = this.getStringValue(PASSWORD_LABEL);
+
             this.diagnosticField.setText("");
             ext.enableAuthDiagCollector(true);
+            ext.setAuthDiagCollectorCredentials(username, password);
 
             // Delete the context if it already exists
             Session session = Model.getSingleton().getSession();
@@ -289,11 +293,9 @@ public class AuthTestDialog extends StandardFieldsDialog {
             context.setAuthenticationMethod(am);
 
             // Set up user
-            String username = this.getStringValue(USERNAME_LABEL);
             User user = new User(context.getId(), username);
             UsernamePasswordAuthenticationCredentials upCreds =
-                    new UsernamePasswordAuthenticationCredentials(
-                            username, this.getStringValue(PASSWORD_LABEL));
+                    new UsernamePasswordAuthenticationCredentials(username, password);
             user.setAuthenticationCredentials(upCreds);
             user.setEnabled(true);
             Control.getSingleton()

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import lombok.Setter;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.Source;
 import net.sf.json.JSONArray;
@@ -75,7 +76,6 @@ import org.zaproxy.addon.authhelper.BrowserBasedAuthenticationMethodType.Browser
 import org.zaproxy.addon.authhelper.internal.AuthenticationStep;
 import org.zaproxy.addon.commonlib.ResourceIdentificationUtils;
 import org.zaproxy.zap.authentication.AuthenticationCredentials;
-import org.zaproxy.zap.authentication.AuthenticationHelper;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.authentication.AuthenticationMethod.AuthCheckingStrategy;
 import org.zaproxy.zap.authentication.AuthenticationMethod.UnsupportedAuthenticationCredentialsException;
@@ -150,6 +150,8 @@ public class AuthUtils {
     private static long timeToWaitMs = TimeUnit.SECONDS.toMillis(5);
 
     private static boolean demoMode;
+
+    @Setter private static HistoryProvider historyProvider = new HistoryProvider();
 
     /**
      * These are session tokens that have been seen in responses but not yet seen in use. When they
@@ -1228,7 +1230,7 @@ public class AuthUtils {
             HttpMessage msg = new HttpMessage(testUri);
             HttpSender unauthSender = new HttpSender(HttpSender.AUTHENTICATION_HELPER_INITIATOR);
             unauthSender.sendAndReceive(msg);
-            AuthenticationHelper.addAuthMessageToHistory(msg);
+            historyProvider.addAuthMessageToHistory(msg);
             int count = 0;
             while (HttpStatusCode.isRedirection(msg.getResponseHeader().getStatusCode())) {
                 testUri =
@@ -1237,7 +1239,7 @@ public class AuthUtils {
                                 true);
                 msg = new HttpMessage(testUri);
                 unauthSender.sendAndReceive(msg);
-                AuthenticationHelper.addAuthMessageToHistory(msg);
+                historyProvider.addAuthMessageToHistory(msg);
                 if (count++ > 50) {
                     return false;
                 }
@@ -1269,7 +1271,7 @@ public class AuthUtils {
             // We've found a login link, now try an authenticated request
             HttpMessage authMsg = new HttpMessage(testUri);
             authSender.sendAndReceive(authMsg, true);
-            AuthenticationHelper.addAuthMessageToHistory(authMsg);
+            historyProvider.addAuthMessageToHistory(authMsg);
 
             String authBody = authMsg.getResponseBody().toString();
             if (authBody.contains(link)) {

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ExtensionAuthhelper.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ExtensionAuthhelper.java
@@ -202,6 +202,13 @@ public class ExtensionAuthhelper extends ExtensionAdaptor {
         }
     }
 
+    public void setAuthDiagCollectorCredentials(String username, String password) {
+        if (this.authDiagCollector != null) {
+            this.authDiagCollector.setUsername(username);
+            this.authDiagCollector.setPassword(password);
+        }
+    }
+
     private ZapMenuItem getAuthTesterMenu() {
         if (authTesterMenu == null) {
             authTesterMenu =

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HistoryProvider.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HistoryProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.authentication.AuthenticationHelper;
+
+/** A very thin layer on top of the History functionality, to make testing easier. */
+public class HistoryProvider {
+
+    public void addAuthMessageToHistory(HttpMessage msg) {
+        AuthenticationHelper.addAuthMessageToHistory(msg);
+    }
+}

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/internal/ClientSideHandlerUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/internal/ClientSideHandlerUnitTest.java
@@ -1,0 +1,132 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper.internal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.authhelper.HistoryProvider;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+import org.zaproxy.zap.model.Context;
+
+public class ClientSideHandlerUnitTest {
+
+    private Context context;
+    private ClientSideHandler csh;
+    private HttpMessageHandlerContext ctx;
+    private List<HttpMessage> history;
+    private HistoryProvider historyProvider;
+
+    private static final String SESSION_TOKEN1 = "1234567890123456789012345678901234567890";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Session session = mock(Session.class);
+        context = new Context(session, 0);
+        context.addIncludeInContextRegex("https://www.example.com.*");
+        csh = new ClientSideHandler(context);
+        ctx = new TestHttpMessageHandlerContext();
+        history = new ArrayList<>();
+        historyProvider = new TestHistoryProvider();
+        csh.setHistoryProvider(historyProvider);
+    }
+
+    @Test
+    void shouldAddMessageToHistory() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage(new URI("https://www.example.com/", true));
+        // When
+        csh.handleMessage(ctx, msg);
+        // Then
+        assertThat(history.size(), is(equalTo(1)));
+    }
+
+    @Test
+    void shouldDetectSimpleLogin() throws Exception {
+        // Given
+        HttpMessage postMsg = new HttpMessage(new URI("https://www.example.com/", true));
+        postMsg.getRequestHeader().setMethod(HttpRequestHeader.POST);
+        postMsg.getRequestHeader()
+                .setHeader(HttpHeader.CONTENT_TYPE, HttpHeader.FORM_URLENCODED_CONTENT_TYPE);
+        postMsg.getRequestBody().setBody("user=test@example.org.com&pass=mySuperSecretPassword");
+        postMsg.getResponseHeader().setHeader(HttpHeader.SET_COOKIE, "session=" + SESSION_TOKEN1);
+
+        HttpMessage getMsg = new HttpMessage(new URI("https://www.example.com/", true));
+        postMsg.getRequestHeader().setHeader(HttpHeader.COOKIE, "session=" + SESSION_TOKEN1);
+        getMsg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "text/html;charset=UTF-8");
+        getMsg.getResponseBody().setBody("Hi test@example.org how are you today?");
+
+        // When
+        csh.handleMessage(ctx, postMsg);
+        csh.handleMessage(ctx, getMsg);
+
+        // Then
+        assertThat(history.size(), is(equalTo(2)));
+        assertThat(csh.getAuthMsg().getHistoryRef().getHistoryId(), is(equalTo(1)));
+    }
+
+    class TestHistoryProvider extends HistoryProvider {
+        @Override
+        public void addAuthMessageToHistory(HttpMessage msg) {
+            history.add(msg);
+            int id = history.size();
+            HistoryReference href = mock(HistoryReference.class);
+            given(href.getHistoryId()).willReturn(id);
+            msg.setHistoryRef(href);
+        }
+    }
+
+    class TestHttpMessageHandlerContext implements HttpMessageHandlerContext {
+
+        @Override
+        public boolean isRecursive() {
+            return false;
+        }
+
+        @Override
+        public boolean isExcluded() {
+            return false;
+        }
+
+        @Override
+        public boolean isFromClient() {
+            return false;
+        }
+
+        @Override
+        public void overridden() {}
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
## Overview
Add sanitized post data to the auth diagnostic data, correctly sanitize set-cookies and added the very start of a framework for testing auto-detection.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
