### PR TITLE
openapi: correct detection while spidering

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct definition detection while spidering.
 
 ## [44] - 2025-01-09
 ### Changed

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpider.java
@@ -78,10 +78,9 @@ public class OpenApiSpider extends SpiderParser {
                     StringUtils.left(message.getResponseBody().toString(), 250)
                             .toLowerCase(Locale.ROOT);
             if (contentType.startsWith("application/vnd.oai.openapi")
-                    || (contentType.contains("json")
-                            || contentType.contains("yaml")
-                                    && (responseBodyStart.contains("swagger")
-                                            || responseBodyStart.contains("openapi")))) {
+                    || ((contentType.contains("json") || contentType.contains("yaml"))
+                            && (responseBodyStart.contains("swagger")
+                                    || responseBodyStart.contains("openapi")))) {
                 return true;
             }
         } catch (Exception e) {


### PR DESCRIPTION
Add missing parentheses so the expression matches the expectations.