### PR TITLE
Auth diag tweaks plus more tests

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Add any session related cookies which are not being tracked.
+- Ignore non proxied requests in auth tester diagnostics.
+- Replace credentials with special tokens.
 
 ### Fixed
 - Bug where some of the data structures were not being reset when the session changed.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollector.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollector.java
@@ -67,7 +67,10 @@ public class AuthDiagnosticCollector implements HttpSenderListener {
     @Override
     public void onHttpResponseReceive(HttpMessage msg, int initiator, HttpSender sender) {
 
-        if (!enabled || collector == null || !AuthUtils.isRelevantToAuthDiags(msg)) {
+        if (!enabled
+                || collector == null
+                || !AuthUtils.isRelevantToAuthDiags(msg)
+                || initiator != HttpSender.PROXY_INITIATOR) {
             return;
         }
 
@@ -224,7 +227,7 @@ public class AuthDiagnosticCollector implements HttpSenderListener {
         if (token.equals(password)) {
             return "F4keP4ssw0rd";
         }
-        return tokenMap.computeIfAbsent(token, s -> "token" + tokenId++);
+        return tokenMap.computeIfAbsent(token, s -> "sanitizedtoken" + tokenId++);
     }
 
     protected JSONObject sanitiseJson(JSONObject jsonObject) {

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HistoryProvider.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HistoryProvider.java
@@ -19,13 +19,84 @@
  */
 package org.zaproxy.addon.authhelper;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.authentication.AuthenticationHelper;
 
 /** A very thin layer on top of the History functionality, to make testing easier. */
 public class HistoryProvider {
 
+    private static final int MAX_NUM_RECORDS_TO_CHECK = 200;
+
+    private static final Logger LOGGER = LogManager.getLogger(HistoryProvider.class);
+
+    private ExtensionHistory extHist;
+
+    private ExtensionHistory getExtHistory() {
+        if (extHist == null) {
+            extHist = AuthUtils.getExtension(ExtensionHistory.class);
+        }
+        return extHist;
+    }
+
     public void addAuthMessageToHistory(HttpMessage msg) {
         AuthenticationHelper.addAuthMessageToHistory(msg);
+    }
+
+    public HttpMessage getHttpMessage(int historyId)
+            throws HttpMalformedHeaderException, DatabaseException {
+        HistoryReference hr = getExtHistory().getHistoryReference(historyId);
+        if (hr != null) {
+            return hr.getHttpMessage();
+        }
+        return null;
+    }
+
+    public int getLastHistoryId() {
+        return getExtHistory().getLastHistoryId();
+    }
+
+    public SessionManagementRequestDetails findSessionTokenSource(String token, int firstId) {
+        int lastId = getLastHistoryId();
+        if (firstId == -1) {
+            firstId = Math.max(0, lastId - MAX_NUM_RECORDS_TO_CHECK);
+        }
+
+        LOGGER.debug("Searching for session token from {} down to {} ", lastId, firstId);
+
+        for (int i = lastId; i >= firstId; i--) {
+            try {
+                HttpMessage msg = getHttpMessage(i);
+                if (msg == null) {
+                    continue;
+                }
+                Optional<SessionToken> es =
+                        AuthUtils.getAllTokens(msg, false).values().stream()
+                                .filter(v -> v.getValue().equals(token))
+                                .findFirst();
+                if (es.isPresent()) {
+                    AuthUtils.incStatsCounter(
+                            msg.getRequestHeader().getURI(),
+                            AuthUtils.AUTH_SESSION_TOKEN_STATS_PREFIX + es.get().getKey());
+                    List<SessionToken> tokens = new ArrayList<>();
+                    tokens.add(
+                            new SessionToken(
+                                    es.get().getSource(), es.get().getKey(), es.get().getValue()));
+                    return new SessionManagementRequestDetails(msg, tokens, Alert.CONFIDENCE_HIGH);
+                }
+            } catch (Exception e) {
+                LOGGER.debug(e.getMessage(), e);
+            }
+        }
+        return null;
     }
 }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollectorUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthDiagnosticCollectorUnitTest.java
@@ -71,7 +71,15 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         adc.onHttpResponseReceive(msg, 1, null);
 
         // Then
-        assertThat(sb.toString(), is(">>>>>\nGET https://example0/\n<<<\nHTTP/1.0 200 OK\n"));
+        assertThat(
+                sb.toString(),
+                is(
+                        """
+                        >>>>>
+                        GET https://example0/
+                        <<<
+                        HTTP/1.0 200 OK
+                        """));
     }
 
     @Test
@@ -130,8 +138,14 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         assertThat(
                 sb.toString(),
                 is(
-                        ">>>>>\nGET https://example0/\ncookie: cookie1=\"token0\"\n<<<\n"
-                                + "HTTP/1.0 200 OK\nset-cookie: cookie2=token1\n"));
+                        """
+                        >>>>>
+                        GET https://example0/
+                        cookie: cookie1=\"sanitizedtoken0\"
+                        <<<
+                        HTTP/1.0 200 OK
+                        set-cookie: cookie2=sanitizedtoken1
+                        """));
     }
 
     @Test
@@ -154,7 +168,10 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
                 sb.toString(),
                 is(
                         equalTo(
-                                "TestHeader: name=\"token0\"\nTestHeader: name2=\"token1\";$Domain=\"https://example0/\"\n")));
+                                """
+                                TestHeader: name=\"sanitizedtoken0\"
+                                TestHeader: name2=\"sanitizedtoken1\";$Domain=\"https://example0/\"
+                                """)));
     }
 
     @Test
@@ -176,7 +193,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
                 sb.toString(),
                 is(
                         equalTo(
-                                "\n[{\"user\":\"token0\",\"password\":\"token1\"},{\"xxx\":\"token2\"}]\n")));
+                                "\n[{\"user\":\"sanitizedtoken0\",\"password\":\"sanitizedtoken1\"},{\"xxx\":\"sanitizedtoken2\"}]\n")));
     }
 
     @Test
@@ -195,7 +212,7 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         adc.appendPostData(new HttpMessage(header, body), true, sb);
 
         // Then
-        assertThat(sb.toString(), is(equalTo("\naaa=token0&ccc=token1&\n")));
+        assertThat(sb.toString(), is(equalTo("\naaa=sanitizedtoken0&ccc=sanitizedtoken1&\n")));
     }
 
     @Test
@@ -266,7 +283,9 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         adc.appendSanitisedHeaders(header, "ThisHeader", sb);
 
         // Then
-        assertThat(sb.toString(), is(equalTo("ThisHeader: token0\nThisHeader: token1\n")));
+        assertThat(
+                sb.toString(),
+                is(equalTo("ThisHeader: sanitizedtoken0\nThisHeader: sanitizedtoken1\n")));
     }
 
     @Test
@@ -279,7 +298,9 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         Object res = adc.sanitiseJson(json);
 
         // Then
-        assertThat(res.toString(), is(equalTo("{\"user\":\"token0\",\"password\":\"token1\"}")));
+        assertThat(
+                res.toString(),
+                is(equalTo("{\"user\":\"sanitizedtoken0\",\"password\":\"sanitizedtoken1\"}")));
     }
 
     @Test
@@ -292,6 +313,8 @@ class AuthDiagnosticCollectorUnitTest extends TestUtils {
         Object res = adc.sanitiseJson(json);
 
         // Then
-        assertThat(res.toString(), is(equalTo("[{\"user\":\"token0\",\"password\":\"token1\"}]")));
+        assertThat(
+                res.toString(),
+                is(equalTo("[{\"user\":\"sanitizedtoken0\",\"password\":\"sanitizedtoken1\"}]")));
     }
 }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/DiagnosticDataLoader.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/DiagnosticDataLoader.java
@@ -1,0 +1,100 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.List;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+
+public class DiagnosticDataLoader {
+
+    public static List<HttpMessage> loadTestData(File file) throws Exception {
+        List<HttpMessage> messages = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line;
+            HttpMessage currentMessage = null;
+            StringBuilder headerBuilder = new StringBuilder();
+            StringBuilder bodyBuilder = new StringBuilder();
+            boolean isResponse = false;
+            boolean isHeader = true;
+
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(">>>>>")) {
+                    // Start/end of the request
+                    if (currentMessage != null) {
+                        // Save previous message
+                        if (!headerBuilder.isEmpty()) {
+                            currentMessage.setResponseHeader(
+                                    new HttpResponseHeader(headerBuilder.toString()));
+                        }
+                        if (!bodyBuilder.isEmpty()) {
+                            currentMessage.setResponseBody(bodyBuilder.toString());
+                            currentMessage
+                                    .getResponseHeader()
+                                    .setContentLength(currentMessage.getResponseBody().length());
+                        }
+                        messages.add(currentMessage);
+                    }
+                    // Start new request message
+                    currentMessage = new HttpMessage();
+                    headerBuilder.setLength(0);
+                    bodyBuilder.setLength(0);
+                    isHeader = true;
+                    isResponse = false;
+                } else if (line.startsWith("<<<")) {
+                    // Start of the response
+                    currentMessage.setRequestHeader(
+                            new HttpRequestHeader(headerBuilder.toString()));
+                    if (!bodyBuilder.isEmpty()) {
+                        currentMessage.setRequestBody(bodyBuilder.toString());
+                        currentMessage
+                                .getRequestHeader()
+                                .setContentLength(currentMessage.getRequestBody().length());
+                    }
+                    isResponse = true;
+                    headerBuilder.setLength(0);
+                    bodyBuilder.setLength(0);
+                } else if (line.isEmpty()) {
+                    if (isHeader) {
+                        isHeader = false;
+                    }
+                } else {
+                    if (isHeader) {
+                        if (headerBuilder.length() == 0 && !isResponse) {
+                            headerBuilder.append(line).append(" HTTP/1.1 \r\n");
+                        } else {
+                            headerBuilder.append(line).append("\r\n");
+                        }
+
+                    } else {
+                        bodyBuilder.append(line).append("\n");
+                    }
+                }
+            }
+        }
+        return messages;
+    }
+}

--- a/addOns/authhelper/src/test/resources/org/zaproxy/addon/authhelper/internal/bodgeit.diags
+++ b/addOns/authhelper/src/test/resources/org/zaproxy/addon/authhelper/internal/bodgeit.diags
@@ -1,0 +1,22 @@
+>>>>>
+GET https://example0/login.jsp
+<<<
+HTTP/1.1 200 
+content-type: text/html;charset=UTF-8
+set-cookie: JSESSIONID=sanitizedtoken0
+>>>>>
+POST https://example0/login.jsp
+content-type: application/x-www-form-urlencoded
+cookie: JSESSIONID="sanitizedtoken0"
+
+password=F4keP4ssw0rd&username=FakeUserName@example.com&
+<<<
+HTTP/1.1 200 
+content-type: text/html;charset=UTF-8
+>>>>>
+GET https://example0/login.jsp
+cookie: JSESSIONID="sanitizedtoken0"
+<<<
+HTTP/1.1 200 
+content-type: text/html;charset=UTF-8
+>>>>>


### PR DESCRIPTION
## Overview
* Only include proxied requests in auth tester diags - the rest are just noise
* Increase the length of the tokens, so we can detect them as tokens in unit tests
* Include creds as special tokens in auth diags
* Simple test infra so we can use auth daigs in unit tests

## Related Issues
Specify any related issues or pull requests by linking to them.

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
