### PR TITLE
authhelper: Expose Client Script Auth via the API

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace credentials with special tokens.
 
 ### Fixed
+- Allow the Client Script Authentication, and Browser Based Authentication method types as well as Header Based Session Management to be configured via the API.
 - Bug where some of the data structures were not being reset when the session changed.
 
 ## [0.23.0] - 2025-03-04

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -59,6 +59,7 @@ import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.authentication.AuthenticationMethodType;
 import org.zaproxy.zap.authentication.GenericAuthenticationCredentials;
 import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType;
+import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.zest.ZestAuthenticationRunner;
@@ -78,6 +79,7 @@ import org.zaproxy.zest.core.v1.ZestStatement;
 public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthenticationMethodType {
 
     public static final int METHOD_IDENTIFIER = 8;
+    private static final String API_METHOD_NAME = "clientScriptBasedAuthentication";
 
     private static final Logger LOGGER =
             LogManager.getLogger(ClientScriptBasedAuthenticationMethodType.class);
@@ -737,5 +739,12 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
             sList.add(o.toString());
         }
         return sList;
+    }
+
+    @Override
+    public ApiDynamicActionImplementor getSetMethodForContextApiAction() {
+        ApiDynamicActionImplementor impl = super.getSetMethodForContextApiAction();
+        impl.setName(API_METHOD_NAME);
+        return impl;
     }
 }


### PR DESCRIPTION
## Overview
Allow the Client Script Authentication method type to be exposed and configured via the API.

Confirmed via the Web API UI (w/ zaproxy/zaproxy#8885) that it is listed separately and configurable.

## Related Issues
N/A

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
