### PR TITLE
authhelper: use DB details and close on notify

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Use TOTP data defined under user credentials for Client Script and Browser Based Authentication, when available.
+- Maintenance changes.
 
 ## [0.24.0] - 2025-03-21
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ExtensionAuthhelper.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ExtensionAuthhelper.java
@@ -110,6 +110,7 @@ public class ExtensionAuthhelper extends ExtensionAdaptor {
 
     private AuthDiagnosticCollector authDiagCollector;
     private AuthhelperParam param;
+    private TableJdo tableJdo;
 
     public ExtensionAuthhelper() {
         super();
@@ -194,6 +195,13 @@ public class ExtensionAuthhelper extends ExtensionAdaptor {
     public void stop() {
         BrowserBasedAuthenticationMethodType.stopProxies();
         AuthUtils.clean();
+    }
+
+    @Override
+    public void destroy() {
+        if (tableJdo != null) {
+            tableJdo.unload();
+        }
     }
 
     @Override
@@ -382,9 +390,7 @@ public class ExtensionAuthhelper extends ExtensionAdaptor {
     @Override
     public void databaseOpen(Database db) throws DatabaseException, DatabaseUnsupportedException {
         try {
-            TableJdo table = new TableJdo();
-            db.addDatabaseListener(table);
-            table.databaseOpen(db.getDatabaseServer());
+            tableJdo = new TableJdo(db);
 
         } catch (Exception e) {
             LOGGER.warn(e.getMessage(), e);

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/db/TableJdo.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/db/TableJdo.java
@@ -19,60 +19,142 @@
  */
 package org.zaproxy.addon.authhelper.internal.db;
 
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
 import javax.jdo.Constants;
 import javax.jdo.JDOHelper;
 import javax.jdo.PersistenceManagerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.datanucleus.PropertyNames;
 import org.flywaydb.core.Flyway;
+import org.parosproxy.paros.db.Database;
 import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.db.DatabaseListener;
 import org.parosproxy.paros.db.DatabaseServer;
-import org.parosproxy.paros.db.DatabaseUnsupportedException;
-import org.parosproxy.paros.db.paros.ParosAbstractTable;
+import org.parosproxy.paros.db.paros.ParosDatabaseServer;
 
-public class TableJdo extends ParosAbstractTable {
+public class TableJdo implements DatabaseListener {
 
-    private static final String USER = "sa";
+    private static final Logger LOGGER = LogManager.getLogger(TableJdo.class);
+
+    private static Method getUrlMethod;
+    private static Method getUserMethod;
+    private static Method getPasswordMethod;
 
     private static PersistenceManagerFactory pmf;
 
+    private final Database db;
+
+    static {
+        try {
+            Class<?> dbServerClass = Class.forName("org.parosproxy.paros.db.DatabaseServer");
+            getUrlMethod = dbServerClass.getMethod("getUrl");
+            getUserMethod = dbServerClass.getMethod("getUser");
+            getPasswordMethod = dbServerClass.getMethod("getPassword");
+
+        } catch (Exception e) {
+            LOGGER.debug("An error occurred while getting the methods:", e);
+        }
+    }
+
+    public TableJdo(Database db) throws DatabaseException {
+        this.db = db;
+
+        db.addDatabaseListener(this);
+        databaseOpen(db.getDatabaseServer());
+    }
+
     @Override
-    public void databaseOpen(DatabaseServer server)
-            throws DatabaseException, DatabaseUnsupportedException {
+    public void databaseOpen(DatabaseServer db) throws DatabaseException {
+        if (getUrlMethod == null) {
+            closing(db);
+        }
+
+        String dbUrl = getUrl(db);
+        String user = getUser(db);
+        String password = getPassword(db);
+        ClassLoader classLoader = this.getClass().getClassLoader();
+        Flyway.configure(classLoader)
+                .table("AUTHHELPER_FLYWAY_SCHEMA_HISTORY")
+                .baselineOnMigrate(true)
+                .baselineVersion("0")
+                .dataSource(dbUrl, user, password)
+                .load()
+                .migrate();
+
+        Properties jdoProperties = new Properties();
+        jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_URL, dbUrl);
+        jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_USER_NAME, user);
+        jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_PASSWORD, password);
+
+        jdoProperties.put(PropertyNames.PROPERTY_CLASSLOADER_PRIMARY, classLoader);
+
+        pmf = JDOHelper.getPersistenceManagerFactory(jdoProperties, "authhelper", classLoader);
+    }
+
+    private static String getUrl(DatabaseServer db) throws DatabaseException {
+        try {
+            if (getUrlMethod != null) {
+                return (String) getUrlMethod.invoke(db);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("An error occurred while getting the URL:", e);
+        }
+
+        try (Connection connection = getConnection(db)) {
+            return connection.getMetaData().getURL();
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
+    }
+
+    private static Connection getConnection(DatabaseServer db) throws SQLException {
+        if (db instanceof ParosDatabaseServer pds) {
+            return pds.getNewConnection();
+        }
+        if (db instanceof ParosDatabaseServer pds) {
+            return pds.getNewConnection();
+        }
+        throw new SQLException("Unknown DB implementation");
+    }
+
+    private static String getUser(DatabaseServer db) {
+        try {
+            if (getUserMethod != null) {
+                return (String) getUserMethod.invoke(db);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("An error occurred while getting the user:", e);
+        }
+
+        return "sa";
+    }
+
+    private static String getPassword(DatabaseServer db) {
+        try {
+            if (getPasswordMethod != null) {
+                return (String) getPasswordMethod.invoke(db);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("An error occurred while getting the password:", e);
+        }
+
+        return "";
+    }
+
+    // @Override
+    public void closing(DatabaseServer db) {
         if (pmf != null) {
             pmf.close();
             pmf = null;
         }
-
-        super.databaseOpen(server);
     }
 
-    @Override
-    protected void reconnect(Connection conn) throws DatabaseException {
-        try {
-            String dbUrl = conn.getMetaData().getURL();
-            ClassLoader classLoader = this.getClass().getClassLoader();
-            Flyway.configure(classLoader)
-                    .table("AUTHHELPER_FLYWAY_SCHEMA_HISTORY")
-                    .baselineOnMigrate(true)
-                    .baselineVersion("0")
-                    .dataSource(dbUrl, USER, "")
-                    .load()
-                    .migrate();
-
-            Properties jdoProperties = new Properties();
-            jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_URL, dbUrl);
-            jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_USER_NAME, USER);
-
-            jdoProperties.put(PropertyNames.PROPERTY_CLASSLOADER_PRIMARY, classLoader);
-
-            pmf = JDOHelper.getPersistenceManagerFactory(jdoProperties, "authhelper", classLoader);
-
-        } catch (SQLException e) {
-            throw new DatabaseException(e);
-        }
+    public void unload() {
+        db.removeDatabaseListener(this);
     }
 
     public static PersistenceManagerFactory getPmf() {


### PR DESCRIPTION
Change to use the new core changes, if available, which allow to remove hardcoded DB details and to properly free resources.