### PR TITLE
automation: correct default value for client auth

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Progress and log messages with regard to setting scan rule threshold or strength no longer include commas in scan rule ID numbers.
 
+### Fixed
+- Address exception when loading Client Script authentication method.
+
 ## [0.48.0] - 2025-03-04
 ### Changed
 - Allow to use variables for the TOTP data.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AuthenticationData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AuthenticationData.java
@@ -452,7 +452,7 @@ public class AuthenticationData extends AutomationData {
                             JobUtils.setPrivateField(
                                     clientScriptMethod,
                                     "diagnostics",
-                                    parameters.getOrDefault(PARAM_DIAGNOSTICS, "false"));
+                                    parameters.getOrDefault(PARAM_DIAGNOSTICS, false));
 
                             try {
                                 MethodUtils.invokeMethod(clientScriptMethod, "loadScript", sw);


### PR DESCRIPTION
Use boolean for the diagnostics default value of the Client Script authentication.