### PR TITLE
authhelper: Skip disabled steps when creating context from Auth Tester

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace credentials with special tokens.
 - Rewrite of the auth request detection code to handle more cases.
 - Add domain to context if creds posted to it and using using auto-detect for session management.
+- Skip disabled authentication steps when creating the context from the Authentication Tester dialog.
 
 ### Fixed
 - Allow the Client Script Authentication, and Browser Based Authentication method types as well as Header Based Session Management to be configured via the API.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthTestDialog.java
@@ -44,6 +44,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.authhelper.AutoDetectSessionManagementMethodType.AutoDetectSessionManagementMethod;
 import org.zaproxy.addon.authhelper.BrowserBasedAuthenticationMethodType.BrowserBasedAuthenticationMethod;
+import org.zaproxy.addon.authhelper.internal.AuthenticationStep;
 import org.zaproxy.addon.authhelper.internal.StepsPanel;
 import org.zaproxy.addon.pscan.ExtensionPassiveScan2;
 import org.zaproxy.zap.ZAP;
@@ -288,7 +289,8 @@ public class AuthTestDialog extends StandardFieldsDialog {
             String browserId = ((BrowserUI) browserCombo.getSelectedItem()).getBrowser().getId();
             am.setBrowserId(browserId);
             am.setLoginPageWait(this.getIntValue(WAIT_LABEL));
-            am.setAuthenticationSteps(stepsPanel.getSteps());
+            am.setAuthenticationSteps(
+                    stepsPanel.getSteps().stream().filter(AuthenticationStep::isEnabled).toList());
             reloadAuthenticationMethod(am);
             context.setAuthenticationMethod(am);
 


### PR DESCRIPTION
## Overview
When saving an Automation Plan based on BBA with custom steps only enabled steps are included.

## Related Issues
n/a

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
