### PR TITLE
spiderAjax: only count URLs in scope

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Only count processed URLs. Browsers can make lots of background requests which distort the numbers.
+
 ## [23.22.0] - 2025-01-10
 ### Added
 - Option to enable browser extensions added by other add-ons, previously they were always enabled but now the default is false.

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -444,7 +444,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
     public void foundMessage(
             HistoryReference historyReference, HttpMessage httpMessage, ResourceState state) {
         boolean added = addHistoryUrl(historyReference, httpMessage, targetSite, state);
-        if (View.isInitialised() && added) {
+        if (View.isInitialised() && state == ResourceState.PROCESSED && added) {
             foundCount++;
             this.foundLabel.setText(Integer.toString(this.foundCount));
         }

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
@@ -50,6 +50,7 @@ import org.zaproxy.zap.extension.spiderAjax.AjaxSpiderParamElem;
 import org.zaproxy.zap.extension.spiderAjax.AjaxSpiderTarget;
 import org.zaproxy.zap.extension.spiderAjax.ExtensionAjax;
 import org.zaproxy.zap.extension.spiderAjax.SpiderListener;
+import org.zaproxy.zap.extension.spiderAjax.SpiderListener.ResourceState;
 import org.zaproxy.zap.extension.spiderAjax.SpiderThread;
 import org.zaproxy.zap.extension.spiderAjax.internal.ExcludedElement;
 import org.zaproxy.zap.users.User;
@@ -444,7 +445,9 @@ public class AjaxSpiderJob extends AutomationJob {
         @Override
         public void foundMessage(
                 HistoryReference historyReference, HttpMessage httpMessage, ResourceState state) {
-            messagesFound++;
+            if (state == ResourceState.PROCESSED) {
+                messagesFound++;
+            }
         }
 
         @Override


### PR DESCRIPTION
## Overview
Only count URLs that are in scope. Browsers can make lots of background requests which distort the numbers.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
