### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Use TOTP data defined under user credentials during authentication when available.
+- Update Zest library to 0.25.0:
+  - Update Selenium to version 4.30.0.
 
 ## [48.4.0] - 2025-02-27
 ### Changed

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     zapAddOn("scripts")
     zapAddOn("selenium")
 
-    api("org.zaproxy:zest:0.24.0") {
+    api("org.zaproxy:zest:0.25.0") {
         // Provided by commonlib add-on.
         exclude(group = "com.fasterxml.jackson.core")
         exclude(group = "com.fasterxml.jackson.dataformat")


### PR DESCRIPTION
Update Zest library to 0.25.0:
 - Update Selenium to version 4.30.0.