### PR TITLE
scripts: Fix NPE when using some scripts after reinstall

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- NPE when using some scripts after re-installing the scripts add-on.
 
 ## [45.9.0] - 2025-03-25
 ### Fixed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -664,7 +664,11 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     public void scriptChanged(ScriptWrapper script) {
         if (hasView()) {
             getConsolePanel().updateButtonStates();
-            if (!script.getName().equals(outputSources.get(script).getName())) {
+            if (outputSources.get(script) == null) {
+                // We don't know about this script, register it
+                registerScriptOutputSource(script);
+            } else if (!script.getName().equals(outputSources.get(script).getName())) {
+                // The script was renamed, re-register it with the new name
                 unregisterScriptOutputSource(script);
                 registerScriptOutputSource(script);
             }


### PR DESCRIPTION
## Overview
Fix NPE when using some scripts after re-installing the scripts add-on.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
