### PR TITLE
automation & pscan: Suppress commas in rule IDs, and minor tweaks

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Correctly handle missing script engines.
 
+### Changed
+- Adjusted further dialog, progress, and log messages with regard to preventing inclusion of commas in scan rule ID numbers. As well as ensuring consistency in use of ID (full caps) for table column headings, and the Add Add-ons dialog.
+
 ## [0.49.0] - 2025-03-25
 ### Added
 - Document how the TOTP data is defined for a user.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PolicyDefinition.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PolicyDefinition.java
@@ -109,7 +109,9 @@ public class PolicyDefinition extends AutomationData {
                         } else {
                             progress.warn(
                                     Constant.messages.getString(
-                                            "automation.error.ascan.rule.unknown", jobName, id));
+                                            "automation.error.ascan.rule.unknown",
+                                            jobName,
+                                            String.valueOf(id)));
                         }
                     }
                 }

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -9,7 +9,7 @@ automation.cmdline.out.template = Writing template to {0}
 
 automation.desc = Provides functionality to simplify using ZAP in an automated manner
 
-automation.dialog.addaddon.id = Add-On Id:
+automation.dialog.addaddon.id = Add-On ID:
 automation.dialog.addaddon.title = Add-On
 
 automation.dialog.addjob.title = Add Job
@@ -79,7 +79,7 @@ automation.dialog.ascan.summary = Context: {0}
 automation.dialog.ascan.tab.adv = Advanced
 automation.dialog.ascan.tab.policydefaults = Policy Defaults
 automation.dialog.ascan.tab.policyrules = Policy Rules
-automation.dialog.ascan.table.header.id = Id
+automation.dialog.ascan.table.header.id = ID
 automation.dialog.ascan.table.header.name = Name
 automation.dialog.ascan.table.header.strength = Strength
 automation.dialog.ascan.table.header.threshold = Threshold
@@ -142,7 +142,7 @@ automation.dialog.contexts.table.header.name = Name
 
 automation.dialog.default = Default
 
-automation.dialog.delay.error.time = Invalid time: must be of the format hh:mm:ss, mm:ss or ss
+automation.dialog.delay.error.time = Invalid time: must be of the format hh:mm:ss, mm:ss, or ss
 automation.dialog.delay.fileName = File Name: 
 automation.dialog.delay.summary = Time: {0} file name: {1}
 automation.dialog.delay.time = Time:
@@ -286,7 +286,7 @@ automation.env.name = Environment
 automation.error.addons.deprecated = The addOns job no longer does anything and should be removed, see https://www.zaproxy.org/docs/desktop/addons/automation-framework/job-addons/
 
 automation.error.ascan.policy.name = Unrecognised active scan policy name for job {0} : {1}
-automation.error.ascan.rule.unknown = Unrecognised active scan rule id for job {0} : {1}
+automation.error.ascan.rule.unknown = Unrecognised active scan rule ID for job {0} : {1}
 automation.error.ascan.strength = Invalid strength for job {0} : {1}
 automation.error.ascan.threshold = Invalid threshold for job {0} : {1}
 

--- a/addOns/pscan/CHANGELOG.md
+++ b/addOns/pscan/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Adjusted further dialog, progress, and log messages with regard to preventing inclusion of commas in scan rule ID numbers. As well as ensuring consistency in use of ID (full caps) for table column headings.
 
 ## [0.2.1] - 2025-03-25
 ### Fixed

--- a/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/automation/jobs/PassiveScanConfigJob.java
+++ b/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/automation/jobs/PassiveScanConfigJob.java
@@ -134,7 +134,7 @@ public class PassiveScanConfigJob extends AutomationJob {
                                     Constant.messages.getString(
                                             "pscan.automation.error.pscan.rule.unknown",
                                             this.getName(),
-                                            id));
+                                            String.valueOf(id)));
                             continue;
                         }
                         AlertThreshold pluginTh =

--- a/addOns/pscan/src/main/resources/org/zaproxy/addon/pscan/resources/Messages.properties
+++ b/addOns/pscan/src/main/resources/org/zaproxy/addon/pscan/resources/Messages.properties
@@ -43,7 +43,7 @@ pscan.automation.dialog.pscanconfig.remove.confirm = Are you sure you want to re
 pscan.automation.dialog.pscanconfig.scanonlyinscope = Scan Only in Scope:
 pscan.automation.dialog.pscanconfig.summary = Rule Count: {0}
 pscan.automation.dialog.pscanconfig.tab.rules = Rules
-pscan.automation.dialog.pscanconfig.table.header.id = Id
+pscan.automation.dialog.pscanconfig.table.header.id = ID
 pscan.automation.dialog.pscanconfig.table.header.name = Name
 pscan.automation.dialog.pscanconfig.table.header.threshold = Threshold
 pscan.automation.dialog.pscanconfig.title = Passive Scan Config Job
@@ -59,9 +59,9 @@ pscan.automation.error.nofile = Cannot access file: {0}
 pscan.automation.error.options.badint = Invalid value for job {0} parameter {1} - {2} should be an integer
 pscan.automation.error.options.badlist = Invalid value for job {0} parameter {1} - {2} should be a list
 pscan.automation.error.pscan.nooptions = Failed to access passive scan options for job {0}
-pscan.automation.error.pscan.rule.unknown = Unrecognised passive scan rule id for job {0} : {1}
+pscan.automation.error.pscan.rule.unknown = Unrecognised passive scan rule ID for job {0} : {1}
 
-pscan.automation.info.pscan.rule.noid = Job {0} ignoring rule with no id 
+pscan.automation.info.pscan.rule.noid = Job {0} ignoring rule with no ID 
 pscan.automation.info.pscan.rule.setthreshold = Job {0} set rule {1} threshold to {2}
 
 pscan.ext.automation.desc = Provides jobs and result data related to the passive scanner.


### PR DESCRIPTION
## Overview

- Use "ID" more consistently.
- Use oxford/serial comma where practical. (I didn't go hunting for these, I just changed one I noticed along the way.)
- Prevent dialogs/progress messages from putting commas in rule IDs.

Edit: Forgot to include screenshot that lead to this.
![image](https://github.com/user-attachments/assets/4206d0bc-894f-4c66-9181-b3a08c2770e0)

## Related Issues

- zaproxy/zap-extensions#6257
- zaproxy/zaproxy#7700

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
