### PR TITLE
spider: ignore irrelevant parameters in bodies

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Include anti-csrf tokens as part of irrelevant parameters.
+- Ignore irrelevant parameters in request bodies (`x-www-form-urlencoded`) (Related to Issue 7771).
 
 ## [0.14.0] - 2025-03-25
 ### Changed

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/options.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/options.html
@@ -132,9 +132,13 @@
 	according to the rule defined by the "Query parameters handling" option.
 
 	<h3>Irrelevant Parameters</h3>
-	Allows to manage the parameters that should be removed when canonicalising the URLs found.
+	Allows to manage the parameters that should be removed when canonicalising the URLs found or request bodies generated (<code>x-www-form-urlencoded</code>).
 	<p>
-	The session names defined in the HTTP Sessions options are taken into account and removed.
+	The parameters with names matching the following are automatically considered irrelevant:
+	<ul>
+		<li>Session names defined in the HTTP Sessions options.
+		<li>Token names defined in the Anti-CSRF Tokens options.
+	</ul>
 
 	<h2>See also</h2>
 	<table>


### PR DESCRIPTION
Ignore the irrelevant parameters in the request bodies of type `x-www-form-urlencoded`.
Include anti-csrf tokens in the irrelevant parameters.

Related to zaproxy/zaproxy#7771.