### PR TITLE
ascanrules: 500 response to an SQLi attack

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- SQL Injection scan rule to treat a 500 response to an SQLi attack as a likely vulnerability.
 
 ## [71] - 2025-03-04
 ### Fixed


### PR DESCRIPTION
## Overview
SQL Injection scan rule to treat a 500 response to an SQLi attack as a likely vulnerability.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
