### PR TITLE
automation: properly handle missing script engine

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correctly handle missing script engines.
 
 ## [0.49.0] - 2025-03-25
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -631,7 +632,7 @@ public class JobUtils {
             }
             if (wrapper == null) {
                 // Register the script
-                ScriptEngineWrapper engineWrapper = extScript.getEngineWrapper(engineName);
+                ScriptEngineWrapper engineWrapper = getEngineWrapper(extScript, engineName);
                 if (engineWrapper == null) {
                     progress.error(
                             Constant.messages.getString(
@@ -661,6 +662,14 @@ public class JobUtils {
             }
         }
         return wrapper;
+    }
+
+    private static ScriptEngineWrapper getEngineWrapper(ExtensionScript extension, String name) {
+        try {
+            return extension.getEngineWrapper(name);
+        } catch (InvalidParameterException e) {
+            return null;
+        }
     }
 
     public static File getFile(String name, AutomationPlan plan) {

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.withSettings;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -378,7 +379,8 @@ class JobUtilsUnitTest extends TestUtils {
         File file = new File("/script.ext");
         String type = "type";
         String engineName = "engine";
-        given(extensionScript.getEngineWrapper(engineName)).willReturn(null);
+        given(extensionScript.getEngineWrapper(engineName))
+                .willThrow(InvalidParameterException.class);
         AutomationProgress progress = mock(AutomationProgress.class);
         // When
         ScriptWrapper obtainedScriptWrapper =


### PR DESCRIPTION
Catch the exception thrown when the engine is missing.
Update test to match the actual behaviour (throw exception instead of returning null).

---
e.g.:
```
20848718 [ZAP-Automation] ERROR org.zaproxy.zap.ZAP.UncaughtExceptionLogger - Exception in thread "ZAP-Automation"
java.security.InvalidParameterException: No such engine: XYZ
	at org.zaproxy.zap.extension.script.ExtensionScript.getEngineWrapper(ExtensionScript.java:471) ~[main/:?]
	at org.zaproxy.addon.automation.jobs.JobUtils.getScriptWrapper(JobUtils.java:634) ~[?:?]
	at org.zaproxy.addon.automation.AuthenticationData.initContextAuthentication(AuthenticationData.java:432) ~[?:?]
	at org.zaproxy.addon.automation.ContextWrapper.createContext(ContextWrapper.java:397) ~[?:?]
	at org.zaproxy.addon.automation.AutomationEnvironment.create(AutomationEnvironment.java:174) ~[?:?]
	at org.zaproxy.addon.automation.ExtensionAutomation.runPlan(ExtensionAutomation.java:369) ~[?:?]
	at org.zaproxy.addon.automation.ExtensionAutomation.lambda$runPlanAsync$4(ExtensionAutomation.java:437) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```