### PR TITLE
automation: remove unused resource message

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Maintenance changes.
+
 ### Fixed
 - Correctly handle missing script engines.
 

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -462,7 +462,6 @@ automation.tests.error.badonfail = Job {0} test of type {1}: invalid onFail {2}
 automation.tests.fail = Job {0} test of type {1} failed: {2} [{3}]
 automation.tests.invalidOnFail = Cannot create test {0}: Invalid onFail value {1}
 automation.tests.invalidType = Unknown test type {0}
-automation.tests.missingOrInvalidProperties = Job {0} skipped a test of type '{1}' with missing or invalid properties
 automation.tests.monitor.error.nostatistic = Job ''{1}'' test of type ''{0}'' missing statistic
 automation.tests.monitor.error.nothreshold = Job ''{1}'' test of type ''{0}'' missing threshold
 automation.tests.monitor.nullInMemoryStats = Job ''{0}'' in memory stats haven't been initialised, monitor tests may give unexpected results


### PR DESCRIPTION
The message is no longer in use by the code (zaproxy/zap-extensions@6ed20d63dd4aa3471536b8d0b85c4c3ae4514949).