### PR TITLE
zest: Extend ScriptNode to ignore core exception

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [48.5.0] - 2025-03-25
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptNode.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptNode.java
@@ -1,0 +1,44 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest;
+
+import org.zaproxy.zap.extension.script.ScriptNode;
+
+@SuppressWarnings("serial")
+public class ZestScriptNode extends ScriptNode {
+
+    public ZestScriptNode() {
+        super();
+    }
+
+    public ZestScriptNode(String name) {
+        super(name);
+    }
+
+    @Override
+    public Object getUserObject() {
+        return this.userObject;
+    }
+
+    @Override
+    public void setUserObject(Object userObject) {
+        this.userObject = userObject;
+    }
+}

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeModel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeModel.java
@@ -65,7 +65,7 @@ public class ZestTreeModel {
     }
 
     private ScriptNode getZestNode(ZestElement ze, int shadowLevel) {
-        ScriptNode zestNode = new ScriptNode(ZestZapUtils.toUiString(ze, true, shadowLevel));
+        ScriptNode zestNode = new ZestScriptNode(ZestZapUtils.toUiString(ze, true, shadowLevel));
         zestNode.setUserObject(new ZestElementWrapper(ze, shadowLevel));
         return zestNode;
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.network.HttpStatusCode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
+import org.zaproxy.zap.extension.zest.ZestScriptNode;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
@@ -104,7 +105,7 @@ public class ZestRequestDialog extends StandardFieldsDialog implements ZestDialo
     public void init(ScriptNode parent, ScriptNode node) {
         this.parent = parent;
         if (node == null) {
-            this.node = new ScriptNode();
+            this.node = new ZestScriptNode();
             request = new ZestRequest();
             this.node.setUserObject(request);
             add = true;


### PR DESCRIPTION
See https://github.com/zaproxy/zaproxy/pull/8912.

For now, the new class is simply overriding the userObject getter and setter to avoid running into the exception added in the above PR. However, we can probably add dedicated getters/setters for the userObject types used by zest for cleaner code in the consumers of this class.