### PR TITLE
scripts: Fix wrong key name

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [45.11.0] - 2025-04-11
 ### Fixed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -464,7 +464,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
                     .setScriptTooltip(
                             script.getEngine().isTextBased()
                                     ? null
-                                    : Constant.messages.getString("scripts.welcome.nontest"));
+                                    : Constant.messages.getString("scripts.welcome.nontext"));
         }
     }
 

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -226,5 +226,5 @@ scripts.type.extender.desc = Extender scripts add new functionality, including g
 scripts.warn.missing.engine = Script Engine "{0}" not available, the script will not run until the engine is installed.
 
 scripts.welcome.cmd = To get started click the Scroll with a plus icon (New Script...) in the Scripts tab on the left hand side.\nOr you can right click on a script template and choose New Script...\nScript output is shown in the main "Output" panel, with each script getting its own tab.\n\n
-scripts.welcome.nontest = This is a graphical script that can only be edited via the Scripts tab on the left hand side.\n\n
+scripts.welcome.nontext = This is a graphical script that can only be edited via the Scripts tab on the left hand side.\n\n
 scripts.welcome.results = Welcome to the ZAP Scripting Console\n\nFor more details see the Help pages.\n\nWARNING - scripts run with the same permissions as ZAP, so do not run any scripts that you do not trust!\n\n


### PR DESCRIPTION
## Overview
Fix key name "test" ➡️ "text" mistake.

## Related Issues
- zaproxy/zap-extensions#6343
