### PR TITLE
zest: allow to copy script path

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Allow to copy the script's file system path from the Edit Zest Script dialogue.
 
 ## [48.5.0] - 2025-03-25
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.swing.JButton;
-import javax.swing.JLabel;
+import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 import javax.swing.JTable;
 import org.apache.logging.log4j.LogManager;
@@ -161,7 +161,7 @@ public class ZestScriptsDialog extends StandardFieldsDialog {
                                     .getI18nKey()),
                     false);
         }
-        this.addReadOnlyField(0, FIELD_FILE, "", false);
+        this.addTextFieldReadOnly(0, FIELD_FILE, "");
         this.addComboField(0, FIELD_PREFIX, this.getSites(), script.getPrefix(), true);
         this.addCheckBoxField(0, FIELD_LOAD, scriptWrapper.isLoadOnStart());
         this.addMultilineField(0, FIELD_DESC, script.getDescription());
@@ -170,7 +170,7 @@ public class ZestScriptsDialog extends StandardFieldsDialog {
         if (scriptWrapper.getFile() != null) {
             this.setFieldValue(FIELD_FILE, scriptWrapper.getFile().getAbsolutePath());
             // Add tooltip in case file name is longer than the dialog
-            ((JLabel) this.getField(FIELD_FILE))
+            ((JComponent) this.getField(FIELD_FILE))
                     .setToolTipText(scriptWrapper.getFile().getAbsolutePath());
         }
         this.getParamsModel().setValues(script.getParameters().getVariables());


### PR DESCRIPTION
Change the file field from a label to a read only text field to allow to copy it (e.g. to paste it in an Automation Framework plan).