### PR TITLE
Zest: fix print statements output

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Print statements should print to the relevant script Output tab.
+
 ### Changed
 - Allow to copy the script's file system path from the Edit Zest Script dialogue.
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -87,6 +87,7 @@ public class ZestScriptWrapper extends ScriptWrapper {
         this.setFile(script.getFile());
         this.setLoadOnStart(script.isLoadOnStart());
         this.setChanged(script.isChanged());
+        this.setWriter(script.getWriter());
     }
 
     public boolean isIncStatusCodeAssertion() {


### PR DESCRIPTION
## Overview
Run a Zest script with a "print" statement - without this fix the output is not shown anywhere, let alone in the right Output tab.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
