### PR TITLE
authhelper: warn of browser absence in CSA script

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Warn when the recorded script used with Client Script Based Authentication does not launch a browser.
+
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.
 - Fix loading/saving of Client Script Based Authentication through the GUI.


### PR DESCRIPTION
Warn and stop the authentication otherwise this will lead to exceptions when attempting to use the non-launched browser.