### PR TITLE
network: Make all default Global Exclude patterns case insensitive & minor tweaks

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - A typo in the help with regard to Transparent Proxying.
 
+### Changed
+- Default Global Exclusions patterns:
+    - All case insensitive (Issue 8930).
+    - Fix a naming mistake in "ExtParam - .NET adx resources (SR/WR.adx?d=)" adx should have been axd.
+    - Extend Image related patterns to include svg and webp.
+    - Extend Audio/Video patterns to include webm.
+
 ## [0.21.0] - 2025-03-04
 ### Fixed
 - Ensure message properties are kept mutable even in case of connection close.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/GlobalExclusionsOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/GlobalExclusionsOptions.java
@@ -35,7 +35,7 @@ public class GlobalExclusionsOptions extends VersionedAbstractParam {
 
     private static final Logger LOGGER = LogManager.getLogger(GlobalExclusionsOptions.class);
 
-    protected static final int CURRENT_CONFIG_VERSION = 1;
+    protected static final int CURRENT_CONFIG_VERSION = 2;
 
     private static final String BASE_KEY = "network.globalExclusions";
 
@@ -54,112 +54,112 @@ public class GlobalExclusionsOptions extends VersionedAbstractParam {
             List.of(
                     new GlobalExclusion(
                             "Extension - Image (ends with .extension)",
-                            "^.*\\.(?:gif|jpe?g|png|ico|icns|bmp)$",
+                            "(?i)^.*\\.(?:gif|jpe?g|png|ico|icns|bmp|svg|webp)$",
                             false),
                     new GlobalExclusion(
                             "Extension - Audio/Video (ends with .extension)",
-                            "^.*\\.(?:mp[34]|mpe?g|m4[ap]|aac|avi|mov|wmv|og[gav])$",
+                            "(?i)^.*\\.(?:mp[34]|mpe?g|m4[ap]|aac|avi|mov|wmv|og[gav]|webm)$",
                             false),
                     new GlobalExclusion(
                             "Extension - PDF & Office (ends with .extension)",
-                            "^.*\\.(?:pdf|docx?|xlsx?|pptx?)$",
+                            "(?i)^.*\\.(?:pdf|docx?|xlsx?|pptx?)$",
                             false),
                     new GlobalExclusion(
                             "Extension - Stylesheet, JavaScript (ends with .extension)",
-                            "^.*\\.(?:css|js)$",
+                            "(?i)^.*\\.(?:css|js)$",
                             false),
                     new GlobalExclusion(
                             "Extension - Flash & related (ends with .extension)",
-                            "^.*\\.(?:sw[fa]|flv)$",
+                            "(?i)^.*\\.(?:sw[fa]|flv)$",
                             false),
                     new GlobalExclusion(
                             "ExtParam - Image (extension plus ?params=values)",
-                            "^[^\\?]*\\.(?:gif|jpe?g|png|ico|icns|bmp)\\?.*$",
+                            "(?i)^[^\\?]*\\.(?:gif|jpe?g|png|ico|icns|bmp|svg|webp)\\?.*$",
                             false),
                     new GlobalExclusion(
                             "ExtParam - Audio/Video (extension plus ?params=values)",
-                            "^[^\\?]*\\.(?:mp[34]|mpe?g|m4[ap]|aac|avi|mov|wmv|og[gav])\\?.*$",
+                            "(?i)^[^\\?]*\\.(?:mp[34]|mpe?g|m4[ap]|aac|avi|mov|wmv|og[gav]|webm)\\?.*$",
                             false),
                     new GlobalExclusion(
                             "ExtParam - PDF & Office (extension plus ?params=values)",
-                            "^[^\\?]*\\.(?:pdf|docx?|xlsx?|pptx?)\\?.*$",
+                            "(?i)^[^\\?]*\\.(?:pdf|docx?|xlsx?|pptx?)\\?.*$",
                             false),
                     new GlobalExclusion(
                             "ExtParam - Stylesheet, JavaScript (extension plus ?params=values)",
-                            "^[^\\?]*\\.(?:css|js)\\?.*$",
+                            "(?i)^[^\\?]*\\.(?:css|js)\\?.*$",
                             false),
                     new GlobalExclusion(
                             "ExtParam - Flash & related (extension plus ?params=values)",
-                            "^[^\\?]*\\.(?:sw[fa]|flv)\\?.*$",
+                            "(?i)^[^\\?]*\\.(?:sw[fa]|flv)\\?.*$",
                             false),
                     new GlobalExclusion(
-                            "ExtParam - .NET adx resources (SR/WR.adx?d=)",
-                            "^[^\\?]*/(?:WebResource|ScriptResource)\\.axd\\?d=.*$",
+                            "ExtParam - .NET axd resources (SR/WR.axd?d=)",
+                            "(?i)^[^\\?]*/(?:WebResource|ScriptResource)\\.axd\\?d=.*$",
                             false),
                     new GlobalExclusion(
                             "Site - Bing API queries",
-                            "^https?://api\\.bing\\.com/qsml\\.aspx?query=.*$",
+                            "(?i)^https?://api\\.bing\\.com/qsml\\.aspx?query=.*$",
                             false),
                     new GlobalExclusion(
                             "Site - Google malware detector updates",
-                            "^https?://(?:safebrowsing-cache|sb-ssl|sb|safebrowsing).*\\.(?:google|googleapis)\\.com/.*$",
+                            "(?i)^https?://(?:safebrowsing-cache|sb-ssl|sb|safebrowsing).*\\.(?:google|googleapis)\\.com/.*$",
                             true),
                     new GlobalExclusion(
                             "Site - Lastpass manager",
-                            "^https?://(?:[^/])*\\.?lastpass\\.com",
+                            "(?i)^https?://(?:[^/])*\\.?lastpass\\.com",
                             false),
                     new GlobalExclusion(
                             "Site - Firefox browser updates",
-                            "^https?://(?:.*addons|aus[0-9])\\.mozilla\\.(?:org|net|com)/.*$",
+                            "(?i)^https?://(?:.*addons|aus[0-9])\\.mozilla\\.(?:org|net|com)/.*$",
                             true),
                     new GlobalExclusion(
                             "Site - Firefox extensions phoning home",
-                            "^https?://(?:[^/])*\\.?(?:getfoxyproxy\\.org|getfirebug\\.com|noscript\\.net)",
+                            "(?i)^https?://(?:[^/])*\\.?(?:getfoxyproxy\\.org|getfirebug\\.com|noscript\\.net)",
                             false),
                     new GlobalExclusion(
                             "Site - Microsoft Windows updates",
                             // http://serverfault.com/questions/332003/what-urls-must-be-in-ies-trusted-sites-list-to-allow-windows-update
-                            "^https?://(?:.*update\\.microsoft|.*\\.windowsupdate)\\.com/.*$",
+                            "(?i)^https?://(?:.*update\\.microsoft|.*\\.windowsupdate)\\.com/.*$",
                             true),
                     new GlobalExclusion(
                             "Site - Google Chrome extension updates",
-                            "^https?://clients2\\.google\\.com/service/update2/crx.*$",
+                            "(?i)^https?://clients2\\.google\\.com/service/update2/crx.*$",
                             true),
                     new GlobalExclusion(
                             "Site - Firefox captive portal detection",
-                            "^https?://detectportal\\.firefox\\.com.*$",
+                            "(?i)^https?://detectportal\\.firefox\\.com.*$",
                             true),
                     new GlobalExclusion(
                             "Site - Google Analytics",
-                            "^https?://www\\.google-analytics\\.com.*$",
+                            "(?i)^https?://www\\.google-analytics\\.com.*$",
                             false),
                     new GlobalExclusion(
                             "Site - Firefox h264 codec download",
                             // https://support.mozilla.org/t5/Firefox/Where-is-a-check-that-http-ciscobinary-openh264-org-openh264-is/m-p/1316497#M1005892
-                            "^https?://ciscobinary\\.openh264\\.org.*$",
+                            "(?i)^https?://ciscobinary\\.openh264\\.org.*$",
                             false),
                     new GlobalExclusion(
                             "Site - Fonts CDNs such as fonts.gstatic.com, etc.",
-                            "^https?://fonts.*$",
+                            "(?i)^https?://fonts.*$",
                             false),
                     new GlobalExclusion(
                             "Site - Mozilla CDN (requests such as getpocket)",
-                            "^https?://.*\\.cdn\\.mozilla\\.(?:com|org|net)/.*$",
+                            "(?i)^https?://.*\\.cdn\\.mozilla\\.(?:com|org|net)/.*$",
                             true),
                     new GlobalExclusion(
                             "Site - Firefox browser telemetry",
-                            "^https?://.*\\.telemetry\\.mozilla\\.(?:com|org|net)/.*$",
+                            "(?i)^https?://.*\\.telemetry\\.mozilla\\.(?:com|org|net)/.*$",
                             true),
                     new GlobalExclusion(
                             "Site - Adblockplus updates and notifications",
-                            "^https?://.*\\.adblockplus\\.org.*$",
+                            "(?i)^https?://.*\\.adblockplus\\.org.*$",
                             false),
                     new GlobalExclusion(
                             "Site - Firefox services",
-                            "^https?://.*\\.services\\.mozilla\\.com.*$",
+                            "(?i)^https?://.*\\.services\\.mozilla\\.com.*$",
                             true),
                     new GlobalExclusion(
-                            "Site - Google updates", "^https?://.*\\.gvt1\\.com.*$", true));
+                            "Site - Google updates", "(?i)^https?://.*\\.gvt1\\.com.*$", true));
 
     private List<GlobalExclusion> globalExclusions = List.of();
     private boolean confirmRemoveGlobalExclusions = true;
@@ -177,6 +177,7 @@ public class GlobalExclusionsOptions extends VersionedAbstractParam {
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     protected void updateConfigsImpl(int fileVersion) {
         switch (fileVersion) {
             case NO_CONFIG_VERSION:
@@ -188,6 +189,68 @@ public class GlobalExclusionsOptions extends VersionedAbstractParam {
                     setGlobalExclusions(DEFAULT_GLOBAL_EXCLUSIONS);
                     break;
                 }
+            case 1:
+                updateToVersion2();
+        }
+    }
+
+    private void updateToVersion2() {
+        List<HierarchicalConfiguration> fields =
+                ((HierarchicalConfiguration) getConfig()).configurationsAt(EXCLUSION_KEY);
+        List<String> oldValues =
+                List.of(
+                        "^.*\\.(?:gif|jpe?g|png|ico|icns|bmp)$",
+                        "^.*\\.(?:mp[34]|mpe?g|m4[ap]|aac|avi|mov|wmv|og[gav])$",
+                        "^.*\\.(?:pdf|docx?|xlsx?|pptx?)$",
+                        "^.*\\.(?:css|js)$",
+                        "^.*\\.(?:sw[fa]|flv)$",
+                        "^[^\\?]*\\.(?:gif|jpe?g|png|ico|icns|bmp)\\?.*$",
+                        "^[^\\?]*\\.(?:mp[34]|mpe?g|m4[ap]|aac|avi|mov|wmv|og[gav])\\?.*$",
+                        "^[^\\?]*\\.(?:pdf|docx?|xlsx?|pptx?)\\?.*$",
+                        "^[^\\?]*\\.(?:css|js)\\?.*$",
+                        "^[^\\?]*\\.(?:sw[fa]|flv)\\?.*$",
+                        "^[^\\?]*/(?:WebResource|ScriptResource)\\.axd\\?d=.*$",
+                        "^https?://api\\.bing\\.com/qsml\\.aspx?query=.*$",
+                        "^https?://(?:safebrowsing-cache|sb-ssl|sb|safebrowsing).*\\.(?:google|googleapis)\\.com/.*$",
+                        "^https?://(?:[^/])*\\.?lastpass\\.com",
+                        "^https?://(?:.*addons|aus[0-9])\\.mozilla\\.(?:org|net|com)/.*$",
+                        "^https?://(?:[^/])*\\.?(?:getfoxyproxy\\.org|getfirebug\\.com|noscript\\.net)",
+                        "^https?://(?:.*update\\.microsoft|.*\\.windowsupdate)\\.com/.*$",
+                        "^https?://clients2\\.google\\.com/service/update2/crx.*$",
+                        "^https?://detectportal\\.firefox\\.com.*$",
+                        "^https?://www\\.google-analytics\\.com.*$",
+                        "^https?://ciscobinary\\.openh264\\.org.*$",
+                        "^https?://fonts.*$",
+                        "^https?://.*\\.cdn\\.mozilla\\.(?:com|org|net)/.*$",
+                        "^https?://.*\\.telemetry\\.mozilla\\.(?:com|org|net)/.*$",
+                        "^https?://.*\\.adblockplus\\.org.*$",
+                        "^https?://.*\\.services\\.mozilla\\.com.*$",
+                        "^https?://.*\\.gvt1\\.com.*$");
+        for (HierarchicalConfiguration sub : fields) {
+            try {
+                String value = sub.getString(GLOBAL_EXCLUSION_VALUE_KEY, "");
+                if (oldValues.contains(value)) {
+                    String name = sub.getString(GLOBAL_EXCLUSION_NAME_KEY, "");
+                    // Fix naming mistake
+                    if (name.contains("adx")) {
+                        name = name.replace("adx", "axd");
+                        sub.setProperty(GLOBAL_EXCLUSION_NAME_KEY, name);
+                    }
+                    // Extend image types pattern(s)
+                    if (value.contains("|bmp)")) {
+                        value = value.replace("|bmp)", "|bmp|svg|webp)");
+                    }
+                    // Extend audio/video types pattern(s)
+                    if (value.contains("|og[gav])")) {
+                        value = value.replace("|og[gav])", "|og[gav]|webm)");
+                    }
+                    // Make them case insensitive
+                    value = "(?i)" + value;
+                    sub.setProperty(GLOBAL_EXCLUSION_VALUE_KEY, value);
+                }
+            } catch (ConversionException e) {
+                LOGGER.warn("An error occurred while reading a global exclusion:", e);
+            }
         }
     }
 


### PR DESCRIPTION
## Overview
- CHANGELOG > Added change note.
- GlobalExclusionsOptions > Update patterns to ensure case insensitivity. Upgrade from config v1 to config v2 includes revising default payloads.
- GlobalExclusionsOptionsUnitTest > Add test to assert that all default patterns are case insensitive. (This may change in the future but is true for now.) Add test to assert that default payloads are case insensitive on upgrade from config v1 to config v2, and that custom exclusions are not changed.

## Related Issues
- Fixes zaproxy/zaproxy#8930

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
