### PR TITLE
dev: add fake SSO auth app

### DIFF
--- a/addOns/dev/CHANGELOG.md
+++ b/addOns/dev/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Basic CSRF test app.
 - Page with input elements that appear after a delay and off the displayed screen.
+- Auth app which uses multiple (faked) domains.
 
 ## [0.9.0] - 2025-01-31
 ### Added

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/AltDomainListener.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/AltDomainListener.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.model.SessionStructure;
+import org.zaproxy.zap.network.HttpSenderListener;
+
+public class AltDomainListener implements HttpSenderListener {
+
+    private Map<String, HttpSenderListener> domainMap = new HashMap<>();
+
+    private static final String ZAP_SSO_HEADER = "zap-dev-sso";
+
+    private static final Logger LOGGER = LogManager.getLogger(AltDomainListener.class);
+
+    public void addDomainListener(String domain, HttpSenderListener listener) {
+        this.domainMap.put(domain, listener);
+    }
+
+    @Override
+    public void onHttpRequestSend(HttpMessage msg, int initiator, HttpSender sender) {
+        try {
+            String host = SessionStructure.getHostName(msg);
+            HttpSenderListener listener = domainMap.get(host);
+            if (listener != null) {
+                msg.getRequestHeader()
+                        .addHeader(ZAP_SSO_HEADER, msg.getRequestHeader().getURI().toString());
+                listener.onHttpRequestSend(msg, initiator, sender);
+            }
+        } catch (URIException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void onHttpResponseReceive(HttpMessage msg, int initiator, HttpSender sender) {
+        try {
+            String url = msg.getRequestHeader().getHeader(ZAP_SSO_HEADER);
+            if (url != null) {
+                URI uri = new URI(url, false);
+                String host = SessionStructure.getHostName(uri);
+                HttpSenderListener listener = domainMap.get(host);
+                if (listener != null) {
+                    listener.onHttpResponseReceive(msg, initiator, sender);
+                }
+                // https:// - the 8 chrs we're stripping off
+                msg.getRequestHeader().setURI(uri);
+                msg.getRequestHeader().setHeader("host", host.substring(8));
+
+                msg.getRequestHeader().setHeader(ZAP_SSO_HEADER, null);
+            }
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public int getListenerOrder() {
+        return 0;
+    }
+}

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/DevHttpSenderListener.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/DevHttpSenderListener.java
@@ -1,0 +1,66 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.network.HttpSenderListener;
+
+public abstract class DevHttpSenderListener implements HttpSenderListener {
+
+    private TestProxyServer server;
+
+    private static final Logger LOGGER = LogManager.getLogger(DevHttpSenderListener.class);
+
+    public DevHttpSenderListener(TestProxyServer server) {
+        this.server = server;
+    }
+
+    @Override
+    public int getListenerOrder() {
+        return 0;
+    }
+
+    public static URI changeTarget(URI uri, String host, int port) throws URIException {
+        return new URI(
+                uri.getScheme(), uri.getUserinfo(), host, port, uri.getPath(), uri.getQuery());
+    }
+
+    @Override
+    public void onHttpRequestSend(HttpMessage msg, int initiator, HttpSender sender) {
+        // Always redirect to the test server.
+        try {
+            msg.getRequestHeader()
+                    .setURI(
+                            changeTarget(
+                                    msg.getRequestHeader().getURI(),
+                                    server.getHost(),
+                                    server.getPort()));
+            msg.getRequestHeader().setHeader("host", server.getHost() + ":" + server.getPort());
+
+        } catch (URIException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+}

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/DevUtils.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/DevUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev;
+
+import java.util.Optional;
+import org.parosproxy.paros.network.HtmlParameter;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpResponseHeader;
+
+public class DevUtils {
+
+    public static void setRedirect(HttpMessage msg, String url) {
+        try {
+            msg.setResponseHeader(new HttpResponseHeader("HTTP/1.1 302 Found"));
+            msg.getResponseHeader().setHeader(HttpHeader.LOCATION, url);
+            msg.getResponseHeader().setContentLength(0);
+            msg.setResponseBody("");
+        } catch (HttpMalformedHeaderException e) {
+            // Should not happen
+        }
+    }
+
+    public static String getUrlParam(HttpMessage msg, String param) {
+        Optional<HtmlParameter> val =
+                msg.getUrlParams().stream().filter(p -> p.getName().equals(param)).findAny();
+        if (val.isPresent()) {
+            return val.get().getValue();
+        }
+        return null;
+    }
+
+    public static String getFormParam(HttpMessage msg, String param) {
+        Optional<HtmlParameter> val =
+                msg.getFormParams().stream().filter(p -> p.getName().equals(param)).findAny();
+        if (val.isPresent()) {
+            return val.get().getValue();
+        }
+        return null;
+    }
+}

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/ExtensionDev.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/ExtensionDev.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.zaproxy.addon.dev.error.LoggedErrorsHandler;
 import org.zaproxy.addon.network.ExtensionNetwork;
+import org.zaproxy.zap.network.HttpSenderListener;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionDev extends ExtensionAdaptor {
@@ -38,6 +39,7 @@ public class ExtensionDev extends ExtensionAdaptor {
     private final LoggedErrorsHandler loggedErrorsHandler;
 
     private TestProxyServer tutorialServer;
+    private AltDomainListener altDomainListener = new AltDomainListener();
 
     private DevParam devParam;
 
@@ -54,6 +56,7 @@ public class ExtensionDev extends ExtensionAdaptor {
         loggedErrorsHandler.hook(extensionHook);
 
         extensionHook.addOptionsParamSet(this.getDevParam());
+        extensionHook.addHttpSenderListener(altDomainListener);
 
         if (Constant.isDevMode()) {
             tutorialServer =
@@ -77,6 +80,10 @@ public class ExtensionDev extends ExtensionAdaptor {
             devParam = new DevParam();
         }
         return devParam;
+    }
+
+    public void addDomainListener(String domain, HttpSenderListener listener) {
+        this.altDomainListener.addDomainListener(domain, listener);
     }
 
     @Override

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestDirectory.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/TestDirectory.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -72,7 +73,7 @@ public class TestDirectory implements HttpMessageHandler {
 
     public String getPageName(HttpMessage msg) {
         String name = msg.getRequestHeader().getURI().getEscapedName();
-        if (name.length() == 0) {
+        if (StringUtils.isEmpty(name)) {
             name = INDEX_PAGE;
         }
         int qIndex = name.indexOf('?');
@@ -107,7 +108,7 @@ public class TestDirectory implements HttpMessageHandler {
             if (body == null) {
                 if (name.equals(this.getName())) {
                     // Redirect with a trailing slash
-                    getServer().redirect(name + "/", msg);
+                    DevUtils.setRedirect(msg, name + "/");
                     return;
                 }
                 LOGGER.debug("Failed to find tutorial file {}", name);

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/passwordNewPage/PasswordNewPageLoginPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/passwordNewPage/PasswordNewPageLoginPage.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.dev.DevUtils;
 import org.zaproxy.addon.dev.TestPage;
 import org.zaproxy.addon.dev.TestProxyServer;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
@@ -69,7 +70,7 @@ public class PasswordNewPageLoginPage extends TestPage {
                 LOGGER.error(e.getMessage(), e);
             }
         } else {
-            getServer().redirect("index.html", msg);
+            DevUtils.setRedirect(msg, "index.html");
         }
     }
 

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieIndexPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieIndexPage.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.dev.DevUtils;
 import org.zaproxy.addon.dev.TestPage;
 import org.zaproxy.addon.dev.TestProxyServer;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
@@ -51,7 +52,7 @@ public class SimpleJsonCookieIndexPage extends TestPage {
 
         if (cookie != null && user != null) {
             // Already logged in, dont display the login page again
-            getServer().redirect("home.html", msg);
+            DevUtils.setRedirect(msg, "home.html");
         } else {
             this.getServer().handleFile(getParent(), this.getName(), msg);
         }

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieProtectedPage.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/simpleJsonCookie/SimpleJsonCookieProtectedPage.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.dev.DevUtils;
 import org.zaproxy.addon.dev.TestPage;
 import org.zaproxy.addon.dev.TestProxyServer;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
@@ -50,7 +51,7 @@ public class SimpleJsonCookieProtectedPage extends TestPage {
 
         if (cookie == null || user == null) {
             // Not logged in
-            getServer().redirect("index.html", msg);
+            DevUtils.setRedirect(msg, "index.html");
         } else {
             this.getServer().handleFile(getParent(), this.getName(), msg);
         }

--- a/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/sso1/SSO1RootDir.java
+++ b/addOns/dev/src/main/java/org/zaproxy/addon/dev/auth/sso1/SSO1RootDir.java
@@ -1,0 +1,211 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.dev.auth.sso1;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.dev.DevHttpSenderListener;
+import org.zaproxy.addon.dev.DevUtils;
+import org.zaproxy.addon.dev.TestAuthDirectory;
+import org.zaproxy.addon.dev.TestDirectory;
+import org.zaproxy.addon.dev.TestProxyServer;
+
+/**
+ * A test app which uses multiple domains: start.sso1.zap Redirects to the sso domain sso.sso1.zap
+ * Handles the login, generates a token used by both the app and the api app.sso1.zap The actual app
+ * (cannot be accessed except via sso) api.sso1.zap An API used by the app
+ */
+public class SSO1RootDir extends TestAuthDirectory {
+
+    private Set<String> tokens = new HashSet<>();
+
+    private static final Logger LOGGER = LogManager.getLogger(SSO1RootDir.class);
+
+    private static final List<String> TEST_PAGES = List.of("test1", "test2", "test3", "test4");
+
+    public SSO1RootDir(TestProxyServer server, String name) {
+        super(server, name);
+        server.addDomainListener(
+                "https://start.sso1.zap",
+                new DevHttpSenderListener(this.getServer()) {
+                    @Override
+                    public void onHttpResponseReceive(
+                            HttpMessage msg, int initiator, HttpSender sender) {
+                        try {
+                            if (msg.getRequestHeader().getURI().getPath().length() <= 1) {
+                                // Redirect to SSO with a "return" param
+                                DevUtils.setRedirect(
+                                        msg, "https://sso.sso1.zap/?service=app.sso1.zap");
+                            }
+                        } catch (URIException e) {
+                            LOGGER.error(e.getMessage(), e);
+                        }
+                    }
+                });
+        server.addDomainListener(
+                "https://sso.sso1.zap",
+                new DevHttpSenderListener(this.getServer()) {
+                    @Override
+                    public void onHttpResponseReceive(
+                            HttpMessage msg, int initiator, HttpSender sender) {
+                        // Initial hack to show this works
+                        String page = getPageName(msg);
+                        boolean redirect = false;
+
+                        try {
+                            String body = "";
+                            String service = DevUtils.getUrlParam(msg, "service");
+                            if (HttpRequestHeader.POST.equals(msg.getRequestHeader().getMethod())) {
+                                service = DevUtils.getFormParam(msg, "service");
+                            }
+                            if (TestDirectory.INDEX_PAGE.equals(page)) {
+                                if (service == null) {
+                                    body =
+                                            server.getTextFile(SSO1RootDir.this, "error.html")
+                                                    .replace(
+                                                            "<!-- ERROR -->",
+                                                            "No service specified");
+
+                                } else {
+                                    if (HttpRequestHeader.POST.equals(
+                                            msg.getRequestHeader().getMethod())) {
+                                        if ("test@test.com"
+                                                        .equals(DevUtils.getFormParam(msg, "user"))
+                                                && "password123"
+                                                        .equals(
+                                                                DevUtils.getFormParam(
+                                                                        msg, "password"))) {
+
+                                            DevUtils.setRedirect(
+                                                    msg,
+                                                    "https://" + service + "/?token=" + getToken());
+                                            redirect = true;
+                                        } else {
+                                            body =
+                                                    server.getTextFile(
+                                                                    SSO1RootDir.this, "login.html")
+                                                            .replace(
+                                                                    "<!-- RESULT -->",
+                                                                    "Bad username or password");
+                                        }
+                                    } else {
+                                        body = server.getTextFile(SSO1RootDir.this, "login.html");
+                                    }
+                                    body = body.replace("<!-- SERVICE -->", service);
+                                }
+                                msg.setResponseBody(body);
+                                if (!redirect) {
+                                    msg.setResponseHeader(
+                                            new HttpResponseHeader(
+                                                    "HTTP/1.1 200 OK\r\n"
+                                                            + "Content-Type: text/html; charset=UTF-8"));
+                                }
+                            }
+                        } catch (Exception e) {
+                            LOGGER.error(e.getMessage(), e);
+                        }
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    }
+                });
+        server.addDomainListener(
+                "https://app.sso1.zap",
+                new DevHttpSenderListener(this.getServer()) {
+                    @Override
+                    public void onHttpResponseReceive(
+                            HttpMessage msg, int initiator, HttpSender sender) {
+                        try {
+                            String page = getPageName(msg);
+                            if (!HttpRequestHeader.GET.equals(msg.getRequestHeader().getMethod())) {
+                                // Passthrough
+                            } else if (TestDirectory.INDEX_PAGE.equals(page)) {
+                                String body = server.getTextFile(SSO1RootDir.this, "app.html");
+
+                                msg.setResponseBody(body);
+                                msg.setResponseHeader(
+                                        new HttpResponseHeader(
+                                                "HTTP/1.1 200 OK\r\n"
+                                                        + "Content-Type: text/html; charset=UTF-8"));
+                            } else if (TEST_PAGES.contains(page)) {
+                                String body = server.getTextFile(SSO1RootDir.this, "app-test.html");
+
+                                msg.setResponseBody(body);
+                                msg.setResponseHeader(
+                                        new HttpResponseHeader(
+                                                "HTTP/1.1 200 OK\r\n"
+                                                        + "Content-Type: text/html; charset=UTF-8"));
+                            }
+                        } catch (Exception e) {
+                            LOGGER.error(e.getMessage(), e);
+                        }
+                    }
+                });
+        server.addDomainListener(
+                "https://api.sso1.zap",
+                new DevHttpSenderListener(this.getServer()) {
+                    @Override
+                    public void onHttpResponseReceive(
+                            HttpMessage msg, int initiator, HttpSender sender) {
+                        boolean redirect = false;
+                        String token = msg.getRequestHeader().getHeader("Authorization");
+                        if (!HttpRequestHeader.GET.equals(msg.getRequestHeader().getMethod())) {
+                            // Passthrough
+                        } else if (!tokens.contains(token)) {
+                            DevUtils.setRedirect(msg, "https://start.sso1.zap");
+                            redirect = true;
+                        } else {
+                            String body = "[\"test1\", \"test2\", \"test3\"]";
+
+                            msg.setResponseBody(body);
+                            try {
+                                msg.setResponseHeader(
+                                        new HttpResponseHeader(
+                                                "HTTP/1.1 200 OK\r\n"
+                                                        + "Content-Type: application/json"));
+                            } catch (HttpMalformedHeaderException e) {
+                                LOGGER.error(e.getMessage(), e);
+                            }
+                        }
+                        if (!redirect) {
+                            msg.getResponseHeader()
+                                    .setHeader(
+                                            "Access-Control-Allow-Origin", "https://app.sso1.zap");
+                            msg.getResponseHeader()
+                                    .setHeader("Access-Control-Allow-Headers", "Authorization");
+                        }
+                    }
+                });
+    }
+
+    private String getToken() {
+        String token = RandomStringUtils.secure().nextAlphanumeric(32);
+        tokens.add(token);
+        return token;
+    }
+}

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/app-test.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/app-test.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Simple App which makes remote API calls</H1>
+	<h2>Test Page</h2>
+	A test page with no real content.
+</div>
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/app.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/app.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Simple App which makes remote API calls</H1>
+	<h2>Links</h2>
+	<div id="links">
+		<a href="https://www.zaproxy.com">https://www.zaproxy.com</a><br>
+	</div>
+
+<script>
+function loadLinks() {
+	var token = sessionStorage.getItem("token");
+	if (! token) {
+		var params = new URLSearchParams(document.location.search);
+		token = params.get("token");
+		if (! token) {
+			window.location.href = "https://start.sso1.zap";
+		}
+		sessionStorage.setItem("token", token);
+	}
+
+	var params = new URLSearchParams(document.location.search);
+	var xhr = new XMLHttpRequest();
+	var url = "https://api.sso1.zap/";
+
+	fetch(url,{
+	  method:"GET",
+	  headers: {"Authorization": token}
+	})
+	.then(res => res.json())
+	.then(
+	  (result) => {
+	    // do something
+	                        var links = document.getElementById("links");
+	
+	                        result.forEach(function(link) {
+	                           var a = document.createElement('a');
+	                           a.href = link;
+	                           a.text = link;
+	                           links.appendChild(a);
+	                           links.appendChild(document.createElement('br'));
+	                        });
+	  },
+	  // We should handle errors here, but hey, its a test app...
+	  (error) => {
+	    // handle error
+	  }
+	)
+
+
+}
+window.addEventListener("load", (event) => {
+	loadLinks();
+});
+
+</script>
+	
+</div>
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/error.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/error.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Simple Login Page on another domain</H1>
+	<h2>Error Page</h2>
+	
+	<div><!-- ERROR --></div>
+	
+</div>
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/index.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>Simple Login Page on another domain</H1>
+	<h2>Start Page</h2>
+	
+	<!-- WIP! -->
+	<a href="https://start.sso1.zap">Go to the app</a>
+	
+</div>
+</body>
+</html>

--- a/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/login.html
+++ b/addOns/dev/src/main/zapHomeFiles/dev-add-on/auth/sso1/login.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>ZAP Test Server</title>
+	<link href="/tutorial.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+<div class="roundContainer">
+	<h1>"SSO" Login Page</H1>
+	<h2>Login</h2>
+	
+	<div id="result"><!-- RESULT --></div>
+
+	<form method="post">
+	<input type="hidden" id="service" name="service" value="<!-- SERVICE -->" />
+	<table style="border: none;">
+	<tr>
+		<td>Username:
+		<td><input id="user" name="user" type="text"></td>
+	</tr>
+	<tr>
+		<td>Password:
+		<td><input id="password" name="password" type="password"></td>
+	</tr>
+	<tr>
+		<td></td>
+		<td><button id="login" type="submit" value="submit">Login</button></td>
+	</tr>
+	</table>
+	</form>
+	<p>
+	Test credentials:
+	<ul>
+		<li>username = test@test.com
+		<li>password = password123
+	</ul>
+	
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Overview
A test app which uses multiple domains: start.sso1.zap Redirects to the sso domain sso.sso1.zap Handles the login, generates a token used by both the app and the api app.sso1.zap The actual app (cannot be accessed except via sso) api.sso1.zap An API used by the app.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
