### PR TITLE
pscanrulesBeta: Address SRI Missing False Positives

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dropped period from extension name used in the GUI.
 - Depends on an updated version of the Common Library add-on.
 
+### Fixed
+- A false positive with the Sub Resource Integrity Attribute Missing scan rule with regard to which link tags it raises alerts on (Issue 8938).
+
 ### Added
 - All rules have been tagged of interest to Penetration Testers, as well as adding tags associated with DEV or QA applicability.
 


### PR DESCRIPTION
## Overview
- CHANGELOG > Add fix note.
- Rule > Adjust handling for link tags to be more specific about rel attribute values and applicability.
- UnitTest > Add/update tests to accommodate the revised behavior.

## Related Issues
- Fixes zaproxy/zaproxy#8938

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
