### PR TITLE
authhelper: inject credentials for CSA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.
 - Fix loading/saving of Client Script Based Authentication through the GUI.
+- Inject user credentials into the script when running the Client Script Based Authentication browser integration.
 
 ## [0.25.0] - 2025-03-25
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/client/ClientScriptBasedAuthHandler.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/client/ClientScriptBasedAuthHandler.java
@@ -19,27 +19,16 @@
  */
 package org.zaproxy.addon.authhelper.client;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.WebDriver;
 import org.zaproxy.addon.authhelper.AuthUtils;
 import org.zaproxy.addon.authhelper.ClientScriptBasedAuthenticationMethodType;
-import org.zaproxy.addon.authhelper.ClientScriptBasedAuthenticationMethodType.ClientScriptBasedAuthenticationMethod;
-import org.zaproxy.addon.authhelper.internal.ZestAuthRunner;
+import org.zaproxy.addon.authhelper.internal.AuthenticationBrowserHook;
 import org.zaproxy.addon.client.spider.AuthenticationHandler;
-import org.zaproxy.addon.network.ExtensionNetwork;
-import org.zaproxy.addon.network.server.ServerInfo;
-import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.extension.selenium.BrowserHook;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
-import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.users.User;
-import org.zaproxy.zest.impl.ZestBasicRunner;
 
 public class ClientScriptBasedAuthHandler implements AuthenticationHandler {
-
-    private static final Logger LOGGER = LogManager.getLogger(ClientScriptBasedAuthHandler.class);
 
     private BrowserHook browserHook;
 
@@ -64,46 +53,6 @@ public class ClientScriptBasedAuthHandler implements AuthenticationHandler {
         if (browserHook != null) {
             AuthUtils.getExtension(ExtensionSelenium.class).deregisterBrowserHook(browserHook);
             browserHook = null;
-        }
-    }
-
-    static class AuthenticationBrowserHook implements BrowserHook {
-
-        private ClientScriptBasedAuthenticationMethod csaMethod;
-        private Context context;
-        private ZestAuthRunner zestRunner;
-
-        AuthenticationBrowserHook(Context context, User user) {
-            this.context = context;
-            AuthenticationMethod method = context.getAuthenticationMethod();
-            if (!(method instanceof ClientScriptBasedAuthenticationMethod)) {
-                throw new IllegalStateException("Unsupported method " + method.getType().getName());
-            }
-            csaMethod = (ClientScriptBasedAuthenticationMethod) method;
-        }
-
-        private ZestBasicRunner getZestRunner(WebDriver webDriver) {
-            if (zestRunner == null) {
-                zestRunner = new ZestAuthRunner();
-                // Always proxy via ZAP
-                ServerInfo mainProxyInfo =
-                        AuthUtils.getExtension(ExtensionNetwork.class).getMainProxyServerInfo();
-                zestRunner.setProxy(mainProxyInfo.getAddress(), mainProxyInfo.getPort());
-            }
-            zestRunner.setWebDriver(webDriver);
-            return zestRunner;
-        }
-
-        @Override
-        public void browserLaunched(SeleniumScriptUtils ssUtils) {
-            ZestBasicRunner runner = getZestRunner(ssUtils.getWebDriver());
-            try {
-                runner.run(csaMethod.getZestScript(), null);
-            } catch (Exception e) {
-                LOGGER.warn(
-                        "An error occurred while trying to execute the Client Script Authentication script: {}",
-                        e.getMessage());
-            }
         }
     }
 }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationBrowserHook.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationBrowserHook.java
@@ -1,0 +1,89 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.WebDriver;
+import org.zaproxy.addon.authhelper.AuthUtils;
+import org.zaproxy.addon.authhelper.ClientScriptBasedAuthenticationMethodType.ClientScriptBasedAuthenticationMethod;
+import org.zaproxy.addon.network.ExtensionNetwork;
+import org.zaproxy.addon.network.server.ServerInfo;
+import org.zaproxy.zap.authentication.AuthenticationMethod;
+import org.zaproxy.zap.authentication.GenericAuthenticationCredentials;
+import org.zaproxy.zap.extension.selenium.BrowserHook;
+import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.users.User;
+import org.zaproxy.zest.impl.ZestBasicRunner;
+
+public class AuthenticationBrowserHook implements BrowserHook {
+
+    private static final Logger LOGGER = LogManager.getLogger(AuthenticationBrowserHook.class);
+
+    private static final String USERNAME = "Username";
+    private static final String PASSWORD = "Password";
+
+    private ClientScriptBasedAuthenticationMethod csaMethod;
+    private Context context;
+    private final User user;
+    private ZestAuthRunner zestRunner;
+
+    public AuthenticationBrowserHook(Context context, User user) {
+        this.context = context;
+        AuthenticationMethod method = context.getAuthenticationMethod();
+        if (!(method instanceof ClientScriptBasedAuthenticationMethod)) {
+            throw new IllegalStateException("Unsupported method " + method.getType().getName());
+        }
+        csaMethod = (ClientScriptBasedAuthenticationMethod) method;
+        this.user = user;
+    }
+
+    private ZestBasicRunner getZestRunner(WebDriver webDriver) {
+        if (zestRunner == null) {
+            zestRunner = new ZestAuthRunner();
+            // Always proxy via ZAP
+            ServerInfo mainProxyInfo =
+                    AuthUtils.getExtension(ExtensionNetwork.class).getMainProxyServerInfo();
+            zestRunner.setProxy(mainProxyInfo.getAddress(), mainProxyInfo.getPort());
+        }
+        zestRunner.setWebDriver(webDriver);
+        return zestRunner;
+    }
+
+    @Override
+    public void browserLaunched(SeleniumScriptUtils ssUtils) {
+        ZestBasicRunner runner = getZestRunner(ssUtils.getWebDriver());
+        try {
+            Map<String, String> paramsValues = new HashMap<>();
+            GenericAuthenticationCredentials credentials =
+                    (GenericAuthenticationCredentials) user.getAuthenticationCredentials();
+            paramsValues.put(USERNAME, credentials.getParam(USERNAME));
+            paramsValues.put(PASSWORD, credentials.getParam(PASSWORD));
+            runner.run(csaMethod.getZestScript(), paramsValues);
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "An error occurred while trying to execute the Client Script Authentication script: {}",
+                    e.getMessage());
+        }
+    }
+}

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/spiderajax/ClientScriptBasedAuthHandler.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/spiderajax/ClientScriptBasedAuthHandler.java
@@ -19,27 +19,16 @@
  */
 package org.zaproxy.addon.authhelper.spiderajax;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.WebDriver;
 import org.zaproxy.addon.authhelper.AuthUtils;
 import org.zaproxy.addon.authhelper.ClientScriptBasedAuthenticationMethodType;
-import org.zaproxy.addon.authhelper.ClientScriptBasedAuthenticationMethodType.ClientScriptBasedAuthenticationMethod;
-import org.zaproxy.addon.authhelper.internal.ZestAuthRunner;
-import org.zaproxy.addon.network.ExtensionNetwork;
-import org.zaproxy.addon.network.server.ServerInfo;
-import org.zaproxy.zap.authentication.AuthenticationMethod;
+import org.zaproxy.addon.authhelper.internal.AuthenticationBrowserHook;
 import org.zaproxy.zap.extension.selenium.BrowserHook;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
-import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 import org.zaproxy.zap.extension.spiderAjax.AuthenticationHandler;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.users.User;
-import org.zaproxy.zest.impl.ZestBasicRunner;
 
 public class ClientScriptBasedAuthHandler implements AuthenticationHandler {
-
-    private static final Logger LOGGER = LogManager.getLogger(ClientScriptBasedAuthHandler.class);
 
     private BrowserHook browserHook;
 
@@ -70,45 +59,5 @@ public class ClientScriptBasedAuthHandler implements AuthenticationHandler {
             return true;
         }
         return false;
-    }
-
-    static class AuthenticationBrowserHook implements BrowserHook {
-
-        private ClientScriptBasedAuthenticationMethod csaMethod;
-        private Context context;
-        private ZestAuthRunner zestRunner;
-
-        AuthenticationBrowserHook(Context context, User user) {
-            this.context = context;
-            AuthenticationMethod method = context.getAuthenticationMethod();
-            if (!(method instanceof ClientScriptBasedAuthenticationMethod)) {
-                throw new IllegalStateException("Unsupported method " + method.getType().getName());
-            }
-            csaMethod = (ClientScriptBasedAuthenticationMethod) method;
-        }
-
-        private ZestBasicRunner getZestRunner(WebDriver webDriver) {
-            if (zestRunner == null) {
-                zestRunner = new ZestAuthRunner();
-                // Always proxy via ZAP
-                ServerInfo mainProxyInfo =
-                        AuthUtils.getExtension(ExtensionNetwork.class).getMainProxyServerInfo();
-                zestRunner.setProxy(mainProxyInfo.getAddress(), mainProxyInfo.getPort());
-            }
-            zestRunner.setWebDriver(webDriver);
-            return zestRunner;
-        }
-
-        @Override
-        public void browserLaunched(SeleniumScriptUtils ssUtils) {
-            ZestBasicRunner runner = getZestRunner(ssUtils.getWebDriver());
-            try {
-                runner.run(csaMethod.getZestScript(), null);
-            } catch (Exception e) {
-                LOGGER.warn(
-                        "An error occurred while trying to execute the Client Script Authentication script: {}",
-                        e.getMessage());
-            }
-        }
     }
 }


### PR DESCRIPTION
Inject the user credentials when running the CSA script on "external" browsers (e.g. AJAX Spider) otherwise it's used the parameters instead of the actual credentials.
Extract class to reduce duplication.