### PR TITLE
spiderAjax: allow any request during auth

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Allow access to domains out of context (e.g. SSO) when using Client Script and Browser Based Authentication.
+
 ## [23.23.0] - 2025-03-25
 ### Changed
 - Maintenance changes.

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
@@ -346,8 +346,14 @@ public class SpiderThread implements Runnable {
 
     private class SpiderProxyListener implements HttpMessageHandler {
 
+        private boolean allowAll = true;
+
         @Override
         public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage httpMessage) {
+            if (allowAll) {
+                return;
+            }
+
             if (!ctx.isFromClient()) {
                 notifyMessage(
                         httpMessage,
@@ -418,6 +424,10 @@ public class SpiderThread implements Runnable {
                 return ResourceState.IO_ERROR;
             }
             return ResourceState.PROCESSED;
+        }
+
+        public void setAllowAll(boolean allow) {
+            this.allowAll = allow;
         }
     }
 
@@ -560,6 +570,7 @@ public class SpiderThread implements Runnable {
                             .getExtension(ExtensionSelenium.class)
                             .getWebDriver(
                                     INITIATOR, browser, LOCAL_PROXY_IP, port, enableExtensions);
+            listener.setAllowAll(false);
         }
 
         private void shutdown() {


### PR DESCRIPTION
Allow any request to pass through the AJAX Spider proxies while authenticating.