### PR TITLE
network: Help typo correction in transparent proxy content

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- A typo in the help with regard to Transparent Proxying.
 
 ## [0.21.0] - 2025-03-04
 ### Fixed

--- a/addOns/network/src/main/javahelp/help/contents/options/localservers.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/localservers.html
@@ -76,7 +76,7 @@
 	<H3>Intercepting/Transparent Proxy</H3>
 	The local proxies can be used as intercepting/transparent proxies for both HTTP and HTTPS. For HTTPS the client applications
 	(e.g. browser) need to use the TLS extension <a href="https://tools.ietf.org/html/rfc6066#section-3">Server Name Indication</a>.
-	This allows you to set up a testing LANs (or VMs) where all HTTP and HTTPS traffic is proxied regardless of software settings.
+	This allows you to set up testing LANs (or VMs) where all HTTP and HTTPS traffic is proxied regardless of software settings.
 	<p>
 	For example, if you have a Linux machine you use for testing, you can do something like the following to forward all HTTP and
 	HTTPS traffic to a local proxy listening on <code>192.168.0.14:8080</code>:


### PR DESCRIPTION
## Overview
Addressed a plural/singular typo in the add-on's help.

## Related Issues
- zaproxy/zaproxy#826