### PR TITLE
authhelper: add AF plan failure to Auth Report

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -8,11 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add configuration support for the wait time after Client Script Based Authentication.
 - Include the Web Element being interacted with in the Client Script Based Authentication diagnostics.
 - Allow to enable authentication diagnostics for Client Script and Browser Based Authentication through the GUI.
+- Automation Framework errors to the Authentication Report.
 
 ### Changed
 - Warn when the recorded script used with Client Script Based Authentication does not launch a browser.
 - Updated to depend on Zest add-on 48.6.0.
 - Maintenance changes.
+- Depend on reports 0.39.0 to include AF errors.
 
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.

--- a/addOns/authhelper/authhelper.gradle.kts
+++ b/addOns/authhelper/authhelper.gradle.kts
@@ -47,7 +47,7 @@ zapAddOn {
                             version.set(">=0.45.0")
                         }
                         register("reports") {
-                            version.set(">=0.36.0")
+                            version.set(">=0.39.0")
                         }
                     }
                 }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/AuthReportData.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/AuthReportData.java
@@ -50,6 +50,7 @@ public class AuthReportData implements Closeable {
         PASS_COUNT("pass.count.failed"),
         SESSION_MGMT("sessmgmt.failed"),
         LOGIN_FAILURES("login.failures"),
+        AF_PLAN_ERRORS("afplan.errors"),
         NO_SUCCESSFUL_LOGINS("no.successful.logins"),
         VERIF_IDENT("verif.failed");
 
@@ -73,6 +74,7 @@ public class AuthReportData implements Closeable {
     private PersistenceManager pm;
     private List<Diagnostic> diagnostics;
     private List<FailureDetail> failureDetails;
+    private List<String> afPlanErrors = new ArrayList<>();
 
     public void addSummaryItem(boolean passed, String key, String description) {
         summaryItems.add(new SummaryItem(passed, key, description));

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
@@ -153,6 +153,10 @@
 			<td>auth.failure.verif_ident</td>
 			<td>Failed to identify verification URL.</td>
 		</tr>
+		<tr>
+			<td>auth.failure.af_plan_errors</td>
+			<td>There were Automation Framework plan errors.</td>
+		</tr>
 	</table>
 
 	<H3>Automation Framework Environment</H3>

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/authhelper.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/authhelper.html
@@ -11,10 +11,12 @@ Authentication Helper
 This add-on helps identify and set up authentication handling in ZAP.<br>
 <p>
 
-The add-on can be used in 2 ways:
+The add-on can be used in various ways:
 <ul>
 <li>To passively detect authentication features.
+<li>To support newer browser based authentication mechanisms.
 <li>To automatically configure ZAP to handle the authentication features discovered.
+<li>To generate a detailed authentication report.
 </ul>
 
 The features currently supported are:
@@ -28,6 +30,7 @@ The features currently supported are:
 <li><a href="autodetect-session.html">Auto-Detect Session Management</a>
 <li><a href="session-header.html">Header Based Session Management</a>
 <li><a href="verification-id.html">Verification Identification</a>
+<li><a href="auth-report-json.html">Authentication Report (JSON)</a>
 </ul>
 
 <p>

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -112,6 +112,7 @@ authhelper.authreport.desc = Authentication Helper Reports
 authhelper.authreport.name = Authentication Helper Reports
 authhelper.authreport.summary.auth.fail = Authentication failed
 authhelper.authreport.summary.auth.pass = Authentication appeared to work
+authhelper.authreport.summary.fail.detail.afplan.errors = There were Automation Framework plan errors.
 authhelper.authreport.summary.fail.detail.login.failures = One or more failed logins.
 authhelper.authreport.summary.fail.detail.no.successful.logins = No successful logins.
 authhelper.authreport.summary.fail.detail.overall.failed = All authentication elements passed yet authentication was deemed a failure in the end.

--- a/addOns/authhelper/src/main/zapHomeFiles/reports/auth-report-json/report.json
+++ b/addOns/authhelper/src/main/zapHomeFiles/reports/auth-report-json/report.json
@@ -23,6 +23,9 @@
 	[#th:block th:if="${reportData.isIncludeSection('afenv')}"]
 	,"afEnv": [[${rptData.getAfEnv()}]]
 	[/th:block]
+	,"afPlanErrors": [[#th:block th:each="afError, afErrorState: ${rptData.getAfPlanErrors()}"][#th:block th:if="${! afErrorState.first}"],[/th:block]
+		[[${afError}]][/th:block]
+	]
 	[#th:block th:if="${reportData.isIncludeSection('statistics')}"]
 	,"statistics": [[#th:block th:each="statItem, statState: ${rptData.getStatistics()}"][#th:block th:if="${! statState.first}"],[/th:block]
 		{

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- The Automation Framework progress to the report data when run via an AF job.
+
 ### Fixed
 - Correct error messages of the Automation Framework job.
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -191,6 +191,7 @@ public class ReportJob extends AutomationJob {
         reportData.setTitle(this.getParameters().getReportTitle());
         reportData.setDescription(this.getParameters().getReportDescription());
         reportData.setContexts(env.getContexts());
+        reportData.addReportObjects("automation.progress", progress);
 
         if (this.getData().getRisks() == null) {
             reportData.setIncludeAllRisks(true);


### PR DESCRIPTION
## Overview
authhelper: add AF plan failure to Auth Report
~~Ready to review but I'll look at adding some more unit tests...~~

