### PR TITLE
Add /buildSrc/.kotlin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .gradle
 /build
 /buildSrc/build
+/buildSrc/.kotlin
 /addOns/**/build
 /testutils/build
 /sharedutils/build


### PR DESCRIPTION
## Overview
Add `/buildSrc/.kotlin` to `.gitignore` per recent build issues.

## Related Issues
Ex: https://github.com/zaproxy/zap-extensions/pull/6386/commits/5a8fa9d555a2834bed189c066abb02b0165c0094

