### PR TITLE
exim: Handle a wider range of request types in Sites Tree export

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Sites Tree export now includes full raw bodies for all HTTP methods (Issue 8941).
 
 ## [0.14.0] - 2025-03-25
 ### Changed


### PR DESCRIPTION
## Overview
### Purpose
Improve the Sites Tree export to handle a wider range of request types, including JSON and XML API requests.

### Goals
- Export request bodies for all HTTP methods, not just POST.
- Include the full raw body in the 'data' field without parsing parameters.
- Apply URL encoding to the entire body instead of just parameter names.

### Changes
- Removed the POST-only check so all HTTP requests follow the same export logic regardless of the method (except for multipart form data)
- Stopped parsing request bodies as `application/x-www-form-urlencoded`; instead, the full raw body is exported after being URL-encoded
- Updated tests to expect fully URL-encoded bodies in exported POST requests, including parameter values
- Added tests to assert that non-POST request bodies are exported, and that JSON/XML bodies are handled correctly.

## Related Issues
Fixes https://github.com/zaproxy/zaproxy/issues/8941

## Checklist
- [x] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
