### PR TITLE
authhelper: clear auth msg in CSA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Inject user credentials into the script when running the Client Script Based Authentication browser integration.
 - Delay when recording diagnostics.
 - Allow to use zero login page wait for Client Script and Browser Based Authentication methods through the GUI.
+- Ensure Client Script Based Authentication method has a clean state when reauthenticating.
 
 ## [0.25.0] - 2025-03-25
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -431,6 +431,9 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                                 user.getContext().getName(),
                                 user.getName())) {
                     diags.insertDiagnostics(zestRunner.getScript().getZestScript());
+                    if (handler != null) {
+                        handler.resetAuthMsg();
+                    }
 
                     authScript.authenticate(
                             new AuthenticationHelper(sender, sessionManagementMethod, user),


### PR DESCRIPTION
Ensure a new auth message is always used when reauthenticating.