### PR TITLE
authhelper: use header config for candidate msg

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated to depend on Zest add-on 48.6.0.
 - Maintenance changes.
 - Depend on reports 0.39.0 to include AF errors.
+- Use Header Based Session Management configuration to find a better candidate authentication message with Client Script and Browser Based Authentication methods.
 
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -887,10 +887,28 @@ public class AuthUtils {
      * @return all of the identified session tokens in the request.
      */
     public static Set<SessionToken> getRequestSessionTokens(HttpMessage msg) {
+        return getRequestSessionTokens(msg, List.of());
+    }
+
+    public static Set<SessionToken> getRequestSessionTokens(
+            HttpMessage msg, List<Pair<String, String>> headerConfigs) {
         Set<SessionToken> map = new HashSet<>();
         List<String> authHeaders = msg.getRequestHeader().getHeaderValues(HttpHeader.AUTHORIZATION);
         for (String header : authHeaders) {
             map.add(new SessionToken(SessionToken.HEADER_SOURCE, HttpHeader.AUTHORIZATION, header));
+        }
+        if (headerConfigs != null) {
+            for (Pair<String, String> entry : headerConfigs) {
+                String name = entry.first;
+                if (HttpHeader.AUTHORIZATION.equalsIgnoreCase(name)
+                        || HttpHeader.COOKIE.equalsIgnoreCase(name)) {
+                    continue;
+                }
+
+                for (String value : msg.getRequestHeader().getHeaderValues(name)) {
+                    map.add(new SessionToken(SessionToken.HEADER_SOURCE, name, value));
+                }
+            }
         }
         List<HttpCookie> cookies = msg.getRequestHeader().getHttpCookies();
         for (HttpCookie cookie : cookies) {

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ClientSideHandler.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ClientSideHandler.java
@@ -139,7 +139,7 @@ public final class ClientSideHandler implements HttpMessageHandler {
             authReq = candidate;
         }
 
-        Set<SessionToken> reqSessionTokens = AuthUtils.getRequestSessionTokens(msg);
+        Set<SessionToken> reqSessionTokens = AuthUtils.getRequestSessionTokens(msg, headerConfigs);
         Set<SessionToken> unkSessionTokens = new HashSet<>();
         for (SessionToken token : reqSessionTokens) {
             if (!SessionToken.COOKIE_SOURCE.equals(token.getSource())) {


### PR DESCRIPTION
Extract the session tokens from the candidate message taking into account the header configuration to ensure it's used if it's a better candidate.