### PR TITLE
retire: Remove unnecessary resource parameters

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated with upstream retire.js pattern changes.
 - Depends on an updated version of the Common Library add-on.
+- Maintenance changes.
 
 ### Added
 - The scan rule as been tagged of interest to Penetration Testers, as well as adding tags associated with DEV or QA applicability.

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -118,9 +118,7 @@ public class RetireScanRule extends PluginPassiveScanner {
                 .setRisk(result.getInformation().getRisk())
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setName(getAlertName())
-                .setDescription(
-                        Constant.messages.getString(
-                                "retire.rule.desc", result.getFilename(), result.getVersion()))
+                .setDescription(Constant.messages.getString("retire.rule.desc"))
                 .setOtherInfo(otherInfo)
                 .setTags(getAllAlertTags(result))
                 .setReference(Constant.messages.getString("retire.rule.references"))


### PR DESCRIPTION
- CHANGELOG > Add maint note.
- RetireScanRule.java > Remove unnecessary resource parameters from alert description.

Part of zaproxy/zaproxy#8940
