### PR TITLE
authhelper: do not reset CSA GUI on save

### DIFF
--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -596,7 +596,6 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
 
             shownMethod.setLoginPageWait(loginPageWait.getValue());
             shownMethod.setDiagnostics(diagnostics.isSelected());
-            shownMethod = null;
         }
 
         // @Override


### PR DESCRIPTION
Address NPEs when doing other actions as the method needs to be retained for the GUI to work correctly.