### PR TITLE
Zest: fix client script recording

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Print statements should print to the relevant script Output tab.
+- Recording client Zest scripts.
 
 ### Changed
 - Allow to copy the script's file system path from the Edit Zest Script dialogue.

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestStatementFromJson.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestStatementFromJson.java
@@ -23,21 +23,26 @@ import net.sf.json.JSONObject;
 import org.zaproxy.zest.core.v1.ZestClientElement;
 import org.zaproxy.zest.core.v1.ZestClientElementClear;
 import org.zaproxy.zest.core.v1.ZestClientElementClick;
+import org.zaproxy.zest.core.v1.ZestClientElementScrollTo;
 import org.zaproxy.zest.core.v1.ZestClientElementSendKeys;
 import org.zaproxy.zest.core.v1.ZestClientElementSubmit;
 import org.zaproxy.zest.core.v1.ZestClientLaunch;
 import org.zaproxy.zest.core.v1.ZestClientSwitchToFrame;
 import org.zaproxy.zest.core.v1.ZestClientWindowClose;
 import org.zaproxy.zest.core.v1.ZestClientWindowResize;
+import org.zaproxy.zest.core.v1.ZestComment;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
 public class ZestStatementFromJson {
+
+    public static final String WINDOW_HANDLE_BROWSER_EXTENSION = "windowHandle1";
 
     private static final String ELEMENT_TYPE = "elementType";
     private static final String WINDOW_HANDLE = "windowHandle";
     private static final String BROWSER_TYPE = "browserType";
     private static final String HEADLESS = "headless";
     private static final String CAPABILITIES = "capabilities";
+    private static final String COMMENT = "comment";
     private static final String URL = "url";
     private static final String TYPE = "type";
     private static final String ELEMENT = "element";
@@ -52,12 +57,14 @@ public class ZestStatementFromJson {
 
     private static final String ZEST_CLIENT_LAUNCH = "ZestClientLaunch";
     private static final String ZEST_CLIENT_ELEMENT_CLICK = "ZestClientElementClick";
+    private static final String ZEST_CLIENT_ELEMENT_SCROLL_TO = "ZestClientElementScrollTo";
     private static final String ZEST_CLIENT_ELEMENT_SEND_KEYS = "ZestClientElementSendKeys";
     private static final String ZEST_CLIENT_ELEMENT_SUBMIT = "ZestClientElementSubmit";
     private static final String ZEST_CLIENT_ELEMENT_CLEAR = "ZestClientElementClear";
     private static final String ZEST_CLIENT_WINDOW_CLOSE = "ZestClientWindowClose";
     private static final String ZEST_CLIENT_SWITCH_TO_FRAME = "ZestClientSwitchToFrame";
     private static final String ZEST_CLIENT_WINDOW_RESIZE = "ZestClientWindowResize";
+    private static final String ZEST_COMMENT = "ZestComment";
 
     public static ZestStatement createZestStatementFromJson(JSONObject json) throws Exception {
         ZestStatement stmt = null;
@@ -66,71 +73,72 @@ public class ZestStatementFromJson {
             switch (elementType) {
                 case ZEST_CLIENT_LAUNCH:
                     stmt =
-                            (ZestStatement)
-                                    new ZestClientLaunch(
-                                            json.getString(WINDOW_HANDLE),
-                                            json.getString(BROWSER_TYPE),
-                                            json.getString(URL),
-                                            json.getString(CAPABILITIES),
-                                            json.getBoolean(HEADLESS));
+                            new ZestClientLaunch(
+                                    json.getString(WINDOW_HANDLE),
+                                    json.getString(BROWSER_TYPE),
+                                    json.getString(URL),
+                                    json.getString(CAPABILITIES),
+                                    json.getBoolean(HEADLESS));
                     break;
 
                 case ZEST_CLIENT_ELEMENT_CLICK:
                     stmt =
-                            (ZestStatement)
-                                    new ZestClientElementClick(
-                                            json.getString(WINDOW_HANDLE),
-                                            json.getString(TYPE),
-                                            json.getString(ELEMENT));
+                            new ZestClientElementClick(
+                                    json.getString(WINDOW_HANDLE),
+                                    json.getString(TYPE),
+                                    json.getString(ELEMENT));
+                    break;
+                case ZEST_CLIENT_ELEMENT_SCROLL_TO:
+                    stmt =
+                            new ZestClientElementScrollTo(
+                                    json.getString(WINDOW_HANDLE),
+                                    json.getString(TYPE),
+                                    json.getString(ELEMENT));
                     break;
                 case ZEST_CLIENT_ELEMENT_SEND_KEYS:
                     stmt =
-                            (ZestStatement)
-                                    new ZestClientElementSendKeys(
-                                            json.getString(WINDOW_HANDLE),
-                                            json.getString(TYPE),
-                                            json.getString(ELEMENT),
-                                            json.getString(VALUE));
+                            new ZestClientElementSendKeys(
+                                    json.getString(WINDOW_HANDLE),
+                                    json.getString(TYPE),
+                                    json.getString(ELEMENT),
+                                    json.getString(VALUE));
                     break;
                 case ZEST_CLIENT_ELEMENT_SUBMIT:
                     stmt =
-                            (ZestStatement)
-                                    new ZestClientElementSubmit(
-                                            json.getString(WINDOW_HANDLE),
-                                            json.getString(TYPE),
-                                            json.getString(ELEMENT));
+                            new ZestClientElementSubmit(
+                                    json.getString(WINDOW_HANDLE),
+                                    json.getString(TYPE),
+                                    json.getString(ELEMENT));
                     break;
                 case ZEST_CLIENT_ELEMENT_CLEAR:
                     stmt =
-                            (ZestStatement)
-                                    new ZestClientElementClear(
-                                            json.getString(WINDOW_HANDLE),
-                                            json.getString(TYPE),
-                                            json.getString(ELEMENT));
+                            new ZestClientElementClear(
+                                    json.getString(WINDOW_HANDLE),
+                                    json.getString(TYPE),
+                                    json.getString(ELEMENT));
                     break;
                 case ZEST_CLIENT_WINDOW_CLOSE:
                     stmt =
-                            (ZestStatement)
-                                    new ZestClientWindowClose(
-                                            json.getString(WINDOW_HANDLE),
-                                            json.getInt(SLEEP_IN_SECONDS));
+                            new ZestClientWindowClose(
+                                    json.getString(WINDOW_HANDLE), json.getInt(SLEEP_IN_SECONDS));
                     break;
                 case ZEST_CLIENT_SWITCH_TO_FRAME:
                     stmt =
-                            (ZestStatement)
-                                    new ZestClientSwitchToFrame(
-                                            json.getString(WINDOW_HANDLE),
-                                            json.getInt(FRAME_INDEX),
-                                            json.getString(FRAME_NAME),
-                                            json.getBoolean(FRAME_ISPARENT));
+                            new ZestClientSwitchToFrame(
+                                    json.getString(WINDOW_HANDLE),
+                                    json.getInt(FRAME_INDEX),
+                                    json.getString(FRAME_NAME),
+                                    json.getBoolean(FRAME_ISPARENT));
                     break;
                 case ZEST_CLIENT_WINDOW_RESIZE:
                     stmt =
-                            (ZestStatement)
-                                    new ZestClientWindowResize(
-                                            json.getString(WINDOW_HANDLE),
-                                            json.getInt(X_VALUE),
-                                            json.getInt(Y_VALUE));
+                            new ZestClientWindowResize(
+                                    json.getString(WINDOW_HANDLE),
+                                    json.getInt(X_VALUE),
+                                    json.getInt(Y_VALUE));
+                    break;
+                case ZEST_COMMENT:
+                    stmt = new ZestComment(json.getString(COMMENT));
                     break;
                 default:
                     throw new Exception("Element type not found " + elementType);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientLaunchDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientLaunchDialog.java
@@ -25,6 +25,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
 import javax.swing.JTable;
@@ -113,7 +114,8 @@ public class ZestClientLaunchDialog extends StandardFieldsDialog implements Zest
                 0,
                 FIELD_BROWSER_TYPE,
                 getBrowserTypes(),
-                Constant.messages.getString(BROWSER_TYPE_PREFIX + browserType));
+                Constant.messages.getString(
+                        BROWSER_TYPE_PREFIX + browserType.toLowerCase(Locale.ROOT)));
         this.addCheckBoxField(0, FIELD_HEADLESS, client.isHeadless());
         this.addTextField(0, FIELD_URL, client.getUrl());
         this.addPadding(0);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -42,7 +42,9 @@ import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
+import org.zaproxy.zap.extension.zest.ZestStatementFromJson;
 import org.zaproxy.zap.view.StandardFieldsDialog;
+import org.zaproxy.zest.core.v1.ZestClientLaunch;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.impl.ZestScriptEngineFactory;
 
@@ -261,6 +263,15 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
             }
             String url = this.getStringValue(FIELD_CLIENT_NODE);
             String browser = this.getStringValue(FIELD_BROWSER);
+            extension.addToParent(
+                    scriptNode,
+                    new ZestClientLaunch(
+                            ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION,
+                            browser,
+                            url.toLowerCase(Locale.ROOT),
+                            false),
+                    false,
+                    false);
             extension.startClientRecording(url);
             Thread browserThread =
                     new Thread(() -> launchBrowser(url, browser), THREAD_PREFIX + threadId++);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/ScriptReorderer.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/ScriptReorderer.java
@@ -1,0 +1,78 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.sf.json.JSONObject;
+import org.zaproxy.zap.extension.zest.ZestStatementFromJson;
+import org.zaproxy.zest.core.v1.ZestStatement;
+
+/**
+ * This class checks the order of added ZestStatements and makes sure the order is maintained based
+ * on their indexes. When recording client side scripts in ZAP the statements are added via API
+ * calls and can end up in the wrong order depending on how quickly they are processed.
+ */
+public class ScriptReorderer {
+
+    private Consumer<ZestStatement> consumer;
+    private int lastIndex;
+
+    private List<OrderedZestStatement> orderedStatements = new ArrayList<>();
+
+    public ScriptReorderer(Consumer<ZestStatement> consumer) {
+        this.consumer = consumer;
+    }
+
+    public void recordStatement(JSONObject json) throws Exception {
+        orderedStatements.add(
+                new OrderedZestStatement(
+                        json.getInt("index"),
+                        ZestStatementFromJson.createZestStatementFromJson(json)));
+        process();
+    }
+
+    private synchronized void process() {
+        Collections.sort(orderedStatements);
+
+        while (!orderedStatements.isEmpty()
+                && orderedStatements.get(0).getIndex() == lastIndex + 1) {
+            OrderedZestStatement ostmt = orderedStatements.remove(0);
+            consumer.accept(ostmt.getStatement());
+            lastIndex++;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class OrderedZestStatement implements Comparable<OrderedZestStatement> {
+        private int index;
+        private ZestStatement statement;
+
+        @Override
+        public int compareTo(OrderedZestStatement o) {
+            return Integer.compare(index, o.getIndex());
+        }
+    }
+}

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestStatementFromJsonUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestStatementFromJsonUnitTest.java
@@ -62,7 +62,9 @@ class ZestStatementFromJsonUnitTest {
         assertThat(stmt, instanceOf(ZestClientLaunch.class));
         ZestClientLaunch clientStmt = (ZestClientLaunch) stmt;
         assertThat(clientStmt.getElementType(), is(equalTo("ZestClientLaunch")));
-        assertThat(clientStmt.getWindowHandle(), is(equalTo("windowHandle1")));
+        assertThat(
+                clientStmt.getWindowHandle(),
+                is(equalTo(ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION)));
         assertThat(clientStmt.getBrowserType(), is(equalTo("firefox")));
         assertThat(clientStmt.isEnabled(), is(equalTo(true)));
         assertThat(clientStmt.isHeadless(), is(equalTo(true)));
@@ -89,7 +91,9 @@ class ZestStatementFromJsonUnitTest {
         assertThat(stmt, instanceOf(ZestClientElementClick.class));
         ZestClientElementClick clientStmt = (ZestClientElementClick) stmt;
         assertThat(clientStmt.getElementType(), is(equalTo("ZestClientElementClick")));
-        assertThat(clientStmt.getWindowHandle(), is(equalTo("windowHandle1")));
+        assertThat(
+                clientStmt.getWindowHandle(),
+                is(equalTo(ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION)));
         assertThat(clientStmt.getType(), is(equalTo("test-type")));
         assertThat(clientStmt.getElement(), is(equalTo("test-element")));
         assertThat(clientStmt.isEnabled(), is(equalTo(true)));
@@ -115,7 +119,9 @@ class ZestStatementFromJsonUnitTest {
         assertThat(stmt, instanceOf(ZestClientElementSendKeys.class));
         ZestClientElementSendKeys clientStmt = (ZestClientElementSendKeys) stmt;
         assertThat(clientStmt.getElementType(), is(equalTo("ZestClientElementSendKeys")));
-        assertThat(clientStmt.getWindowHandle(), is(equalTo("windowHandle1")));
+        assertThat(
+                clientStmt.getWindowHandle(),
+                is(equalTo(ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION)));
         assertThat(clientStmt.getType(), is(equalTo("test-type")));
         assertThat(clientStmt.getElement(), is(equalTo("test-element")));
         assertThat(clientStmt.getValue(), is(equalTo("test-value")));
@@ -141,7 +147,9 @@ class ZestStatementFromJsonUnitTest {
         assertThat(stmt, instanceOf(ZestClientElementSubmit.class));
         ZestClientElementSubmit clientStmt = (ZestClientElementSubmit) stmt;
         assertThat(clientStmt.getElementType(), is(equalTo("ZestClientElementSubmit")));
-        assertThat(clientStmt.getWindowHandle(), is(equalTo("windowHandle1")));
+        assertThat(
+                clientStmt.getWindowHandle(),
+                is(equalTo(ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION)));
         assertThat(clientStmt.getType(), is(equalTo("test-type")));
         assertThat(clientStmt.getElement(), is(equalTo("test-element")));
         assertThat(clientStmt.isEnabled(), is(equalTo(true)));
@@ -166,7 +174,9 @@ class ZestStatementFromJsonUnitTest {
         assertThat(stmt, instanceOf(ZestClientElementClear.class));
         ZestClientElementClear clientStmt = (ZestClientElementClear) stmt;
         assertThat(clientStmt.getElementType(), is(equalTo("ZestClientElementClear")));
-        assertThat(clientStmt.getWindowHandle(), is(equalTo("windowHandle1")));
+        assertThat(
+                clientStmt.getWindowHandle(),
+                is(equalTo(ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION)));
         assertThat(clientStmt.getType(), is(equalTo("test-type")));
         assertThat(clientStmt.getElement(), is(equalTo("test-element")));
         assertThat(clientStmt.isEnabled(), is(equalTo(true)));
@@ -190,7 +200,9 @@ class ZestStatementFromJsonUnitTest {
         assertThat(stmt, instanceOf(ZestClientWindowClose.class));
         ZestClientWindowClose clientStmt = (ZestClientWindowClose) stmt;
         assertThat(clientStmt.getElementType(), is(equalTo("ZestClientWindowClose")));
-        assertThat(clientStmt.getWindowHandle(), is(equalTo("windowHandle1")));
+        assertThat(
+                clientStmt.getWindowHandle(),
+                is(equalTo(ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION)));
         assertThat(clientStmt.getSleepInSeconds(), is(equalTo(2)));
         assertThat(clientStmt.isEnabled(), is(equalTo(true)));
     }
@@ -215,7 +227,9 @@ class ZestStatementFromJsonUnitTest {
         assertThat(stmt, instanceOf(ZestClientSwitchToFrame.class));
         ZestClientSwitchToFrame clientStmt = (ZestClientSwitchToFrame) stmt;
         assertThat(clientStmt.getElementType(), is(equalTo("ZestClientSwitchToFrame")));
-        assertThat(clientStmt.getWindowHandle(), is(equalTo("windowHandle1")));
+        assertThat(
+                clientStmt.getWindowHandle(),
+                is(equalTo(ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION)));
         assertThat(clientStmt.getFrameIndex(), is(equalTo(2)));
         assertThat(clientStmt.getFrameName(), is(equalTo("my-frame")));
         assertThat(clientStmt.isParent(), is(equalTo(false)));
@@ -241,7 +255,9 @@ class ZestStatementFromJsonUnitTest {
         assertThat(stmt, instanceOf(ZestClientWindowResize.class));
         ZestClientWindowResize clientStmt = (ZestClientWindowResize) stmt;
         assertThat(clientStmt.getElementType(), is(equalTo("ZestClientWindowResize")));
-        assertThat(clientStmt.getWindowHandle(), is(equalTo("windowHandle1")));
+        assertThat(
+                clientStmt.getWindowHandle(),
+                is(equalTo(ZestStatementFromJson.WINDOW_HANDLE_BROWSER_EXTENSION)));
         assertThat(clientStmt.getX(), is(equalTo(1000)));
         assertThat(clientStmt.getY(), is(equalTo(2000)));
         assertThat(clientStmt.isEnabled(), is(equalTo(true)));

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/internal/ScriptReordererUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/internal/ScriptReordererUnitTest.java
@@ -1,0 +1,150 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zest.core.v1.ZestComment;
+import org.zaproxy.zest.core.v1.ZestStatement;
+
+class ScriptReordererUnitTest {
+
+    private ScriptReorderer reorderer;
+    private List<ZestStatement> processedStatements;
+
+    @BeforeEach
+    void setup() {
+        processedStatements = new ArrayList<>();
+        reorderer = new ScriptReorderer(processedStatements::add);
+    }
+
+    @Test
+    void shouldHandleStatementsInRightOrder() throws Exception {
+        // Given / When
+        reorderer.recordStatement(createJsonStatement(1));
+        reorderer.recordStatement(createJsonStatement(2));
+        reorderer.recordStatement(createJsonStatement(3));
+        reorderer.recordStatement(createJsonStatement(4));
+
+        // Then
+        assertThat(processedStatements.size(), is(equalTo(4)));
+        assertThat(((ZestComment) processedStatements.get(0)).getComment(), is(equalTo("Index 1")));
+        assertThat(((ZestComment) processedStatements.get(1)).getComment(), is(equalTo("Index 2")));
+        assertThat(((ZestComment) processedStatements.get(2)).getComment(), is(equalTo("Index 3")));
+        assertThat(((ZestComment) processedStatements.get(3)).getComment(), is(equalTo("Index 4")));
+    }
+
+    @Test
+    void shouldHandleStatementsInReverseOrder() throws Exception {
+        // Given / When
+        reorderer.recordStatement(createJsonStatement(4));
+        reorderer.recordStatement(createJsonStatement(3));
+        reorderer.recordStatement(createJsonStatement(2));
+        reorderer.recordStatement(createJsonStatement(1));
+
+        // Then
+        assertThat(processedStatements.size(), is(equalTo(4)));
+        assertThat(((ZestComment) processedStatements.get(0)).getComment(), is(equalTo("Index 1")));
+        assertThat(((ZestComment) processedStatements.get(1)).getComment(), is(equalTo("Index 2")));
+        assertThat(((ZestComment) processedStatements.get(2)).getComment(), is(equalTo("Index 3")));
+        assertThat(((ZestComment) processedStatements.get(3)).getComment(), is(equalTo("Index 4")));
+    }
+
+    @Test
+    void shouldHandleStatementsInRandomOrder() throws Exception {
+        // Given / When
+        reorderer.recordStatement(createJsonStatement(2));
+        reorderer.recordStatement(createJsonStatement(4));
+        reorderer.recordStatement(createJsonStatement(3));
+        reorderer.recordStatement(createJsonStatement(1));
+
+        // Then
+        assertThat(processedStatements.size(), is(equalTo(4)));
+        assertThat(((ZestComment) processedStatements.get(0)).getComment(), is(equalTo("Index 1")));
+        assertThat(((ZestComment) processedStatements.get(1)).getComment(), is(equalTo("Index 2")));
+        assertThat(((ZestComment) processedStatements.get(2)).getComment(), is(equalTo("Index 3")));
+        assertThat(((ZestComment) processedStatements.get(3)).getComment(), is(equalTo("Index 4")));
+    }
+
+    @Test
+    void shouldIgnoreStatementsNotStartingAtOne() throws Exception {
+        // Given / When
+        reorderer.recordStatement(createJsonStatement(2));
+        reorderer.recordStatement(createJsonStatement(3));
+        reorderer.recordStatement(createJsonStatement(4));
+
+        // Then
+        assertThat(processedStatements.size(), is(equalTo(0)));
+    }
+
+    @Test
+    void shouldNotProcessStatementsIfGap() throws Exception {
+        // Given / When
+        reorderer.recordStatement(createJsonStatement(1));
+        reorderer.recordStatement(createJsonStatement(2));
+        reorderer.recordStatement(createJsonStatement(3));
+        reorderer.recordStatement(createJsonStatement(5));
+        reorderer.recordStatement(createJsonStatement(6));
+        reorderer.recordStatement(createJsonStatement(7));
+
+        // Then
+        assertThat(processedStatements.size(), is(equalTo(3)));
+        assertThat(((ZestComment) processedStatements.get(0)).getComment(), is(equalTo("Index 1")));
+        assertThat(((ZestComment) processedStatements.get(1)).getComment(), is(equalTo("Index 2")));
+        assertThat(((ZestComment) processedStatements.get(2)).getComment(), is(equalTo("Index 3")));
+    }
+
+    @Test
+    void shouldThrowExceptionIfNoIndex() {
+        // Given / When
+        JSONObject stmt = createJsonStatement(1);
+        stmt.remove("index");
+
+        // Then
+        assertThrows(JSONException.class, () -> reorderer.recordStatement(stmt));
+    }
+
+    @Test
+    void shouldThrowExceptionIfBadZestStatement() {
+        // Given / When
+        JSONObject stmt = createJsonStatement(1);
+        stmt.remove("elementType");
+
+        // Then
+        assertThrows(Exception.class, () -> reorderer.recordStatement(stmt));
+    }
+
+    private static JSONObject createJsonStatement(int index) {
+        JSONObject json = new JSONObject();
+        json.put("index", index);
+        json.put("elementType", "ZestComment");
+        json.put("comment", "Index " + index);
+        return json;
+    }
+}


### PR DESCRIPTION
## Overview
With this change you should be able to use the Zest recorder to successfully record client scripts.
ZAP will launch the specified browser and scart recording wothout you having to do anything else.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
