### PR TITLE
alertFilters: workaround core issue

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Use the alert reference for statistics.
+- Workaround core issue that prevents the filters to be correctly applied (Issue 8888).
 
 ### Added
 - Added parameter descriptions for the ZAP API.

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -472,7 +472,10 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
         int historyId = recordAlert.getHistoryId();
         if (historyId > 0) {
             HistoryReference href = this.getExtHistory().getHistoryReference(historyId);
-            return new Alert(recordAlert, href);
+            Alert alert = new Alert(recordAlert, href);
+            // TODO remove once targeting 2.17+
+            alert.setHistoryId(recordAlert.getHistoryId());
+            return alert;
         } else {
             // Not ideal :/
             return new Alert(recordAlert);


### PR DESCRIPTION
Set the history ID after creating the alert so the filter is correctly applied.

---
Same as zaproxy/zaproxy#8939 but in the add-on.