### PR TITLE
authhelper: handle missing username field

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Delay when recording diagnostics.
 - Allow to use zero login page wait for Client Script and Browser Based Authentication methods through the GUI.
 - Ensure Client Script Based Authentication method has a clean state when reauthenticating.
+- Handle missing username field in Browser Based Authentication.
 
 ## [0.25.0] - 2025-03-25
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -517,7 +517,7 @@ public class AuthUtils {
             }
             sleep(TIME_TO_SLEEP_IN_MSECS);
         }
-        if (userField != null && pwdField != null) {
+        if ((userField != null || userAdded) && pwdField != null) {
             if (!userAdded) {
                 LOGGER.debug("Entering user field on {}", wd.getCurrentUrl());
                 fillUserName(diags, wd, username, userField);
@@ -529,12 +529,14 @@ public class AuthUtils {
                 }
                 sendReturn(diags, wd, pwdField);
             } catch (Exception e) {
-                // Handle the case where the password field was present but hidden / disabled
-                LOGGER.debug("Handling hidden password field on {}", wd.getCurrentUrl());
-                sendReturnAndSleep(diags, wd, userField);
-                sleep(TIME_TO_SLEEP_IN_MSECS);
-                fillPassword(diags, wd, password, pwdField);
-                sendReturn(diags, wd, pwdField);
+                if (userField != null) {
+                    // Handle the case where the password field was present but hidden / disabled
+                    LOGGER.debug("Handling hidden password field on {}", wd.getCurrentUrl());
+                    sendReturnAndSleep(diags, wd, userField);
+                    sleep(TIME_TO_SLEEP_IN_MSECS);
+                    fillPassword(diags, wd, password, pwdField);
+                    sendReturn(diags, wd, pwdField);
+                }
             }
 
             while (it.hasNext()) {


### PR DESCRIPTION
Continue with the authentication steps when the username is no longer present but the username was already submitted.