### PR TITLE
authhelper: handle "duplicated" cookies in HBSM

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow to use zero login page wait for Client Script and Browser Based Authentication methods through the GUI.
 - Ensure Client Script Based Authentication method has a clean state when reauthenticating.
 - Handle missing username field in Browser Based Authentication.
+- Correct the processing of cookies with the same name in Header Based Session Management method.
 
 ## [0.25.0] - 2025-03-25
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -210,15 +211,16 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
                         message.getRequestHeader().getURI(),
                         hbSession.getHeaders().size());
 
-                Map<String, String> trackedCookies =
+                Set<String> trackedCookies =
                         Stream.of(hbSession.getHttpState().getCookies())
-                                .collect(Collectors.toMap(Cookie::getName, Cookie::getValue));
+                                .map(Cookie::getName)
+                                .collect(Collectors.toSet());
 
                 List<HttpCookie> cookies = message.getRequestHeader().getHttpCookies();
                 for (Pair<String, String> header : hbSession.getHeaders()) {
                     if (HttpHeader.COOKIE.equalsIgnoreCase(header.first)) {
                         String[] kv = header.second.split("=");
-                        if (!trackedCookies.containsKey(kv[0])) {
+                        if (!trackedCookies.contains(kv[0])) {
                             cookies.add(new HttpCookie(kv[0], kv[1]));
                         } else {
                             LOGGER.debug(


### PR DESCRIPTION
Collect just the names which is the only data needed when checking for cookies already being tracked.