### PR TITLE
network: change cookie processing default log lvl

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Fix a naming mistake in "ExtParam - .NET adx resources (SR/WR.adx?d=)" adx should have been axd.
     - Extend Image related patterns to include svg and webp.
     - Extend Audio/Video patterns to include webm.
+- Change default log level of cookies processing to error to avoid flooding the logs with warnings when the cookies are rejected/invalid.
 
 ## [0.21.0] - 2025-03-04
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -220,6 +220,10 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                         "org.bouncycastle.jsse.provider.ProvTlsServer"),
                 Level.WARN);
 
+        // Do not WARN by default on invalid/rejected cookies.
+        setLogLevel(
+                List.of("org.apache.hc.client5.http.protocol.ResponseProcessCookies"), Level.ERROR);
+
         // Force initialisation.
         TlsUtils.getSupportedTlsProtocols();
 


### PR DESCRIPTION
Change default log level of cookies processing to error to avoid flooding the logs with warnings when the cookies are rejected/invalid.