### PR TITLE
spider: skip all javascript scheme

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Include anti-csrf tokens as part of irrelevant parameters.
 - Ignore irrelevant parameters in request bodies (`x-www-form-urlencoded`) (Related to Issue 7771).
+- Skip all URIs with `javascript` schemes.
 
 ## [0.14.0] - 2025-03-25
 ### Changed

--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation("io.kaitai:kaitai-struct-runtime:0.10")
 
     testImplementation(project(":testutils"))
+    testImplementation(libs.log4j.core)
 }
 
 val japicmp by tasks.existing(JapicmpTask::class) {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/UrlCanonicalizer.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/UrlCanonicalizer.java
@@ -31,6 +31,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.util.URIUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.zaproxy.addon.spider.SpiderParam.HandleParametersOption;
@@ -85,7 +86,7 @@ public final class UrlCanonicalizer {
      * @return the canonical url
      */
     public static String getCanonicalUrl(ParseContext ctx, String url, String baseURL) {
-        if ("javascript:".equals(url)) {
+        if (StringUtils.startsWithIgnoreCase(url, "javascript:")) {
             return null;
         }
 


### PR DESCRIPTION
Skip all that start with javascript scheme which the spider is not able to handle so there's no need to warn about them.