### PR TITLE
authhelp: CSA - refresh page if no verif URL found

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Depend on reports 0.39.0 to include AF errors.
 - Use Header Based Session Management configuration to find a better candidate authentication message with Client Script and Browser Based Authentication methods.
+- Client Script authentication to refresh the page of no suitable verification URL found.
 
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -562,7 +562,7 @@ public class AuthUtils {
                 // This can happen for more traditional apps - refresh the current one in case
                 // its a good option.
                 wd.get(wd.getCurrentUrl());
-                AuthUtils.sleep(TimeUnit.SECONDS.toMillis(1));
+                AuthUtils.sleep(TimeUnit.SECONDS.toMillis(waitInSecs));
                 diags.recordStep(
                         wd,
                         Constant.messages.getString("authhelper.auth.method.diags.steps.refresh"));


### PR DESCRIPTION
## Overview
When using client side authentication, refresh the page if no verification URL found.
Duplicates the functionality from BBA.

## Related Issues

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
