### PR TITLE
authhelper: wait for session detection in CSA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow to enable authentication diagnostics for Client Script and Browser Based Authentication through the GUI.
 - Automation Framework errors to the Authentication Report.
 - Replace TOTP token during Client Script Based Authentication.
+- Include more diagnostics in Client Script and Browser Based Authentication methods.
 
 ### Changed
 - Warn when the recorded script used with Client Script Based Authentication does not launch a browser.
@@ -18,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Depend on reports 0.39.0 to include AF errors.
 - Use Header Based Session Management configuration to find a better candidate authentication message with Client Script and Browser Based Authentication methods.
 - Client Script authentication to refresh the page of no suitable verification URL found.
+- Wait for the detection of the session method in Client Script Based Authentication method.
 
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -342,6 +342,10 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
 
                 HttpMessage authMsg = handler.getAuthMsg();
                 if (authMsg != null) {
+                    diags.recordStep(
+                            authMsg,
+                            Constant.messages.getString(
+                                    "authhelper.auth.method.diags.steps.authmessage"));
                     // Update the session as it may have changed
                     for (int i = 0; i < AuthUtils.getWaitLoopCount(); i++) {
                         // The session management method is set via a pscan rule, so make sure it is

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -56,6 +56,7 @@ authhelper.auth.method.browser.steps.ui.warn.invalid.title = Invalid Authenticat
 authhelper.auth.method.clientscript.name = Client Script Authentication
 
 authhelper.auth.method.diags.steps.authenticated = Authenticated Message
+authhelper.auth.method.diags.steps.authmessage = Authentication With Primary Message
 authhelper.auth.method.diags.steps.fallback = Authentication With Fallback Message
 authhelper.auth.method.diags.steps.finish = Finished Steps
 authhelper.auth.method.diags.steps.loginlink = Login Link


### PR DESCRIPTION
Wait for the detected method before proceeding to extract the session in case one was detected (like done in BBA).
Include also the same final diag steps in CSA as done for BBA and include in both the authentication message used/found.