### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client element waitForMsec parameter.
 
 ### Changed
-- Update Zest library to 0.27.0:
+- Update Zest library to 0.28.0:
   - Allow to access the `WebElement` referenced by a `ZestClientElement`.
   - Add new `waitForMsec` parameter to all client elements.
   - Change `ZestClientElementClick`, `ZestClientElementSendKeys`, and `ZestClientElementSubmit` to wait for the element to also be enabled when using `waitForMsec`.
   - Update Selenium to version 4.32.0.
   - Change `ZestClientElementClick` to click on the position of the element instead of the element itself when obscured, to better reproduce a manual click.
+  - Change `ZestClientElementScrollTo` to only scroll to the element when not already in view.
 - Allow to copy the script's file system path from the Edit Zest Script dialogue.
 
 ### Fixed

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     zapAddOn("scripts")
     zapAddOn("selenium")
 
-    api("org.zaproxy:zest:0.27.0") {
+    api("org.zaproxy:zest:0.28.0") {
         // Provided by commonlib add-on.
         exclude(group = "com.fasterxml.jackson.core")
         exclude(group = "com.fasterxml.jackson.dataformat")


### PR DESCRIPTION
Update Zest library to 0.28.0:
 - Change `ZestClientElementScrollTo` to only scroll to the element when not already in view.