### PR TITLE
authhelper: include interaction name in CSA diags

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use Header Based Session Management configuration to find a better candidate authentication message with Client Script and Browser Based Authentication methods.
 - Client Script authentication to refresh the page of no suitable verification URL found.
 - Wait for the detection of the session method in Client Script Based Authentication method.
+- Include the name of the interaction in the Client Script Based Authentication diagnostics.
 
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -49,6 +49,7 @@ import org.zaproxy.addon.authhelper.internal.db.DiagnosticScreenshot;
 import org.zaproxy.addon.authhelper.internal.db.DiagnosticStep;
 import org.zaproxy.addon.authhelper.internal.db.DiagnosticWebElement;
 import org.zaproxy.addon.authhelper.internal.db.TableJdo;
+import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.network.HttpSenderListener;
 import org.zaproxy.zest.core.v1.ZestClientElement;
 import org.zaproxy.zest.core.v1.ZestClientElementClear;
@@ -150,7 +151,8 @@ public class AuthenticationDiagnostics implements AutoCloseable {
                 screenshotDiag.setWindowHandle(element.getWindowHandle());
                 screenshotDiag.setDescription(
                         Constant.messages.getString(
-                                "authhelper.auth.method.diags.zest.interaction"));
+                                "authhelper.auth.method.diags.zest.interaction",
+                                ZestZapUtils.toUiString(element, false)));
                 i += 1;
                 zestScript.getStatements().add(i, screenshotDiag);
             } else if (stmt instanceof ZestClientWindowClose close) {

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -68,7 +68,7 @@ authhelper.auth.method.diags.steps.start = URL Accessed
 authhelper.auth.method.diags.steps.unauthenticated = Unauthenticated Message
 authhelper.auth.method.diags.steps.username = Auto Fill Username
 authhelper.auth.method.diags.zest.close = Browser Closed
-authhelper.auth.method.diags.zest.interaction = Element Interaction
+authhelper.auth.method.diags.zest.interaction = Interaction: {0}
 authhelper.auth.method.diags.zest.open = Browser Opened
 
 authhelper.auth.test.dialog.button.copy = Copy


### PR DESCRIPTION
Include the name of the interaction as it makes it easier to read what's happening from the diagnostic steps.