### PR TITLE
authhelper: Ensure expected alerts are raised for Session Mgmt

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Verification URL comparison.
 - Use the session token from JSON string response.
 - Do not auto configure the Header Based Session Management method with duplicated session tokens.
+- Ensure that auth messages with both known and unknown Session tokens are correctly processed.
 
 ## [0.25.0] - 2025-03-25
 ### Changed


### PR DESCRIPTION
## Overview
- CHANGELOG > Add Fix note.
- SessionDetectionScanRule > Adjust logic to ensure more/proper capture.
- SessionDetectionScanRuleUnitTest > Ensure a HistoryProvider is set where needed (which is now slightly different). Add test for adjusted logic.

![image](https://github.com/user-attachments/assets/2d4913ce-c2a0-4f1a-8e3c-aa482fc5fb41)

## Related Issues
Specify any related issues or pull requests by linking to them.

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
