### PR TITLE
authhelper: Rule adjustments to skip unwanted messages

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clear fields before sending keys for Browser Based Authentication, including when using steps.
 - Do not add an empty line to the start of the Other Info of Session Management Response Identified scan rule's alerts.
 - Update the Client Script Based Authentication help page with the new Automation Framework `scriptInline` field.
+- The Authentication Request Detection and Session Management Detection scan rules now skip resources (images, css, js, etc) which are unlikely to be relevant.
+- The Verification Detection scan rule now skips messages that seem related to login/logout/registration functionality.
 
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -155,6 +155,41 @@ public class AuthUtils {
                                 }
                             })
                     .build();
+
+    /**
+     * A list of commonly used string in authentication request URLs. A URL containing any of these
+     * strings as well as a recognised user and password parameter will be treated as a high
+     * confidence match.
+     */
+    static final List<String> AUTH_URL_SEGMENTS =
+            List.of("login", "signin", "sign-in", "inloggen", "accueil");
+
+    /**
+     * A list of commonly used string in register request URLs. A URL containing any of these
+     * strings NOT be counted as an authentication request even if there are recognised user and
+     * password parameters.
+     */
+    static final List<String> REGISTER_URL_SEGMENTS = List.of("register", "signup", "sign-up");
+
+    /** A list of URL path or query strings which are poor candidates for verification. */
+    static final Set<String> POOR_CANDIDATE_INDICATORS;
+
+    static {
+        POOR_CANDIDATE_INDICATORS = new HashSet<>();
+        POOR_CANDIDATE_INDICATORS.addAll(
+                List.of(
+                        "logout",
+                        "logoff",
+                        "signout",
+                        "signoff",
+                        "log-out",
+                        "sign-out",
+                        "log-off",
+                        "sign-off"));
+        POOR_CANDIDATE_INDICATORS.addAll(AUTH_URL_SEGMENTS);
+        POOR_CANDIDATE_INDICATORS.addAll(REGISTER_URL_SEGMENTS);
+    }
+
     static final int MAX_UNAUTH_REDIRECTIONS = 50;
 
     private static AuthenticationBrowserHook browserHook;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -55,6 +55,9 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (!AuthUtils.isRelevantToAuth(msg)) {
+            return;
+        }
         Map<String, SessionToken> responseTokens = AuthUtils.getResponseSessionTokens(msg);
 
         if (!responseTokens.isEmpty()) {

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationDetectionScanRule.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.authhelper;
 import java.util.List;
 import java.util.Set;
 import net.htmlparser.jericho.Source;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -54,7 +55,7 @@ public class VerificationDetectionScanRule extends PluginPassiveScanner {
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
-        if (!AuthUtils.isRelevantToAuth(msg)) {
+        if (!AuthUtils.isRelevantToAuth(msg) || isPoorCandidate(msg)) {
             return;
         }
         if (!HttpRequestHeader.GET.equals(msg.getRequestHeader().getMethod())
@@ -91,6 +92,12 @@ public class VerificationDetectionScanRule extends PluginPassiveScanner {
                 }
             }
         }
+    }
+
+    private static boolean isPoorCandidate(HttpMessage msg) {
+        String escapedPathQuery = msg.getRequestHeader().getURI().getEscapedPathQuery();
+        return AuthUtils.POOR_CANDIDATE_INDICATORS.stream()
+                .anyMatch(keyword -> StringUtils.containsIgnoreCase(escapedPathQuery, keyword));
     }
 
     protected AlertBuilder getAlert(VerificationRequestDetails verifDetails) {

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/VerificationDetectionScanRuleUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/VerificationDetectionScanRuleUnitTest.java
@@ -19,12 +19,162 @@
  */
 package org.zaproxy.addon.authhelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.model.Context;
+
 /** Unit test for {@link VerificationDetectionScanRule}. */
 class VerificationDetectionScanRuleUnitTest
         extends PassiveScannerTest<VerificationDetectionScanRule> {
 
+    private static final Set<String> BASE_URLS =
+            Set.of("https://www.example.com/%s", "ttps://www.example.com/?action=%s");
+
     @Override
     protected VerificationDetectionScanRule createScanner() {
         return new VerificationDetectionScanRule();
+    }
+
+    /* Provides URLs with poor candidate strings both as path components and query values */
+    private static Stream<String> providePoorCandidates() {
+        return BASE_URLS.stream()
+                .flatMap(
+                        url ->
+                                AuthUtils.POOR_CANDIDATE_INDICATORS.stream()
+                                        // Format the URL with the indicator
+                                        .map(url::formatted));
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePoorCandidates")
+    void shouldIgnorePoorCandidateUrl(String url) throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET %s HTTP/1.1".formatted(url));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        try (MockedStatic<AuthUtils> authUtilMock = mockStatic(AuthUtils.class)) {
+            // Did not pass pre-conditions
+            authUtilMock.verify(() -> AuthUtils.getRequestSessionTokens(any()), times(0));
+        }
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "Blah",
+                "text/css",
+                "text/javascript",
+                "image/png",
+                "image/svg+xml",
+                "font/ttf"
+            })
+    void shouldIgnoreUnknownOrUnwantedContentTypes(String contentType)
+            throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/user/ HTTP/1.1");
+        msg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
+        msg.getRequestHeader().setHeader(HttpHeader.REFERER, "https://www.example.com/");
+        msg.setResponseBody("<html>User: jsmith</html>");
+        msg.setResponseHeader(
+                """
+                HTTP/1.1 200 OK\r
+                Server: Apache-Coyote/1.1\r
+                Content-Type: text/html;charset=ISO-8859-1\r
+                Content-Length: %s\r\n\r
+                """
+                        .formatted(msg.getResponseBody().length()));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        try (MockedStatic<AuthUtils> authUtilMock = mockStatic(AuthUtils.class)) {
+            // Did not pass pre-conditions
+            authUtilMock.verify(() -> AuthUtils.getRequestSessionTokens(any()), times(0));
+        }
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    /* Provides URLs with misc candidate strings both as path components and query values */
+    private static Stream<String> providePotentiallyGoodCandidates() {
+        // Get a 'matrix' of both sets
+        return BASE_URLS.stream()
+                .flatMap(
+                        url ->
+                                Set.of(
+                                                "query",
+                                                "update",
+                                                "1234",
+                                                "02a3f4ec-f3df-4aa0-a2bd-3fdcdb02aa55")
+                                        .stream()
+                                        // Format the URL with the component
+                                        .map(url::formatted));
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePotentiallyGoodCandidates")
+    void shouldVerifyPotentiallyGoodCandidateUrl(String url) throws HttpMalformedHeaderException {
+        // Given
+        String tokenName = "x-auth-header";
+        String tokenValue = "fdb0f2d1-6f5c-4dd7-a829-e1cb7a114f23";
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET %s HTTP/1.1".formatted(url));
+        msg.getRequestHeader().addHeader(tokenName, tokenValue);
+        SessionToken testToken =
+                new SessionToken(SessionToken.HEADER_SOURCE, tokenName, tokenValue);
+        Context testContext = new Context(mock(Session.class), 1);
+        testContext.setIncludeInContextRegexs(List.of("https?://www.example.com.*"));
+        try (MockedStatic<AuthUtils> authUtilMock = mockStatic(AuthUtils.class)) {
+            when(AuthUtils.isRelevantToAuth(any())).thenReturn(true);
+            when(AuthUtils.getRequestSessionTokens(any())).thenReturn(Set.of(testToken));
+            when(AuthUtils.getRelatedContexts(any())).thenReturn(List.of(testContext));
+            when(AuthUtils.getVerificationDetailsForContext(testContext.getId()))
+                    .thenReturn(new VerificationRequestDetails());
+            // When
+            scanHttpResponseReceive(msg);
+            // Then
+            ArgumentCaptor<Context> ctxCaptor = ArgumentCaptor.forClass(Context.class);
+            ArgumentCaptor<VerificationRequestDetails> verifCaptor =
+                    ArgumentCaptor.forClass(VerificationRequestDetails.class);
+            ArgumentCaptor<VerificationDetectionScanRule> ruleCaptor =
+                    ArgumentCaptor.forClass(VerificationDetectionScanRule.class);
+
+            authUtilMock.verify(
+                    () ->
+                            AuthUtils.processVerificationDetails(
+                                    ctxCaptor.capture(),
+                                    verifCaptor.capture(),
+                                    ruleCaptor.capture()),
+                    times(1));
+            assertThat(ctxCaptor.getValue(), is(sameInstance(testContext)));
+            VerificationRequestDetails vrd = verifCaptor.getValue();
+            assertThat(vrd.getContextId(), is(equalTo(1)));
+            assertThat(vrd.getScore(), is(equalTo(2)));
+            assertThat(vrd.getToken(), is(equalTo(tokenValue)));
+            assertThat(ruleCaptor.getValue(), is(sameInstance(rule)));
+        }
     }
 }


### PR DESCRIPTION
## Overview
- CHANGELOG > Added changes notes.
- Scan rules > Added functionality to skip resource (css, js, image, etc) messages, and logout/login/register functionality where applicable.
- Unit tests > Added tests for new behavior.

## Related Issues
n/a

## Checklist
- [ ] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [x] Check code coverage
- [x] Sign-off commits
- [x] Squash commits
- [x] Use a descriptive title
