### PR TITLE
authhelper: prevent header config duplication

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correct redirection handling when checking verification URLs.
 - Verification URL comparison.
 - Use the session token from JSON string response.
+- Do not auto configure the Header Based Session Management method with duplicated session tokens.
 
 ## [0.25.0] - 2025-03-25
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -20,6 +20,7 @@
 package org.zaproxy.addon.authhelper;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,7 +82,7 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                 msg.getRequestHeader().getURI());
         if (!requestTokens.isEmpty()) {
             // The request is using at least one session token, do we know where they come from?
-            List<SessionToken> foundTokens = new ArrayList<>();
+            Set<SessionToken> foundTokens = new HashSet<>();
             for (SessionToken st : requestTokens) {
                 SessionToken sourceToken = AuthUtils.containsSessionToken(st.getValue());
                 if (sourceToken != null) {
@@ -122,9 +123,10 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                     foundTokens.forEach(t -> LOGGER.debug("Found tokens {}", t.getToken()));
                 }
                 List<Context> contextList = AuthUtils.getRelatedContexts(msg);
+                List<SessionToken> foundTokensList = new ArrayList<>(foundTokens);
                 SessionManagementRequestDetails smDetails =
                         new SessionManagementRequestDetails(
-                                msg, foundTokens, Alert.CONFIDENCE_MEDIUM);
+                                msg, foundTokensList, Alert.CONFIDENCE_MEDIUM);
 
                 for (Context context : contextList) {
                     if (isBetterAutoDetectSessionMagagement(context, smDetails)) {
@@ -137,7 +139,8 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                                 new HeaderBasedSessionManagementMethodType();
                         HeaderBasedSessionManagementMethod method =
                                 type.createSessionManagementMethod(context.getId());
-                        method.setHeaderConfigs(AuthUtils.getHeaderTokens(msg, foundTokens, true));
+                        method.setHeaderConfigs(
+                                AuthUtils.getHeaderTokens(msg, foundTokensList, true));
 
                         context.setSessionManagementMethod(method);
                         Stats.incCounter("stats.auth.configure.session.header");


### PR DESCRIPTION
Use a set to collect the tokens to prevent the configuration of the header session management method with duplicated tokens.