### PR TITLE
authhelper: dedup tokens on extraction

### DIFF
--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -815,7 +816,7 @@ public class AuthUtils {
     public static List<Pair<String, String>> getHeaderTokens(
             HttpMessage msg, List<SessionToken> tokens, boolean incCookies) {
         List<Pair<String, String>> list = new ArrayList<>();
-        for (SessionToken token : tokens) {
+        for (SessionToken token : new TreeSet<>(tokens)) {
             for (HttpHeaderField header : msg.getRequestHeader().getHeaders()) {
                 if (HttpHeader.COOKIE.equalsIgnoreCase(header.getName())) {
                     // Handle cookies below so we can separate them out

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -20,7 +20,6 @@
 package org.zaproxy.addon.authhelper;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,7 +81,7 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                 msg.getRequestHeader().getURI());
         if (!requestTokens.isEmpty()) {
             // The request is using at least one session token, do we know where they come from?
-            Set<SessionToken> foundTokens = new HashSet<>();
+            List<SessionToken> foundTokens = new ArrayList<>();
             for (SessionToken st : requestTokens) {
                 SessionToken sourceToken = AuthUtils.containsSessionToken(st.getValue());
                 if (sourceToken != null) {
@@ -123,10 +122,9 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                     foundTokens.forEach(t -> LOGGER.debug("Found tokens {}", t.getToken()));
                 }
                 List<Context> contextList = AuthUtils.getRelatedContexts(msg);
-                List<SessionToken> foundTokensList = new ArrayList<>(foundTokens);
                 SessionManagementRequestDetails smDetails =
                         new SessionManagementRequestDetails(
-                                msg, foundTokensList, Alert.CONFIDENCE_MEDIUM);
+                                msg, foundTokens, Alert.CONFIDENCE_MEDIUM);
 
                 for (Context context : contextList) {
                     if (isBetterAutoDetectSessionMagagement(context, smDetails)) {
@@ -139,8 +137,7 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                                 new HeaderBasedSessionManagementMethodType();
                         HeaderBasedSessionManagementMethod method =
                                 type.createSessionManagementMethod(context.getId());
-                        method.setHeaderConfigs(
-                                AuthUtils.getHeaderTokens(msg, foundTokensList, true));
+                        method.setHeaderConfigs(AuthUtils.getHeaderTokens(msg, foundTokens, true));
 
                         context.setSessionManagementMethod(method);
                         Stats.incCounter("stats.auth.configure.session.header");

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionToken.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionToken.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import java.util.Objects;
 import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
 
-public class SessionToken {
+public class SessionToken implements Comparable<SessionToken> {
 
     public static final String COOKIE_SOURCE = "cookie";
     public static final String ENV_SOURCE = "env";
@@ -94,5 +94,32 @@ public class SessionToken {
         return Objects.equals(key, other.key)
                 && Objects.equals(source, other.source)
                 && Objects.equals(value, other.value);
+    }
+
+    @Override
+    public int compareTo(SessionToken o) {
+        int result = compareStrings(source, o.source);
+        if (result != 0) {
+            return result;
+        }
+
+        result = compareStrings(key, o.key);
+        if (result != 0) {
+            return result;
+        }
+
+        return compareStrings(value, value);
+    }
+
+    private static int compareStrings(String string, String otherString) {
+        if (string == null) {
+            if (otherString == null) {
+                return 0;
+            }
+            return -1;
+        } else if (otherString == null) {
+            return 1;
+        }
+        return string.compareTo(otherString);
     }
 }


### PR DESCRIPTION
Deduplicate when extracting the header configuration to keep the scanner logic as before.