### PR TITLE
authhelper: remove extra newline in other info

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Wait for the detection of the session method in Client Script Based Authentication method.
 - Include the name of the interaction in the Client Script Based Authentication diagnostics.
 - Clear fields before sending keys for Browser Based Authentication, including when using steps.
+- Do not add an empty line to the start of the Other Info of Session Management Response Identified scan rule's alerts.
 
 ### Fixed
 - Correct descriptions of the Zest script steps in the Authentication Report.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/SessionDetectionScanRule.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import net.htmlparser.jericho.Source;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -174,9 +175,6 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
     }
 
     protected AlertBuilder getAlert(SessionManagementRequestDetails smDetails) {
-        StringBuilder sb = new StringBuilder();
-        smDetails.getTokens().stream().forEach(t -> sb.append("\n").append(t.getToken()));
-
         // Base param and evidence on the first token - there will always be at least one
         SessionToken token = smDetails.getTokens().get(0);
 
@@ -190,7 +188,10 @@ public class SessionDetectionScanRule extends PluginPassiveScanner {
                 .setSolution(Constant.messages.getString("authhelper.session-detect.soln"))
                 .setReference(
                         "https://www.zaproxy.org/docs/desktop/addons/authentication-helper/session-mgmt-id")
-                .setOtherInfo(sb.toString());
+                .setOtherInfo(
+                        smDetails.getTokens().stream()
+                                .map(SessionToken::getToken)
+                                .collect(Collectors.joining("\n")));
     }
 
     @Override

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/SessionDetectionScanRuleUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/SessionDetectionScanRuleUnitTest.java
@@ -210,7 +210,7 @@ class SessionDetectionScanRuleUnitTest extends PassiveScannerTest<SessionDetecti
         assertThat(alertsRaised.get(0).getUri(), is(equalTo("https://example0/login.jsp")));
         assertThat(alertsRaised.get(0).getMethod(), is(equalTo("GET")));
         assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("JSESSIONID")));
-        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("\ncookie:JSESSIONID")));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("cookie:JSESSIONID")));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
@@ -239,17 +239,17 @@ class SessionDetectionScanRuleUnitTest extends PassiveScannerTest<SessionDetecti
         assertThat(alertsRaised.get(0).getUri(), is(equalTo("https://example0/login")));
         assertThat(alertsRaised.get(0).getMethod(), is(equalTo("GET")));
         assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("session")));
-        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("\ncookie:session")));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("cookie:session")));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
         assertThat(alertsRaised.get(1).getUri(), is(equalTo("https://example0/dashboard")));
         assertThat(alertsRaised.get(1).getMethod(), is(equalTo("GET")));
         assertThat(alertsRaised.get(1).getEvidence(), is(equalTo("session")));
-        assertThat(alertsRaised.get(1).getOtherInfo(), is(equalTo("\ncookie:session")));
+        assertThat(alertsRaised.get(1).getOtherInfo(), is(equalTo("cookie:session")));
         assertThat(alertsRaised.get(1).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
         assertThat(alertsRaised.get(2).getUri(), is(equalTo("https://example0/login")));
         assertThat(alertsRaised.get(2).getMethod(), is(equalTo("GET")));
         assertThat(alertsRaised.get(2).getEvidence(), is(equalTo("session")));
-        assertThat(alertsRaised.get(2).getOtherInfo(), is(equalTo("\ncookie:session")));
+        assertThat(alertsRaised.get(2).getOtherInfo(), is(equalTo("cookie:session")));
         assertThat(alertsRaised.get(2).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
@@ -277,7 +277,7 @@ class SessionDetectionScanRuleUnitTest extends PassiveScannerTest<SessionDetecti
         assertThat(alertsRaised.size(), is(equalTo(1)));
         assertThat(alertsRaised.get(0).getUri(), is(equalTo("https://example0/auth")));
         assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("PHPSESSID")));
-        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("\ncookie:PHPSESSID")));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("cookie:PHPSESSID")));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
@@ -307,7 +307,7 @@ class SessionDetectionScanRuleUnitTest extends PassiveScannerTest<SessionDetecti
         assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("session")));
         assertThat(
                 alertsRaised.get(0).getOtherInfo(),
-                is(equalTo("\ncookie:session\ncookie:AWSALBCORS\ncookie:AWSALB")));
+                is(equalTo("cookie:session\ncookie:AWSALBCORS\ncookie:AWSALB")));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
@@ -335,21 +335,21 @@ class SessionDetectionScanRuleUnitTest extends PassiveScannerTest<SessionDetecti
         assertThat(alertsRaised.size(), is(equalTo(3)));
         assertThat(alertsRaised.get(0).getUri(), is(equalTo("https://example0/sign_in")));
         assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("_mastodon_session")));
-        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("\ncookie:_mastodon_session")));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("cookie:_mastodon_session")));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
 
         assertThat(alertsRaised.get(1).getUri(), is(equalTo("https://example0/")));
         assertThat(alertsRaised.get(1).getEvidence(), is(equalTo("_session_id")));
         assertThat(
                 alertsRaised.get(1).getOtherInfo(),
-                is(equalTo("\ncookie:_session_id\ncookie:_mastodon_session")));
+                is(equalTo("cookie:_session_id\ncookie:_mastodon_session")));
         assertThat(alertsRaised.get(1).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
 
         assertThat(alertsRaised.get(2).getUri(), is(equalTo("https://example0/")));
         assertThat(alertsRaised.get(2).getEvidence(), is(equalTo("_session_id")));
         assertThat(
                 alertsRaised.get(2).getOtherInfo(),
-                is(equalTo("\ncookie:_session_id\ncookie:_mastodon_session")));
+                is(equalTo("cookie:_session_id\ncookie:_mastodon_session")));
         assertThat(alertsRaised.get(2).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 


### PR DESCRIPTION
Concatenate the session tokens without adding a newline at the start as it was giving the impression there was something missing as the tokens were starting on the second line.