### PR TITLE
selenium: workaround Chrome extension install

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update Selenium to version 4.33.0.
+
 ### Fixed
 - Prevent concurrent modification exceptions.
+- Restore loading of extensions with newer Chrome versions.
 
 ## [15.36.0] - 2025-03-25
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -1025,11 +1025,13 @@ public class ExtensionSelenium extends ExtensionAdaptor {
     }
 
     private static void addChromeArguments(ChromeOptions options) {
-        List<String> arguments =
-                getSeleniumOptions().getBrowserArguments(Browser.CHROME.getId()).stream()
-                        .filter(BrowserArgument::isEnabled)
-                        .map(BrowserArgument::getArgument)
-                        .collect(Collectors.toList());
+        List<String> arguments = new ArrayList<>();
+        // FIXME https://github.com/SeleniumHQ/selenium/issues/15788
+        arguments.add("--disable-features=DisableLoadExtensionCommandLineSwitch");
+        getSeleniumOptions().getBrowserArguments(Browser.CHROME.getId()).stream()
+                .filter(BrowserArgument::isEnabled)
+                .map(BrowserArgument::getArgument)
+                .forEach(arguments::add);
         if (!arguments.isEmpty()) {
             options.addArguments(arguments);
         }


### PR DESCRIPTION
Add the flag to restore the wanted/previous behaviour, until BiDi supports adding extensions.