### PR TITLE
authhelper: wait on CSA browser hook

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use the session token from JSON string response.
 - Do not auto configure the Header Based Session Management method with duplicated session tokens.
 - Ensure that auth messages with both known and unknown Session tokens are correctly processed.
+- Respect Client Script Based Authentication's Login Page Wait when authenticating in browsers (e.g. AJAX Spider).
 
 ## [0.25.0] - 2025-03-25
 ### Changed

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationBrowserHook.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationBrowserHook.java
@@ -21,6 +21,7 @@ package org.zaproxy.addon.authhelper.internal;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebDriver;
@@ -82,6 +83,11 @@ public class AuthenticationBrowserHook implements BrowserHook {
             ZestScript zs = csaMethod.getZestScript();
             runner.setup(user, zs);
             runner.run(zs, paramsValues);
+
+            int sleepTime = csaMethod.getLoginPageWait();
+            if (sleepTime > 0) {
+                AuthUtils.sleep(TimeUnit.SECONDS.toMillis(sleepTime));
+            }
         } catch (Exception e) {
             LOGGER.warn(
                     "An error occurred while trying to execute the Client Script Authentication script: {}",


### PR DESCRIPTION
Wait also when running the script through the browser hook, to respect the option in both cases.