### PR TITLE
pscan: log all errors

### DIFF
--- a/addOns/pscan/CHANGELOG.md
+++ b/addOns/pscan/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Adjusted further dialog, progress, and log messages with regard to preventing inclusion of commas in scan rule ID numbers. As well as ensuring consistency in use of ID (full caps) for table column headings.
 - Depend on the Common Library add-on.
+- Log all errors that might happen during the passive scan.
 
 ### Added
 - The Stats Passive Scan Rule been tagged of interest to Penetration Testers, as well as adding tags associated with DEV or QA applicability.

--- a/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/internal/scanner/PassiveScanTask.java
+++ b/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/internal/scanner/PassiveScanTask.java
@@ -222,6 +222,8 @@ public class PassiveScanTask implements Runnable {
                     // Ignore
                 }
             }
+        } catch (Throwable e) {
+            LOGGER.error("An error occurred while scanning the record {}", href.getHistoryId(), e);
         } finally {
             completed = true;
             stopTime = System.currentTimeMillis();


### PR DESCRIPTION
Catch Throwable to ensure we don't miss any errors during the passive scan, which might hide bugs.