### PR TITLE
selenium: Browser extension debugging option

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- ZAP developer browser debugging mode.
 
 ## [15.37.0] - 2025-06-06
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
@@ -110,6 +110,8 @@ public class SeleniumOptions extends VersionedAbstractParam {
     private static final String CONFIRM_REMOVE_BROWSER_ARG =
             SELENIUM_BASE_KEY + ".confirmRemoveBrowserArg";
 
+    private static final String DEV_BROWSER_DEBUG = SELENIUM_BASE_KEY + ".devBrowserDebug";
+
     /** The configuration key to read/write the path to ChromeDriver. */
     private static final String CHROME_DRIVER_KEY = SELENIUM_BASE_KEY + ".chromeDriver";
 
@@ -149,6 +151,7 @@ public class SeleniumOptions extends VersionedAbstractParam {
 
     private Map<String, List<BrowserArgument>> browserArguments = new HashMap<>();
     private boolean confirmRemoveBrowserArgument = true;
+    private boolean devBrowserDebug = true;
 
     public SeleniumOptions() {
         extensionsDir = new File(Constant.getZapHome() + "/selenium/extensions/");
@@ -200,6 +203,7 @@ public class SeleniumOptions extends VersionedAbstractParam {
         browserArguments.put(Browser.FIREFOX.getId(), readBrowserArguments(FIREFOX_ARGS_KEY));
 
         confirmRemoveBrowserArgument = getBoolean(CONFIRM_REMOVE_BROWSER_ARG, true);
+        devBrowserDebug = getBoolean(DEV_BROWSER_DEBUG, false);
     }
 
     /**
@@ -542,6 +546,15 @@ public class SeleniumOptions extends VersionedAbstractParam {
 
     boolean isConfirmRemoveBrowserArgument() {
         return confirmRemoveBrowserArgument;
+    }
+
+    public boolean isDevBrowserDebug() {
+        return devBrowserDebug;
+    }
+
+    public void setDevBrowserDebug(boolean devBrowserDebug) {
+        this.devBrowserDebug = devBrowserDebug;
+        getConfig().setProperty(DEV_BROWSER_DEBUG, devBrowserDebug);
     }
 
     List<BrowserArgument> getBrowserArguments(String browser) {

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
@@ -31,6 +31,7 @@ import java.util.ResourceBundle;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.BorderFactory;
 import javax.swing.GroupLayout;
+import javax.swing.GroupLayout.ParallelGroup;
 import javax.swing.GroupLayout.SequentialGroup;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -45,6 +46,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.border.TitledBorder;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.extension.selenium.internal.BrowserArgumentsDialog;
@@ -88,6 +90,7 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
     private final OptionsBrowserExtensionsTableModel browserExtModel;
     private final AtomicBoolean confirmRemoveBrowserArgument;
     private final String temporaryBrowserProfile;
+    private final JCheckBox devBrowserDebugCheckbox;
     private static String directory;
 
     private ExtensionSelenium extSelenium;
@@ -329,6 +332,26 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         browserExtLayout.setVerticalGroup(
                 browserExtLayout.createSequentialGroup().addComponent(browserExtOptionsPanel));
 
+        JPanel devPanel = new JPanel();
+        GroupLayout devLayout = new GroupLayout(devPanel);
+        devPanel.setLayout(devLayout);
+        devLayout.setAutoCreateGaps(true);
+        devLayout.setAutoCreateContainerGaps(true);
+
+        devPanel.setBorder(
+                BorderFactory.createTitledBorder(
+                        null,
+                        resourceBundle.getString("selenium.options.dev.title"),
+                        TitledBorder.DEFAULT_JUSTIFICATION,
+                        TitledBorder.DEFAULT_POSITION,
+                        FontUtils.getFont(FontUtils.Size.standard)));
+        devBrowserDebugCheckbox =
+                new JCheckBox(resourceBundle.getString("selenium.options.dev.browserdebug"), true);
+        devLayout.setHorizontalGroup(
+                devLayout.createSequentialGroup().addComponent(devBrowserDebugCheckbox));
+        devLayout.setVerticalGroup(
+                devLayout.createSequentialGroup().addComponent(devBrowserDebugCheckbox));
+
         JPanel innerPanel = new JPanel();
         GroupLayout layout = new GroupLayout(innerPanel);
         innerPanel.setLayout(layout);
@@ -336,16 +359,24 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         layout.setAutoCreateGaps(true);
         layout.setAutoCreateContainerGaps(true);
 
-        layout.setHorizontalGroup(
+        ParallelGroup pGroup =
                 layout.createParallelGroup()
                         .addComponent(driversPanel)
                         .addComponent(binariesPanel)
-                        .addComponent(browserExtPanel));
-        layout.setVerticalGroup(
+                        .addComponent(browserExtPanel);
+        SequentialGroup sGroup =
                 layout.createSequentialGroup()
                         .addComponent(driversPanel)
                         .addComponent(binariesPanel)
-                        .addComponent(browserExtPanel));
+                        .addComponent(browserExtPanel);
+
+        if (Constant.isDevBuild()) {
+            pGroup.addComponent(devPanel);
+            sGroup.addComponent(devPanel);
+        }
+
+        layout.setHorizontalGroup(pGroup);
+        layout.setVerticalGroup(sGroup);
 
         setLayout(new BorderLayout());
         add(
@@ -519,6 +550,9 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         confirmRemoveBrowserArgument.set(seleniumOptions.isConfirmRemoveBrowserArgument());
 
         browserExtModel.setExtensions(seleniumOptions.getBrowserExtensions());
+        if (Constant.isDevBuild()) {
+            devBrowserDebugCheckbox.setSelected(seleniumOptions.isDevBrowserDebug());
+        }
         directory = seleniumOptions.getLastDirectory();
     }
 
@@ -579,6 +613,9 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         seleniumOptions.setLastDirectory(directory);
 
         seleniumOptions.setConfirmRemoveBrowserArgument(confirmRemoveBrowserArgument.get());
+        if (Constant.isDevBuild()) {
+            seleniumOptions.setDevBrowserDebug(devBrowserDebugCheckbox.isSelected());
+        }
     }
 
     @Override

--- a/addOns/selenium/src/main/resources/org/zaproxy/zap/extension/selenium/resources/Messages.properties
+++ b/addOns/selenium/src/main/resources/org/zaproxy/zap/extension/selenium/resources/Messages.properties
@@ -55,6 +55,8 @@ selenium.options.browser.arguments.table.header.argument = Argument
 selenium.options.browser.arguments.table.header.enabled = Enabled
 selenium.options.browser.arguments.title = Browser Arguments
 selenium.options.combo.profile.temp = <temporary>
+selenium.options.dev.browserdebug = Browser Extension Debug
+selenium.options.dev.title = ZAP Developer Options
 selenium.options.dialog.remove.button.cancel = Cancel
 selenium.options.dialog.remove.button.remove = Remove
 selenium.options.dialog.remove.label.checkbox = Do not show this message again
@@ -82,6 +84,7 @@ selenium.options.webdrivers.title = WebDrivers
 
 selenium.scripts.interface.error = The provided Selenium script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
 selenium.scripts.type.selenium = Selenium
+selenium.warn.message.browser.debug = Browser Extension Debugging Mode\nLoad the extension(s) you wish to test and then click 'OK'
 
 selenium.warn.message.browser.not.found = {0} not found. Are you sure it's in your PATH?\nSee https://www.zaproxy.org/faq/no-browser/
 selenium.warn.message.failed.start.browser = Failed to start/connect to ''{0}'', is the browser available/supported?\nSee https://www.zaproxy.org/faq/no-browser/

--- a/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/SeleniumAPIUnitTest.java
+++ b/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/SeleniumAPIUnitTest.java
@@ -86,8 +86,8 @@ class SeleniumAPIUnitTest extends TestUtils {
         // Given / When
         api = new SeleniumAPI(options, extension);
         // Then
-        assertThat(api.getApiActions(), hasSize(12));
-        assertThat(api.getApiViews(), hasSize(10));
+        assertThat(api.getApiActions(), hasSize(13));
+        assertThat(api.getApiViews(), hasSize(11));
         assertThat(api.getApiOthers(), hasSize(0));
     }
 


### PR DESCRIPTION
## Overview
Added this specifically for testing the ZAP browser extension, but it may be useful in other cases as well.
The new option is only enabled in dev mode.
If selected then Firefox/Chrome are launched without any of the configured extensions but the ZAP desktop waits until the user OKs the new dialog.
The browsers open the closest screen we can get to for managing extensions, allowing us to load any local extensions we want.
This allows us to load unsigned extensions which would otherwise be blocked.

## Related Issues
Will be useful for testing https://github.com/zaproxy/browser-extension/pull/203

## Checklist
- [ ] Update help
- [ ] Update changelog
- [ ] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [ ] Sign-off commits
- [ ] Squash commits
- [ ] Use a descriptive title

For more details, please refer to the [developer rules and guidelines](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/).
