### PR TITLE
authhelper: allow empty header list

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Changed
 - Send the referer header on verification if set on the original request.
+- Removed requirement to set at least one header in the GUI for Header-Based Session Management.
 
 ### Fixed
 - Do not fail the authentication on diagnostic errors.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/HeaderBasedSessionManagementMethodType.java
@@ -456,7 +456,7 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
     @Override
     public ApiDynamicActionImplementor getSetMethodForContextApiAction() {
         return new ApiDynamicActionImplementor(
-                API_METHOD_NAME, new String[] {PARAM_HEADERS}, null) {
+                API_METHOD_NAME, new String[0], new String[] {PARAM_HEADERS}) {
 
             @Override
             public void handleAction(JSONObject params) throws ApiException {
@@ -464,9 +464,12 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
                         ApiUtils.getContextByParamId(params, SessionManagementAPI.PARAM_CONTEXT_ID);
                 HeaderBasedSessionManagementMethod smm =
                         createSessionManagementMethod(context.getId());
-                // Headers are newline separated key: value pairs
-                String[] headerArray = params.getString(PARAM_HEADERS).split("\n");
-                smm.setHeaderConfigs(getHeaderPairs(headerArray));
+                String headersStr = params.optString(PARAM_HEADERS, "");
+                if (!headersStr.isBlank()) {
+                    // Headers are newline separated key: value pairs
+                    String[] headerArray = headersStr.split("\n");
+                    smm.setHeaderConfigs(getHeaderPairs(headerArray));
+                }
                 context.setSessionManagementMethod(smm);
             }
         };
@@ -517,11 +520,6 @@ public class HeaderBasedSessionManagementMethodType extends SessionManagementMet
                             Constant.messages.getString(
                                     "authhelper.session.method.header.error.value"));
                 }
-            }
-            if (headers.isEmpty()) {
-                throw new IllegalStateException(
-                        Constant.messages.getString(
-                                "authhelper.session.method.header.error.headers"));
             }
         }
 

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -150,7 +150,6 @@ authhelper.session-detect.name = Session Management Response Identified
 authhelper.session-detect.soln = This is an informational alert rather than a vulnerability and so there is nothing to fix.
 
 authhelper.session.method.auto.name = Auto-Detect Session Management
-authhelper.session.method.header.error.headers = You must specify at least one header
 authhelper.session.method.header.error.json.parse = Unable to parse authentication response body from {0} as JSON: {1} 
 authhelper.session.method.header.error.value = You must specify both a header and value
 authhelper.session.method.header.label.footer = Any number of headers are supported - a new row is added when any characters are added to the last field.\nThe following tokens can be used in the values:\n* {%json:path.to.data%}\tJSON authentication response data\n* {%env:env_var%}\tenvironmental variable\n* {%script:glob_var%}\tglobal script variable\n* {%header:env_var%}\tauthentication response header\n* {%url:key%}\t\tauthentication URL param


### PR DESCRIPTION
## Overview
authhelper: allow empty header list (fixes zaproxy/zaproxy#8889)
Removed requirement to set a header value for headerBasedSessionManagement

## Related Issues
zaproxy/zaproxy#8889

## Checklist
- [na] Update help
- [x] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [x] Write tests
- [ ] Check code coverage
- [ ] Squash commits
- [x] Use a descriptive title