### PR TITLE
scripts: update help

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update help with newer JavaScript engine and links.
 
 ## [45.12.0] - 2025-06-20
 ### Changed

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
@@ -8,10 +8,10 @@
 <H1>Script Console</H1>
 <p>
 The Script Console add-on allows you to run scripts that can be embedded within ZAP and can access internal ZAP data structures.<br/>
-It supports any scripting language that supports JSR 223 (http://www.jcp.org/en/jsr/detail?id=223) , including:
+It supports any scripting language that supports <a href="https://www.jcp.org/en/jsr/detail?id=223">JSR 223</a>, including:
 <ul>
-<li>ECMAScript / JavaScript (using <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/">Nashorn engine</a>, included by default)</li>
-<li>Zest <a href="https://developer.mozilla.org/en-US/docs/zest">https://developer.mozilla.org/en-US/docs/zest</a> (included by default)</li>
+<li>ECMAScript / JavaScript (through the <a href="https://www.zaproxy.org/docs/desktop/addons/graalvm-javascript/">GraalVM JavaScript add-on</a>)</li>
+<li><a href="https://www.zaproxy.org/docs/desktop/addons/zest/">Zest</a></li>
 <li>Groovy <a href="http://groovy-lang.org/">http://groovy-lang.org/</a></li>
 <li>Python <a href="http://www.jython.org">http://www.jython.org</a></li>
 <li>Ruby - <a href="http://jruby.org/">http://jruby.org/</a></li>


### PR DESCRIPTION
Link to the Graal add-on instead of Nashorn.
Remove mention that JavaScript/Zest are included by default, they aren't for all distributions.
Link to the Zest add-on help as the older link is a 404.