### PR TITLE
network: ensure positive Root CA cert's serial

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Use only positive serial numbers for the Root CA certificate (Issue 8984).
 
 ## [0.22.0] - 2025-06-20
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
@@ -53,7 +53,6 @@ import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Random;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.DERIA5String;
@@ -177,7 +176,7 @@ public final class CertificateUtils {
         X509v3CertificateBuilder certBuilder =
                 new JcaX509v3CertificateBuilder(
                         name,
-                        BigInteger.valueOf(new Random().nextInt()),
+                        BigInteger.valueOf(Math.abs(new SecureRandom().nextInt() + 0L)),
                         startDate,
                         expireDate,
                         name,


### PR DESCRIPTION
Use only positive numbers when generating the serial.

Fix zaproxy/zaproxy#8984.