### PR TITLE
llm: tidy up resource messages/title

### DIFF
--- a/addOns/llm/src/main/java/org/zaproxy/addon/llm/ui/ImportDialog.java
+++ b/addOns/llm/src/main/java/org/zaproxy/addon/llm/ui/ImportDialog.java
@@ -157,8 +157,7 @@ public class ImportDialog extends AbstractDialog {
                     Constant.messages.getString("llm.importDialog.import.success", endpointCount));
             return true;
         } else {
-            showWarningDialog(
-                    Constant.messages.getString("llm.importDialog.import.failure", endpointCount));
+            showWarningDialog(Constant.messages.getString("llm.importDialog.import.failure"));
             return false;
         }
     }

--- a/addOns/llm/src/main/javahelp/org/zaproxy/addon/llm/resources/help/helpset.hs
+++ b/addOns/llm/src/main/javahelp/org/zaproxy/addon/llm/resources/help/helpset.hs
@@ -3,7 +3,7 @@
   PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
          "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
 <helpset version="2.0" xml:lang="en-GB">
-  <title>LLM Integration Add-On</title>
+  <title>LLM Support Add-On</title>
 
   <maps>
      <homeID>addon.llm</homeID>

--- a/addOns/llm/src/main/resources/org/zaproxy/addon/llm/resources/Messages.properties
+++ b/addOns/llm/src/main/resources/org/zaproxy/addon/llm/resources/Messages.properties
@@ -4,7 +4,7 @@ llm.importDialog.chooseFileButton = Choose File
 llm.importDialog.error.fileNotFound = Cannot access the specified file at:\n{0}
 llm.importDialog.error.missingOpenAPI = An OpenAPI file or URL must be specified.
 llm.importDialog.fileFilterDescription = OpenAPI File (*.json/*.yaml)
-llm.importDialog.import.failure = "No endpoints could be imported. Please check the provided URL or file for validity.";
+llm.importDialog.import.failure = No endpoints could be imported. Please check the provided URL or file for validity.
 llm.importDialog.import.success = {0} Endpoint has been imported. Check History for details.
 llm.importDialog.importButton = Import
 llm.importDialog.labelOpenAPI = OpenAPI File location or URL
@@ -30,9 +30,9 @@ llm.provider.none = None
 llm.provider.ollama = Ollama
 
 llm.reviewalert.error = Issue check failed. Please review your LLM settings and check the log for a detailed error message.
-llm.reviewalert.otherinfo = {0}\n\n LLM Explanation:\n\n{1}
+llm.reviewalert.otherinfo = {0}\n\nLLM Explanation:\n\n{1}
 
 llm.topmenu.import.importOpenAPI = LLM/AI OpenAPI Importer
 llm.topmenu.import.importOpenAPI.fail = Unable to access endpoint defined in {0}
 llm.topmenu.import.importOpenAPI.tooltip = The file must be compliant with the formal OpenAPI specification.
-llm.topmenu.import.importOpenAPI.url.fail = Invalid URL: {0}.\n {1}
+llm.topmenu.import.importOpenAPI.url.fail = Invalid URL: {0}.\n{1}


### PR DESCRIPTION
Remove unnecessary spaces after newlines.
Remove extraneous characters.
Remove unused parameter when getting resource message.
Change the helpset title to match the name of the add-on.