### PR TITLE
callhome: Add Value Generator (Form Handler) Stats

### DIFF
--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- LLM stats to telemetry.
+- LLM, and Value Generator (Form Handler) stats to telemetry.
 
 ## [0.14.0] - 2025-01-09
 ### Changed

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
@@ -296,6 +296,7 @@ public class ExtensionCallHome extends ExtensionAdaptor
                     || key.startsWith("stats.config.")
                     || key.startsWith("stats.error.")
                     || key.startsWith("stats.exim.")
+                    || key.startsWith("stats.formhandler.")
                     || key.startsWith("stats.fuzz.")
                     || key.startsWith("stats.graphql.")
                     || key.startsWith("stats.hud.")


### PR DESCRIPTION
## Overview
Adds the formhandler (Value Generator) to the tracked telemetry.

## Related Issues
- zaproxy/zap-extensions#4515
