### PR TITLE
authhelper: do not fail auth on diag errors

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Do not fail the authentication on diagnostic errors.
 
 ## [0.27.0] - 2025-07-03
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -353,6 +353,8 @@ public class AuthenticationDiagnostics implements AutoCloseable {
             tx.begin();
             pm.makePersistent(diagnostic);
             tx.commit();
+        } catch (Exception e) {
+            LOGGER.warn("Failed to persist diagnostics:", e);
         } finally {
             if (tx.isActive()) {
                 tx.rollback();

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/db/TableJdo.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/db/TableJdo.java
@@ -29,6 +29,7 @@ import javax.jdo.PersistenceManagerFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.datanucleus.PropertyNames;
+import org.datanucleus.store.rdbms.RDBMSPropertyNames;
 import org.flywaydb.core.Flyway;
 import org.parosproxy.paros.db.Database;
 import org.parosproxy.paros.db.DatabaseException;
@@ -91,6 +92,8 @@ public class TableJdo implements DatabaseListener {
         jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_PASSWORD, password);
 
         jdoProperties.put(PropertyNames.PROPERTY_CLASSLOADER_PRIMARY, classLoader);
+        jdoProperties.put(
+                RDBMSPropertyNames.PROPERTY_RDBMS_STRING_LENGTH_EXCEEDED_ACTION, "TRUNCATE");
 
         pmf = JDOHelper.getPersistenceManagerFactory(jdoProperties, "authhelper", classLoader);
     }


### PR DESCRIPTION
Catch exceptions that might be thrown while persisting the auth diags.
Also, truncate the diagnostic values if they don't fit the DB columns, instead of failing to persist everything.