### PR TITLE
Error logs to always include stack trace.

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Depends on an updated version of the Common Library add-on.
 
+### Fixed
+- Error logs to always include stack trace.
+
 ### Added
 - Rules (as applicable) have been tagged in relation to HIPAA and PCI DSS.
 - The 403 Bypass scan rule now has a CWE reference.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
@@ -243,7 +243,7 @@ public class CsrfTokenScanRule extends AbstractAppPlugin implements CommonActive
                 formIdx++;
             }
         } catch (IOException e) {
-            LOGGER.error(e);
+            LOGGER.debug(e, e);
         }
     }
 

--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Error logs to always include stack trace.
 
 ## [17] - 2025-01-09
 ### Changed

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -434,7 +434,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             }
 
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
     }
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -97,7 +97,7 @@ public class BruteForceURLFuzz implements Runnable {
                     manager.setAuto(false);
                 }
             } catch (IOException e) {
-                LOGGER.error(e);
+                LOGGER.error(e, e);
             }
         }
 
@@ -108,7 +108,7 @@ public class BruteForceURLFuzz implements Runnable {
             // get dir name
             currentDir = tempDirToCheck.getName();
         } catch (InterruptedException e) {
-            LOGGER.debug(e);
+            LOGGER.debug(e, e);
         }
 
         LOGGER.info("Starting fuzz on {}{}{dir}{}", firstPart, urlFuzzStart, urlFuzzEnd);
@@ -125,7 +125,7 @@ public class BruteForceURLFuzz implements Runnable {
                     GenBaseCase.genURLFuzzBaseCase(manager, firstPart + urlFuzzStart, urlFuzzEnd);
 
         } catch (IOException e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
 
         // baseCaseObj = new BaseCase(null, failcode, true, failurl, baseCase);

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
@@ -109,7 +109,7 @@ public class BruteForceWorkGenerator implements Runnable {
                     manager.setAuto(false);
                 }
             } catch (IOException e) {
-                LOGGER.error(e);
+                LOGGER.error(e, e);
             }
         }
 
@@ -124,7 +124,7 @@ public class BruteForceWorkGenerator implements Runnable {
                 // get any extention that need to be checked
                 extToCheck = tempDirToCheck.getExts();
             } catch (InterruptedException e) {
-                LOGGER.debug(e);
+                LOGGER.debug(e, e);
             }
 
             started = currentDir;
@@ -142,7 +142,7 @@ public class BruteForceWorkGenerator implements Runnable {
                             GenBaseCase.genBaseCase(manager, firstPart + currentDir, true, null);
 
                 } catch (IOException e) {
-                    LOGGER.error(e);
+                    LOGGER.error(e, e);
                 }
 
                 // baseCaseObj = new BaseCase(null, failcode, true, failurl, baseCase);
@@ -178,7 +178,7 @@ public class BruteForceWorkGenerator implements Runnable {
                                             manager, firstPart + currentDir, false, fileExtention);
 
                         } catch (IOException e) {
-                            LOGGER.error(e);
+                            LOGGER.error(e, e);
                         }
 
                         // call function to generate the brute force

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
@@ -106,7 +106,7 @@ public class WorkerGenerator implements Runnable {
         } catch (FileNotFoundException ex) {
             LOGGER.error("File '{}' not found!", inputFile, ex);
         } catch (IOException ex) {
-            LOGGER.error(ex);
+            LOGGER.error(ex, ex);
         }
         // -------------------------------------------------
 
@@ -133,7 +133,7 @@ public class WorkerGenerator implements Runnable {
                     manager.setAuto(false);
                 }
             } catch (IOException e) {
-                LOGGER.error(e);
+                LOGGER.error(e, e);
             }
         }
 
@@ -178,7 +178,7 @@ public class WorkerGenerator implements Runnable {
                     baseCaseObj =
                             GenBaseCase.genBaseCase(manager, firstPart + currentDir, true, null);
                 } catch (IOException e) {
-                    LOGGER.error(e);
+                    LOGGER.error(e, e);
                 }
 
                 // end of dir fail case
@@ -278,7 +278,7 @@ public class WorkerGenerator implements Runnable {
                 } catch (FileNotFoundException e) {
                     LOGGER.error("File '{}' not found!", inputFile, e);
                 } catch (IOException e) {
-                    LOGGER.error(e);
+                    LOGGER.error(e, e);
                 }
             }
 
@@ -308,7 +308,7 @@ public class WorkerGenerator implements Runnable {
                                     GenBaseCase.genBaseCase(
                                             manager, firstPart + currentDir, false, fileExtention);
                         } catch (IOException e) {
-                            LOGGER.error(e);
+                            LOGGER.error(e, e);
                         }
 
                         // if the manager has sent the stop command then exit
@@ -380,7 +380,7 @@ public class WorkerGenerator implements Runnable {
                         } catch (FileNotFoundException e) {
                             LOGGER.error("File '{}' not found!", inputFile, e);
                         } catch (IOException e) {
-                            LOGGER.error(e);
+                            LOGGER.error(e, e);
                         }
                     }
                 } // end of file ext loop

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
@@ -676,7 +676,7 @@ public class BruteForcePanel extends AbstractPanel implements BruteForceListenne
                                 .getPath();
                 startScan(dir, true);
             } catch (Exception e) {
-                LOGGER.error(e);
+                LOGGER.error(e, e);
             }
         }
     }

--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated Chrome and Firefox extensions to v0.1.4.
 
+### Fixed
+- Error logs to always include stack trace.
 
 ## [0.16.0] - 2025-06-20
 ### Added

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -906,7 +906,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
                             messagesTableModel.addHistoryReference(historyRef, state);
                         });
             } catch (HttpMalformedHeaderException | DatabaseException e) {
-                LOGGER.error(e);
+                LOGGER.error(e, e);
             }
         }
     }

--- a/addOns/llm/CHANGELOG.md
+++ b/addOns/llm/CHANGELOG.md
@@ -7,3 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Allow to perform API sequencing and alert review.
 - Basic stats
+
+### Fixed
+- Error logs to always include stack trace.

--- a/addOns/llm/src/main/java/org/zaproxy/addon/llm/ui/LlmReviewAlertMenu.java
+++ b/addOns/llm/src/main/java/org/zaproxy/addon/llm/ui/LlmReviewAlertMenu.java
@@ -55,7 +55,7 @@ public class LlmReviewAlertMenu extends PopupMenuItemAlert {
         } catch (Exception e) {
             View.getSingleton()
                     .showWarningDialog(Constant.messages.getString("llm.reviewalert.error"));
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
     }
 

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Warn logs to always include stack trace.
 
 ## [45] - 2025-03-24
 ### Fixed

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/TableOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/TableOpenApi.java
@@ -88,7 +88,7 @@ public class TableOpenApi extends ParosAbstractTable {
             int columnSize = DbUtils.getColumnSize(conn, "OPENAPI_SPECS", "DEFINITION");
             LOGGER.debug("Definition column size is now: {}", columnSize);
         } catch (SQLException e) {
-            LOGGER.warn(e);
+            LOGGER.warn(e, e);
         }
     }
 

--- a/addOns/paramdigger/CHANGELOG.md
+++ b/addOns/paramdigger/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.16.0.
 
+### Fixed
+- Error logs to always include stack trace.
+
 ## [0.3.0] - 2024-07-15
 ### Added
 - Support for menu weights (Issue 8369)

--- a/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/Utils.java
+++ b/addOns/paramdigger/src/main/java/org/zaproxy/addon/paramdigger/Utils.java
@@ -52,7 +52,7 @@ public class Utils {
                 params.add(StringUtils.strip(line));
             }
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
         return params;
     }

--- a/addOns/saml/CHANGELOG.md
+++ b/addOns/saml/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.16.0.
 - Maintenance changes.
 
+### Fixed
+- Error logs to always include stack trace.
+
 ## [10] - 2022-10-28
 ### Changed
 - Update minimum ZAP version to 2.12.0.

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLUtils.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLUtils.java
@@ -182,7 +182,7 @@ public class SAMLUtils {
                     break;
             }
         } catch (UnsupportedEncodingException | SAMLException e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
         return "";
     }

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update help with newer JavaScript engine and links.
 
+### Fixed
+- Error logs to always include stack trace.
+
 ## [45.12.0] - 2025-06-20
 ### Changed
 - Maintenance changes.

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
@@ -225,7 +225,7 @@ public class RunScriptAction extends ScriptAction {
                 reportScriptError(progress, jobName, parameters, script.getLastException());
             }
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
             reportScriptError(progress, jobName, parameters, e);
         } finally {
             extScript.removeScriptOutputListener(scriptJobOutputListener);

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Error logs to always include stack trace.
 
 ## [23.24.0] - 2025-06-20
 ### Added

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
@@ -540,7 +540,7 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
         try {
             new Thread(spiderThread, "ZAP-AjaxSpiderApi").start();
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
     }
 

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -397,7 +397,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
         try {
             new Thread(runnable, "ZAP-AjaxSpider").start();
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
     }
 

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
@@ -515,7 +515,7 @@ public class SpiderThread implements Runnable {
 
             notifySpiderListenersFoundMessage(historyRef, httpMessage, state);
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
     }
 

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Error logs to always include stack trace.
 
 ## [33] - 2025-06-20
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
@@ -512,13 +512,13 @@ public class WebSocketProxyV13 extends WebSocketProxy {
             try {
                 System.arraycopy(closeCode, 0, newPayload, 0, closeCode.length);
             } catch (IndexOutOfBoundsException e) {
-                LOGGER.error(e);
+                LOGGER.error(e, e);
             }
 
             try {
                 System.arraycopy(payload, 2, newPayload, closeCode.length, payload.length - 2);
             } catch (IndexOutOfBoundsException e) {
-                LOGGER.error(e);
+                LOGGER.error(e, e);
             }
 
             return newPayload;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketProxyListenerBreak.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketProxyListenerBreak.java
@@ -133,7 +133,7 @@ public class WebSocketProxyListenerBreak implements WebSocketObserver {
                 message.setPayload((byte[]) payload);
             }
         } catch (WebSocketException e) {
-            LOGGER.error(e);
+            LOGGER.error(e, e);
         }
     }
 }


### PR DESCRIPTION
## Overview
Quick and dirty grep to find error logs like `LOGGER.error(e);`

## Related Issues

