### PR TITLE
spiderAjax: fix config key for logoutAvoidance

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
 ### Fixed
+- Correct configuration key for Logout Avoidance (Issue 8994).
 - Error logs to always include stack trace.
 
 ## [23.24.0] - 2025-06-20

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -83,7 +83,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
      * @see #CONFIG_VERSION_KEY
      * @see #updateConfigsImpl(int)
      */
-    private static final int CURRENT_CONFIG_VERSION = 6;
+    private static final int CURRENT_CONFIG_VERSION = 7;
 
     private static final String AJAX_SPIDER_BASE_KEY = "ajaxSpider";
 
@@ -208,7 +208,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
                     new AllowedResource(
                             AllowedResource.createDefaultPattern("^http.*\\.css(?:\\?.*)?$")));
 
-    private static final String LOGOUT_AVOIDANCE_KEY = ".logoutAvoidance";
+    private static final String LOGOUT_AVOIDANCE_KEY = AJAX_SPIDER_BASE_KEY + ".logoutAvoidance";
 
     private int numberOfBrowsers;
     private int maxCrawlDepth;
@@ -387,6 +387,10 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
                 if (!getConfig().getKeys(ALL_ALLOWED_RESOURCES_KEY).hasNext()) {
                     setAllowedResources(DEFAULT_ALLOWED_RESOURCES);
                 }
+            case 6:
+                boolean oldLogoutAvoidance = getBoolean("logoutAvoidance", false);
+                getConfig().setProperty(LOGOUT_AVOIDANCE_KEY, oldLogoutAvoidance);
+                getConfig().clearProperty("logoutAvoidance");
         }
     }
 

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParamUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParamUnitTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
@@ -196,6 +197,46 @@ class AjaxSpiderParamUnitTest {
             // Then
             assertThat(param.getNumberOfBrowsers(), is(equalTo(3)));
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldUpdateLogoutAvoidanceKeyOnConfigUpdate(boolean logoutAvoidance) {
+        // Given
+        configuration = new ZapXmlConfiguration();
+        configuration.setProperty("ajaxSpider[@version]", 6);
+        configuration.setProperty("logoutAvoidance", logoutAvoidance);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.isLogoutAvoidance(), is(equalTo(logoutAvoidance)));
+        assertThat(configuration.getProperty("logoutAvoidance"), is(nullValue()));
+        assertThat(
+                configuration.getBoolean("ajaxSpider.logoutAvoidance"),
+                is(equalTo(logoutAvoidance)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadLogoutAvoidanceFromConfig(boolean logoutAvoidance) {
+        // Given
+        configuration.setProperty("ajaxSpider.logoutAvoidance", logoutAvoidance);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.isLogoutAvoidance(), is(equalTo(logoutAvoidance)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAndPersistLogoutAvoidance(boolean logoutAvoidance) throws Exception {
+        // Given / When
+        param.setLogoutAvoidance(logoutAvoidance);
+        // Then
+        assertThat(param.isLogoutAvoidance(), is(equalTo(logoutAvoidance)));
+        assertThat(
+                configuration.getBoolean("ajaxSpider.logoutAvoidance"),
+                is(equalTo(logoutAvoidance)));
     }
 
     private void persistAllowedResource(int idx, String regex, Boolean enabled) {


### PR DESCRIPTION
Add the missing key prefix.

Fix zaproxy/zaproxy#8994.