### PR TITLE
Client: log missing Firefox at debug

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Error logs to always include stack trace.
+- Log Firefox missing at debug instead of error.
 
 ## [0.16.0] - 2025-06-20
 ### Added

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -45,6 +45,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.WebDriverException;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
@@ -368,6 +369,9 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
                 LOGGER.error(
                         "Failed to get or create Firefox profile {}", ZAP_FIREFOX_PROFILE_NAME);
             }
+        } catch (WebDriverException e) {
+            // Will happen if Firefox is not available.
+            LOGGER.debug(e.getMessage(), e);
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
         }


### PR DESCRIPTION
## Overview
We should not log an error if Firefox is missing, the user could be using Chrome or Edge.

## Related Issues

https://groups.google.com/g/zaproxy-users/c/cAgxv-X57lo/m/lYE2UHHEDAAJ
