### PR TITLE
exim: fix mapper setup

### DIFF
--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation("de.sstoehr:har-reader:3.1.4") {
         // Provided by commonlib add-on:
         exclude(group = "com.fasterxml.jackson.core")
+        exclude(group = "com.fasterxml.jackson.datatype")
     }
     implementation(files("lib/pkts-core-3.0.11-tcp-streams-branch.jar"))
     implementation(files("lib/pkts-streams-3.0.11-tcp-streams-branch.jar"))

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarUtils.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarUtils.java
@@ -20,9 +20,11 @@
 package org.zaproxy.addon.exim.har;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.sstoehr.harreader.model.HarContent;
 import de.sstoehr.harreader.model.HarCookie;
 import de.sstoehr.harreader.model.HarCreatorBrowser;
@@ -104,9 +106,10 @@ public final class HarUtils {
 
     public static final ObjectMapper JSON_MAPPER =
             JsonMapper.builder()
+                    .addModule(new JavaTimeModule())
+                    .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
                     .serializationInclusion(JsonInclude.Include.NON_DEFAULT)
-                    .build()
-                    .findAndRegisterModules();
+                    .build();
 
     private static final ObjectWriter JSON_WRITER = JSON_MAPPER.writerWithDefaultPrettyPrinter();
 


### PR DESCRIPTION
Add the time module explicitly to ensure it's found and adjust configuration for the zoned date parsing.
Exclude all Jackson dependencies from the add-on, as they are used from commonlib.