### PR TITLE
authhelper: track all auth / csrf related headers

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add wait authentication step to Browser Based Authentication.
 - Include Web Element's selector in the Authentication Report.
-- Support for tracking authorization headers automatically for Header based auth.
+- Support for tracking authentication and CSRF headers automatically for Header based auth.
 - Add Authentication Report section for the log file.
 
 ## Changed

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/session-header.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/session-header.html
@@ -13,7 +13,7 @@ of headers.
 <p>
 If used in conjunction with <a href="browser-auth.html">Browser Based Authentication</a> or 
 <a href="client-script.html">Client Script Authentication</a> then it will also maintain all
-of the cookies and Authorization headers set as part of authentication.
+of the cookies and any headers with names containing the strings "auth" or "csrf" (ignoring case) set as part of authentication.
 <p>
 The header values can include the following tokens:
 


### PR DESCRIPTION
## Overview
This was just tracking `authorization` headers - now changed to track any headers which match `*auth*` and `*csrf*`.
