### PR TITLE
exim: use LF for HAR files and fix tests

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update dependency.
+- Use always the same newlines (LF) when exporting HAR files.
 
 ## [0.14.0] - 2025-03-25
 ### Changed

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarExporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarExporter.java
@@ -20,6 +20,8 @@
 package org.zaproxy.addon.exim.har;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import de.sstoehr.harreader.model.HarLog;
 import java.io.IOException;
 import java.io.Writer;
@@ -33,7 +35,13 @@ public class HarExporter implements ExporterType {
 
     @Override
     public void begin(Writer writer) throws IOException {
-        generator = HarUtils.JSON_MAPPER.createGenerator(writer).useDefaultPrettyPrinter();
+        generator =
+                HarUtils.JSON_MAPPER
+                        .createGenerator(writer)
+                        .useDefaultPrettyPrinter()
+                        .setPrettyPrinter(
+                                new DefaultPrettyPrinter()
+                                        .withObjectIndenter(new DefaultIndenter("  ", "\n")));
 
         generator.writeStartObject();
         generator.writeObjectFieldStart("log");

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarUtils.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarUtils.java
@@ -20,6 +20,8 @@
 package org.zaproxy.addon.exim.har;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -111,7 +113,9 @@ public final class HarUtils {
                     .serializationInclusion(JsonInclude.Include.NON_DEFAULT)
                     .build();
 
-    private static final ObjectWriter JSON_WRITER = JSON_MAPPER.writerWithDefaultPrettyPrinter();
+    private static final ObjectWriter JSON_WRITER =
+            JSON_MAPPER.writer(
+                    new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", "\n")));
 
     private HarUtils() {}
 

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/ExportJobUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/ExportJobUnitTest.java
@@ -35,6 +35,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -152,14 +155,15 @@ class ExportJobUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldReportExporterCount() {
+    void shouldReportExporterCount() throws IOException {
         // Given
         AutomationPlan plan = new AutomationPlan();
         AutomationProgress progress = plan.getProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         ContextWrapper contextWrapper = new ContextWrapper(mock(Context.class));
         given(env.getContextWrapper(any())).willReturn(contextWrapper);
-        String yamlStr = "parameters:\n  fileName: /some/file";
+        Path file = Files.createTempFile("zap", "export");
+        String yamlStr = "parameters:\n  fileName: " + file.toString();
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
         ExporterResult result = mock();
@@ -178,7 +182,9 @@ class ExportJobUnitTest extends TestUtils {
         assertThat(progress.hasErrors(), is(equalTo(false)));
         assertThat(
                 progress.getInfos(),
-                hasItem("Job export: Exported 42 message(s) / node(s) to /some/file."));
+                hasItem(
+                        "Job export: Exported 42 message(s) / node(s) to %s."
+                                .formatted(file.toString())));
     }
 
     @Test

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/PruneJobUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/automation/PruneJobUnitTest.java
@@ -20,8 +20,9 @@
 package org.zaproxy.addon.exim.automation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -142,12 +143,13 @@ class PruneJobUnitTest extends TestUtils {
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(progress.hasErrors(), is(equalTo(true)));
         assertThat(progress.getErrors().size(), is(equalTo(1)));
-        assertThat(progress.getErrors(), contains(startsWith("Job prune Read 0 node(s) from ")));
         assertThat(
                 progress.getErrors(),
                 contains(
-                        endsWith(
-                                ", deleted 0 node(s), and failed with Exception loading file, for more details see the log file: Invalid file path (No such file or directory)")));
+                        allOf(
+                                startsWith("Job prune Read 0 node(s) from "),
+                                containsString(
+                                        ", deleted 0 node(s), and failed with Exception loading file, for more details see the log file: Invalid file path ("))));
     }
 
     private static void assertValidTemplate(String value) {


### PR DESCRIPTION
Export HAR files with same newlines regardless of the default newlines.
Fix tests on Windows.