### PR TITLE
network: address some test failures on Windows

### DIFF
--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -856,7 +856,7 @@ class ExtensionNetworkUnitTest extends TestUtils {
                 allOf(
                         containsString(CertificateUtils.BEGIN_CERTIFICATE_TOKEN),
                         containsString(
-                                "MIIC9TCCAl6gAwIBAgIJANL8E4epRNznMA0GCSqGSIb3DQEBBQUAMFsxGDAWBgNV\n"),
+                                "MIIC9TCCAl6gAwIBAgIJANL8E4epRNznMA0GCSqGSIb3DQEBBQUAMFsxGDAWBgNV"),
                         containsString(CertificateUtils.END_CERTIFICATE_TOKEN),
                         not(containsString(CertificateUtils.BEGIN_PRIVATE_KEY_TOKEN))));
     }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
@@ -375,7 +375,7 @@ class NetworkApiUnitTest extends TestUtils {
                 allOf(
                         containsString(CertificateUtils.BEGIN_CERTIFICATE_TOKEN),
                         containsString(
-                                "MIIC9TCCAl6gAwIBAgIJANL8E4epRNznMA0GCSqGSIb3DQEBBQUAMFsxGDAWBgNV\n"),
+                                "MIIC9TCCAl6gAwIBAgIJANL8E4epRNznMA0GCSqGSIb3DQEBBQUAMFsxGDAWBgNV"),
                         containsString(CertificateUtils.END_CERTIFICATE_TOKEN),
                         not(containsString(CertificateUtils.BEGIN_PRIVATE_KEY_TOKEN))));
         assertThat(apiMessage, is(sameInstance(message)));

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.network.internal.cert;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -377,7 +378,7 @@ class CertificateUtilsUnitTest {
         // When
         String pem = CertificateUtils.keyStoreToCertificatePem(keyStore);
         // Then
-        assertThat(pem, is(equalTo(CERTIFICATE_PEM)));
+        assertThat(pem, is(equalToCompressingWhiteSpace(CERTIFICATE_PEM)));
     }
 
     @Test
@@ -412,7 +413,7 @@ class CertificateUtilsUnitTest {
         // When
         CertificateUtils.keyStoreToCertificatePem(keyStore, file);
         // Then
-        assertThat(contents(file), is(equalTo(CERTIFICATE_PEM)));
+        assertThat(contents(file), is(equalToCompressingWhiteSpace(CERTIFICATE_PEM)));
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/Pkcs11DriversUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/Pkcs11DriversUnitTest.java
@@ -330,7 +330,7 @@ class Pkcs11DriversUnitTest extends TestUtils {
     private static void assertHomeDrivers(Matcher<String> matcher) {
         String content;
         try {
-            content = new String(Files.readAllBytes(homeDriversPath()), StandardCharsets.UTF_8);
+            content = Files.readString(homeDriversPath()).replace(System.lineSeparator(), "\n");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Ignore/normalise line endings.
Check for presence of expected message in the error instead of actual position.
Wait some milliseconds to ensure the timings are actually set.