### PR TITLE
webuipoc: fix build on Windows

### DIFF
--- a/addOns/webuipoc/src/main/pocs/reactWebUI/.env
+++ b/addOns/webuipoc/src/main/pocs/reactWebUI/.env
@@ -1,0 +1,2 @@
+PUBLIC_URL=/reactWebUI/
+BUILD_PATH=./dist

--- a/addOns/webuipoc/src/main/pocs/reactWebUI/package.json
+++ b/addOns/webuipoc/src/main/pocs/reactWebUI/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "PUBLIC_URL=/reactWebUI/ BUILD_PATH=./dist react-scripts build",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint"


### PR DESCRIPTION
Move the env vars to the env file as setting them directly in the command is not supported by all OSes.