### PR TITLE
network: correct unknown proxy host check

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use only positive serial numbers for the Root CA certificate (Issue 8984).
 
+### Fixed
+- Correctly inform about unknown proxy host on all OSes.
+
 ## [0.22.0] - 2025-06-20
 ### Fixed
 - A typo in the help with regard to Transparent Proxying.

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -383,7 +383,7 @@ public class HttpSenderApache
             return false;
         }
         // Exception message can be just the host or the host plus some other details.
-        return exceptionMessage.startsWith(options.getHttpProxy().getHost());
+        return exceptionMessage.contains(options.getHttpProxy().getHost());
     }
 
     private void sendImpl0(


### PR DESCRIPTION
Check that the proxy host is contained in the exception message as it can appear in different places depending on the OS.