### PR TITLE
2.15 pscanrules Add Java version check rule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [61.1.0] - 2025-07-25
+### Added
+- A ZAP is Out of Date rule.
+
 ### Changed
 - Updated help with specific Category identifiers for use with the Custom Payloads add-on for rules:
     - Application Error Disclosure

--- a/addOns/pscanrules/gradle.properties
+++ b/addOns/pscanrules/gradle.properties
@@ -1,2 +1,2 @@
-version=62
+version=61.1.0
 release=false

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ExtensionPscanRules.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ExtensionPscanRules.java
@@ -20,7 +20,11 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.SessionChangedListener;
+import org.parosproxy.paros.model.Session;
 
 /**
  * A null extension just to cause the message bundle and help file to get loaded
@@ -47,5 +51,27 @@ public class ExtensionPscanRules extends ExtensionAdaptor {
     @Override
     public boolean canUnload() {
         return true;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        extensionHook.addSessionListener(new PscanSessionChangedListener());
+    }
+
+    private static class PscanSessionChangedListener implements SessionChangedListener {
+
+        @Override
+        public void sessionChanged(Session session) {
+            ZapVersionScanRule.clear();
+        }
+
+        @Override
+        public void sessionAboutToChange(Session session) {}
+
+        @Override
+        public void sessionScopeChanged(Session session) {}
+
+        @Override
+        public void sessionModeChanged(Mode mode) {}
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ZapVersionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ZapVersionScanRule.java
@@ -1,0 +1,213 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.YearMonth;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.Version;
+import org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class ZapVersionScanRule extends PluginPassiveScanner implements CommonPassiveScanRuleInfo {
+
+    private static final String MESSAGE_PREFIX = "pscanrules.zapversion.";
+
+    private static final int PLUGIN_ID = 10116;
+
+    private static final Logger LOGGER = LogManager.getLogger(ZapVersionScanRule.class);
+
+    /** Used to make sure we only raise one alert per host. */
+    private static Set<String> hosts = new HashSet<>();
+
+    private static String latestVersionStr;
+    private static Integer risk;
+
+    @Override
+    public void scanHttpRequestSend(HttpMessage msg, int id) {
+        try {
+            int risk = getRisk();
+            if (risk <= 0) {
+                return;
+            }
+            String host = msg.getRequestHeader().getURI().getHost();
+            synchronized (hosts) {
+                if (hosts.contains(host)) {
+                    return;
+                }
+                hosts.add(host);
+            }
+            buildAlert(risk, getLatestVersionStr()).raise();
+        } catch (Exception e) {
+            LOGGER.debug(e.getMessage(), e);
+        }
+    }
+
+    private int getRisk() {
+        if (risk != null) {
+            return risk;
+        }
+        if (Constant.isDevBuild()) {
+            // Assume the user is keeping this up to date
+            risk = -1;
+            return risk;
+        }
+
+        if (Constant.isDailyBuild()) {
+            risk = getDateRisk(Constant.PROGRAM_VERSION, LocalDate.now());
+            return risk;
+        }
+
+        String latestVersion = getLatestVersionStr();
+        if (latestVersion == null) {
+            // No CFU req yet, might be done next time?
+            return -1;
+        }
+        risk = getVersionRisk(Constant.PROGRAM_VERSION, latestVersion);
+        return risk;
+    }
+
+    /**
+     * Returns the risk based on 2 semantic version strings like "2.16.1"
+     *
+     * @param currentVer the version of ZAP being run
+     * @param latestVer the latest ZAP version based on the Check For Updates call
+     * @return the risk, where <= 0: no risk, 1: low, 2: medium, 3: high
+     */
+    protected static int getVersionRisk(String currentVer, String latestVer) {
+        try {
+            Version cv = new Version(currentVer);
+            Version lv = new Version(latestVer);
+
+            if (cv.getMajorVersion() == lv.getMajorVersion()) {
+                // Easy case, no major version difference
+                return intToRisk(lv.getMinorVersion() - cv.getMinorVersion(), 0);
+            }
+            if (lv.getMajorVersion() - cv.getMajorVersion() > 1) {
+                // 2+ major version differences
+                return Alert.RISK_HIGH;
+            }
+            // 1 major version difference, always min of medium risk
+            return intToRisk(lv.getMinorVersion(), Alert.RISK_MEDIUM);
+        } catch (Exception e) {
+            LOGGER.debug(e.getMessage(), e);
+            return -1;
+        }
+    }
+
+    private static int intToRisk(int i, int minRisk) {
+        if (i < minRisk) {
+            return minRisk;
+        }
+        if (i > Alert.RISK_HIGH) {
+            return Alert.RISK_HIGH;
+        }
+        return i;
+    }
+
+    /**
+     * Returns the risk based on 1 date-stamped version string like "D-2025-06-30"
+     *
+     * @param currentVer the date-stamped version of ZAP being run
+     * @param today todays date (makes testing so much easier)
+     * @return the risk, where <= 0: no risk, 1: low, 2: medium, 3: high
+     */
+    protected static int getDateRisk(String currentVer, LocalDate today) {
+        if (currentVer == null || !currentVer.startsWith("D-")) {
+            return -1;
+        }
+        YearMonth yearMonth = YearMonth.parse(currentVer.substring(2, 9));
+        LocalDate pastDate = yearMonth.atDay(1);
+        return diffToRisk(Period.between(pastDate, today).getYears());
+    }
+
+    private static int diffToRisk(int diff) {
+        if (diff > Alert.RISK_HIGH) {
+            return Alert.RISK_HIGH;
+        }
+        return diff;
+    }
+
+    private static String getLatestVersionStr() {
+        if (latestVersionStr == null) {
+            ExtensionAutoUpdate ext =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionAutoUpdate.class);
+
+            if (ext != null) {
+                try {
+                    Object ver = MethodUtils.invokeMethod(ext, true, "getLatestVersionNumber");
+
+                    latestVersionStr = (String) ver;
+                } catch (Exception e) {
+                    LOGGER.debug(e.getMessage(), e);
+                }
+            }
+        }
+        return latestVersionStr;
+    }
+
+    private AlertBuilder buildAlert(int risk, String latest) {
+        AlertBuilder ab =
+                newAlert()
+                        .setRisk(risk)
+                        .setConfidence(Alert.CONFIDENCE_HIGH)
+                        .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                        .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "soln"))
+                        .setReference(Constant.messages.getString(MESSAGE_PREFIX + "refs"))
+                        .setCweId(1104) // CWE-1104: Use of Unmaintained Third Party Components
+                        .setWascId(45); // WASC-45: Application Misconfiguration
+        if (latest != null) {
+            ab.setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "otherinfo", latest));
+        }
+
+        return ab;
+    }
+
+    @Override
+    public int getPluginId() {
+        return PLUGIN_ID;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(buildAlert(Alert.RISK_MEDIUM, null).build());
+    }
+
+    protected static void clear() {
+        hosts.clear();
+    }
+}

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -420,3 +420,9 @@ pscanrules.xpoweredbyheaderinfoleak.name = Server Leaks Information via "X-Power
 pscanrules.xpoweredbyheaderinfoleak.otherinfo.msg = The following X-Powered-By headers were also found:\n
 pscanrules.xpoweredbyheaderinfoleak.refs = https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework\nhttps://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html
 pscanrules.xpoweredbyheaderinfoleak.soln = Ensure that your web server, application server, load balancer, etc. is configured to suppress "X-Powered-By" headers.
+
+pscanrules.zapversion.desc = The version of ZAP you are using to test your app is out of date and is no longer being updated.\nThe risk level is set based on how out of date your ZAP version is.
+pscanrules.zapversion.name = ZAP is Out of Date
+pscanrules.zapversion.otherinfo = The latest version of ZAP is {0}
+pscanrules.zapversion.refs = https://www.zaproxy.org/download/
+pscanrules.zapversion.soln = Download the latest version of ZAP from https://www.zaproxy.org/download/ and install it.

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ZapVersionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ZapVersionScanRuleUnitTest.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ZapVersionScanRuleUnitTest extends PassiveScannerTest<ZapVersionScanRule> {
+
+    LocalDate today = LocalDate.of(2025, 7, 10);
+
+    @Override
+    protected ZapVersionScanRule createScanner() {
+        return new ZapVersionScanRule();
+    }
+
+    @Test
+    void shouldHandleInvalidDateVersionStrings() {
+        // Given / When / then
+        assertThat(ZapVersionScanRule.getDateRisk("2020-01-01", today), is(equalTo(-1)));
+        assertThat(ZapVersionScanRule.getDateRisk("d-2020-01-01", today), is(equalTo(-1)));
+        assertThat(ZapVersionScanRule.getDateRisk("D_2020-01-01", today), is(equalTo(-1)));
+        assertThat(ZapVersionScanRule.getDateRisk(null, today), is(equalTo(-1)));
+        assertThat(ZapVersionScanRule.getDateRisk(null, null), is(equalTo(-1)));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                "D-2030-03-29, -4",
+                "D-2026-07-07, 0",
+                "D-2025-07-06, 0",
+                "D-2024-08-11, 0",
+                "D-2024-07-30, 1",
+                "D-2024-06-11, 1",
+                "D-2020-01-01, 3",
+                "D-2010-09-01, 3"
+            })
+    void shouldReturnExpectedDateRisks(String version, String riskStr) {
+        assertThat(
+                ZapVersionScanRule.getDateRisk(version, today),
+                is(equalTo(Integer.parseInt(riskStr))));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                "2.18.1, 2.16.0, 0",
+                "2.16.1, 2.16.0, 0",
+                "2.15.0, 2.16.0, 1",
+                "2.14.1, 2.16.0, 2",
+                "2.16.1, 3.1.0, 2",
+                "2.8.0, 2.16.0, 3",
+                "2.16.1, 3.5.0, 3",
+                "2.14.1, 2.17.0, 3"
+            })
+    void shouldReturnExpectedVersionRisks(
+            String currentVersion, String latestVersion, String riskStr) {
+        assertThat(
+                ZapVersionScanRule.getVersionRisk(currentVersion, latestVersion),
+                is(equalTo(Integer.parseInt(riskStr))));
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,12 +47,6 @@ allprojects {
         dependencies {
             "errorprone"("com.google.errorprone:error_prone_core:2.26.1")
         }
-
-        java {
-            val javaVersion = JavaVersion.VERSION_17
-            sourceCompatibility = javaVersion
-            targetCompatibility = javaVersion
-        }
     }
 
     tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
## Overview

Back-port the ZAP is Out of Date scan rule to 2.16