### PR TITLE
automation: refer to output panel for errors

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for step delay in Browser Based Authentication.
 - Support for min wait for in Client Script Authentication.
 
+### Changed
+- Refer to output panel for errors.
+
 ### Fixed
 - Bug in handling headers with colons in the values.
 - Use default authentication poll frequency when none specified, if the value is less than one a progress warning occurs.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
@@ -593,16 +593,11 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
         this.getOutputArea().setText(listToStr(progress.getAllMessages()));
         if (progress.hasErrors()) {
             View.getSingleton()
-                    .showWarningDialog(
-                            Constant.messages.getString(
-                                    "automation.panel.load.error",
-                                    listToStr(progress.getErrors())));
+                    .showWarningDialog(Constant.messages.getString("automation.panel.load.error"));
         } else if (progress.hasWarnings()) {
             View.getSingleton()
                     .showWarningDialog(
-                            Constant.messages.getString(
-                                    "automation.panel.load.warning",
-                                    listToStr(progress.getWarnings())));
+                            Constant.messages.getString("automation.panel.load.warning"));
         }
     }
 

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -412,9 +412,9 @@ automation.out.title.fail = Automation plan failures:
 automation.out.title.good = Automation plan succeeded!
 automation.out.title.warn = Automation plan warnings:
 
-automation.panel.load.error = YAML file loaded with errors: {0}
-automation.panel.load.failed = YAML file failed to load: {0}
-automation.panel.load.warning = YAML file loaded with warnings: {0}
+automation.panel.load.error = YAML file loaded with errors.\nSee the Automation / Output panel for details.
+automation.panel.load.failed = YAML file failed to load:\n{0}
+automation.panel.load.warning = YAML file loaded with warnings.\nSee the Automation / Output panel for details.
 automation.panel.load.yaml = YAML Configuration Files
 automation.panel.table.env.name = Environment
 automation.panel.table.header.alwaysrun = Always Run


### PR DESCRIPTION
## Overview
If you try to load an AF plan with an error in it you often get a _very_ wide dialog where you cant even see the button :/
This splits them so you can actually see the info.

## Related Issues

