### PR TITLE
ascanrules: Oracle SQLi use DBMS_SESSION.SLEEP

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update alert references to latest locations to fix 404s and resolve redirections.
+- The SQL Injection - Oracle (Time Based) rule now uses DBMS_SESSION.SLEEP instead of an "expensive" query.
 
 ### Fixed
 - Hidden Files rule raising false positives if server returning 200 for files that don't exist (Issue 8434).

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -413,7 +413,9 @@ to minimise load on the web server, application server, and database, in order t
 load delays rather than by SQL injection delays. <br>
 The scan rule tests only for time-based SQL injection vulnerabilities.<br>
 <br>
-Note that this rule does not currently allow you to change the length of time used for the timing attacks due to the way the delay is caused. 
+The scan rule tests only for time-based SQL injection vulnerabilities.<br>
+<p>
+Post 2.5.0 you can change the length of time used for the attack by changing the <code>rules.common.sleep</code> parameter via the Options 'Rule configuration' panel.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionOracleTimingScanRule.java">SqlInjectionOracleTimingScanRule.java</a>
 <br>


### PR DESCRIPTION
## Overview
The SQL Injection - Oracle (Time Based) rule now uses DBMS_SESSION.SLEEP instead of an "expensive" query.

## Related Issues
- zaproxy/zap-extensions#6566
- zaproxy/zap-extensions#6605
