### PR TITLE
ascanrules: Add unit tests for some rXSS alert situations

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The Remote OS Command Injection scan rule has been broken into two rules; one feedback based, and one time based (Issue 7341). This includes assigning the time based rule ID 90037.
 - The External Redirect scan rule payload were slightly re-ordered to prioritize HTTPS variants.
 - For Alerts raised by the SQL Injection scan rules the Attack field values are now simply the payload, not an assembled description.
+- The Cross Site Scripting (Reflected) scan rule was updated to address potential false negatives when the injection context is a tag name and there is some filtering.
 
 ### Added
 - Rules (as applicable) have been tagged in relation to HIPAA and PCI DSS.

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -855,8 +855,9 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin
         // In this case the parent effectively changes
         List<HtmlContext> context2 =
                 performAttack(msg, param, attackString1, context, HtmlContext.IGNORE_PARENT);
-        if (context2 == null) {
-            context2 = performAttack(msg, param, TAG_ONCLICK_ALERT, context, 0);
+
+        if (context2 == null || context2.isEmpty()) {
+            context2 = performAttack(msg, param, TAG_ONCLICK_ALERT, null, 0);
             if (context2 == null) {
                 return false;
             }

--- a/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInElementName.html
+++ b/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInElementName.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <@@@q@@@ id="name">name</button>
+  </body>
+</html>


### PR DESCRIPTION
## Overview
Add unit tests to cover the Alerts raised at:
- 510
- 602
- 645
- 823
- 866

~~I'm still looking at the last case which is currently missed at 823, but these may as well go in to start.~~
Not user facing and arguably covered by the existing "Maintenance Changes" note.