### PR TITLE
authhelper: importing a context use defaults for new stepDelay (BBA) and minWaitFor (CSA) properties

### DIFF
--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -122,6 +122,7 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
 
     public static final String DEFAULT_BROWSER_ID = Browser.FIREFOX_HEADLESS.getId();
     private static final int DEFAULT_PAGE_WAIT = 5;
+    private static final int DEFAULT_STEP_DELAY = 0;
 
     private static final Logger LOGGER =
             LogManager.getLogger(BrowserBasedAuthenticationMethodType.class);
@@ -655,7 +656,8 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
             throw new ConfigurationException(e);
         }
         try {
-            method.setStepDelay(config.getInt(CONTEXT_CONFIG_AUTH_BROWSER_STEPDELAY));
+            method.setStepDelay(
+                    config.getInt(CONTEXT_CONFIG_AUTH_BROWSER_STEPDELAY, DEFAULT_STEP_DELAY));
         } catch (Exception e) {
             throw new ConfigurationException(e);
         }
@@ -835,7 +837,7 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
             this.add(loginUrlWait, LayoutHelper.getGBC(1, y, 1, 1.0d, 0.0d));
             y++;
 
-            stepDelay = new ZapNumberSpinner(0, 0, Integer.MAX_VALUE);
+            stepDelay = new ZapNumberSpinner(0, DEFAULT_STEP_DELAY, Integer.MAX_VALUE);
             JLabel stepDelayLabel =
                     new JLabel(
                             Constant.messages.getString(

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -88,6 +88,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
             CONTEXT_CONFIG_AUTH_SCRIPT + ".minwaitfor";
 
     private static final int DEFAULT_PAGE_WAIT = 5;
+    private static final int DEFAULT_MIN_WAIT_FOR = 0;
 
     private ExtensionScript extensionScript;
 
@@ -679,7 +680,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                 this.add(loginPageWait, LayoutHelper.getGBC(1, y, 2, 1.0d, 0.0d));
                 y++;
 
-                minWaitFor = new ZapNumberSpinner(0, 0, Integer.MAX_VALUE);
+                minWaitFor = new ZapNumberSpinner(0, DEFAULT_MIN_WAIT_FOR, Integer.MAX_VALUE);
                 JLabel minWaitForLabel =
                         new JLabel(
                                 Constant.messages.getString(
@@ -797,7 +798,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
             throw new ConfigurationException(e);
         }
         try {
-            method.setMinWaitFor(config.getInt(CONTEXT_CONFIG_MIN_WAIT_FOR));
+            method.setMinWaitFor(config.getInt(CONTEXT_CONFIG_MIN_WAIT_FOR, DEFAULT_MIN_WAIT_FOR));
         } catch (Exception e) {
             throw new ConfigurationException(e);
         }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodTypeUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodTypeUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -125,6 +126,23 @@ class BrowserBasedAuthenticationMethodTypeUnitTest {
         assertThat(method2.getLoginPageWait(), is(equalTo(7)));
         assertThat(method2.getStepDelay(), is(equalTo(3)));
         assertThat(method2.getBrowserId(), is(equalTo("example")));
+    }
+
+    @Test
+    void shouldLoadContextExportV0() {
+        // Given
+        String loginUrl = "https://www.example.com";
+        BrowserBasedAuthenticationMethodType type = new BrowserBasedAuthenticationMethodType();
+        BrowserBasedAuthenticationMethod method1 = type.createAuthenticationMethod(0);
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        config.setProperty("context.authentication.browser.loginpageurl", loginUrl);
+        config.setProperty("context.authentication.browser.loginpagewait", 2);
+        // When
+        assertDoesNotThrow(() -> method1.getType().importData(config, method1));
+        // Then
+        assertThat(method1.getLoginPageUrl(), is(equalTo(loginUrl)));
+        assertThat(method1.getLoginPageWait(), is(equalTo(2)));
+        assertThat(method1.getStepDelay(), is(equalTo(0)));
     }
 
     @Test

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodTypeUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodTypeUnitTest.java
@@ -1,0 +1,66 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.authhelper.ClientScriptBasedAuthenticationMethodType.ClientScriptBasedAuthenticationMethod;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.utils.I18N;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+class ClientScriptBasedAuthenticationMethodTypeUnitTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        Constant.messages = mock(I18N.class);
+        Control.initSingletonForTesting(mock(Model.class), mock(ExtensionLoader.class));
+    }
+
+    @Test
+    void shouldLoadContextExportV0() {
+        // Given
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.getName()).willReturn("test_auth_script");
+
+        ClientScriptBasedAuthenticationMethodType type =
+                new ClientScriptBasedAuthenticationMethodType();
+        ClientScriptBasedAuthenticationMethod method1 = type.createAuthenticationMethod(0);
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        method1.setScriptWrapper(scriptWrapper);
+        config.setProperty("context.authentication.script.loginpagewait", 2);
+        // When
+        assertDoesNotThrow(() -> method1.getType().importData(config, method1));
+        // Then
+        assertThat(method1.getLoginPageWait(), is(equalTo(2)));
+        assertThat(method1.getMinWaitFor(), is(equalTo(0)));
+    }
+}


### PR DESCRIPTION
## Overview
When importing BBA info (ex: Context Import) ensure that suitable defaults are used in the case of missing properties (ex: stepdelay).

## Related Issues
- Fixes zaproxy/zaproxy#9022
