### PR TITLE
automation: Allow selecting rules via Alert Tags

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for min wait for in Client Script Authentication.
 - Support for url in activeScan job.
 - Support for stopping plans and jobs.
+- Allow selecting rules in policy definitions using alert tags.
 
 ### Changed
 - Refer to output panel for errors.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanPolicyDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanPolicyDialog.java
@@ -22,16 +22,30 @@ package org.zaproxy.addon.automation.gui;
 import java.awt.Dimension;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.automation.jobs.PolicyDefinition;
+import org.zaproxy.addon.automation.jobs.PolicyDefinition.AlertTagRuleConfig;
 import org.zaproxy.addon.automation.jobs.PolicyDefinition.Rule;
+import org.zaproxy.zap.extension.ascan.ScanPolicy;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
@@ -47,13 +61,38 @@ public abstract class ActiveScanPolicyDialog extends StandardFieldsDialog {
             "automation.dialog.ascan.defaultthreshold";
     protected static final String DEFAULT_STRENGTH_PARAM =
             "automation.dialog.ascan.defaultstrength";
+    protected static final String TAG_RULE_THRESHOLD_PARAM =
+            "automation.dialog.ascanpolicyalerttags.threshold";
+    protected static final String TAG_RULE_STRENGTH_PARAM =
+            "automation.dialog.ascanpolicyalerttags.strength";
 
     private JButton addButton = null;
     private JButton modifyButton = null;
     private JButton removeButton = null;
+    private JButton previewRulesButton;
 
     private JTable rulesTable = null;
     private AscanRulesTableModel rulesModel = null;
+
+    private JTable includedTagsTable;
+    private final AlertTagsTableModel includedTagsTableModel =
+            new AlertTagsTableModel(
+                    Constant.messages.getString(
+                            "automation.dialog.ascanpolicyalerttags.includedtagpatterns"));
+    private final JButton addIncludedAlertTagButton =
+            createAddAlertTagButton(includedTagsTableModel);
+    private final JButton removeIncludedAlertTagButton =
+            createRemoveAlertTagButton(includedTagsTableModel, this::getIncludedAlertTagsTable);
+
+    private final AlertTagsTableModel excludedTagsTableModel =
+            new AlertTagsTableModel(
+                    Constant.messages.getString(
+                            "automation.dialog.ascanpolicyalerttags.excludedtagpatterns"));
+    private JTable excludedTagsTable;
+    private final JButton addExcludedAlertTagButton =
+            createAddAlertTagButton(excludedTagsTableModel);
+    private final JButton removeExcludedAlertTagButton =
+            createRemoveAlertTagButton(excludedTagsTableModel, this::getExcludedAlertTagsTable);
 
     public ActiveScanPolicyDialog(String title, Dimension dimension, String[] tabLabels) {
         super(View.getSingleton().getMainFrame(), title, dimension, tabLabels);
@@ -185,4 +224,159 @@ public abstract class ActiveScanPolicyDialog extends StandardFieldsDialog {
     }
 
     protected abstract List<Rule> getRules();
+
+    protected AlertTagRuleConfig getAlertTagRule() {
+        return null;
+    }
+
+    protected void addTagRuleTab(
+            int tabIndex, List<String> allThresholds, List<String> allStrengths) {
+        AlertTagRuleConfig alertTagRule = getAlertTagRule();
+        if (alertTagRule == null) {
+            alertTagRule = new AlertTagRuleConfig();
+        }
+
+        String tagRuleThresholdName = JobUtils.thresholdToI18n(alertTagRule.getThreshold().name());
+        if (tagRuleThresholdName.isEmpty()) {
+            tagRuleThresholdName = JobUtils.thresholdToI18n(AlertThreshold.MEDIUM.name());
+        }
+        String tagRuleStrengthName = JobUtils.strengthToI18n(alertTagRule.getStrength().name());
+        if (tagRuleStrengthName.isEmpty()) {
+            tagRuleStrengthName = JobUtils.strengthToI18n(AttackStrength.MEDIUM.name());
+        }
+        this.addComboField(tabIndex, TAG_RULE_THRESHOLD_PARAM, allThresholds, tagRuleThresholdName);
+        this.addComboField(tabIndex, TAG_RULE_STRENGTH_PARAM, allStrengths, tagRuleStrengthName);
+        this.addTableField(
+                tabIndex,
+                getIncludedAlertTagsTable(),
+                List.of(addIncludedAlertTagButton, removeIncludedAlertTagButton));
+        this.addTableField(
+                tabIndex,
+                getExcludedAlertTagsTable(),
+                List.of(addExcludedAlertTagButton, removeExcludedAlertTagButton));
+    }
+
+    protected JButton getPreviewRulesButton() {
+        if (previewRulesButton == null) {
+            previewRulesButton =
+                    new JButton(
+                            Constant.messages.getString(
+                                    "automation.dialog.ascanpolicy.button.previewrules"));
+            JTable effectiveRulesTable = new JXTable();
+            var previewScrollPane = new JScrollPane(effectiveRulesTable);
+            previewScrollPane.setPreferredSize(DisplayUtils.getScaledDimension(500, 400));
+            AscanRulesTableModel effectiveRulesModel = new AscanRulesTableModel();
+            effectiveRulesTable.setModel(effectiveRulesModel);
+            previewRulesButton.addActionListener(
+                    e -> {
+                        String defaultThreshold = getStringValue(DEFAULT_THRESHOLD_PARAM);
+                        String defaultStrength = getStringValue(DEFAULT_STRENGTH_PARAM);
+                        Map<Integer, Rule> effectiveRulesMap = new HashMap<>();
+                        new ScanPolicy()
+                                .getPluginFactory()
+                                .getAllPlugin()
+                                .forEach(
+                                        plugin ->
+                                                effectiveRulesMap.put(
+                                                        plugin.getId(),
+                                                        new Rule(
+                                                                plugin.getId(),
+                                                                plugin.getName(),
+                                                                defaultThreshold,
+                                                                defaultStrength)));
+                        PolicyDefinition.computeEffectiveRules(
+                                        createAlertTagRuleConfig(), getRulesModel().getRules())
+                                .forEach(
+                                        rule -> {
+                                            if (AlertThreshold.DEFAULT
+                                                    .name()
+                                                    .toLowerCase(Locale.ROOT)
+                                                    .equals(rule.getThreshold())) {
+                                                rule.setThreshold(defaultThreshold);
+                                            }
+                                            if (AttackStrength.DEFAULT
+                                                    .name()
+                                                    .toLowerCase(Locale.ROOT)
+                                                    .equals(rule.getStrength())) {
+                                                rule.setStrength(defaultStrength);
+                                            }
+                                            effectiveRulesMap.put(rule.getId(), rule);
+                                        });
+                        effectiveRulesModel.setRules(effectiveRulesMap.values().stream().toList());
+                        effectiveRulesModel.fireTableDataChanged();
+                        JOptionPane.showMessageDialog(
+                                this,
+                                previewScrollPane,
+                                Constant.messages.getString(
+                                        "automation.dialog.ascanpolicy.dialog.effectiverules"),
+                                JOptionPane.PLAIN_MESSAGE);
+                    });
+        }
+        return previewRulesButton;
+    }
+
+    protected AlertTagRuleConfig createAlertTagRuleConfig() {
+        return new AlertTagRuleConfig(
+                includedTagsTableModel.getAlertTagPatterns(),
+                excludedTagsTableModel.getAlertTagPatterns(),
+                AttackStrength.valueOf(
+                        JobUtils.i18nToStrength(this.getStringValue(TAG_RULE_STRENGTH_PARAM))
+                                .toUpperCase(java.util.Locale.ROOT)),
+                AlertThreshold.valueOf(
+                        JobUtils.i18nToThreshold(this.getStringValue(TAG_RULE_THRESHOLD_PARAM))
+                                .toUpperCase(java.util.Locale.ROOT)));
+    }
+
+    private JTable getIncludedAlertTagsTable() {
+        if (includedTagsTable == null) {
+            includedTagsTable =
+                    createAlertTagsTable(
+                            includedTagsTableModel,
+                            getAlertTagRule().getIncludePatterns(),
+                            removeIncludedAlertTagButton);
+        }
+        return includedTagsTable;
+    }
+
+    private JTable getExcludedAlertTagsTable() {
+        if (excludedTagsTable == null) {
+            excludedTagsTable =
+                    createAlertTagsTable(
+                            excludedTagsTableModel,
+                            getAlertTagRule().getExcludePatterns(),
+                            removeExcludedAlertTagButton);
+        }
+        return excludedTagsTable;
+    }
+
+    private JButton createAddAlertTagButton(AlertTagsTableModel model) {
+        var button = new JButton(Constant.messages.getString("automation.dialog.button.add"));
+        button.addActionListener(
+                e -> {
+                    var dialog = new AddAlertTagDialog(this, model, -1);
+                    dialog.setVisible(true);
+                });
+        return button;
+    }
+
+    private JButton createRemoveAlertTagButton(
+            AlertTagsTableModel model, Supplier<JTable> tableSupplier) {
+        var button = new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+        button.setEnabled(false);
+        button.addActionListener(e -> model.remove(tableSupplier.get().getSelectedRow()));
+        return button;
+    }
+
+    private JTable createAlertTagsTable(
+            AlertTagsTableModel model, List<Pattern> patterns, JButton removeButton) {
+        JTable table = new JTable(model);
+        model.setAlertTagPatterns(new ArrayList<>(patterns));
+        table.getSelectionModel()
+                .addListSelectionListener(
+                        e -> {
+                            boolean singleRowSelected = table.getSelectedRowCount() == 1;
+                            removeButton.setEnabled(singleRowSelected);
+                        });
+        return table;
+    }
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAlertTagDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAlertTagDialog.java
@@ -1,0 +1,100 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import static java.util.function.Predicate.not;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.zap.extension.ascan.ScanPolicy;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+@SuppressWarnings("serial")
+public class AddAlertTagDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.ascanpolicyalerttags.addalerttag";
+
+    private static final String ALERT_TAG_PARAM = "automation.dialog.ascanpolicyalerttags.alerttag";
+
+    private String alertTagPattern;
+    private AlertTagsTableModel alertTagsTableModel;
+    private int tableIndex;
+
+    public AddAlertTagDialog(
+            ActiveScanPolicyDialog parent,
+            AlertTagsTableModel alertTagsTableModel,
+            int tableIndex) {
+        super(parent, TITLE, DisplayUtils.getScaledDimension(400, 100));
+        this.alertTagsTableModel = alertTagsTableModel;
+        this.alertTagPattern =
+                tableIndex != -1
+                        ? alertTagsTableModel.getAlertTagPatterns().get(tableIndex).pattern()
+                        : null;
+        this.tableIndex = tableIndex;
+
+        List<String> allActiveAlertTags =
+                new ScanPolicy()
+                        .getPluginFactory().getAllPlugin().stream()
+                                .map(Plugin::getAlertTags)
+                                .filter(Objects::nonNull)
+                                .filter(not(Map::isEmpty))
+                                .map(Map::keySet)
+                                .flatMap(Set::stream)
+                                .distinct()
+                                .sorted()
+                                .toList();
+        this.addComboField(ALERT_TAG_PARAM, allActiveAlertTags, alertTagPattern, true);
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        this.alertTagPattern = this.getStringValue(ALERT_TAG_PARAM).trim();
+        if (this.tableIndex == -1) {
+            alertTagsTableModel.add(Pattern.compile(this.alertTagPattern));
+        } else {
+            alertTagsTableModel.update(this.tableIndex, Pattern.compile(this.alertTagPattern));
+        }
+    }
+
+    @Override
+    public String validateFields() {
+        String str = this.getStringValue(ALERT_TAG_PARAM).trim();
+        if (!JobUtils.containsVars(str)) {
+            // Can only validate strings that dont contain env vars
+            try {
+                Pattern.compile(str);
+            } catch (Exception e) {
+                return Constant.messages.getString(
+                        "automation.dialog.ascanpolicyalerttags.error.badregex", str);
+            }
+        }
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AlertTagsTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AlertTagsTableModel.java
@@ -1,0 +1,131 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import javax.swing.table.AbstractTableModel;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+
+@SuppressWarnings("serial")
+public class AlertTagsTableModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String columnName;
+
+    private List<Pattern> alertTagPatterns = new ArrayList<>();
+
+    public AlertTagsTableModel(String columnName) {
+        super();
+        this.columnName = Objects.requireNonNull(columnName, "Column name must not be null");
+    }
+
+    @Override
+    public int getColumnCount() {
+        return 1;
+    }
+
+    @Override
+    public int getRowCount() {
+        return alertTagPatterns.size();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        Pattern alertTagPattern = this.alertTagPatterns.get(row);
+        if (alertTagPattern != null) {
+            return alertTagPattern.pattern();
+        }
+        return null;
+    }
+
+    @Override
+    public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+        if (aValue instanceof String alertTagPatternStr) {
+            try {
+                Pattern alertTagPattern = Pattern.compile(alertTagPatternStr);
+                this.alertTagPatterns.set(rowIndex, alertTagPattern);
+                this.fireTableCellUpdated(rowIndex, columnIndex);
+            } catch (PatternSyntaxException e) {
+                View.getSingleton()
+                        .showWarningDialog(
+                                Constant.messages.getString(
+                                        "automation.dialog.ascanpolicyalerttags.error.badregex",
+                                        alertTagPatternStr));
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "Expected a String value for alert tag pattern, but got: " + aValue);
+        }
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return true;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        if (col != 0) {
+            throw new IndexOutOfBoundsException("Column index out of bounds: " + col);
+        }
+        return columnName;
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    public List<Pattern> getAlertTagPatterns() {
+        return alertTagPatterns;
+    }
+
+    public void setAlertTagPatterns(List<Pattern> alertTagPatterns) {
+        this.alertTagPatterns = Objects.requireNonNullElseGet(alertTagPatterns, ArrayList::new);
+    }
+
+    public void clear() {
+        this.alertTagPatterns.clear();
+    }
+
+    public void add(Pattern alertTagPattern) {
+        this.alertTagPatterns.add(alertTagPattern);
+        this.fireTableRowsInserted(
+                this.alertTagPatterns.size() - 1, this.alertTagPatterns.size() - 1);
+    }
+
+    public void update(int tableIndex, Pattern alertTagPattern) {
+        this.alertTagPatterns.set(tableIndex, alertTagPattern);
+        this.fireTableRowsUpdated(tableIndex, tableIndex);
+    }
+
+    public void remove(int index) {
+        if (index < this.alertTagPatterns.size()) {
+            this.alertTagPatterns.remove(index);
+            this.fireTableRowsDeleted(index, index);
+        }
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AscanRulesTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AscanRulesTableModel.java
@@ -67,7 +67,7 @@ public class AscanRulesTableModel extends AbstractTableModel {
         if (rule != null) {
             switch (col) {
                 case 0:
-                    return rule.getId();
+                    return String.valueOf(rule.getId());
                 case 1:
                     return rule.getName();
                 case 2:

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
@@ -38,6 +38,11 @@ This job supports <a href="test-monitor.html">monitor</a> tests.
     policyDefinition:                  # The policy definition - only used if the 'policy' is not set
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
+      alertTags:                       # Add rules based on alert tags; does not override or remove rules listed explicitly under "rules"
+        include: []                    # List of alert tags to include, regex supported
+        exclude: []                    # List of alert tags to exclude from this include list, regex supported
+        strength:                      # String: The Attack Strength for this set of rules, one of Low, Medium, High, Insane, default: Medium
+        threshold:                     # String: The Alert Threshold for this set of rules, one of Off, Low, Medium, High, default: Medium
       rules:                           # A list of one or more active scan rules and associated settings which override the defaults
       - id:                            # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
         name:                          # String: The name of the rule for documentation purposes - this is not required or actually used
@@ -52,6 +57,7 @@ This job supports <a href="test-monitor.html">monitor</a> tests.
 <p>
 The policy can be one defined by a previous <a href="job-ascanpolicy.html">activeScan-policy</a> job, or by a scan policy file
 that has been put in <code>policies</code> directory under ZAP's <a href="https://www.zaproxy.org/faq/what-is-the-default-directory-that-zap-uses/">HOME directory</a> .
+For more information on how ZAP processes the policy definition, see the <a href="job-ascanpolicy.html">activeScan-policy</a> job documentation.
 
 <H2>Job Data</H2>
 The following class will be made available to add-ons that provide access to the Job Data such as the Reporting add-on.

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascanpolicy.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascanpolicy.html
@@ -20,6 +20,11 @@ like <a href="job-ascan.html">activeScan</a> job.
     policyDefinition:                  # The policy definition
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
+      alertTags:                       # Add rules based on alert tags; does not override or remove rules listed explicitly under "rules"
+        include: []                    # List of alert tags to include, regex supported
+        exclude: []                    # List of alert tags to exclude from this include list, regex supported
+        strength:                      # String: The Attack Strength for this set of rules, one of Low, Medium, High, Insane, default: Medium
+        threshold:                     # String: The Alert Threshold for this set of rules, one of Off, Low, Medium, High, default: Medium
       rules:                           # A list of one or more active scan rules and associated settings which override the defaults
       - id:                            # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
         name:                          # Comment: The name of the rule for documentation purposes - this is not required or actually used
@@ -28,6 +33,20 @@ like <a href="job-ascan.html">activeScan</a> job.
     enabled:                           # Bool: If set to false the job will not be run, default: true
     alwaysRun:                         # Bool: If set and the job is enabled then it will run even if the plan exits early, default: false
 </pre>
+
+<h2>Policy Definition Hierarchy</h2>
+ZAP processes the policy definition in the following order:
+
+<ol>
+    <li><strong>Default behavior</strong>: All rules start with the default strength and threshold settings. We expect
+        the default threshold to be set to <code>Off</code> in most cases.
+    <li><strong>Alert tag processing</strong>: Rules matching the <code>include</code> patterns are enabled with the
+        specified alert tag strength and threshold, and rules matching any <code>exclude</code> pattern are removed from
+        the included set. For a full list of default alert tags, see <a href="https://www.zaproxy.org/alerttags/">Alert
+            Tags</a>.
+    <li><strong>Individual rule overrides</strong>: Explicitly listed rules under the <code>rules</code> section take
+        precedence over alert tag settings and policy defaults.
+</ol>
 
 </BODY>
 </HTML>

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -79,6 +79,7 @@ automation.dialog.ascan.remove.confirm = Are you sure you want to remove this ru
 automation.dialog.ascan.scanheaders = Scan All Headers:
 automation.dialog.ascan.summary = Context: {0}
 automation.dialog.ascan.tab.adv = Advanced
+automation.dialog.ascan.tab.policyalerttags = Policy Alert Tags
 automation.dialog.ascan.tab.policydefaults = Policy Defaults
 automation.dialog.ascan.tab.policyrules = Policy Rules
 automation.dialog.ascan.table.header.id = ID
@@ -120,10 +121,20 @@ automation.dialog.ascanconfig.tab.iv = Input Vectors
 automation.dialog.ascanconfig.threads = Threads Per Host:
 automation.dialog.ascanconfig.title = Active Scan Config Job
 
+automation.dialog.ascanpolicy.button.previewrules = Preview Rules
+automation.dialog.ascanpolicy.dialog.effectiverules = Effective Rules
 automation.dialog.ascanpolicy.error.badname = You must supply a policy name
 automation.dialog.ascanpolicy.name = Policy Name:
 automation.dialog.ascanpolicy.summary = Scan Policy: {0}
 automation.dialog.ascanpolicy.title = Active Scan Policy Job
+
+automation.dialog.ascanpolicyalerttags.addalerttag = Add Alert Tag
+automation.dialog.ascanpolicyalerttags.alerttag = Alert Tag:
+automation.dialog.ascanpolicyalerttags.error.badregex = Invalid Alert Tag pattern: ''{0}'' is not a valid regular expression.
+automation.dialog.ascanpolicyalerttags.excludedtagpatterns = Excluded Alert Tag Patterns
+automation.dialog.ascanpolicyalerttags.includedtagpatterns = Included Alert Tag Patterns
+automation.dialog.ascanpolicyalerttags.strength = Strength:
+automation.dialog.ascanpolicyalerttags.threshold = Threshold:
 
 automation.dialog.button.add = Add
 automation.dialog.button.modify = Modify

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-max.yaml
@@ -17,6 +17,11 @@
     policyDefinition:                  # The policy definition - only used if the 'policy' is not set
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
+      alertTags:                       # Add rules by alert tags; overrides default settings but not rules explicitly listed under "rules"
+        include: []                    # List of alert tags to include, regex supported
+        exclude: []                    # List of alert tags to exclude from the include list, regex supported
+        strength:                      # String: The Attack Strength for this set of rules, one of Low, Medium, High, Insane, default: Medium
+        threshold:                     # String: The Alert Threshold for this set of rules, one of Off, Low, Medium, High, default: Medium
       rules:                           # A list of one or more active scan rules and associated settings which override the defaults
       - id:                            # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
         name:                          # Comment: The name of the rule for documentation purposes - this is not required or actually used

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-policy-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-policy-max.yaml
@@ -4,6 +4,11 @@
     policyDefinition:                  # The policy definition
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
+      alertTags:                       # Add rules by alert tags; overrides default settings but not rules explicitly listed under "rules"
+        include: []                    # List of alert tags to include, regex supported
+        exclude: []                    # List of alert tags to exclude from the include list, regex supported
+        strength:                      # String: The Attack Strength for this set of rules, one of Low, Medium, High, Insane, default: Medium
+        threshold:                     # String: The Alert Threshold for this set of rules, one of Off, Low, Medium, High, default: Medium
       rules:                           # A list of one or more active scan rules and associated settings which override the defaults
       - id:                            # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
         name:                          # Comment: The name of the rule for documentation purposes - this is not required or actually used

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-policy-min.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-policy-min.yaml
@@ -4,6 +4,11 @@
     policyDefinition:                  # The policy definition
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
+      alertTags:                       # Add rules by alert tags; overrides default settings but not rules explicitly listed under "rules"
+        include: []                    # List of alert tags to include, regex supported
+        exclude: []                    # List of alert tags to exclude from the include list, regex supported
+        strength:                      # String: The Attack Strength for this set of rules, one of Low, Medium, High, Insane, default: Medium
+        threshold:                     # String: The Alert Threshold for this set of rules, one of Off, Low, Medium, High, default: Medium
       rules:                           # A list of one or more active scan rules and associated settings which override the defaults
       - id:                            # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
         name:                          # Comment: The name of the rule for documentation purposes - this is not required or actually used

--- a/addOns/automation/src/test/java/org/parosproxy/paros/core/scanner/PluginTestHelper.java
+++ b/addOns/automation/src/test/java/org/parosproxy/paros/core/scanner/PluginTestHelper.java
@@ -19,6 +19,8 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import java.util.Map;
+
 public class PluginTestHelper extends AbstractPlugin {
 
     @Override
@@ -56,4 +58,9 @@ public class PluginTestHelper extends AbstractPlugin {
 
     @Override
     public void notifyPluginCompleted(HostProcess parent) {}
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return Map.of("TEST_TAG", "TEST_VALUE");
+    }
 }

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PolicyDefinitionUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PolicyDefinitionUnitTest.java
@@ -53,6 +53,7 @@ import org.parosproxy.paros.core.scanner.PluginTestHelper;
 import org.yaml.snakeyaml.Yaml;
 import org.zaproxy.addon.automation.AutomationPlan;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.jobs.PolicyDefinition.AlertTagRuleConfig;
 import org.zaproxy.addon.automation.jobs.PolicyDefinition.Rule;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
 import org.zaproxy.zap.utils.I18N;
@@ -367,5 +368,187 @@ class PolicyDefinitionUnitTest {
         String ruleYaml = AutomationPlan.writeObjectAsString(rule);
         // Then
         assertThat(ruleYaml, containsString("id: " + id));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"TEST_TAG", "TEST_.*"})
+    void shouldAddRuleUsingAlertTags(String tagPattern) {
+        // Given
+        String yamlStr =
+                String.format(
+                        """
+                defaultStrength: low
+                defaultThreshold: 'off'
+                alertTags:
+                  include:
+                    - %s
+                  exclude: []
+                  strength: insane
+                  threshold: high
+                """,
+                        tagPattern);
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        // When
+        policyDefinition.parsePolicyDefinition(data, "test", progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(policyDefinition.getDefaultStrength(), is(equalTo("low")));
+        assertThat(policyDefinition.getDefaultThreshold(), is(equalTo("off")));
+        List<Rule> rules = policyDefinition.getEffectiveRules();
+        assertThat(rules.size(), is(equalTo(1)));
+        assertThat(rules.get(0).getId(), is(equalTo(50000)));
+        assertThat(rules.get(0).getName(), is(equalTo("PluginTestHelper")));
+        assertThat(rules.get(0).getStrength(), is(equalTo("insane")));
+        assertThat(rules.get(0).getThreshold(), is(equalTo("high")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"TEST_TAG", "TEST_.*"})
+    void shouldExcludeIncludedRulesUsingAlertTags(String tagPattern) {
+        // Given
+        String yamlStr =
+                String.format(
+                        """
+                defaultStrength: low
+                defaultThreshold: medium
+                alertTags:
+                  include:
+                  - .*
+                  exclude:
+                  - %s
+                """,
+                        tagPattern);
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        // When
+        policyDefinition.parsePolicyDefinition(data, "test", progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(policyDefinition.getEffectiveRules().isEmpty(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotAddSameRuleTwice() {
+        // Given
+        String yamlStr =
+                """
+                defaultStrength: low
+                defaultThreshold: 'off'
+                rules:
+                - id: 50000
+                  name: rule1
+                  strength: insane
+                  threshold: high
+                alertTags:
+                  include:
+                    - TEST_TAG
+                  exclude: []
+                  strength: low
+                  threshold: medium
+                """;
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        // When
+        policyDefinition.parsePolicyDefinition(data, "test", progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        List<Rule> rules = policyDefinition.getEffectiveRules();
+        assertThat(rules.size(), is(equalTo(1)));
+        assertThat(rules.get(0).getId(), is(equalTo(50000)));
+        assertThat(rules.get(0).getName(), is(equalTo("PluginTestHelper")));
+        assertThat(rules.get(0).getStrength(), is(equalTo("insane")));
+        assertThat(rules.get(0).getThreshold(), is(equalTo("high")));
+    }
+
+    @Test
+    void shouldLoadPlansWithNullAlertTagFields() {
+        // Given
+        String yamlStr =
+                """
+                defaultStrength: low
+                defaultThreshold: medium
+                alertTags:
+                  include: null
+                  exclude: null
+                  strength: null
+                  threshold: null
+                """;
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        // When
+        policyDefinition.parsePolicyDefinition(data, "test", progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(policyDefinition.getAlertTagRule(), is(equalTo(new AlertTagRuleConfig())));
+    }
+
+    @Test
+    void shouldHandleInvalidThresholdValue() {
+        // Given
+        String yamlStr =
+                """
+                defaultStrength: low
+                defaultThreshold: 'off'
+                alertTags:
+                  include:
+                    - TEST_TAG
+                  exclude: []
+                  strength: medium
+                  threshold: invalidThreshold
+                """;
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        // When
+        policyDefinition.parsePolicyDefinition(data, "test", progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(
+                progress.getWarnings().get(0), is(equalTo("!automation.error.ascan.threshold!")));
+    }
+
+    @Test
+    void shouldHandleInvalidStrengthValue() {
+        // Given
+        String yamlStr =
+                """
+                defaultStrength: low
+                defaultThreshold: 'off'
+                alertTags:
+                  include:
+                    - TEST_TAG
+                  exclude: []
+                  strength: invalidStrength
+                  threshold: medium
+                """;
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        // When
+        policyDefinition.parsePolicyDefinition(data, "test", progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(progress.getWarnings().get(0), is(equalTo("!automation.error.ascan.strength!")));
     }
 }

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -98,6 +98,11 @@ jobs:
     policyDefinition:                  # The policy definition
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
+      alertTags:                       # Add rules by alert tags; overrides default settings but not rules explicitly listed under "rules"
+        include: []                    # List of alert tags to include, regex supported
+        exclude: []                    # List of alert tags to exclude from the include list, regex supported
+        strength:                      # String: The Attack Strength for this set of rules, one of Low, Medium, High, Insane, default: Medium
+        threshold:                     # String: The Alert Threshold for this set of rules, one of Off, Low, Medium, High, default: Medium
       rules:                           # A list of one or more active scan rules and associated settings which override the defaults
       - id:                            # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
         name:                          # Comment: The name of the rule for documentation purposes - this is not required or actually used
@@ -141,6 +146,11 @@ jobs:
     policyDefinition:                  # The policy definition - only used if the 'policy' is not set
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
+      alertTags:                       # Add rules by alert tags; overrides default settings but not rules explicitly listed under "rules"
+        include: []                    # List of alert tags to include, regex supported
+        exclude: []                    # List of alert tags to exclude from the include list, regex supported
+        strength:                      # String: The Attack Strength for this set of rules, one of Low, Medium, High, Insane, default: Medium
+        threshold:                     # String: The Alert Threshold for this set of rules, one of Off, Low, Medium, High, default: Medium
       rules:                           # A list of one or more active scan rules and associated settings which override the defaults
       - id:                            # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
         name:                          # Comment: The name of the rule for documentation purposes - this is not required or actually used

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
@@ -26,6 +26,11 @@ jobs:
     policyDefinition:                  # The policy definition
       defaultStrength:                 # String: The default Attack Strength for all rules, one of Low, Medium, High, Insane (not recommended), default: Medium
       defaultThreshold:                # String: The default Alert Threshold for all rules, one of Off, Low, Medium, High, default: Medium
+      alertTags:                       # Add rules by alert tags; overrides default settings but not rules explicitly listed under "rules"
+        include: []                    # List of alert tags to include, regex supported
+        exclude: []                    # List of alert tags to exclude from the include list, regex supported
+        strength:                      # String: The Attack Strength for this set of rules, one of Low, Medium, High, Insane, default: Medium
+        threshold:                     # String: The Alert Threshold for this set of rules, one of Off, Low, Medium, High, default: Medium
       rules:                           # A list of one or more active scan rules and associated settings which override the defaults
       - id:                            # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
         name:                          # Comment: The name of the rule for documentation purposes - this is not required or actually used


### PR DESCRIPTION
## Overview
Allow selecting rules in scan policies via Alert Tags.
<img width="674" height="562" alt="image" src="https://github.com/user-attachments/assets/248305aa-dfd4-479c-9736-43d6b0a4f486" />

