### PR TITLE
reports: include AF state in json-plus report

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Provide/log details on report errors through the Automation Framework job.
+- Allow to include Automation Framework errors and warnings in the Traditional JSON Report with Requests and Responses report.
 
 ## [0.39.0] - 2025-06-20
 ### Changed

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json-plus.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json-plus.html
@@ -21,14 +21,20 @@
 			<td>Sequence Details</td>
 			<td>sequencedetails</td>
 		</tr>
+		<tr>
+			<td>Automation Framework State</td>
+			<td>afstate</td>
+		</tr>
 	</table>
 
-	<H3>Sample</H3>
-	<H4>About riskdesc</H4>
+	<H3>About riskdesc</H3>
 	riskdesc - Is a combination identifier, showing Risk followed by
 	Confidence (in brackets). For example
 	<code>High (Medium)</code>
 	would indicate a High risk issue identified with Medium confidence.
+
+	<H3>Sample</H3>
+
 	<pre>
 {
     "@version": "Dev Build",
@@ -98,7 +104,21 @@
                     ]
                 },
                 ...
-            ],
+            ]
+        }
+    ]
+}
+</pre>
+
+	<h4>Statistics Section</h4>
+	The report can also include statistics, per site and global, for
+	example:
+	<pre>
+{
+    ...
+    "site":[
+        {
+            ...
             "statistics": {
                 "site.specific.stat.a": 1,
                 "site.specific.stat.b": 2
@@ -109,13 +129,16 @@
         "global.stat.a": 1,
         "global.stat.b": 2
     }
-
+}
 </pre>
 
+	<h4>Sequence Details Section</h4>
 	The report can also include details of Sequences and related active
 	scanning results, for example:
 
 	<pre>
+{
+    ...
     "sequences": [
       {
         "name": "Seq name",
@@ -170,8 +193,24 @@
         ]
       }
     ]
+}
 </pre>
 
+	<h4>Automation Framework State Section</h4>
+	The report can also include Automation Framework errors and warnings,
+	for example:
+
+	<pre>
+{
+    ...
+    "afPlanErrors": [
+        "AError A"
+    ],
+    "afPlanWarns": [
+        "Warning B"
+    ]
+}
+</pre>
 </BODY>
 </HTML>
 

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/Messages.properties
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/Messages.properties
@@ -1,3 +1,4 @@
 # i18n strings specific to this report template
+report.template.section.afstate = Automation Framework State
 report.template.section.sequencedetails = Sequence Details
 report.template.section.statistics = Statistics

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
@@ -88,6 +88,12 @@
     "statistics":{ [#th:block th:each="stat, statState: ${helper.getGlobalStats('')}"][#th:block th:if="${! statState.first}"],[/th:block]
         [[${stat.key}]]: [[${stat.value}]]
         [/th:block]
-    }[/th:block]
+    }[/th:block][#th:block th:with="progress=${reportData.reportObjects.get('automation.progress')}" th:if="${reportData.isIncludeSection('afstate')}" ],
+    "afPlanErrors": [[#th:block th:if="${progress && progress.errors}"][#th:block th:each="error, errorState: ${progress.errors}"][#th:block th:if="${! errorState.first}"],[/th:block]
+        [[${error}]][/th:block][/th:block]
+    ],
+    "afPlanWarns": [[#th:block th:if="${progress && progress.warnings}"][#th:block th:each="warn, warnState: ${progress.warnings}"][#th:block th:if="${! warnState.first}"],[/th:block]
+        [[${warn}]][/th:block][/th:block]
+    ][/th:block]
 }
 

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/template.yaml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/template.yaml
@@ -5,3 +5,4 @@ extension: json
 sections:
  - statistics
  - sequencedetails
+ - afstate

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json-plus.json
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json-plus.json
@@ -66,6 +66,10 @@
         }
     ],
     "statistics":{ 
-    }
+    },
+    "afPlanErrors": [
+    ],
+    "afPlanWarns": [
+    ]
 }
 


### PR DESCRIPTION
Include the errors/warns of the AF in a new section.
