### PR TITLE
authhelper: use login URLs for verification

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -13,12 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for min wait for time in Client Script Authentication.
 
 ## Changed
+- Now depends on minimum Common Library version 1.35.0.
 - Send the referer header on verification if set on the original request.
 - Removed requirement to set at least one header in the GUI for Header-Based Session Management.
 - Include step for errors in the authentication diagnostics.
 - Browser based authentication to also support HTTP basic authentication for Firefox.
 - Verification rule to improve detection.
 - Add support for Microsoft login in Browser Based Authentication.
+- Consider login like URLs as candidates for verification URL.
 
 ### Fixed
 - Do not fail the authentication on diagnostic errors.

--- a/addOns/authhelper/authhelper.gradle.kts
+++ b/addOns/authhelper/authhelper.gradle.kts
@@ -56,7 +56,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.33.0 & < 2.0.0")
+                    version.set(">= 1.35.0 & < 2.0.0")
                 }
                 register("database") {
                     version.set(">=0.8.0 & < 1.0.0")

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationRequestDetails.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationRequestDetails.java
@@ -24,6 +24,8 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -44,10 +46,12 @@ public class VerificationRequestDetails {
     private boolean structuredResponse;
     private String evidence = "";
     private int contextId;
+    @Getter @Setter private boolean lowPriority;
 
     public VerificationRequestDetails() {
         this.msg = null;
         this.token = null;
+        this.lowPriority = true;
     }
 
     private static String urlEncode(String str) {
@@ -195,6 +199,10 @@ public class VerificationRequestDetails {
 
         @Override
         public int compare(VerificationRequestDetails o1, VerificationRequestDetails o2) {
+            int result = Boolean.compare(o1.isLowPriority(), o2.isLowPriority());
+            if (result != 0) {
+                return -result;
+            }
             return Integer.compare(o1.getScore(), o2.getScore());
         }
     }

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update dependency.
+- Expose constant related to authentication.
 
 ## [1.34.0] - 2025-07-04
 ### Added

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AuthConstants.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AuthConstants.java
@@ -20,7 +20,6 @@
 package org.zaproxy.addon.commonlib;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -36,29 +35,41 @@ public final class AuthConstants {
     private static final Set<String> REGISTRATION_INDICATORS =
             Set.of("register", "signup", "sign-up");
 
+    private static final Set<String> LOGOUT_INDICATORS =
+            Set.of(
+                    "logout",
+                    "logoff",
+                    "signout",
+                    "signoff",
+                    "log-out",
+                    "sign-out",
+                    "log-off",
+                    "sign-off");
+
     private static final Set<String> AUTHENTICATION_RELATED_INDICATORS;
 
     static {
         AUTHENTICATION_RELATED_INDICATORS = new HashSet<>();
-        AUTHENTICATION_RELATED_INDICATORS.addAll(
-                List.of(
-                        "logout",
-                        "logoff",
-                        "signout",
-                        "signoff",
-                        "log-out",
-                        "sign-out",
-                        "log-off",
-                        "sign-off"));
+        AUTHENTICATION_RELATED_INDICATORS.addAll(LOGOUT_INDICATORS);
         AUTHENTICATION_RELATED_INDICATORS.addAll(LOGIN_INDICATORS);
         AUTHENTICATION_RELATED_INDICATORS.addAll(REGISTRATION_INDICATORS);
     }
+
+    private AuthConstants() {}
 
     /**
      * @return A set of Strings which represent indications of a login page or parameter value.
      */
     public static Set<String> getLoginIndicators() {
         return LOGIN_INDICATORS;
+    }
+
+    /**
+     * @return A set of Strings which represent indications of a logout URL or parameter value.
+     * @since 1.35.0
+     */
+    public static Set<String> getLogoutIndicators() {
+        return LOGOUT_INDICATORS;
     }
 
     /**


### PR DESCRIPTION
Consider login like URLs as verification candidates, with lower priority, sites might have good verification URLs even with "login" in the URL.