### PR TITLE
Fix proxy errors during CSA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for min wait for time in Client Script Authentication.
 
 ## Changed
-- Now depends on minimum Common Library version 1.35.0.
+- Now depends on minimum Common Library version 1.35.0 and Zest version 48.9.0.
 - Send the referer header on verification if set on the original request.
 - Removed requirement to set at least one header in the GUI for Header-Based Session Management.
 - Include step for errors in the authentication diagnostics.
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Do not fail the authentication on diagnostic errors.
 - Do not configure poll authentication verification without logged in indicator.
 - Handle errors collecting the browser storage diagnostics.
+- Fix proxy errors during authentication with Client Script Based Authentication.
 
 ## [0.27.0] - 2025-07-03
 ### Added

--- a/addOns/authhelper/authhelper.gradle.kts
+++ b/addOns/authhelper/authhelper.gradle.kts
@@ -71,7 +71,7 @@ zapAddOn {
                     version.set("15.*")
                 }
                 register("zest") {
-                    version.set(">=48.8.0")
+                    version.set(">=48.9.0")
                 }
             }
         }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -450,6 +450,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                             return null;
                         }
 
+                        zestRunner.setAutoCloseProxy(false);
                         zestRunner.registerHandler(getHandler(user));
                         zestScript.add(
                                 new ZestActionSleep(TimeUnit.SECONDS.toMillis(getLoginPageWait())));
@@ -597,6 +598,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                                             // Ignore
                                         }
                                     });
+                    zestRunner.closeProxy();
                 }
             }
         }

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Allow to keep auhtenticator's proxy running after the authentication.
 
 ## [48.8.0] - 2025-07-03
 


### PR DESCRIPTION
The proxy that the browser was using could be closed too early when used by Client Script Based Authentication, which could try refresh the page after authentication to trigger more requests and increase the likelihood of obtaining a verification URL.

---
Fixes exceptions like:
```
ERROR User - An error occurred while authenticating:
org.openqa.selenium.WebDriverException: Reached error page: about:neterror?e=proxyConnectFailure&u=…&c=UTF-8&d=Firefox%20is%20configured%20to%20use%20a%20proxy%20server%20that%20is%20refusing%20connections.
Build info: version: '4.35.0', revision: '1c58e5028b'
System info: os.name: 'Linux', os.arch: 'amd64', os.version: '…', java.version: '…'
Driver info: org.openqa.selenium.firefox.FirefoxDriver
Command: [d0c87c9e-457f-4d7b-8840-25d531f8f779, get {url=…}]
Capabilities {…}
Session ID: d0c87c9e-457f-4d7b-8840-25d531f8f779
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(Unknown Source) ~[?:?]
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Unknown Source) ~[?:?]
	at java.base/java.lang.reflect.Constructor.newInstance(Unknown Source) ~[?:?]
	at org.openqa.selenium.remote.ErrorCodec.decode(ErrorCodec.java:167) ~[?:?]
	at org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:138) ~[?:?]
	at org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:50) ~[?:?]
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:215) ~[?:?]
	at org.openqa.selenium.remote.service.DriverCommandExecutor.invokeExecute(DriverCommandExecutor.java:216) ~[?:?]
	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:174) ~[?:?]
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:557) ~[?:?]
	at org.openqa.selenium.remote.RemoteWebDriver.get(RemoteWebDriver.java:325) ~[?:?]
	at org.zaproxy.addon.authhelper.ClientScriptBasedAuthenticationMethodType$ClientScriptBasedAuthenticationMethod.authenticate(ClientScriptBasedAuthenticationMethodType.java:512) ~[?:?]
	at org.zaproxy.zap.users.User.authenticate(User.java:271) [zap-D-2025-08-18.jar:D-2025-08-18]
```