### PR TITLE
automation: Do not warn if "enabled" or "alwaysRun" properties specified

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Bug in handling headers with colons in the values.
 - Use default authentication poll frequency when none specified, if the value is less than one a progress warning occurs.
+- Do not warn if "enabled" or "alwaysRun" properties specified.
 
 ## [0.51.0] - 2025-07-17
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationPlan.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationPlan.java
@@ -103,7 +103,7 @@ public class AutomationPlan {
                 }
                 LinkedHashMap<?, ?> jobData = (LinkedHashMap<?, ?>) jobObj;
 
-                Object jobType = jobData.get("type");
+                Object jobType = jobData.remove("type");
                 if (jobType == null) {
                     progress.error(
                             Constant.messages.getString("automation.error.job.notype", jobType));
@@ -113,7 +113,7 @@ public class AutomationPlan {
                 if (job != null) {
                     try {
                         job = job.newJob();
-                        Object jobName = jobData.get("name");
+                        Object jobName = jobData.remove("name");
                         if (jobName != null) {
                             if (jobName instanceof String) {
                                 job.setName((String) jobName);
@@ -132,7 +132,7 @@ public class AutomationPlan {
                             continue;
                         }
 
-                        Object jobEnabled = jobData.get("enabled");
+                        Object jobEnabled = jobData.remove("enabled");
                         if (jobEnabled != null) {
                             if (jobEnabled instanceof Boolean enableBool) {
                                 job.setEnabled(enableBool);
@@ -143,7 +143,7 @@ public class AutomationPlan {
                             }
                         }
 
-                        Object alwaysRun = jobData.get("alwaysRun");
+                        Object alwaysRun = jobData.remove("alwaysRun");
                         if (alwaysRun != null) {
                             if (alwaysRun instanceof Boolean jobBool) {
                                 job.setAlwaysRun(jobBool);

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanConfigJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanConfigJob.java
@@ -95,10 +95,6 @@ public class ActiveScanConfigJob extends AutomationJob {
                             JobUtils.verifyRegexes(jobData.get(key), key.toString(), progress));
                     break;
 
-                case "name":
-                case "type":
-                    break;
-
                 default:
                     progress.warn(
                             Constant.messages.getString(

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -103,9 +103,7 @@ public class ActiveScanJob extends AutomationJob {
                             params, this.parameters, this.getName(), null, progress);
                     break;
                 case "policyDefinition":
-                case "name":
                 case "tests":
-                case "type":
                     // Handled before we get here
                     break;
                 default:

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJob.java
@@ -89,9 +89,7 @@ public class ActiveScanPolicyJob extends AutomationJob {
                     policyDefinition.parsePolicyDefinition(
                             jobData.get(key), this.getName(), progress);
                     break;
-                case "name":
                 case "tests":
-                case "type":
                     // Handled before we get here
                     break;
                 default:

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -419,7 +419,6 @@ class ActiveScanJobUnitTest {
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
         LinkedHashMap<String, String> data = new LinkedHashMap<>();
-        data.put("name", "blah");
         data.put("tests", "");
         // The only invalid one
         data.put("unexpected", "data");

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJobUnitTest.java
@@ -163,7 +163,6 @@ class ActiveScanPolicyJobUnitTest {
         ActiveScanPolicyJob job = new ActiveScanPolicyJob();
         AutomationProgress progress = new AutomationProgress();
         LinkedHashMap<String, String> data = new LinkedHashMap<>();
-        data.put("name", "blah");
         data.put("tests", "");
         // The only invalid one
         data.put("unexpected", "data");

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [8] - 2025-01-10
 ### Added

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceActiveScanJob.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/automation/SequenceActiveScanJob.java
@@ -116,9 +116,7 @@ public class SequenceActiveScanJob extends AutomationJob {
                             params, this.parameters, this.getName(), null, progress);
                     break;
                 case "policyDefinition":
-                case "name":
                 case "tests":
-                case "type":
                     // Handled before we get here
                     break;
                 default:


### PR DESCRIPTION
<details><summary>Simple plan with all jobs disabled</summary>
<p>

env:
  contexts:
  - name: Default Context
    urls:
    - https://www.zaproxy.org
    authentication:
      verification:
        method: response
        pollFrequency: 60
        pollUnits: requests
    sessionManagement:
      method: cookie
    technology: {}
    structure: {}
  parameters: {}
jobs:
- type: activeScan-config
  parameters: {}
  inputVectors:
    scripts: true
  enabled: false
  alwaysRun: true
- type: activeScan-policy
  parameters: {}
  policyDefinition:
    defaultStrength: MEDIUM
  enabled: false
  alwaysRun: true
- type: alertFilter
  parameters: {}
  enabled: false
  alwaysRun: true
- type: passiveScan-config
  parameters: {}
  enabled: false
  alwaysRun: true
- type: replacer
  parameters: {}
  enabled: false
  alwaysRun: true
- type: script
  parameters:
    name: hi
    type: active
    action: add
    engine: "ECMAScript : Graal.js"
    inline: print('hi');
  enabled: false
  alwaysRun: true
- type: requestor
  parameters: {}
  enabled: false
  alwaysRun: true
- type: graphql
  parameters: {}
  enabled: false
  alwaysRun: true
- type: import
  parameters: {}
  enabled: false
  alwaysRun: true
- type: openapi
  parameters: {}
  enabled: false
  alwaysRun: true
- type: postman
  parameters: {}
  enabled: false
  alwaysRun: true
- type: sequence-import
  parameters: {}
  enabled: false
  alwaysRun: true
- type: soap
  parameters: {}
  enabled: false
  alwaysRun: true
- type: spider
  parameters: {}
  enabled: false
  alwaysRun: true
  tests:
  - name: At least 100 URLs found
    type: stats
    onFail: INFO
    statistic: automation.spider.urls.added
    operator: '>='
    value: 100
- type: spiderAjax
  parameters: {}
  enabled: false
  alwaysRun: true
  tests:
  - name: At least 100 URLs found
    type: stats
    onFail: INFO
    statistic: spiderAjax.urls.added
    operator: '>='
    value: 100
- type: spiderClient
  parameters: {}
  enabled: false
  alwaysRun: true
- type: delay
  parameters: {}
  enabled: false
  alwaysRun: true
- type: passiveScan-wait
  parameters: {}
  enabled: false
  alwaysRun: true
- type: prune
  parameters: {}
  enabled: false
  alwaysRun: true
- type: activeScan
  parameters: {}
  policyDefinition:
    defaultStrength: MEDIUM
  enabled: false
  alwaysRun: true
- type: sequence-activeScan
  parameters: {}
  policyDefinition:
    defaultStrength: MEDIUM
  enabled: false
  alwaysRun: true
- type: export
  parameters: {}
  enabled: false
  alwaysRun: true
- type: outputSummary
  parameters: {}
  enabled: false
  alwaysRun: true
- type: report
  parameters:
    reportTitle: ZAP by Checkmarx Scanning Report
  enabled: false
  alwaysRun: true
- type: exitStatus
  parameters: {}
  enabled: false
  alwaysRun: true

</p>
</details> 