### PR TITLE
authhelper: include messages' RTT in auth report

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Send the referer header on verification if set on the original request.
 - Removed requirement to set at least one header in the GUI for Header-Based Session Management.
 - Include step for errors in the authentication diagnostics.
+- Include messages' RTT in the Authentication Report.
 - Browser based authentication to also support HTTP basic authentication for Firefox.
 - Verification rule to improve detection.
 - Add support for Microsoft login in Browser Based Authentication.

--- a/addOns/authhelper/src/main/zapHomeFiles/reports/auth-report-json/report.json
+++ b/addOns/authhelper/src/main/zapHomeFiles/reports/auth-report-json/report.json
@@ -99,6 +99,7 @@
 					,"messages": [[#th:block th:each="entry, state: ${messages}" th:with="message=${helper.getHttpMessage(entry.messageId)}"][#th:block th:if="${! state.first}"],[/th:block]
 						{[#th:block th:if="${message}"]
 							"created": [[${entry.createTimestamp}]],
+							"rtt": [[${message.timeElapsedMillis}]],
 							"initiator": [[${entry.initiator}]],
 							"requestHeader": [[${message.requestHeader.toString()}]],
 							"requestBody": [[${message.requestBody.toString()}]],


### PR DESCRIPTION
Allow to know how much time the requests are taking during the authentication.