### PR TITLE
automation: Stop plan option

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for step delay in Browser Based Authentication.
 - Support for min wait for in Client Script Authentication.
 - Support for url in activeScan job.
+- Support for stopping plans and jobs.
 
 ### Changed
 - Refer to output panel for errors.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationAPI.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationAPI.java
@@ -51,6 +51,7 @@ public class AutomationAPI extends ApiImplementor {
     private static final String PREFIX = "automation";
 
     private static final String ACTION_RUN_PLAN = "runPlan";
+    private static final String ACTION_STOP_PLAN = "stopPlan";
     private static final String ACTION_END_DELAY_JOB = "endDelayJob";
     private static final String VIEW_PLAN_PROGRESS = "planProgress";
 
@@ -72,6 +73,7 @@ public class AutomationAPI extends ApiImplementor {
         super();
         this.extension = extension;
         this.addApiAction(new ApiAction(ACTION_RUN_PLAN, new String[] {PARAM_FILE_PATH}));
+        this.addApiAction(new ApiAction(ACTION_STOP_PLAN, new String[] {PARAM_PLAN_ID}));
         this.addApiAction(new ApiAction(ACTION_END_DELAY_JOB));
         this.addApiView(new ApiView(VIEW_PLAN_PROGRESS, new String[] {PARAM_PLAN_ID}));
     }
@@ -101,6 +103,14 @@ public class AutomationAPI extends ApiImplementor {
             } catch (IOException | ApiException e) {
                 throw new ApiException(Type.DOES_NOT_EXIST, e.getMessage());
             }
+        } else if (name.equals(ACTION_STOP_PLAN)) {
+            AutomationPlan plan = extension.getPlan(params.getInt(PARAM_PLAN_ID));
+
+            if (plan == null) {
+                throw new ApiException(Type.DOES_NOT_EXIST);
+            }
+            extension.stopPlan(plan);
+            return ApiResponseElement.OK;
         } else if (name.equals(ACTION_END_DELAY_JOB)) {
             DelayJob.setEndJob(true);
             return ApiResponseElement.OK;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
@@ -162,6 +162,9 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
      */
     public void planFinished() {}
 
+    /** Called to stop any running jobs early. Must be implemented by long running jobs. */
+    public void stop() {}
+
     public abstract void runJob(AutomationEnvironment env, AutomationProgress progress);
 
     public abstract String getType();

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationPlan.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationPlan.java
@@ -53,6 +53,7 @@ public class AutomationPlan {
     private boolean changed = false;
     private Date started;
     private Date finished;
+    private boolean stopping;
 
     private static final Logger LOGGER = LogManager.getLogger(AutomationPlan.class);
     private static final ObjectMapper YAML_OBJECT_MAPPER;
@@ -291,6 +292,7 @@ public class AutomationPlan {
 
     void setStarted(Date started) {
         this.started = started;
+        this.stopping = false;
     }
 
     void setFinished(Date finished) {
@@ -303,6 +305,15 @@ public class AutomationPlan {
 
     public Date getFinished() {
         return finished;
+    }
+
+    public boolean isStopping() {
+        return stopping;
+    }
+
+    public void stopPlan() {
+        this.stopping = true;
+        getJobs().forEach(AutomationJob::stop);
     }
 
     public String toYaml() throws IOException {

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -353,6 +353,10 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
         return Collections.unmodifiableList(runningPlans);
     }
 
+    public void stopPlan(AutomationPlan plan) {
+        plan.stopPlan();
+    }
+
     public AutomationProgress runPlan(AutomationPlan plan, boolean resetProgress) {
         runningPlans.add(plan);
         if (resetProgress) {
@@ -384,7 +388,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
 
         for (AutomationJob job : jobsToRun) {
 
-            if (env.isTimeToQuit() && !job.isAlwaysRun()) {
+            if (plan.isStopping() || (env.isTimeToQuit() && !job.isAlwaysRun())) {
                 continue;
             }
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
@@ -74,72 +74,67 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
 
     private static final ImageIcon PLAY_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/131.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/131.png"));
     private static final ImageIcon LOAD_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/047.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/047.png"));
     private static final ImageIcon SAVE_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/096.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/096.png"));
     private static final ImageIcon SAVE_AS_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            AutomationPanel.class.getResource(
-                                    ExtensionAutomation.RESOURCES_DIR + "save-as.png")));
+                    AutomationPanel.class.getResource(
+                            ExtensionAutomation.RESOURCES_DIR + "save-as.png"));
+    private static final ImageIcon STOP_ICON =
+            DisplayUtils.getScaledIcon(
+                    AutomationPanel.class.getResource("/resource/icon/16/142.png"));
     private static final ImageIcon ADD_PLAN_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            AutomationPanel.class.getResource(
-                                    ExtensionAutomation.RESOURCES_DIR + "clipboard--plus.png")));
+                    AutomationPanel.class.getResource(
+                            ExtensionAutomation.RESOURCES_DIR + "clipboard--plus.png"));
     private static final ImageIcon DOWN_ARROW_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            AutomationPanel.class.getResource(
-                                    ExtensionAutomation.RESOURCES_DIR + "task-move-down.png")));
+                    AutomationPanel.class.getResource(
+                            ExtensionAutomation.RESOURCES_DIR + "task-move-down.png"));
     private static final ImageIcon UP_ARROW_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            AutomationPanel.class.getResource(
-                                    ExtensionAutomation.RESOURCES_DIR + "task-move-up.png")));
+                    AutomationPanel.class.getResource(
+                            ExtensionAutomation.RESOURCES_DIR + "task-move-up.png"));
     private static final ImageIcon ADD_JOB_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            AutomationPanel.class.getResource(
-                                    ExtensionAutomation.RESOURCES_DIR + "task--plus.png")));
+                    AutomationPanel.class.getResource(
+                            ExtensionAutomation.RESOURCES_DIR + "task--plus.png"));
     private static final ImageIcon REMOVE_JOB_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            AutomationPanel.class.getResource(
-                                    ExtensionAutomation.RESOURCES_DIR + "task--minus.png")));
+                    AutomationPanel.class.getResource(
+                            ExtensionAutomation.RESOURCES_DIR + "task--minus.png"));
     private static final ImageIcon ADD_TEST_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            AutomationPanel.class.getResource(
-                                    ExtensionAutomation.RESOURCES_DIR + "question-plus.png")));
+                    AutomationPanel.class.getResource(
+                            ExtensionAutomation.RESOURCES_DIR + "question-plus.png"));
     private static final ImageIcon REMOVE_TEST_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(
-                            AutomationPanel.class.getResource(
-                                    ExtensionAutomation.RESOURCES_DIR + "question-minus.png")));
+                    AutomationPanel.class.getResource(
+                            ExtensionAutomation.RESOURCES_DIR + "question-minus.png"));
 
     protected static final ImageIcon GREEN_BALL_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/152.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/152.png"));
     protected static final ImageIcon RED_BALL_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/151.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/151.png"));
     protected static final ImageIcon YELLOW_BALL_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/154.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/154.png"));
     protected static final ImageIcon ORANGE_BALL_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/156.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/156.png"));
     protected static final ImageIcon WHITE_BALL_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/160.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/160.png"));
     protected static final ImageIcon GREY_BALL_ICON =
             DisplayUtils.getScaledIcon(
-                    new ImageIcon(AutomationPanel.class.getResource("/resource/icon/16/158.png")));
+                    AutomationPanel.class.getResource("/resource/icon/16/158.png"));
 
     private static final Logger LOGGER = LogManager.getLogger(AutomationPanel.class);
 
@@ -151,6 +146,7 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
     private JButton runPlanButton;
     private JButton savePlanButton;
     private JButton saveAsPlanButton;
+    private JButton stopPlanButton;
     private JButton jobUpButton;
     private JButton jobDownButton;
     private JButton addJobButton;
@@ -193,6 +189,7 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
             toolbar.add(getSavePlanButton());
             toolbar.add(getSaveAsPlanButton());
             toolbar.add(getRunPlanButton());
+            toolbar.add(getStopPlanButton());
             toolbar.addSeparator();
             toolbar.add(getAddJobButton());
             toolbar.add(getRemoveJobButton());
@@ -218,6 +215,8 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
                         if (currentPlan == null) {
                             return;
                         }
+                        runPlanButton.setEnabled(false);
+                        getStopPlanButton().setEnabled(true);
                         ext.runPlanAsync(currentPlan);
                     });
         }
@@ -299,6 +298,24 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
             saveAsPlanButton.addActionListener(e -> savePlan(true));
         }
         return saveAsPlanButton;
+    }
+
+    private JButton getStopPlanButton() {
+        if (stopPlanButton == null) {
+            stopPlanButton = new JButton();
+            stopPlanButton.setIcon(STOP_ICON);
+            stopPlanButton.setToolTipText(
+                    Constant.messages.getString("automation.dialog.plan.stop"));
+            stopPlanButton.setEnabled(false);
+            stopPlanButton.addActionListener(
+                    e -> {
+                        if (currentPlan != null) {
+                            stopPlanButton.setEnabled(false);
+                            ext.stopPlan(currentPlan);
+                        }
+                    });
+        }
+        return stopPlanButton;
     }
 
     private JButton getLoadPlanButton() {
@@ -572,8 +589,7 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
             optionsButton = new JButton();
             optionsButton.setToolTipText(Constant.messages.getString("automation.dialog.options"));
             optionsButton.setIcon(
-                    DisplayUtils.getScaledIcon(
-                            new ImageIcon(ZAP.class.getResource("/resource/icon/16/041.png"))));
+                    DisplayUtils.getScaledIcon(ZAP.class.getResource("/resource/icon/16/041.png")));
 
             optionsButton.addActionListener(
                     e ->
@@ -605,10 +621,15 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
         currentPlan = plan;
         getOutputArea().setText("");
         getTreeModel().setPlan(currentPlan);
-        getRunPlanButton().setEnabled(currentPlan != null);
+        getRunPlanButton()
+                .setEnabled(
+                        currentPlan != null
+                                && (currentPlan.getStarted() == null
+                                        || currentPlan.getFinished() != null));
         getAddJobButton().setEnabled(currentPlan != null);
         getSavePlanButton().setEnabled(false);
         getSaveAsPlanButton().setEnabled(currentPlan != null);
+        getStopPlanButton().setEnabled(currentPlan != null && !getRunPlanButton().isEnabled());
     }
 
     public List<String> getUnsavedPlans() {
@@ -801,6 +822,10 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
                 break;
             case AutomationEventPublisher.PLAN_STARTED:
                 this.getOutputArea().setText("");
+                break;
+            case AutomationEventPublisher.PLAN_FINISHED:
+                this.getRunPlanButton().setEnabled(true);
+                this.getStopPlanButton().setEnabled(false);
                 break;
             case AutomationEventPublisher.PLAN_ERROR_MESSAGE:
                 outputMessage(

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/DelayJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/DelayJob.java
@@ -121,6 +121,11 @@ public class DelayJob extends AutomationJob {
     }
 
     @Override
+    public void stop() {
+        endJob = true;
+    }
+
+    @Override
     public String getType() {
         return JOB_NAME;
     }

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/automation.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/automation.html
@@ -55,10 +55,14 @@ The <a href="options.html">Automation Options</a> screen allows you to configure
 <H2><a name="api">API</a></H2>
 The following API endpoints are provided by this add-on:
 <ul>
+<li>Action: endDelayJob() - ends the currently running delay job, if any</li>
 <li>Action: runPlan(filePath) - loads and asynchronously runs the plan in the specified file, returning a planId</li>
+<li>Action: stopPlan(planId) - stops the running plan identified by the planId</li>
 <li>View: planProgress(planId) - returns the progress details for the specified planId</li>
 </ul>
 If the ZAP desktop is being used then the plan will also be shown in the GUI to make it easier to diagnose any problems.
+<p>
+Note that some jobs may not stop immediately, for example if authentication is being handled.
 
 <H2><a name="environment">Environment</a></H2>
 The <a href="environment.html">environment</a> section of the file defines the applications which the rest of the jobs can act on.

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/gui.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/gui.html
@@ -19,8 +19,9 @@ A toolbar provides the following buttons:
 <ul>
 <li>New Plan... - this launches the New Plan dialog
 <li>Load Plan... - this allows you to load a plan from a yaml file
-<li>Save Plan... - this saves the current plan to a yaml file
-<li>Run Plan... - this runs the current plan
+<li>Save Plan - this saves the current plan to a yaml file
+<li>Run Plan - this runs the current plan
+<li>Stop Plan - this stops the current plan
 <li>Add Job... - this launches the Add Job dialog to add a job to the current plan
 <li>Remove Job... - this removes the selected job from the current plan
 <li>Move Job Up - this moves the selected job up one place in the current plan

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -1,5 +1,7 @@
-automation.api.action.runplan = Loads and asynchronously runs the plan in the specified file, returning a planId
-automation.api.view.planprogress = Returns the progress details for the specified planId
+automation.api.action.endDelayJob = Ends the currently running delay job, if any
+automation.api.action.runPlan = Loads and asynchronously runs the plan in the specified file, returning a planId
+automation.api.action.stopPlan = Stops the running plan identified by the planId
+automation.api.view.planProgress = Returns the progress details for the specified planId
 
 automation.cmdline.autogenconf.help = Generate template automation file using the current configuration
 automation.cmdline.autogenmax.help = Generate template automation file with all parameters
@@ -224,9 +226,10 @@ automation.dialog.options = Options
 automation.dialog.plan.load = Load Plan...
 automation.dialog.plan.loosechanges = The current plan has unsaved changes.\nProceed and lose these changes?
 automation.dialog.plan.new = New Plan...
-automation.dialog.plan.run = Run Plan...
-automation.dialog.plan.save = Save Plan...
+automation.dialog.plan.run = Run Plan
+automation.dialog.plan.save = Save Plan
 automation.dialog.plan.save-as = Save Plan As...
+automation.dialog.plan.stop = Stop Plan
 
 automation.dialog.requestor.remove.confirm = Are you sure you want to remove this Request?
 automation.dialog.requestor.summary = URL Count: {0}

--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Edge recorder link to help.
+- Support for stopping the spiderCient automation job.
 
 ### Changed
 - Updated Chrome and Firefox extensions to v0.1.5.

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/automation/ClientSpiderJob.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/automation/ClientSpiderJob.java
@@ -54,6 +54,7 @@ public class ClientSpiderJob extends AutomationJob {
 
     private Data data;
     private Parameters parameters = new Parameters();
+    private boolean forceStop;
 
     public ClientSpiderJob() {
         this.data = new Data(this, parameters);
@@ -106,6 +107,7 @@ public class ClientSpiderJob extends AutomationJob {
         }
         uriStr = env.replaceVars(uriStr);
 
+        forceStop = false;
         int scanId = -1;
         try {
             scanId =
@@ -134,12 +136,11 @@ public class ClientSpiderJob extends AutomationJob {
         }
 
         // Wait for the client spider to finish
-        boolean forceStop = false;
 
         while (true) {
             this.sleep(500);
 
-            if (!spider.isRunning()) {
+            if (!spider.isRunning() || forceStop) {
                 break;
             }
             if (!this.runMonitorTests(progress) || System.currentTimeMillis() > endTime) {
@@ -151,6 +152,11 @@ public class ClientSpiderJob extends AutomationJob {
             spider.stopScan();
             progress.info(Constant.messages.getString("automation.info.jobstopped", getType()));
         }
+    }
+
+    @Override
+    public void stop() {
+        forceStop = true;
     }
 
     protected ClientOptions paramsToOptions() {

--- a/addOns/pscan/CHANGELOG.md
+++ b/addOns/pscan/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Allow to configure the option max body size through the API (Issue 8974).
+- Support for stopping the passiveScan-wait automation job.
 
 ### Changed
 - To only record `stats.pscan.<rule-name>` statistics for scanners that have no IDs.

--- a/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/automation/jobs/PassiveScanWaitJob.java
+++ b/addOns/pscan/src/main/java/org/zaproxy/addon/pscan/automation/jobs/PassiveScanWaitJob.java
@@ -53,6 +53,7 @@ public class PassiveScanWaitJob extends AutomationJob {
 
     private Data data;
     private Parameters parameters = new Parameters();
+    private boolean forceStop;
 
     public PassiveScanWaitJob() {
         this.pscan =
@@ -75,13 +76,14 @@ public class PassiveScanWaitJob extends AutomationJob {
     @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
         long endTime = Long.MAX_VALUE;
+        forceStop = false;
         Integer maxDuration = this.parameters.getMaxDuration();
         if (maxDuration != null && maxDuration > 0) {
             endTime = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(maxDuration);
         }
 
         while (pscan.getRecordsToScan() > 0) {
-            if (System.currentTimeMillis() > endTime) {
+            if (System.currentTimeMillis() > endTime || forceStop) {
                 break;
             }
             try {
@@ -91,6 +93,11 @@ public class PassiveScanWaitJob extends AutomationJob {
             }
         }
         progress.addJobResultData(this.getJobResultData());
+    }
+
+    @Override
+    public void stop() {
+        forceStop = true;
     }
 
     @Override

--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Support for stopping the spider automation job.
 
 ## [0.15.0] - 2025-06-20
 ### Changed

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Support for stopping the spiderAjax automation job.
 
 ## [23.25.0] - 2025-07-10
 ### Fixed

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
@@ -78,6 +78,7 @@ public class AjaxSpiderJob extends AutomationJob {
 
     private Data data;
     private Parameters parameters = new Parameters();
+    private boolean forceStop;
 
     public AjaxSpiderJob() {
         this.data = new Data(this, parameters);
@@ -326,6 +327,7 @@ public class AjaxSpiderJob extends AutomationJob {
         AjaxSpiderTarget target = targetBuilder.build();
         JobSpiderListener listener = new JobSpiderListener();
 
+        forceStop = false;
         SpiderThread spiderThread =
                 getExtSpider()
                         .createSpiderThread(
@@ -344,7 +346,6 @@ public class AjaxSpiderJob extends AutomationJob {
         }
 
         // Wait for the ajax spider to finish
-        boolean forceStop = false;
         int numUrlsFound = 0;
         int lastCount = 0;
 
@@ -355,7 +356,7 @@ public class AjaxSpiderJob extends AutomationJob {
             Stats.incCounter("spiderAjax.urls.added", numUrlsFound - lastCount);
             lastCount = numUrlsFound;
 
-            if (!spiderThread.isRunning()) {
+            if (!spiderThread.isRunning() || forceStop) {
                 break;
             }
             if (!this.runMonitorTests(progress) || System.currentTimeMillis() > endTime) {
@@ -371,6 +372,11 @@ public class AjaxSpiderJob extends AutomationJob {
         progress.info(
                 Constant.messages.getString(
                         "automation.info.urlsfound", this.getType(), numUrlsFound));
+    }
+
+    @Override
+    public void stop() {
+        forceStop = true;
     }
 
     private ContextWrapper getContextWrapper(


### PR DESCRIPTION
I _think_ the only long running job not covered is [sequence-activeScan](https://www.zaproxy.org/docs/desktop/addons/sequence-scanner/automation/) - that looks like it could be harder. And as its probably not really used much I dont think its quite so important.
Will look at adding API support as well, but that might be in another PR..

Also, do we want a "Are you sure" dialog on stop?