### PR TITLE
authhelper: correct test expectations

### DIFF
--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/report/ExtensionAuthhelperReportUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/report/ExtensionAuthhelperReportUnitTest.java
@@ -34,10 +34,6 @@ import static org.mockito.Mockito.withSettings;
 import java.io.File;
 import java.nio.file.Files;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import net.sf.json.JSONArray;
@@ -275,15 +271,12 @@ class ExtensionAuthhelperReportUnitTest extends TestUtils {
         String report = Files.readString(r.toPath());
 
         // Then
-        LocalDateTime localDateTime = LocalDateTime.now();
-        ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault());
-        String current = zonedDateTime.format(DateTimeFormatter.RFC_1123_DATE_TIME);
         String expected =
                 """
                 {
                 	"@programName": "ZAP",
                 	"@version": "Test Build",
-                	"@generated": "@@@replace@@@",
+                	"@generated": "",
                 	"site":  "https:\\/\\/www.example.com"
                 \t
                 	,"summaryItems": [
@@ -323,12 +316,10 @@ class ExtensionAuthhelperReportUnitTest extends TestUtils {
                 	,\"diagnostics\": [
                 	]
                 }
-                """
-                        .replace("@@@replace@@@", current);
-        report =
-                report.replaceAll(
-                        "[a-zA-Z]{3}, \\d{1,2} [a-zA-Z]{3} \\d{4} \\d{2}:\\d{2}:\\d{2}", current);
-        assertThat(report, is(equalTo(expected)));
+                """;
+        assertThat(
+                report.replaceFirst("@generated\": \"[^\"]+\"", "@generated\": \"\""),
+                is(equalTo(expected)));
     }
 
     static Template getTemplateFromYamlFile(String templateName) throws Exception {


### PR DESCRIPTION
Remove the date from the report since it's not being formatted properly and the date and its format is not relevant to the test.

---

From https://github.com/zaproxy/zap-extensions/actions/runs/17371633380/job/49308565625#step:6:2081
```
 ExtensionAuthhelperReportUnitTest > shouldGenerateFilledAuthJsonReportHandlingSpecialCharacters() FAILED
    java.lang.AssertionError: 
    Expected: is "{\n\t\"@programName\": \"ZAP\",\n\t\"@version\": \"Test Build\",\n\t\"@generated\": \"Mon, 1 Sep 2025 08:13:23 GMT\",\n\t\"site\":  \"https:\\/\\/www.example.com\"\n\t\n\t,\"summaryItems\": [\n\t\t{\n\t\t\t\"description\": \"Bob's \\\"Item\\\"\",\n\t\t\t\"passed\": true,\n\t\t\t\"key\": \"summary.1\"\n\t\t},\n\t\t{\n\t\t\t\"description\": \"Foo bar\",\n\t\t\t\"passed\": true,\n\t\t\t\"key\": \"summary.\\\"2\\\"\"\n\t\t}\n\t]\n\t\n\t\n\t\n\t,\"afEnv\": \"  env:\\n  contexts:\\n      name: 'some \\\"quote\\\" name'\\n\"\n\t\n\t,\"afPlanErrors\": [\n\t]\n\t\n\t,\"statistics\": [\n\t\t{\n\t\t\t\"key\": \"stats.auth.1\",\n\t\t\t\"scope\": \"foo \\\"random\\\" bar\",\n\t\t\t\"value\": 123\n\t\t},\n\t\t{\n\t\t\t\"key\": \"stats.foo.oops \\\"foo\\\" bar\",\n\t\t\t\"scope\": \"global\",\n\t\t\t\"value\": 0\n\t\t}\n\t]\n\t\n\t\n\t,\"logFile\": \"Log content\"\n\t,\"diagnostics\": [\n\t]\n}\n"
         but: was "{\n\t\"@programName\": \"ZAP\",\n\t\"@version\": \"Test Build\",\n\t\"@generated\": \"Mon, 1 Sept 2025 08:13:23\",\n\t\"site\":  \"https:\\/\\/www.example.com\"\n\t\n\t,\"summaryItems\": [\n\t\t{\n\t\t\t\"description\": \"Bob's \\\"Item\\\"\",\n\t\t\t\"passed\": true,\n\t\t\t\"key\": \"summary.1\"\n\t\t},\n\t\t{\n\t\t\t\"description\": \"Foo bar\",\n\t\t\t\"passed\": true,\n\t\t\t\"key\": \"summary.\\\"2\\\"\"\n\t\t}\n\t]\n\t\n\t\n\t\n\t,\"afEnv\": \"  env:\\n  contexts:\\n      name: 'some \\\"quote\\\" name'\\n\"\n\t\n\t,\"afPlanErrors\": [\n\t]\n\t\n\t,\"statistics\": [\n\t\t{\n\t\t\t\"key\": \"stats.auth.1\",\n\t\t\t\"scope\": \"foo \\\"random\\\" bar\",\n\t\t\t\"value\": 123\n\t\t},\n\t\t{\n\t\t\t\"key\": \"stats.foo.oops \\\"foo\\\" bar\",\n\t\t\t\"scope\": \"global\",\n\t\t\t\"value\": 0\n\t\t}\n\t]\n\t\n\t\n\t,\"logFile\": \"Log content\"\n\t,\"diagnostics\": [\n\t]\n}\n"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.zaproxy.addon.authhelper.report.ExtensionAuthhelperReportUnitTest.shouldGenerateFilledAuthJsonReportHandlingSpecialCharacters(ExtensionAuthhelperReportUnitTest.java:331)

293 tests completed, 1 failed
```
