### PR TITLE
reports: Add ISO 8601 date field to structured reports (JSON/XML)

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Corrected a minor typo and image alt tags in the help.
 
+### Added
+- An ISO 8601 date and time field (ex: "created": "2025-09-03T12:49:35.236211400Z") has been added to the Traditional JSON, Traditional JSON with Requests and Responses, Traditional XML, Traditional XML with Requests and Responses.
+
 ## [0.40.0] - 2025-09-02
 ### Changed
 - Provide/log details on report errors through the Automation Framework job.

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -392,10 +393,13 @@ public class ExtensionReports extends ExtensionAdaptor {
                 }
             }
 
+            Instant currentDateTime = Instant.now();
             synchronized (SIMPLE_DATE_FORMAT) {
                 context.setVariable(
-                        "generatedString", SIMPLE_DATE_FORMAT.format(System.currentTimeMillis()));
+                        "generatedString",
+                        SIMPLE_DATE_FORMAT.format(currentDateTime.toEpochMilli()));
             }
+            context.setVariable("created", currentDateTime.toString());
             context.setVariable("zapVersion", Constant.PROGRAM_VERSION);
             context.setVariable("programName", Constant.PROGRAM_NAME_SHORT);
 

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json-plus.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json-plus.html
@@ -27,18 +27,13 @@
 		</tr>
 	</table>
 
-	<H3>About riskdesc</H3>
-	riskdesc - Is a combination identifier, showing Risk followed by
-	Confidence (in brackets). For example
-	<code>High (Medium)</code>
-	would indicate a High risk issue identified with Medium confidence.
-
 	<H3>Sample</H3>
 
 	<pre>
 {
     "@version": "Dev Build",
     "@generated": "Fri, 4 Feb 2022 13:04:51",
+    "created": "2022-02-04T13:04:51.236211400Z",
     "site":[
         {
             "@name": "http://localhost:8080",

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json.html
@@ -7,15 +7,12 @@
 	<H1>Traditional JSON Report</H1>
 
 	<H3>Sample</H3>
-	<H4>About riskdesc</H4>
-	riskdesc - Is a combination identifier, showing Risk followed by
-	Confidence (in brackets). For example
-	<code>High (Medium)</code>
-	would indicate a High risk issue identified with Medium confidence.
+
 	<pre>
 {
     "@version": "Dev Build",
     "@generated": "Fri, 4 Feb 2022 13:04:51",
+    "created": "2022-02-04T13:04:51.236211400Z",
     "site":[
         {
             "@name": "http://localhost:8080",

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-xml-plus.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-xml-plus.html
@@ -7,14 +7,10 @@
 	<H1>Traditional XML Report with Requests and Responses</H1>
 
 	<H3>Sample</H3>
-	<H4>About riskdesc</H4>
-	riskdesc - Is a combination identifier, showing Risk followed by
-	Confidence (in brackets). For example
-	<code>High (Medium)</code>
-	would indicate a High risk issue identified with Medium confidence.
+
 	<pre>
         &lt;?xml version=&quot;1.0&quot;?&gt;
-        &lt;OWASPZAPReport version=&quot;2.11.1&quot; generated=&quot;Fr., 30 Sep. 2022 08:40:35&quot;&gt;
+        &lt;OWASPZAPReport version=&quot;2.11.1&quot; generated=&quot;Fr., 30 Sep. 2022 08:40:35&quot; created=&quot;2022-09-30T08:40:35.236211400Z&quot;&gt;
                         &lt;site name=&quot;http://localhost:8080&quot; host=&quot;localhost&quot; port=&quot;8080&quot; ssl=&quot;false&quot;&gt;
                                 &lt;alerts&gt;
                                         

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-xml.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-xml.html
@@ -7,14 +7,10 @@
 	<H1>Traditional XML Report</H1>
 
 	<H3>Sample</H3>
-	<H4>About riskdesc</H4>
-	riskdesc - Is a combination identifier, showing Risk followed by
-	Confidence (in brackets). For example
-	<code>High (Medium)</code>
-	would indicate a High risk issue identified with Medium confidence.
+
 	<pre>
 &lt;?xml version="1.0"?&gt;
-&lt;OWASPZAPReport version="Dev Build" generated="Fri, 4 Feb 2022 17:42:18"&gt;
+&lt;OWASPZAPReport version="Dev Build" generated="Fri, 4 Feb 2022 17:42:18" created="2022-02-04T17:42:18.236211400Z"&gt;
     
         &lt;site name="http://localhost:8080" host="localhost" port="8080" ssl="false"&gt;
             &lt;alerts&gt;

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/reports.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/reports.html
@@ -109,6 +109,19 @@
 	reports directory. The "reports" folder in your ZAP home directory is
 	used by default.
 
+	<H3>Field Descriptions</H3>
+
+	<H4>riskdesc</H4>
+	riskdesc - Is a combination identifier, showing Risk followed by
+	Confidence (in brackets). For example
+	<code>High (Medium)</code>
+	would indicate a High risk issue identified with Medium confidence.
+
+	<H4>created</H4>
+	The
+	<code>created</code>
+	field is an instant in the ISO-8601 representation.
+
 	<H2>See also</H2>
 	<table>
 		<tr>

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
@@ -2,6 +2,7 @@
     "@programName": [[${programName}]],
     "@version": [[${zapVersion}]],
     "@generated": [[${generatedString}]],
+    "created": [[${created}]],
     "site":[ [#th:block th:each="site, siteState: ${reportData.sites}"][#th:block th:if="${! siteState.first}"],[/th:block]
         {
             "@name": "[(${helper.legacyEscapeText(site, true)})]",

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json/report.json
@@ -2,6 +2,7 @@
 	"@programName": [[${programName}]],
 	"@version": [[${zapVersion}]],
 	"@generated": [[${generatedString}]],
+	"created": [[${created}]],
 	"site":[ [#th:block th:each="site, siteState: ${reportData.sites}"][#th:block th:if="${! siteState.first}"],[/th:block]
 		{
 			"@name": "[(${helper.legacyEscapeText(site, true)})]",

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml-plus/report.xml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml-plus/report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <OWASPZAPReport
-	th:attr="programName=${programName}, version=${zapVersion}, generated=${generatedString}">
+	th:attr="programName=${programName}, version=${zapVersion}, generated=${generatedString}, created=${created}">
 	<th:block th:each="site: ${reportData.sites}">
 		<site th:name="${site}"
 			th:attr="host=${helper.getHostForSite(site)}, port=${helper.getPortForSite(site)}, ssl=${helper.isSslSite(site)}">

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <OWASPZAPReport
-	th:attr="programName=${programName}, version=${zapVersion}, generated=${generatedString}">
+	th:attr="programName=${programName}, version=${zapVersion}, generated=${generatedString}, created=${created}">
 	<th:block th:each="site: ${reportData.sites}">
 		<site th:name="${site}"
 			th:attr="host=${helper.getHostForSite(site)}, port=${helper.getPortForSite(site)}, ssl=${helper.isSslSite(site)}">

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -791,6 +791,7 @@ class ExtensionReportsUnitTest extends TestUtils {
     private static String cleanReport(String str) {
         return str.replaceFirst("generated=\".*\"", "generated=\"DATE\"")
                 .replaceFirst("@generated\": \".*\"", "@generated\": \"DATE\"")
+                .replaceFirst("created\": \".*\"", "created\": \"DATE\"")
                 .replaceAll("basic-.*/", "dir")
                 .replaceAll("[\\n\\r\\t ]+", " ");
     }

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json-plus.json
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json-plus.json
@@ -2,6 +2,7 @@
     "@programName": "ZAP",
     "@version": "Dev Build",
     "@generated": "Thu, 5 Jun 2025 16:12:29",
+    "created": "2025-06-05T16:12:29.236211400Z",
     "site":[ 
         {
             "@name": "http://example.com",

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json.json
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-json.json
@@ -2,6 +2,7 @@
 	"@programName": "ZAP",
 	"@version": "Dev Build",
 	"@generated": "Thu, 17 Jun 2021 16:04:28",
+    "created": "2021-06-17T16:04:28.236211400Z",
 	"site":[ 
 		{
 			"@name": "http://example.com",

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml-plus.xml
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml-plus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<OWASPZAPReport programName="ZAP" version="Dev Build" generated="Thu, 5 Jun 2025 16:15:14">
+<OWASPZAPReport programName="ZAP" version="Dev Build" generated="Thu, 5 Jun 2025 16:15:14" created="2025-06-05T16:15:14.236211400Z">
 	
 		<site name="http://example.com" host="example.com" port="80" ssl="false">
 			<alerts>

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml.xml
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<OWASPZAPReport programName="ZAP" version="Dev Build" generated="Mon, 11 Mar 2024 17:44:48">
+<OWASPZAPReport programName="ZAP" version="Dev Build" generated="Mon, 11 Mar 2024 17:44:48" created="2024-03-11T17:44:48.236211400Z">
 	
 		<site name="http://example.com" host="example.com" port="80" ssl="false">
 			<alerts>


### PR DESCRIPTION
## Overview
- Templates > Updated with new field ("created").
- CHANGELOG > Added note.
- ExtensionReports & UnitTest > Add new data element and update unit tests.
- Help > Update samples and informational/explanation content.
- UnitTest Resources > Updated to include the new "created" field.

## Related Issues
- https://groups.google.com/g/zaproxy-users/c/2AVjKM8HN28
