### PR TITLE
reports: Help Typo Fix and alt tag adjustments

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Corrected a minor typo and image alt tags in the help.
 
 ## [0.40.0] - 2025-09-02
 ### Changed

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-html-plus.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-html-plus.html
@@ -52,10 +52,10 @@
 	If "Sequence Details" are included in the report. Both a summary
 	section and details section will be included.
 	<p></p>
-	<img alt="Traditional HTML Plus - Sequences Summary"
+	<img alt="Sequences Summary"
 		src="../../common/images/report-traditional-html-sequence-summary.png">
 	<p></p>
-	<img alt="Traditional HTML OPlus - Sequences Details"
+	<img alt="Sequences Details"
 		src="../../common/images/report-traditional-html-plus-sequence-details.png">
 
 	<H3>Themes</H3>

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-html.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-html.html
@@ -42,10 +42,10 @@
 	If "Sequence Details" are included in the report. Both a summary
 	section and details section will be included.
 	<p></p>
-	<img alt="Traditional HTML - Sequences Summary"
+	<img alt="Sequences Summary"
 		src="../../common/images/report-traditional-html-sequence-summary.png">
 	<p></p>
-	<img alt="Traditional HTML - Sequences Details"
+	<img alt="Sequences Details"
 		src="../../common/images/report-traditional-html-sequence-details.png">
 
 </BODY>


### PR DESCRIPTION
## Overview
Fix "OPlus" ➡️ "Plus" typo in help content.
