### PR TITLE
openapi: correct empty object generation

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Warn logs to always include stack trace.
+- Correct generation of empty object.
 
 ## [45] - 2025-03-24
 ### Fixed

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -177,7 +177,7 @@ public class DataGenerator {
             } else if (property.getProperties() != null && !property.getProperties().isEmpty()) {
                 return generators.getBodyGenerator().generate(property);
             } else {
-                return "";
+                return "{}";
             }
         }
         return generateValue(name, property, false);

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/DataGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/DataGeneratorUnitTest.java
@@ -82,6 +82,22 @@ class DataGeneratorUnitTest extends TestUtils {
         assertEquals("{\"id\":10,\"name\":\"John Doe\"}", data);
     }
 
+    @Test
+    void shouldGenerateEmptyPropertyObject() throws IOException {
+        // Given
+        OpenAPI openAPI = parseResource("defn-with-query-params.yml");
+        Parameter parameter =
+                openAPI.getPaths()
+                        .get("/content-json-empty-object")
+                        .getGet()
+                        .getParameters()
+                        .get(0);
+        // When
+        String data = generator.generate(parameter.getName(), parameter);
+        // Then
+        assertEquals("{\"data\":{}}", data);
+    }
+
     private OpenAPI parseResource(String fileName) throws IOException {
         ParseOptions options = new ParseOptions();
         options.setResolveFully(true);

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/generators/defn-with-query-params.yml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/generators/defn-with-query-params.yml
@@ -18,6 +18,19 @@ paths:
         '200':
           description: OK
 
+  /content-json-empty-object:
+    get:
+      parameters:
+        - name: param
+          in: query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyEmptyObject'
+      responses:
+        '200':
+          description: OK
+
   /without-schema:
     get:
       parameters:
@@ -39,3 +52,10 @@ components:
           format: int64
         name:
           type: string
+    PropertyEmptyObject:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties: true
+


### PR DESCRIPTION
Use an empty object for map without properties instead of an empty string, which would generate invalid JSON (e.g. `{"data":}` vs `{"data":{}}`).

---
Reported in Slack.
