### PR TITLE
authhelper: add diag HTTP msgs to sites/history

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Changed
 - Search also for login elements with ARIA role button.
+- Show always the diagnostic HTTP messages in the Sites tree and History tab when importing the Authentication Report.
 
 ## [0.28.0] - 2025-09-02
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ui/diags/AllDiagnosticsPanel.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ui/diags/AllDiagnosticsPanel.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.awt.BorderLayout;
+import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
@@ -53,6 +54,7 @@ import org.jdesktop.swingx.error.ErrorInfo;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.AbstractPanel;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
@@ -69,6 +71,7 @@ import org.zaproxy.addon.authhelper.internal.db.DiagnosticWebElement.SelectorTyp
 import org.zaproxy.addon.authhelper.internal.db.TableJdo;
 import org.zaproxy.addon.commonlib.ui.ReadableFileChooser;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
+import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.view.TabbedPanel2;
@@ -526,6 +529,9 @@ public class AllDiagnosticsPanel extends AbstractPanel {
             return;
         }
 
+        ExtensionHistory extensionHistory =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+
         for (Map<String, Object> messageData : messagesData) {
             try {
                 HttpMessage message = new HttpMessage();
@@ -554,6 +560,14 @@ public class AllDiagnosticsPanel extends AbstractPanel {
                         List.of(
                                 Constant.messages.getString(
                                         "authhelper.authdiags.message.tag.initiator", initiator)));
+
+                if (extensionHistory != null) {
+                    EventQueue.invokeLater(
+                            () -> {
+                                extensionHistory.addHistory(ref);
+                                SessionStructure.addPath(extensionHistory.getModel(), ref, message);
+                            });
+                }
 
                 DiagnosticMessage diagnosticMessage = new DiagnosticMessage();
                 diagnosticMessage.setStep(diagnosticStep);


### PR DESCRIPTION
The messages could already be shown by changing the filters or if the messages had alerts raised on them, showing always makes it easier to go through all of the HTTP messages when needed.