### PR TITLE
authhelper: log exception with diags enabled

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Add login word variant for Spanish.
+- Log exception during authentication with diagnostics enabled.
 
 ## Changed
 - Search also for login elements with ARIA role button.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -473,6 +473,14 @@ return getSelector(arguments[0], document)
         }
     }
 
+    public void reportFlowException(Exception cause) {
+        if (!enabled) {
+            return;
+        }
+
+        LOGGER.info("Exception during steps:", cause);
+    }
+
     public void recordStep(String description) {
         if (!enabled) {
             return;

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/DefaultAuthenticator.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/DefaultAuthenticator.java
@@ -118,6 +118,8 @@ public class DefaultAuthenticator implements Authenticator {
                 }
                 AuthUtils.sendReturnAndSleep(diags, wd, pwdField, stepDelayInSecs);
             } catch (Exception e) {
+                diags.reportFlowException(e);
+
                 if (userField != null) {
                     // Handle the case where the password field was present but hidden / disabled
                     LOGGER.debug("Handling hidden password field on {}", wd.getCurrentUrl());


### PR DESCRIPTION
Log the exception that might happen during the authentication when the diagnostics are enabled as that will provide more information about the possible problem.