### PR TITLE
spider: skip two slash URI

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Do not warn when canonicalising apparent URI, `//`.
 
 ## [0.16.0] - 2025-09-02
 ### Added

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/UrlCanonicalizer.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/UrlCanonicalizer.java
@@ -86,7 +86,7 @@ public final class UrlCanonicalizer {
      * @return the canonical url
      */
     public static String getCanonicalUrl(ParseContext ctx, String url, String baseURL) {
-        if (StringUtils.startsWithIgnoreCase(url, "javascript:")) {
+        if (StringUtils.startsWithIgnoreCase(url, "javascript:") || "//".equals(url)) {
             return null;
         }
 

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/UrlCanonicalizerUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/UrlCanonicalizerUnitTest.java
@@ -208,6 +208,15 @@ class UrlCanonicalizerUnitTest {
     }
 
     @Test
+    void shouldIgnoreTwoSlashUri() {
+        // Given / When
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(ctx, "//", BASE_URL);
+        // Then
+        assertThat(canonicalizedUri, canonicalizedUri, is(equalTo(null)));
+        assertThat(logEvents, not(hasItem(startsWith("WARN "))));
+    }
+
+    @Test
     void shouldReturnCanonicalUriWithPercentEncodedPath() throws URIException {
         // Given
         String uri = new URI("http://example.com/path/%C3%A1/", true).toString();


### PR DESCRIPTION
Do not attempt to canonicalize two slash URI since it's not a valid one.
The HTML parser might find such "URIs" when searching elements' text.