### PR TITLE
tech detection: Add link with sites tree button

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- The Technology panel toolbar now includes a toggle button to link its displayed contents to the Sites Tree selection.
 
 ### Fixed
 - Icon sizing in the Technology table when a transparent placeholder needs to be used.

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -56,14 +56,9 @@ import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
 import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.view.ScanPanel;
-import org.zaproxy.zap.view.SiteMapListener;
-import org.zaproxy.zap.view.SiteMapTreeCellRenderer;
 
 public class ExtensionWappalyzer extends ExtensionAdaptor
-        implements SessionChangedListener,
-                SiteMapListener,
-                ApplicationHolder,
-                ExampleAlertProvider {
+        implements SessionChangedListener, ApplicationHolder, ExampleAlertProvider {
 
     public static final String NAME = "ExtensionWappalyzer";
 
@@ -173,7 +168,6 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
         super.hook(extensionHook);
 
         extensionHook.addSessionListener(this);
-        extensionHook.addSiteMapListener(this);
 
         if (hasView()) {
             @SuppressWarnings("unused")
@@ -248,6 +242,10 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
         super.unload();
 
         getPscanExtension().getPassiveScannersManager().remove(passiveScanner);
+
+        if (techPanel != null) {
+            techPanel.unload();
+        }
     }
 
     @Override
@@ -272,9 +270,9 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
 
     public TechTableModel getTechModelForSite(String site) {
         TechTableModel model = this.siteTechMap.computeIfAbsent(site, s -> new TechTableModel());
-        if (hasView()) {
+        if (techPanel != null) {
             // Add to site pulldown
-            this.getTechPanel().addSite(site);
+            this.techPanel.addSite(site);
         }
         return model;
     }
@@ -362,16 +360,6 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
             getExtensionSearch().search(p.pattern(), type, true, false);
         }
     }
-
-    @Override
-    public void nodeSelected(SiteNode node) {
-        // Event from SiteMapListenner
-        this.getTechPanel().siteSelected(normalizeSite(node.getHistoryReference().getURI()));
-    }
-
-    @Override
-    public void onReturnNodeRendererComponent(
-            SiteMapTreeCellRenderer arg0, boolean arg1, SiteNode arg2) {}
 
     @Override
     public void sessionAboutToChange(Session arg0) {

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -22,12 +22,15 @@ Right clicking on a technology will display a 'Show evidence' menu under which a
 Selecting a regex will switch to the 'Search' tab and search through the history for that regex. Note: If multiple rows are selected
 the menu will not be displayed.
 <p>
-Beside the site selection drop down is an Export button which can be used to export a CSV (comma separated values) file based on the
+Beside the site selection drop down is a button (with a Globe icon) which controls whether or not the Technology tab's display is linked to the selection in the Sites Tree.
+<p>
+Next is an Export button which can be used to export a CSV (comma separated values) file based on the
 table information currently being displayed.
 <p>
 The toolbar also includes:
 <ul>
   <li>An enable/disable toggle button which controls whether the technology detection passive scan rule is functioning or not. This enabled state is persisted between ZAP sessions.</li>
+  <li>A button (with a gear icon) which will open the add-on's Options panel when clicked.</li>
 </ul>
 
 <H2>Reporting</H2>

--- a/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
+++ b/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
@@ -84,6 +84,9 @@ wappalyzer.toolbar.options.name = Options
 wappalyzer.toolbar.site.label = Site:
 wappalyzer.toolbar.site.select = -- Select Site --
 
+wappalyzer.toolbar.toggle.site.link.disabled.tooltip = Link with Sites Selection
+wappalyzer.toolbar.toggle.site.link.enabled.tooltip = Unlink with Sites Selection
+
 wappalyzer.toolbar.toggle.state.disabled = Disabled
 wappalyzer.toolbar.toggle.state.disabled.tooltip = Click to Enable Technology Detection
 wappalyzer.toolbar.toggle.state.enabled = Enabled


### PR DESCRIPTION
## Overview
Instead of simply defaulting to "Link with Sites Tree" the add-on now has a button allowing the user to control the behavior. (Default enabled to mimic existing behavior)

Update extension/panel. Add CHANGELOG entry. Update help. Add necessary support resources.

## Related Issues
- Related but not exact: zaproxy/zaproxy#8169
