### PR TITLE
tech detection: correct placeholder icon sizing

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Icon sizing in the Technology table when a transparent placeholder needs to be used.
 
 ## [21.48.0] - 2025-09-02
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -89,12 +89,12 @@ public class TechPanel extends AbstractPanel {
 
                 @Override
                 public int getIconWidth() {
-                    return 32;
+                    return TechsJsonParser.SIZE;
                 }
 
                 @Override
                 public int getIconHeight() {
-                    return 32;
+                    return TechsJsonParser.SIZE;
                 }
             };
 

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechsJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechsJsonParser.java
@@ -57,7 +57,7 @@ public class TechsJsonParser {
     private static final String FIELD_CONFIDENCE = "confidence:";
     private static final String FIELD_VERSION = "version:";
     private static final String FIELD_SEPARATOR = "\\\\;";
-    private static final int SIZE = 16;
+    static final int SIZE = 16;
 
     private static final Logger LOGGER = LogManager.getLogger(TechsJsonParser.class);
     private final PatternErrorHandler patternErrorHandler;


### PR DESCRIPTION
## Overview
- CHANGELOG > Add fix note.
- TechJsonParser > Increase visibility of SIZE constant.
- TechPanel > Use SIZE as the height and width of the placeholder transparent icon.

Before:
<img width="303" height="265" alt="image" src="https://github.com/user-attachments/assets/7c6e6286-4f9c-4def-9f26-2016dc79def5" />

After:
<img width="273" height="381" alt="image" src="https://github.com/user-attachments/assets/f1f466bb-f851-4cf3-9611-a72cda62b8a7" />


(Ignore the difference in listed Tech, that's a timing thing.)