### PR TITLE
authhelper: add verif URL stats to auth report

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -7,10 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add login word variant for Spanish.
 - Log exception during authentication with diagnostics enabled.
+- Add the statistics of the site of the verification URL to the Authentication Report.
 
 ### Changed
 - Search also for login elements with ARIA role button.
 - Show always the diagnostic HTTP messages in the Sites tree and History tab when importing the Authentication Report.
+- Include the site in the site statistics of the Authentication Report.
 
 ### Fixed
 - Collect the current value of the element's attributes for the authentication diagnostics.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/AuthReportData.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/AuthReportData.java
@@ -96,7 +96,11 @@ public class AuthReportData implements Closeable {
     }
 
     public void addStatsItem(String key, String scope, long value) {
-        statistics.put(key, new StatsItem(key, scope, value));
+        addStatsItem(key, scope, null, value);
+    }
+
+    public void addStatsItem(String key, String scope, String site, long value) {
+        statistics.put(key, new StatsItem(key, scope, site, value));
     }
 
     public Object[] getStatistics() {
@@ -151,5 +155,10 @@ public class AuthReportData implements Closeable {
 
     public record SummaryItem(boolean passed, String key, String description) {}
 
-    public record StatsItem(String key, String scope, long value) {}
+    public record StatsItem(String key, String scope, String site, long value) {
+
+        public StatsItem(String key, String scope, long value) {
+            this(key, scope, null, value);
+        }
+    }
 }

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
@@ -352,11 +352,13 @@
 		{
 			"key": "stats.auth.browser.foundfields",
 			"scope": "site",
+			"site:" "https://www.example.org",
 			"value": 1
 		},
 		{
 			"key": "stats.auth.browser.passed",
 			"scope": "site",
+			"site:" "https://www.example.org",
 			"value": 1
 		},
 		{
@@ -397,11 +399,13 @@
 		{
 			"key": "stats.auth.sessiontoken.accesstoken",
 			"scope": "site",
+			"site:" "https://www.example.org",
 			"value": 9
 		},
 		{
 			"key": "stats.auth.sessiontoken.token",
 			"scope": "site",
+			"site:" "https://www.example.org",
 			"value": 6
 		},
 		{
@@ -412,11 +416,13 @@
 		{
 			"key": "stats.auth.state.loggedin",
 			"scope": "site",
+			"site:" "https://www.example.org",
 			"value": 2
 		},
 		{
 			"key": "stats.auth.success",
 			"scope": "site",
+			"site:" "https://www.example.org",
 			"value": 1
 		}
 	]

--- a/addOns/authhelper/src/main/zapHomeFiles/reports/auth-report-json/report.json
+++ b/addOns/authhelper/src/main/zapHomeFiles/reports/auth-report-json/report.json
@@ -30,7 +30,8 @@
 	,"statistics": [[#th:block th:each="statItem, statState: ${rptData.getStatistics()}"][#th:block th:if="${! statState.first}"],[/th:block]
 		{
 			"key": [[${statItem.key}]],
-			"scope": [[${statItem.scope}]],
+			"scope": [[${statItem.scope}]],[#th:block th:if="${statItem.site}"]
+			"site": [[${statItem.site}]],[/th:block]
 			"value": [[${statItem.value}]]
 		}[/th:block]
 	]


### PR DESCRIPTION
Add the stats for the site of the verification URL which might be different than the target site.