### PR TITLE
authhelper: report login failure if not logged in

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Collect the current value of the element's attributes for the authentication diagnostics.
+- In the Authentication Report set authentication successful only when the login was verified with the indicators.
 
 ## [0.28.0] - 2025-09-02
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/AuthReportData.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/report/AuthReportData.java
@@ -24,10 +24,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.TreeMap;
 import javax.jdo.PersistenceManager;
 import javax.jdo.PersistenceManagerFactory;
 import javax.jdo.Query;
@@ -53,6 +52,7 @@ public class AuthReportData implements Closeable {
         OVERALL("overall.failed"),
         PASS_COUNT("pass.count.failed"),
         SESSION_MGMT("sessmgmt.failed"),
+        LOGGED_IN("loggedin.failed"),
         LOGIN_FAILURES("login.failures"),
         AF_PLAN_ERRORS("afplan.errors"),
         NO_SUCCESSFUL_LOGINS("no.successful.logins"),
@@ -73,7 +73,7 @@ public class AuthReportData implements Closeable {
     private boolean validReport;
     private String afEnv;
     private List<SummaryItem> summaryItems = new ArrayList<>();
-    private Map<String, StatsItem> statistics = new TreeMap<>();
+    private List<StatsItem> statistics = new ArrayList<>();
     private List<String> nextSteps = new ArrayList<>();
     private PersistenceManager pm;
     private List<Diagnostic> diagnostics;
@@ -100,11 +100,16 @@ public class AuthReportData implements Closeable {
     }
 
     public void addStatsItem(String key, String scope, String site, long value) {
-        statistics.put(key, new StatsItem(key, scope, site, value));
+        statistics.add(new StatsItem(key, scope, site, value));
+    }
+
+    List<StatsItem> getStatisticsImpl() {
+        return statistics;
     }
 
     public Object[] getStatistics() {
-        return statistics.values().toArray();
+        Collections.sort(statistics, (a, b) -> a.key().compareTo(b.key));
+        return statistics.toArray();
     }
 
     public List<Diagnostic> getDiagnostics() {

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
@@ -150,6 +150,10 @@
 			<td>Failed to identify session management.</td>
 		</tr>
 		<tr>
+			<td>auth.failure.logged_in</td>
+			<td>No indication found of being logged in.</td>
+		</tr>
+		<tr>
 			<td>auth.failure.login_failures</td>
 			<td>One or more failed logins.</td>
 		</tr>

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -199,6 +199,7 @@ authhelper.authreport.name = Authentication Helper Reports
 authhelper.authreport.summary.auth.fail = Authentication failed
 authhelper.authreport.summary.auth.pass = Authentication appeared to work
 authhelper.authreport.summary.fail.detail.afplan.errors = There were Automation Framework plan errors.
+authhelper.authreport.summary.fail.detail.loggedin.failed = No indication found of being logged in.
 authhelper.authreport.summary.fail.detail.login.failures = One or more failed logins.
 authhelper.authreport.summary.fail.detail.no.successful.logins = No successful logins.
 authhelper.authreport.summary.fail.detail.overall.failed = All authentication elements passed yet authentication was deemed a failure in the end.


### PR DESCRIPTION
Check that the logged in indicator is set and no unknown indicator, to not assume (wrongly) that the login was successful/verified.