### PR TITLE
pscanrulesAlpha: Add reference and example alert check unit tests

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update alert references to latest locations to fix 404s and resolve redirections.
 
 ## [45] - 2025-06-20
 ### Added

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -49,20 +49,20 @@ The Fetch Metadata Request headers are:
 
 <p>
 Sec-Fetch-Site indicates the relationship between a request initiator's origin and the origin of requested resource.
-(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site">Sec-Fetch-Site</a>)
+(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site">Sec-Fetch-Site</a>)
 
 <p>
 Sec-Fetch-Mode allows the server to distinguish between requests originating from a user navigating between HTML
 pages and requests to load images and other resources.
-(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode">Sec-Fetch-Mode</a>)
+(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Mode">Sec-Fetch-Mode</a>)
 
 <p>
 Sec-Fetch-Dest indicates where and how the requested resource will be used.
-(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest">Sec-Fetch-Dest</a>)
+(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest">Sec-Fetch-Dest</a>)
 
 <p>
 Sec-Fetch-User is only sent for requests initiated by user activation.
-(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User">Sec-Fetch-User</a>)
+(from <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-User">Sec-Fetch-User</a>)
 
 <p>
  Alerts generated:

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -28,42 +28,42 @@ pscanalpha.metadata-request-headers.name = Fetch Metadata Request Headers
 pscanalpha.metadata-request-headers.sfd.invalid-values.desc = Specifies how and where the data would be used. For instance, if the value is audio, then the requested resource must be audio data and not any other type of resource.
 
 pscanalpha.metadata-request-headers.sfd.invalid-values.name = Sec-Fetch-Dest Header Has an Invalid Value
-pscanalpha.metadata-request-headers.sfd.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest
+pscanalpha.metadata-request-headers.sfd.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest
 pscanalpha.metadata-request-headers.sfd.invalid-values.soln = Sec-Fetch-Dest header must have one of the following values: audio, audioworklet, document, embed, empty, font, frame, iframe, image, manifest, object, paintworklet, report, script, serviceworker, sharedworker, style, track, video, worker, xslt.
 pscanalpha.metadata-request-headers.sfd.missing.desc = Specifies how and where the data would be used. For instance, if the value is audio, then the requested resource must be audio data and not any other type of resource.
 
 pscanalpha.metadata-request-headers.sfd.missing.name = Sec-Fetch-Dest Header is Missing
-pscanalpha.metadata-request-headers.sfd.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest
+pscanalpha.metadata-request-headers.sfd.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest
 pscanalpha.metadata-request-headers.sfd.missing.soln = Ensure that Sec-Fetch-Dest header is included in request headers.
 pscanalpha.metadata-request-headers.sfm.invalid-values.desc = Allows to differentiate between requests for navigating between HTML pages and requests for loading resources like images, audio etc.
 
 pscanalpha.metadata-request-headers.sfm.invalid-values.name = Sec-Fetch-Mode Header Has an Invalid Value
-pscanalpha.metadata-request-headers.sfm.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode
+pscanalpha.metadata-request-headers.sfm.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Mode
 pscanalpha.metadata-request-headers.sfm.invalid-values.soln = Sec-Fetch-Mode header must have one of the following values: cors, no-cors, navigate, same-origin, or websocket.
 pscanalpha.metadata-request-headers.sfm.missing.desc = Allows to differentiate between requests for navigating between HTML pages and requests for loading resources like images, audio etc.
 
 pscanalpha.metadata-request-headers.sfm.missing.name = Sec-Fetch-Mode Header is Missing
-pscanalpha.metadata-request-headers.sfm.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode
+pscanalpha.metadata-request-headers.sfm.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Mode
 pscanalpha.metadata-request-headers.sfm.missing.soln = Ensure that Sec-Fetch-Mode header is included in request headers.
 pscanalpha.metadata-request-headers.sfs.invalid-values.desc = Specifies the relationship between request initiator's origin and target's origin.
 
 pscanalpha.metadata-request-headers.sfs.invalid-values.name = Sec-Fetch-Site Header Has an Invalid Value
-pscanalpha.metadata-request-headers.sfs.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site
+pscanalpha.metadata-request-headers.sfs.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site
 pscanalpha.metadata-request-headers.sfs.invalid-values.soln = Sec-Fetch-Site header must have one of the following values: same-origin, same-site, cross-origin, or none.
 pscanalpha.metadata-request-headers.sfs.missing.desc = Specifies the relationship between request initiator's origin and target's origin.
 
 pscanalpha.metadata-request-headers.sfs.missing.name = Sec-Fetch-Site Header is Missing
-pscanalpha.metadata-request-headers.sfs.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site
+pscanalpha.metadata-request-headers.sfs.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site
 pscanalpha.metadata-request-headers.sfs.missing.soln = Ensure that Sec-Fetch-Site header is included in request headers.
 pscanalpha.metadata-request-headers.sfu.invalid-values.desc = Specifies if a navigation request was initiated by a user.
 
 pscanalpha.metadata-request-headers.sfu.invalid-values.name = Sec-Fetch-User Header Has an Invalid Value
-pscanalpha.metadata-request-headers.sfu.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User
+pscanalpha.metadata-request-headers.sfu.invalid-values.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-User
 pscanalpha.metadata-request-headers.sfu.invalid-values.soln = Sec-Fetch-User header must have the value set to ?1.
 pscanalpha.metadata-request-headers.sfu.missing.desc = Specifies if a navigation request was initiated by a user.
 
 pscanalpha.metadata-request-headers.sfu.missing.name = Sec-Fetch-User Header is Missing
-pscanalpha.metadata-request-headers.sfu.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User
+pscanalpha.metadata-request-headers.sfu.missing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-User
 pscanalpha.metadata-request-headers.sfu.missing.soln = Ensure that Sec-Fetch-User header is included in user initiated requests.
 
 pscanalpha.name = Passive Scan Rules - alpha

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FullPathDisclosureScanRuleUnitTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -176,6 +177,19 @@ class FullPathDisclosureScanRuleUnitTest extends PassiveScannerTest<FullPathDisc
         // Then
         assertThat(alertsRaised, hasSize(1));
         assertEquals(defaultPath, alertsRaised.get(0).getEvidence());
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlerts() {
+        // Given / When
+        List<Alert> examples = rule.getExampleAlerts();
+        // Then
+        assertThat(examples.size(), is(equalTo(1)));
+        Alert alert = examples.get(0);
+        assertThat(alert.getName(), is(equalTo("Full Path Disclosure")));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_LOW)));
+        assertThat(alert.getAlertRef(), is(equalTo("110009")));
+        assertThat(alert.getCweId(), is(equalTo(209)));
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
@@ -27,5 +28,11 @@ abstract class PassiveScannerTest<T extends PassiveScanner> extends PassiveScann
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionPscanRulesAlpha());
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 }


### PR DESCRIPTION
## Overview
- Ensure all scan rules have tests for example alerts and valid references.
- Update alert references to latest locations to fix 404s and resolve redirections.
