### PR TITLE
pscanrulesBeta: Add valid reference check unit tests

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update alert references to latest locations to fix 404s and resolve redirections.
 
 ## [45] - 2025-09-10
 ### Changed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/SiteIsolationScanRule.java
@@ -54,13 +54,13 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * </ul>
  *
  * @see <a
- *     href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)">CORP
+ *     href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cross-Origin_Resource_Policy">CORP
  *     on MDN</a>
  * @see <a
- *     href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy">COEP
+ *     href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy">COEP
  *     on MDN</a>
  * @see <a
- *     href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy">COOP
+ *     href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy">COOP
  *     on MDN</a>
  * @see <a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header">COOP Specs</a>
  * @see <a href="https://html.spec.whatwg.org/multipage/origin.html#coep">COEP Specs</a>

--- a/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -8,7 +8,7 @@ pscanbeta.inpagebanner.soln = Configure the server to prevent such information l
 
 pscanbeta.jsfunction.desc = A dangerous JS function seems to be in use that would leave the site vulnerable.
 pscanbeta.jsfunction.name = Dangerous JS Functions
-pscanbeta.jsfunction.refs = https://angular.io/guide/security
+pscanbeta.jsfunction.refs = https://v17.angular.io/guide/security
 pscanbeta.jsfunction.soln = See the references for security advice on the use of these functions.
 
 pscanbeta.jso.desc = Java Serialization seems to be in use. If not correctly validated, an attacker can send a specially crafted object. This can lead to a dangerous "Remote Code Execution". A magic sequence identifying JSO has been detected (Base64: rO0AB, Raw: 0xac, 0xed, 0x00, 0x05).
@@ -28,11 +28,11 @@ pscanbeta.payloader.name = Passive Scan Rules Beta Custom Payloads
 
 pscanbeta.permissionspolicymissing.deprecated.desc = The header has now been renamed to Permissions-Policy.
 pscanbeta.permissionspolicymissing.deprecated.name = Deprecated Feature Policy Header Set
-pscanbeta.permissionspolicymissing.deprecated.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy\nhttps://scotthelme.co.uk/goodbye-feature-policy-and-hello-permissions-policy/
+pscanbeta.permissionspolicymissing.deprecated.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy\nhttps://scotthelme.co.uk/goodbye-feature-policy-and-hello-permissions-policy/
 pscanbeta.permissionspolicymissing.deprecated.soln = Ensure that your web server, application server, load balancer, etc. is configured to set the Permissions-Policy header instead of the Feature-Policy header.
 pscanbeta.permissionspolicymissing.desc = Permissions Policy Header is an added layer of security that helps to restrict from unauthorized access or usage of browser/client features by web resources. This policy ensures the user privacy by limiting or specifying the features of the browsers can be used by the web resources. Permissions Policy provides a set of standard HTTP headers that allow website owners to limit which features of browsers can be used by the page such as camera, microphone, location, full screen etc.
 pscanbeta.permissionspolicymissing.name = Permissions Policy Header Not Set
-pscanbeta.permissionspolicymissing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy\nhttps://developer.chrome.com/blog/feature-policy/\nhttps://scotthelme.co.uk/a-new-security-header-feature-policy/\nhttps://w3c.github.io/webappsec-feature-policy/\nhttps://www.smashingmagazine.com/2018/12/feature-policy/
+pscanbeta.permissionspolicymissing.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy\nhttps://developer.chrome.com/blog/feature-policy/\nhttps://scotthelme.co.uk/a-new-security-header-feature-policy/\nhttps://w3c.github.io/webappsec-feature-policy/\nhttps://www.smashingmagazine.com/2018/12/feature-policy/
 pscanbeta.permissionspolicymissing.soln = Ensure that your web server, application server, load balancer, etc. is configured to set the Permissions-Policy header.
 
 pscanbeta.servletparameterpollution.desc = Unspecified form action: HTTP parameter override attack potentially possible. This is a known problem with Java Servlets but other platforms may also be vulnerable.
@@ -42,21 +42,21 @@ pscanbeta.servletparameterpollution.soln = All forms must specify the action URL
 
 pscanbeta.site-isolation.coep.desc = Cross-Origin-Embedder-Policy header is a response header that prevents a document from loading any cross-origin resources that don't explicitly grant the document permission (using CORP or CORS).
 pscanbeta.site-isolation.coep.name = Cross-Origin-Embedder-Policy Header Missing or Invalid
-pscanbeta.site-isolation.coep.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
+pscanbeta.site-isolation.coep.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy
 pscanbeta.site-isolation.coep.soln = Ensure that the application/web server sets the Cross-Origin-Embedder-Policy header appropriately, and that it sets the Cross-Origin-Embedder-Policy header to 'require-corp' for documents.\nIf possible, ensure that the end user uses a standards-compliant and modern web browser that supports the Cross-Origin-Embedder-Policy header (https://caniuse.com/mdn-http_headers_cross-origin-embedder-policy).
 pscanbeta.site-isolation.coop.desc = Cross-Origin-Opener-Policy header is a response header that allows a site to control if others included documents share the same browsing context. Sharing the same browsing context with untrusted documents might lead to data leak.
 pscanbeta.site-isolation.coop.name = Cross-Origin-Opener-Policy Header Missing or Invalid
-pscanbeta.site-isolation.coop.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+pscanbeta.site-isolation.coop.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy
 pscanbeta.site-isolation.coop.soln = Ensure that the application/web server sets the Cross-Origin-Opener-Policy header appropriately, and that it sets the Cross-Origin-Opener-Policy header to 'same-origin' for documents.\n'same-origin-allow-popups' is considered as less secured and should be avoided.\nIf possible, ensure that the end user uses a standards-compliant and modern web browser that supports the Cross-Origin-Opener-Policy header (https://caniuse.com/mdn-http_headers_cross-origin-opener-policy).
 pscanbeta.site-isolation.corp.desc = Cross-Origin-Resource-Policy header is an opt-in header designed to counter side-channels attacks like Spectre. Resource should be specifically set as shareable amongst different origins.
 pscanbeta.site-isolation.corp.name = Cross-Origin-Resource-Policy Header Missing or Invalid
-pscanbeta.site-isolation.corp.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy
+pscanbeta.site-isolation.corp.refs = https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy
 pscanbeta.site-isolation.corp.soln = Ensure that the application/web server sets the Cross-Origin-Resource-Policy header appropriately, and that it sets the Cross-Origin-Resource-Policy header to 'same-origin' for all web pages.\n'same-site' is considered as less secured and should be avoided.\nIf resources must be shared, set the header to 'cross-origin'.\nIf possible, ensure that the end user uses a standards-compliant and modern web browser that supports the Cross-Origin-Resource-Policy header (https://caniuse.com/mdn-http_headers_cross-origin-resource-policy).
 pscanbeta.site-isolation.name = Insufficient Site Isolation Against Spectre Vulnerability
 
 pscanbeta.sourcecodedisclosure.desc = Application Source Code was disclosed by the web server.
 pscanbeta.sourcecodedisclosure.name = Source Code Disclosure
-pscanbeta.sourcecodedisclosure.refs = https://www.wsj.com/articles/BL-CIOB-2999
+pscanbeta.sourcecodedisclosure.refs = https://nhimg.org/twitter-breach
 pscanbeta.sourcecodedisclosure.soln = Ensure that application Source Code is not available with alternative extensions, and ensure that source code is not present within other files or data deployed to the web server, or served by the web server.
 
 pscanbeta.sri-integrity.desc = The integrity attribute is missing on a script or link tag served by an external server. The integrity tag prevents an attacker who have gained access to this server from injecting a malicious content.

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrulesBeta;
 
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
@@ -28,5 +29,11 @@ abstract class PassiveScannerTest<T extends PluginPassiveScanner>
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionPscanRulesBeta());
+    }
+
+    @Test
+    @Override
+    public void shouldHaveValidReferences() {
+        super.shouldHaveValidReferences();
     }
 }


### PR DESCRIPTION
## Overview
- Ensure all scan rules have tests for valid references.
- Update alert references to latest locations to fix 404s and resolve redirections.
