### PR TITLE
Validate state of alert references

### DIFF
--- a/.github/workflows/ci_remote.yml
+++ b/.github/workflows/ci_remote.yml
@@ -1,0 +1,27 @@
+name: CI Remote
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Once a month
+    - cron:  '0 8 18 * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+        with:
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            wdm
+      - run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g --continue --no-parallel test
+        env:
+          ZAP_REMOTE_TESTS: 1

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -144,6 +144,10 @@ subprojects {
         }
     }
 
+    tasks.withType<Test>().configureEach {
+        inputs.property("ZAP_REMOTE_TESTS", if (System.getenv("ZAP_REMOTE_TESTS") == "1") "1" else "0")
+    }
+
     configurations {
         "compileClasspath" {
             exclude(group = "log4j")

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
-import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 
@@ -28,11 +27,5 @@ abstract class ActiveScannerTest<T extends AbstractPlugin> extends ActiveScanner
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionAscanRules());
-    }
-
-    @Test
-    @Override
-    public void shouldHaveValidReferences() {
-        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ActiveScannerTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ActiveScannerTest.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrulesAlpha;
 
-import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 
@@ -28,11 +27,5 @@ abstract class ActiveScannerTest<T extends AbstractPlugin> extends ActiveScanner
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionAscanRulesAlpha());
-    }
-
-    @Test
-    @Override
-    public void shouldHaveValidReferences() {
-        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
-import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 
@@ -28,11 +27,5 @@ abstract class ActiveScannerTest<T extends AbstractPlugin> extends ActiveScanner
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionAscanRulesBeta());
-    }
-
-    @Test
-    @Override
-    public void shouldHaveValidReferences() {
-        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRuleUnitTest.java
@@ -29,12 +29,25 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.PolicyTag;
+import org.zaproxy.addon.network.common.ZapSocketTimeoutException;
+import org.zaproxy.zap.testutils.AlertReferenceError;
 
 class CrossDomainScanRuleUnitTest extends ActiveScannerTest<CrossDomainScanRule> {
 
     @Override
     protected CrossDomainScanRule createScanner() {
         return new CrossDomainScanRule();
+    }
+
+    @Override
+    public boolean isAllowedReferenceError(
+            AlertReferenceError.Cause cause, String reference, Object detail) {
+        if (reference.startsWith("https://www.adobe.com/")
+                && detail instanceof ZapSocketTimeoutException) {
+            // Reference behind CDN which times out when accessed through CI.
+            return true;
+        }
+        return false;
     }
 
     @Test

--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Use example links in Active/Passive Rule templates' references.
 
 ## [0.9.0] - 2025-01-09
 ### Changed

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/active/Active default template GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/active/Active default template GraalJS.js
@@ -10,8 +10,8 @@ name: Active Vulnerability Title
 description: Full description
 solution: The solution
 references:
-  - Reference 1
-  - Reference 2
+  - https://www.example.org/reference1
+  - https://www.example.org/reference2
 category: INJECTION  # info_gather, browser, server, misc, injection
 risk: INFO  # info, low, medium, high
 confidence: LOW  # false_positive, low, medium, high, user_confirmed

--- a/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/passive/Passive default template GraalJS.js
+++ b/addOns/graaljs/src/main/zapHomeFiles/scripts/templates/passive/Passive default template GraalJS.js
@@ -13,8 +13,8 @@ name: Passive Vulnerability Title
 description: Full description
 solution: The solution
 references:
-  - Reference 1
-  - Reference 2
+  - https://www.example.org/reference1
+  - https://www.example.org/reference2
 risk: INFO  # info, low, medium, high
 confidence: LOW  # false_positive, low, medium, high, user_confirmed
 cweId: 0

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/ActiveDefaultTemplateGraalJsScriptTest.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/ActiveDefaultTemplateGraalJsScriptTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.zaproxy.zap.testutils.AlertReferenceError;
 
 class ActiveDefaultTemplateGraalJsScriptTest extends GraalJsActiveScriptScanRuleTestUtils {
     @Override
@@ -51,6 +52,16 @@ class ActiveDefaultTemplateGraalJsScriptTest extends GraalJsActiveScriptScanRule
         assertThat(name, is(not(emptyOrNullString())));
     }
 
+    @Override
+    public boolean isAllowedReferenceError(
+            AlertReferenceError.Cause cause, String reference, Object detail) {
+        if (cause == AlertReferenceError.Cause.UNEXPECTED_STATUS_CODE && ((int) detail) == 404) {
+            // These are example.org references.
+            return true;
+        }
+        return false;
+    }
+
     @Test
     void shouldRaiseAlert() throws Exception {
         // Given
@@ -65,7 +76,11 @@ class ActiveDefaultTemplateGraalJsScriptTest extends GraalJsActiveScriptScanRule
         assertThat(alert.getName(), is(equalTo("Active Vulnerability Title")));
         assertThat(alert.getDescription(), is(equalTo("Full description")));
         assertThat(alert.getSolution(), is(equalTo("The solution")));
-        assertThat(alert.getReference(), is(equalTo("Reference 1\nReference 2")));
+        assertThat(
+                alert.getReference(),
+                is(
+                        equalTo(
+                                "https://www.example.org/reference1\nhttps://www.example.org/reference2")));
         assertThat(alert.getOtherInfo(), is(equalTo("Any other Info")));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PassiveDefaultTemplateGraalJsScriptTest.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PassiveDefaultTemplateGraalJsScriptTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.AlertReferenceError;
 
 class PassiveDefaultTemplateGraalJsScriptTest extends GraalJsPassiveScriptScanRuleTestUtils {
     @Override
@@ -49,6 +50,16 @@ class PassiveDefaultTemplateGraalJsScriptTest extends GraalJsPassiveScriptScanRu
         assertThat(name, is(not(emptyOrNullString())));
     }
 
+    @Override
+    public boolean isAllowedReferenceError(
+            AlertReferenceError.Cause cause, String reference, Object detail) {
+        if (cause == AlertReferenceError.Cause.UNEXPECTED_STATUS_CODE && ((int) detail) == 404) {
+            // These are example.org references.
+            return true;
+        }
+        return false;
+    }
+
     @Test
     void shouldRaiseAlert() throws Exception {
         // Given
@@ -63,7 +74,11 @@ class PassiveDefaultTemplateGraalJsScriptTest extends GraalJsPassiveScriptScanRu
         assertThat(alert.getName(), is(equalTo("Passive Vulnerability Title")));
         assertThat(alert.getDescription(), is(equalTo("Full description")));
         assertThat(alert.getSolution(), is(equalTo("The solution")));
-        assertThat(alert.getReference(), is(equalTo("Reference 1\nReference 2")));
+        assertThat(
+                alert.getReference(),
+                is(
+                        equalTo(
+                                "https://www.example.org/reference1\nhttps://www.example.org/reference2")));
         assertThat(alert.getOtherInfo(), is(equalTo("Any other info")));
         assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
         assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PassiveScannerTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PassiveScannerTest.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
-import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
@@ -29,11 +28,5 @@ abstract class PassiveScannerTest<T extends PluginPassiveScanner>
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionPscanRules());
-    }
-
-    @Test
-    @Override
-    public void shouldHaveValidReferences() {
-        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
-import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
@@ -28,11 +27,5 @@ abstract class PassiveScannerTest<T extends PassiveScanner> extends PassiveScann
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionPscanRulesAlpha());
-    }
-
-    @Test
-    @Override
-    public void shouldHaveValidReferences() {
-        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscanrulesBeta;
 
-import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
@@ -29,11 +28,5 @@ abstract class PassiveScannerTest<T extends PluginPassiveScanner>
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionPscanRulesBeta());
-    }
-
-    @Test
-    @Override
-    public void shouldHaveValidReferences() {
-        super.shouldHaveValidReferences();
     }
 }

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -285,12 +285,6 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         assertRefs(example);
     }
 
-    @Test
-    @Override
-    public void shouldHaveValidReferences() {
-        super.shouldHaveValidReferences();
-    }
-
     private static void assertRefs(Alert alert) {
         assertThat(
                 alert.getReference(),

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/TechPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/TechPassiveScannerUnitTest.java
@@ -538,12 +538,6 @@ class TechPassiveScannerUnitTest extends PassiveScannerTestUtils<TechPassiveScan
         assertThat(helpLink, is(not(emptyString())));
     }
 
-    @Test
-    @Override
-    public void shouldHaveValidReferences() {
-        super.shouldHaveValidReferences();
-    }
-
     private void scan(HttpMessage msg) {
         rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
     }

--- a/gradle/ci.gradle.kts
+++ b/gradle/ci.gradle.kts
@@ -2,7 +2,7 @@
 
 fun isEnvVarTrue(envvar: String) = System.getenv(envvar) == "true"
 
-if (isEnvVarTrue("CI") && System.getenv("GITHUB_WORKFLOW") == "Java CI") {
+if (isEnvVarTrue("CI")) {
 
     allprojects {
         tasks.withType(Test::class).configureEach {

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/AlertReferenceError.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/AlertReferenceError.java
@@ -21,14 +21,15 @@ package org.zaproxy.zap.testutils;
 
 import java.util.function.Function;
 
-class AlertReferenceError {
+public class AlertReferenceError {
 
-    enum Cause {
+    public enum Cause {
         INVALID_URI(e -> "Invalid URI: '" + e.reference + "'. Reason: " + e.detail),
         NOT_HTTPS(e -> "Not HTTPS: " + e.reference),
         NOT_LINK(e -> "Not link: " + e.reference),
         UNEXPECTED_STATUS_CODE(
                 e -> "Unexpected status code, 200 != " + e.detail + ", for: " + e.reference),
+        REDIRECTED(e -> "Redirected from " + e.reference + " to: " + e.detail),
         IO_EXCEPTION(e -> "I/O exception: " + e.detail + ", for: " + e.reference);
 
         private final Function<AlertReferenceError, String> toString;


### PR DESCRIPTION
Add CI remote workflow that validates the state of the references, once a month.

Close zaproxy/zaproxy#5364.

---
Follow up to https://github.com/zaproxy/zap-extensions/pull/4559#discussion_r1434362323