### PR TITLE
graaljs: Add script test utils

### DIFF
--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/ActiveDefaultTemplateGraalJsScriptTest.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/ActiveDefaultTemplateGraalJsScriptTest.java
@@ -1,0 +1,78 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.graaljs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.ResourceBundle;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+
+class ActiveDefaultTemplateGraalJsScriptTest extends GraalJsActiveScriptScanRuleTestUtils {
+    @Override
+    public Path getScriptPath() throws Exception {
+        return Path.of(
+                getClass()
+                        .getResource("/scripts/templates/active/Active default template GraalJS.js")
+                        .toURI());
+    }
+
+    @Override
+    protected boolean isIgnoreAlertsRaisedInSendReasonableNumberOfMessages() {
+        return true;
+    }
+
+    @Override
+    public void shouldHaveI18nNonEmptyName(String name, ResourceBundle extensionResourceBundle) {
+        assertThat(name, is(not(emptyOrNullString())));
+    }
+
+    @Test
+    void shouldRaiseAlert() throws Exception {
+        // Given
+        rule.init(getHttpMessage("/path?param=value"), this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertThat(alert.getPluginId(), is(equalTo(12345)));
+        assertThat(alert.getAlertRef(), is(equalTo("12345")));
+        assertThat(alert.getName(), is(equalTo("Active Vulnerability Title")));
+        assertThat(alert.getDescription(), is(equalTo("Full description")));
+        assertThat(alert.getSolution(), is(equalTo("The solution")));
+        assertThat(alert.getReference(), is(equalTo("Reference 1\nReference 2")));
+        assertThat(alert.getOtherInfo(), is(equalTo("Any other Info")));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));
+        assertThat(alert.getTags(), is(equalTo(Map.of("name1", "value1", "name2", "value2"))));
+        assertThat(alert.getMsgUri().getPathQuery(), is(equalTo("/path?param=Your attack")));
+        assertThat(alert.getParam(), is(equalTo("param")));
+        assertThat(alert.getAttack(), is(equalTo("Your attack")));
+        assertThat(alert.getEvidence(), is(equalTo("Evidence")));
+    }
+}

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/GraalJsActiveScriptScanRuleTestUtils.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/GraalJsActiveScriptScanRuleTestUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.graaljs;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
+import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+import org.zaproxy.zap.extension.script.ScriptEngineWrapper;
+import org.zaproxy.zap.extension.script.ScriptType;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.scripts.scanrules.ActiveScriptScanRule;
+import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
+import org.zaproxy.zap.testutils.ScriptScanRuleTestUtils;
+
+public abstract class GraalJsActiveScriptScanRuleTestUtils
+        extends ActiveScannerTestUtils<ActiveScriptScanRule> implements ScriptScanRuleTestUtils {
+
+    private final ScriptEngineWrapper scriptEngineWrapper =
+            new GraalJsEngineWrapper(
+                    GraalJsActiveScriptScanRuleTestUtils.class.getClassLoader(), List.of(), null);
+
+    @Override
+    public ScriptEngineWrapper getScriptEngineWrapper() {
+        return scriptEngineWrapper;
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        setUpExtScript();
+    }
+
+    @Override
+    public void setUpMessages() {
+        mockMessages(new ExtensionGraalJs());
+    }
+
+    @Override
+    protected ActiveScriptScanRule createScanner() {
+        try {
+            ScanRuleMetadata metadata =
+                    getScriptInterface(ScanRuleMetadataProvider.class).getMetadata();
+            var scriptWrapper = new ScriptWrapper();
+            scriptWrapper.setFile(getScriptPath().toFile());
+            scriptWrapper.setEngine(scriptEngineWrapper);
+            scriptWrapper.setType(
+                    new ScriptType(ExtensionActiveScan.SCRIPT_TYPE_ACTIVE, null, null, true));
+            scriptWrapper.setEnabled(true);
+
+            return new ActiveScriptScanRule(scriptWrapper, metadata);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create active scan rule from script", e);
+        }
+    }
+}

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/GraalJsPassiveScriptScanRuleTestUtils.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/GraalJsPassiveScriptScanRuleTestUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.graaljs;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
+import org.zaproxy.zap.extension.script.ScriptEngineWrapper;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.scripts.scanrules.PassiveScriptScanRule;
+import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
+import org.zaproxy.zap.testutils.ScriptScanRuleTestUtils;
+
+public abstract class GraalJsPassiveScriptScanRuleTestUtils
+        extends PassiveScannerTestUtils<PassiveScriptScanRule> implements ScriptScanRuleTestUtils {
+
+    private final ScriptEngineWrapper scriptEngineWrapper =
+            new GraalJsEngineWrapper(
+                    GraalJsPassiveScriptScanRuleTestUtils.class.getClassLoader(), List.of(), null);
+
+    @Override
+    public ScriptEngineWrapper getScriptEngineWrapper() {
+        return scriptEngineWrapper;
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        setUpExtScript();
+    }
+
+    @Override
+    public void setUpMessages() {
+        mockMessages(new ExtensionGraalJs());
+    }
+
+    @Override
+    protected PassiveScriptScanRule createScanner() {
+        try {
+            return new PassiveScriptScanRule(
+                    mock(ScriptWrapper.class),
+                    getScriptInterface(ScanRuleMetadataProvider.class).getMetadata());
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create passive scan rule from script", e);
+        }
+    }
+}

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PassiveDefaultTemplateGraalJsScriptTest.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PassiveDefaultTemplateGraalJsScriptTest.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.graaljs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.ResourceBundle;
+import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+
+class PassiveDefaultTemplateGraalJsScriptTest extends GraalJsPassiveScriptScanRuleTestUtils {
+    @Override
+    public Path getScriptPath() throws Exception {
+        return Path.of(
+                getClass()
+                        .getResource(
+                                "/scripts/templates/passive/Passive default template GraalJS.js")
+                        .toURI());
+    }
+
+    @Override
+    public void shouldHaveI18nNonEmptyName(String name, ResourceBundle extensionResourceBundle) {
+        assertThat(name, is(not(emptyOrNullString())));
+    }
+
+    @Test
+    void shouldRaiseAlert() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage(new URI("http://example.com/path?param=value", true));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertThat(alert.getPluginId(), is(equalTo(12345)));
+        assertThat(alert.getAlertRef(), is(equalTo("12345")));
+        assertThat(alert.getName(), is(equalTo("Passive Vulnerability Title")));
+        assertThat(alert.getDescription(), is(equalTo("Full description")));
+        assertThat(alert.getSolution(), is(equalTo("The solution")));
+        assertThat(alert.getReference(), is(equalTo("Reference 1\nReference 2")));
+        assertThat(alert.getOtherInfo(), is(equalTo("Any other info")));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));
+        assertThat(alert.getTags(), is(equalTo(Map.of("name1", "value1", "name2", "value2"))));
+        assertThat(alert.getMsgUri().getPathQuery(), is(equalTo("/path?param=value")));
+        assertThat(alert.getParam(), is(equalTo("The param")));
+        assertThat(alert.getEvidence(), is(equalTo("Evidence")));
+    }
+}

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.testutils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -210,23 +209,11 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
                 () -> {
                     setUp();
                     try {
-                        shouldHaveI18nNonEmptyName();
+                        shouldHaveI18nNonEmptyName(rule.getName(), extensionResourceBundle);
                     } finally {
                         shutDownServer();
                     }
                 });
-    }
-
-    private void shouldHaveI18nNonEmptyName() {
-        // Given / When
-        String name = rule.getName();
-        // Then
-        assertThat(name, is(not(emptyOrNullString())));
-        assertThat(
-                "Name does not seem to be i18n'ed, not found in the resource bundle:" + name,
-                extensionResourceBundle.keySet().stream()
-                        .map(extensionResourceBundle::getString)
-                        .anyMatch(str -> str.equals(name)));
     }
 
     private DynamicTest testExampleAlerts() {

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
@@ -148,7 +148,7 @@ public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends 
                 "shouldHaveI18nNonEmptyName",
                 () -> {
                     setUp();
-                    shouldHaveI18nNonEmptyName();
+                    shouldHaveI18nNonEmptyName(rule.getName(), extensionResourceBundle);
                 });
     }
 
@@ -159,18 +159,6 @@ public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends 
                     setUp();
                     shouldHaveExampleAlerts();
                 });
-    }
-
-    private void shouldHaveI18nNonEmptyName() {
-        // Given / When
-        String name = rule.getName();
-        // Then
-        assertThat(name, is(not(emptyOrNullString())));
-        assertThat(
-                "Name does not seem to be i18n'ed, not found in the resource bundle: " + name,
-                extensionResourceBundle.keySet().stream()
-                        .map(extensionResourceBundle::getString)
-                        .anyMatch(str -> str.equals(name)));
     }
 
     private void shouldHaveExampleAlerts() {

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ScanRuleTests.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ScanRuleTests.java
@@ -21,7 +21,9 @@ package org.zaproxy.zap.testutils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -59,6 +62,15 @@ interface ScanRuleTests {
                         "shouldHaveExpectedAlertRefsInExampleAlerts",
                         this::shouldHaveExpectedAlertRefsInExampleAlerts));
         return tests;
+    }
+
+    default void shouldHaveI18nNonEmptyName(String name, ResourceBundle extensionResourceBundle) {
+        assertThat(name, is(not(emptyOrNullString())));
+        assertThat(
+                "Name does not seem to be i18n'ed, not found in the resource bundle:" + name,
+                extensionResourceBundle.keySet().stream()
+                        .map(extensionResourceBundle::getString)
+                        .anyMatch(str -> str.equals(name)));
     }
 
     default void shouldHaveExpectedAlertRefsInExampleAlerts() {

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ScriptScanRuleTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ScriptScanRuleTestUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.testutils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.script.Compilable;
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptEngineWrapper;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+
+public interface ScriptScanRuleTestUtils {
+
+    Path getScriptPath() throws Exception;
+
+    ScriptEngineWrapper getScriptEngineWrapper();
+
+    default void setUpExtScript() throws Exception {
+        ExtensionScript mockExtScript = mock(ExtensionScript.class);
+        lenient()
+                .doAnswer(invocation -> getScriptInterface(invocation.getArgument(1)))
+                .when(mockExtScript)
+                .getInterface(any(ScriptWrapper.class), any());
+        if (Control.getSingleton() != null) {
+            Control.getSingleton().getExtensionLoader().addExtension(mockExtScript);
+        }
+    }
+
+    default <T> T getScriptInterface(Class<T> clazz) throws Exception {
+        ScriptEngine scriptEngine = getScriptEngineWrapper().getEngine();
+        if (Control.getSingleton() != null) {
+            scriptEngine.put("control", Control.getSingleton());
+        }
+        if (Model.getSingleton() != null) {
+            scriptEngine.put("model", Model.getSingleton());
+        }
+        try (Reader reader = Files.newBufferedReader(getScriptPath(), StandardCharsets.UTF_8)) {
+            ((Compilable) scriptEngine).compile(reader).eval();
+        }
+        return ((Invocable) scriptEngine).getInterface(clazz);
+    }
+}


### PR DESCRIPTION
Add utility classes to the graaljs add-on to make it easier to write tests for script scan rules.
Also add tests for the default script templates included with the add-on.
