### PR TITLE
automation: correct default value in docs

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Correct Session Management script's path validation with variables.
+- Correct default value for Active Scan option `handleAntiCSRFTokens` in templates and help.
 
 ## [0.52.0] - 2025-09-02
 ### Added

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
@@ -30,7 +30,7 @@ This job supports <a href="test-monitor.html">monitor</a> tests.
       addQueryParam:                   # Bool: If set will add an extra query parameter to requests that do not have one, default: false
       defaultPolicy:                   # String: The name of the default scan policy to use, default: Default Policy
       delayInMs:                       # Int: The delay in milliseconds between each request, use to reduce the strain on the target, default 0
-      handleAntiCSRFTokens:            # Bool: If set then automatically handle anti CSRF tokens, default: false
+      handleAntiCSRFTokens:            # Bool: If set then automatically handle anti CSRF tokens, default: true
       injectPluginIdInHeader:          # Bool: If set then the relevant rule Id will be injected into the X-ZAP-Scan-ID header of each request, default: false
       scanHeadersAllRequests:          # Bool: If set then the headers of requests that do not include any parameters will be scanned, default: false
       threadPerHost:                   # Int: The max number of threads per host, default: 2 * Number of available processor cores

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascanconfig.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascanconfig.html
@@ -19,7 +19,7 @@ This job configures the active scanner, for custom active scans (e.g. Sequence).
       maxScanDurationInMins:               # Int: The max time in minutes the active scanner will be allowed to run for, default: 0 unlimited
       maxAlertsPerRule:                    # Int: Maximum number of alerts to raise per rule, default: 0 unlimited
       defaultPolicy:                       # String: The name of the default scan policy to use, default: Default Policy
-      handleAntiCSRFTokens:                # Bool: If set then automatically handle anti CSRF tokens, default: false
+      handleAntiCSRFTokens:                # Bool: If set then automatically handle anti CSRF tokens, default: true
       injectPluginIdInHeader:              # Bool: If set then the relevant rule ID will be injected into the X-ZAP-Scan-ID header of each request, default: false
       threadPerHost:                       # Int: The max number of threads per host, default: 2 * Number of available processor cores
     inputVectors:                          # The input vectors used during the active scan.

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-config-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-config-max.yaml
@@ -4,7 +4,7 @@
       maxScanDurationInMins:               # Int: The max time in minutes the active scanner will be allowed to run for, default: 0 unlimited
       maxAlertsPerRule:                    # Int: Maximum number of alerts to raise per rule, default: 0 unlimited
       defaultPolicy:                       # String: The name of the default scan policy to use, default: Default Policy
-      handleAntiCSRFTokens:                # Bool: If set then automatically handle anti CSRF tokens, default: false
+      handleAntiCSRFTokens:                # Bool: If set then automatically handle anti CSRF tokens, default: true
       injectPluginIdInHeader:              # Bool: If set then the relevant rule ID will be injected into the X-ZAP-Scan-ID header of each request, default: false
       threadPerHost:                       # Int: The max number of threads per host, default: 2 * Number of available processor cores
     inputVectors:                          # The input vectors used during the active scan.

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-max.yaml
@@ -9,7 +9,7 @@
       addQueryParam:                   # Bool: If set will add an extra query parameter to requests that do not have one, default: false
       defaultPolicy:                   # String: The name of the default scan policy to use, default: Default Policy
       delayInMs:                       # Int: The delay in milliseconds between each request, use to reduce the strain on the target, default 0
-      handleAntiCSRFTokens:            # Bool: If set then automatically handle anti CSRF tokens, default: false
+      handleAntiCSRFTokens:            # Bool: If set then automatically handle anti CSRF tokens, default: true
       injectPluginIdInHeader:          # Bool: If set then the relevant rule Id will be injected into the X-ZAP-Scan-ID header of each request, default: false
       scanHeadersAllRequests:          # Bool: If set then the headers of requests that do not include any parameters will be scanned, default: false
       threadPerHost:                   # Int: The max number of threads per host, default: 2 * Number of available processor cores

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -65,7 +65,7 @@ jobs:
       maxScanDurationInMins:               # Int: The max time in minutes the active scanner will be allowed to run for, default: 0 unlimited
       maxAlertsPerRule:                    # Int: Maximum number of alerts to raise per rule, default: 0 unlimited
       defaultPolicy:                       # String: The name of the default scan policy to use, default: Default Policy
-      handleAntiCSRFTokens:                # Bool: If set then automatically handle anti CSRF tokens, default: false
+      handleAntiCSRFTokens:                # Bool: If set then automatically handle anti CSRF tokens, default: true
       injectPluginIdInHeader:              # Bool: If set then the relevant rule ID will be injected into the X-ZAP-Scan-ID header of each request, default: false
       threadPerHost:                       # Int: The max number of threads per host, default: 2 * Number of available processor cores
     inputVectors:                          # The input vectors used during the active scan.
@@ -138,7 +138,7 @@ jobs:
       addQueryParam:                   # Bool: If set will add an extra query parameter to requests that do not have one, default: false
       defaultPolicy:                   # String: The name of the default scan policy to use, default: Default Policy
       delayInMs:                       # Int: The delay in milliseconds between each request, use to reduce the strain on the target, default 0
-      handleAntiCSRFTokens:            # Bool: If set then automatically handle anti CSRF tokens, default: false
+      handleAntiCSRFTokens:            # Bool: If set then automatically handle anti CSRF tokens, default: true
       injectPluginIdInHeader:          # Bool: If set then the relevant rule Id will be injected into the X-ZAP-Scan-ID header of each request, default: false
       scanHeadersAllRequests:          # Bool: If set then the headers of requests that do not include any parameters will be scanned, default: false
       threadPerHost:                   # Int: The max number of threads per host, default: 2 * Number of available processor cores


### PR DESCRIPTION
Correct default value for `handleAntiCSRFTokens` in the templates and help.