### PR TITLE
graaljs: update Graal JavaScript engine

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update Graal JavaScript engine to version 25 (Issues 8477 and 9010).
 - Use example links in Active/Passive Rule templates' references.
 
 ## [0.9.0] - 2025-01-09

--- a/addOns/graaljs/graaljs.gradle.kts
+++ b/addOns/graaljs/graaljs.gradle.kts
@@ -42,10 +42,9 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("scripts")
 
-    val graalJsVersion = "22.3.3"
-    implementation("org.graalvm.js:js:$graalJsVersion")
+    val graalJsVersion = "25.0.0"
+    implementation("org.graalvm.js:js-community:$graalJsVersion")
     implementation("org.graalvm.js:js-scriptengine:$graalJsVersion")
-    implementation("org.javadelight:delight-graaljs-sandbox:0.1.2")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/ExtensionGraalJs.java
+++ b/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/ExtensionGraalJs.java
@@ -39,6 +39,7 @@ public class ExtensionGraalJs extends ExtensionAdaptor {
 
     static {
         System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");
+        System.setProperty("polyglotimpl.AttachLibraryFailureAction", "ignore");
     }
 
     public static final String NAME = "ExtensionGraalJs";

--- a/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/GraalJsEngineWrapper.java
+++ b/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/GraalJsEngineWrapper.java
@@ -77,6 +77,7 @@ public class GraalJsEngineWrapper extends DefaultEngineWrapper {
                         .option("js.load", "true")
                         .option("js.print", "true")
                         .option("js.nashorn-compat", "true")
+                        .option("js.ecmascript-version", "2024")
                         .allowAllAccess(true)
                         .hostClassLoader(hostClassLoader);
 

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PacScriptUnitTest.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PacScriptUnitTest.java
@@ -40,8 +40,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.zaproxy.zap.extension.graaljs.PacScript.Setting;
 import org.zaproxy.zap.extension.graaljs.PacScript.Setting.Type;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -51,7 +49,6 @@ import org.zaproxy.zap.testutils.TestUtils;
  *
  * @author aine-rb
  */
-@EnabledForJreRange(min = JRE.JAVA_8, max = JRE.JAVA_11)
 class PacScriptUnitTest extends TestUtils {
 
     private static final String DATERANGE_FILE_NAME = "dateRange.pac";


### PR DESCRIPTION
Update to latest version, 25.
Remove sandbox in `PacScript` as it does not work and update to use Graal directly.

Fix zaproxy/zaproxy#8477.
Fix zaproxy/zaproxy#9010.