### PR TITLE
selenium: use specified Firefox for profile mgmt

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Use configured Firefox binary when creating profiles.
 
 ## [15.40.0] - 2025-09-02
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -1377,7 +1377,8 @@ public class ExtensionSelenium extends ExtensionAdaptor {
      */
     public ProfileManager getProfileManager(Browser browser) {
         if (Browser.FIREFOX.equals(browser)) {
-            return profileManagerMap.computeIfAbsent(browser, s -> new FirefoxProfileManager());
+            return profileManagerMap.computeIfAbsent(
+                    browser, s -> new FirefoxProfileManager(getOptions()));
         }
         return null;
     }

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/internal/FirefoxProfileManager.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/internal/FirefoxProfileManager.java
@@ -34,9 +34,9 @@ import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.manager.SeleniumManager;
 import org.openqa.selenium.manager.SeleniumManagerOutput;
-import org.openqa.selenium.manager.SeleniumManagerOutput.Result;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.selenium.ProfileManager;
+import org.zaproxy.zap.extension.selenium.SeleniumOptions;
 import org.zaproxy.zap.utils.Stats;
 
 public class FirefoxProfileManager implements ProfileManager {
@@ -48,9 +48,15 @@ public class FirefoxProfileManager implements ProfileManager {
 
     private static final Logger LOGGER = LogManager.getLogger(FirefoxProfileManager.class);
 
+    private final SeleniumOptions options;
+
     private Path profileDirectory;
     private List<String> profiles;
     private Runtime runtime = Runtime.getRuntime();
+
+    public FirefoxProfileManager(SeleniumOptions options) {
+        this.options = options;
+    }
 
     private Path getProfilesDirectory() {
         if (profileDirectory == null) {
@@ -143,21 +149,8 @@ public class FirefoxProfileManager implements ProfileManager {
             return dir;
         }
 
-        SeleniumManagerOutput.Result smOutput =
-                SeleniumManager.getInstance()
-                        .getBinaryPaths(
-                                List.of("--offline", "--avoid-stats", "--browser", "firefox"));
-        if (smOutput.getCode() != 0) {
-            LOGGER.debug(
-                    "Executed SeleniumManager with exit code: {} Message: {}",
-                    smOutput.getCode(),
-                    smOutput.getMessage());
-            return null;
-        }
-
-        String path = getBrowserPath(smOutput);
+        String path = getBrowserPath();
         if (path == null || path.isEmpty()) {
-            LOGGER.warn("Unable to find Firefox binary through SeleniumManager.");
             return null;
         }
 
@@ -186,7 +179,24 @@ public class FirefoxProfileManager implements ProfileManager {
         return profileDir;
     }
 
-    private static String getBrowserPath(Result smOutput) {
+    private String getBrowserPath() {
+        String optionsPath = options.getFirefoxBinaryPath();
+        if (!optionsPath.isEmpty()) {
+            return optionsPath;
+        }
+
+        SeleniumManagerOutput.Result smOutput =
+                SeleniumManager.getInstance()
+                        .getBinaryPaths(
+                                List.of("--offline", "--avoid-stats", "--browser", "firefox"));
+        if (smOutput.getCode() != 0) {
+            LOGGER.debug(
+                    "Executed SeleniumManager with exit code: {} Message: {}",
+                    smOutput.getCode(),
+                    smOutput.getMessage());
+            return null;
+        }
+
         String path = smOutput.getBrowserPath();
         if (path != null && !path.isEmpty()) {
             return path;
@@ -196,6 +206,7 @@ public class FirefoxProfileManager implements ProfileManager {
         } catch (WebDriverException ignore) {
             // Nothing to do, fallback attempt.
         }
+        LOGGER.warn("Unable to find Firefox binary through SeleniumManager.");
         return null;
     }
 }


### PR DESCRIPTION
Use the Firefox binary specified in the options when managing profiles, if none fallback to previous behaviour.