### PR TITLE
Update Maven URLs and build JavaDoc on check

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -104,6 +104,10 @@ subprojects {
     if (mavenPublishAddOn) {
         apply(plugin = "maven-publish")
         apply(plugin = "signing")
+
+        tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {
+            dependsOn(tasks.named(JavaPlugin.JAVADOC_TASK_NAME))
+        }
     }
     if (japicmpAddOn) {
         apply(plugin = "me.champeau.gradle.japicmp")
@@ -326,8 +330,8 @@ subprojects {
         publishing {
             repositories {
                 maven {
-                    val releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-                    val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+                    val releasesRepoUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+                    val snapshotsRepoUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
                     setUrl(provider { if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl })
 
                     if (ossrhUsername != null && ossrhPassword != null) {

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/timing/OnlineSimpleLinearRegression.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/timing/OnlineSimpleLinearRegression.java
@@ -31,7 +31,7 @@ package org.zaproxy.addon.commonlib.timing;
  * computations. <br>
  * <br>
  * By convention, we fix correlation and slope at 1.0 and the intercept at 0.0 when insufficient
- * data points (<2) have been added.
+ * data points (&lt;2) have been added.
  *
  * @since 1.20.0
  */

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/timing/TimingUtils.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/timing/TimingUtils.java
@@ -56,9 +56,9 @@ public class TimingUtils {
      * @param requestSender function that takes in the expected time, sends the request, and returns
      *     the actual delay.
      * @param correlationErrorRange the interval of acceptance for the regression correlation. for
-     *     example, input 0.2 will return true if 0.8 < correlation
+     *     example, input 0.2 will return true if 0.8 &lt; correlation
      * @param slopeErrorRange the interval of acceptance for the regression slope. for example,
-     *     input 0.2 will return true if 0.8 < slope < 1.2
+     *     input 0.2 will return true if 0.8 &lt; slope &lt; 1.2
      * @return true if the response times correlate linearly, false otherwise.
      * @throws IllegalArgumentException if less than 3 is provided as the requestsLimit OR if less
      *     than 5 is provided as the secondsLimit


### PR DESCRIPTION
Update the Maven URLs to latest locations.
Build the JavaDoc for add-ons that are meant to be published to Maven Central to ensure there are no errors when publishing them.
Address JavaDoc errors.