### PR TITLE
automation: Clarify plan load warning/error dialog text

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Adjust the text for the plan load warning/error dialog text to be clear which output panel it's referring to.
 
 ## [0.53.0] - 2025-09-18
 ### Fixed

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -428,9 +428,9 @@ automation.out.title.fail = Automation plan failures:
 automation.out.title.good = Automation plan succeeded!
 automation.out.title.warn = Automation plan warnings:
 
-automation.panel.load.error = YAML file loaded with errors.\nSee the Automation / Output panel for details.
+automation.panel.load.error = YAML file loaded with errors.\nSee the Automation tab's Output panel for details.
 automation.panel.load.failed = YAML file failed to load:\n{0}
-automation.panel.load.warning = YAML file loaded with warnings.\nSee the Automation / Output panel for details.
+automation.panel.load.warning = YAML file loaded with warnings.\nSee the Automation tab's Output panel for details.
 automation.panel.load.yaml = YAML Configuration Files
 automation.panel.table.env.name = Environment
 automation.panel.table.header.alwaysrun = Always Run


### PR DESCRIPTION
## Overview
<img width="1042" height="374" alt="image" src="https://github.com/user-attachments/assets/e090efc9-e8bd-4870-8578-a163d4bc2eb9" />

Made me look at the general Output panel. The "/" seemed like an or to me.