### PR TITLE
automation: reinstate scan policy validation

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Reinstate the validation of the Scan Policy in the `activeScan` job.
 - Adjust the text for the plan load warning/error dialog text to be clear which output panel it's referring to.
 
 ## [0.53.0] - 2025-09-18

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -115,6 +115,19 @@ public class ActiveScanJob extends AutomationJob {
                     break;
             }
         }
+
+        if (!StringUtils.isEmpty(getParameters().getPolicy())) {
+            try {
+                getExtAScan().getPolicyManager().getPolicy(getParameters().getPolicy());
+            } catch (ConfigurationException e) {
+                progress.error(
+                        Constant.messages.getString(
+                                "automation.error.ascan.policy.name",
+                                this.getName(),
+                                getParameters().getPolicy()));
+            }
+        }
+
         policyDefinition.parsePolicyDefinition(
                 jobData.get("policyDefinition"), this.getName(), progress);
         this.verifyUser(this.getParameters().getUser(), progress);


### PR DESCRIPTION
Validate the policy in the `activeScan` job, which was lost in a previous change.
Remove the test case `shouldApplyCustomConfigParams` as it's already covered by `shouldVerifyParameters` (and the latter is more accurate).