### PR TITLE
spider: ignore common empty schemes

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
-- Do not warn when canonicalising apparent URI, `//`.
+- Do not warn when canonicalising apparent URI, `//`, nor empty `tel` and `mailto`.
 
 ## [0.16.0] - 2025-09-02
 ### Added

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/UrlCanonicalizer.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/UrlCanonicalizer.java
@@ -86,7 +86,10 @@ public final class UrlCanonicalizer {
      * @return the canonical url
      */
     public static String getCanonicalUrl(ParseContext ctx, String url, String baseURL) {
-        if (StringUtils.startsWithIgnoreCase(url, "javascript:") || "//".equals(url)) {
+        if (StringUtils.startsWithIgnoreCase(url, "javascript:")
+                || StringUtils.startsWithIgnoreCase(url, "tel:")
+                || StringUtils.startsWithIgnoreCase(url, "mailto:")
+                || "//".equals(url)) {
             return null;
         }
 

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/UrlCanonicalizerUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/UrlCanonicalizerUnitTest.java
@@ -196,7 +196,9 @@ class UrlCanonicalizerUnitTest {
                 "javascript:",
                 "javascript://Something",
                 "javascript:ignore()",
+                "mailto:",
                 "mailto:ignore@example.com",
+                "tel:",
                 "tel:+1-900-555-0191"
             })
     void shouldIgnoreURIsWithNoAuthority(String uri) {


### PR DESCRIPTION
Do not warn on empty `tel` and `mailto`.