### PR TITLE
graphql, openapi: Bump dependency versions

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [0.28.0] - 2025-03-26
 ### Fixed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     zapAddOn("spider")
     zapAddOn("wappalyzer")
 
-    implementation("com.graphql-java:graphql-java:22.3")
+    implementation("com.graphql-java:graphql-java:24.3")
 
     testImplementation(project(":testutils"))
     testImplementation(libs.log4j.core)

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Dependency updates.
 
 ## [46] - 2025-09-10
 

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -65,14 +65,14 @@ dependencies {
     zapAddOn("commonlib")
     zapAddOn("spider")
 
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.23") {
+    implementation("io.swagger.parser.v3:swagger-parser:2.1.34") {
         // Provided by commonlib add-on:
         exclude(group = "com.fasterxml.jackson")
         exclude(group = "com.fasterxml.jackson.core")
         exclude(group = "com.fasterxml.jackson.dataformat")
         exclude(group = "com.fasterxml.jackson.datatype")
     }
-    implementation("io.swagger:swagger-compat-spec-parser:1.0.71") {
+    implementation("io.swagger:swagger-compat-spec-parser:1.0.75") {
         // Provided by commonlib add-on:
         exclude(group = "com.fasterxml.jackson")
         exclude(group = "com.fasterxml.jackson.core")
@@ -82,6 +82,7 @@ dependencies {
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
+    implementation("org.apache.commons:commons-lang3:3.19.0")
     implementation(libs.log4j.slf4j2)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/HeadersGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/HeadersGenerator.java
@@ -28,7 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpHeaderField;
 import org.zaproxy.zap.extension.openapi.converter.swagger.OperationModel;
@@ -129,9 +129,7 @@ public class HeadersGenerator {
     private static String getPartialMatch(Set<String> values, String... wantedMatches) {
         for (String wantedMatch : wantedMatches) {
             Optional<String> match =
-                    values.stream()
-                            .filter(e -> StringUtils.containsIgnoreCase(e, wantedMatch))
-                            .findFirst();
+                    values.stream().filter(e -> Strings.CI.contains(e, wantedMatch)).findFirst();
             if (match.isPresent()) {
                 return match.get();
             }


### PR DESCRIPTION
- `com.graphql-java:graphql-java`: `22.3`  -> `24.3`
- `io.swagger.parser.v3:swagger-parser`: `2.1.23` -> `2.1.34`
- `io.swagger:swagger-compat-spec-parser`: `1.0.71` -> `1.0.75`