### PR TITLE
network: reset warned content-type values

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Reset warned invalid content-type values on newer ZAP versions (Issue 9082).
 
 ## [0.23.0] - 2025-09-02
 ### Added


### PR DESCRIPTION
Reset the warned content-type values on session changes.

Part of zaproxy/zaproxy#9082.