### PR TITLE
wappalyzer: Fix HTML list tag in Wappalyzer help page

### DIFF
--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -28,7 +28,7 @@ table information currently being displayed.
 The toolbar also includes:
 <ul>
   <li>An enable/disable toggle button which controls whether the technology detection passive scan rule is functioning or not. This enabled state is persisted between ZAP sessions.</li>
-<ul>
+</ul>
 
 <H2>Reporting</H2>
 


### PR DESCRIPTION
## Overview
Corrected an improperly closed `<ul>` tag to `</ul>` in the help documentation for the Wappalyzer add-on.