### PR TITLE
scripts: ignore auth script errors for AF warns

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Do not report authentication script errors as warnings in the Automation Framework for consistent behavior with all authentication methods, which handle errors as authentication failures.
 
 ## [45.13.0] - 2025-09-02
 ### Changed

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ExtensionScriptAutomation.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ExtensionScriptAutomation.java
@@ -36,6 +36,7 @@ import org.zaproxy.addon.automation.AutomationEventPublisher;
 import org.zaproxy.addon.automation.AutomationPlan;
 import org.zaproxy.addon.automation.ExtensionAutomation;
 import org.zaproxy.zap.ZAP;
+import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType;
 import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -162,8 +163,11 @@ public class ExtensionScriptAutomation extends ExtensionAdaptor {
 
         @Override
         public void scriptError(ScriptWrapper script) {
-            if (ExtensionScript.TYPE_STANDALONE.equals(script.getTypeName())) {
+            if (ExtensionScript.TYPE_STANDALONE.equals(script.getTypeName())
+                    || ScriptBasedAuthenticationMethodType.SCRIPT_TYPE_AUTH.equals(
+                            script.getTypeName())) {
                 // Errors of stand alone scripts are handled directly by the job.
+                // Authentication script errors are handled as auth failures.
                 return;
             }
 


### PR DESCRIPTION
The authentication script errors should be handled as authentication failures to have the same behaviour for all authentication methods.