### PR TITLE
graphql: Improve GraphQL fingerprinting with specificity scoring

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Added specificity handling to GraphQL engine fingerprinting to improve performance in some circumstances and reduce false positives.
 
 ## [0.30.0] - 2026-02-03
 ### Added


### PR DESCRIPTION
## Overview

Implements **specificity-based ordering** for GraphQL framework fingerprinting to increase efficiency and potentially reduce false positives by checking specific patterns before generic ones.

This is one of a set of PRs that I'm working on for GraphQL Fingerprinting.

---

~~This also fixes a bug whereby the handlers were always reset on instantiation when they should have only been reset if null. So the Tech Detection support had been broken. (I can move that fix to a separate PR if necessary.)~~

## Changes

- **`FingerprintCheck` record**: Encapsulates each check with a specificity score (0-100), validated at construction
- **Descending order iteration**: Checks run in order of decreasing specificity; first match wins
- **Refactored structure**: Extracted `performPatternBasedDetection()` and `raiseAlertForFramework()` for clarity
- **Minor fix**: Added null/JSON check in `checkStrawberryEngine()`

## Specificity Tiers

| Tier | Score | Description | Examples |
|------|-------|-------------|----------|
| A | 90-95 | Unique error patterns | tartiflette, hasura, dgraph |
| B | 80-89 | Distinctive patterns | wpgraphql, absinthe, sangria |
| C | 70-79 | Language/framework hints | graphql-java, gqlgen, juniper |
| D | 60-69 | Common GraphQL errors | apollo, graphene, mercurius |
| E | 50-59 | Very generic | lighthouse |

## Scoring Guidelines for Future Contributors

When adding a new fingerprint check, assign a specificity score based on **how unique the matched pattern is to that specific framework**:

- **90+**: Pattern includes framework name, unique identifiers, or error text that only that framework produces
- **70-89**: Pattern is distinctive (e.g., language-specific error format, unusual field names) but could theoretically appear elsewhere
- **60-69**: Pattern uses common GraphQL error structures that multiple frameworks might produce
- **50-59**: Pattern matches very generic errors; high false-positive risk

When in doubt, start lower—a false negative (missed detection) is less harmful than a false positive (wrong framework reported).

## AI Disclosure

Portions of this contribution were prepared by copilot or augment code.