### PR TITLE
ascanrulesBeta: Skip error responses in SourceCodeDisclosureFileInclusion

### DIFF
--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -218,7 +218,7 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
      */
     @Override
     public void scan(HttpMessage originalmsg, String paramname, String paramvalue) {
-        if (isClientError(getBaseMsg()) || isServerError(getBaseMsg())) {
+        if (isClientOrServerError(getBaseMsg())) {
             return;
         }
         try {
@@ -309,6 +309,15 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
                     // send the modified message (with the url filename), and see what we get back
                     sendAndReceive(sourceattackmsg, false); // do not follow redirects
 
+                    // Skip if attack response is a client/server error.
+                    // Error pages naturally differ from success pages and comparing
+                    // them leads to false positives (see zaproxy/zaproxy#9184).
+                    if (isClientOrServerError(sourceattackmsg)) {
+                        LOGGER.debug(
+                                "Skipping [{}] due to error response status", prefixedUrlfilename);
+                        continue;
+                    }
+
                     int randomversussourcefilenamematchpercentage =
                             DiceMatcher.getMatchPercentage(
                                     randomfileattackmsg.getResponseBody().toString(),
@@ -396,6 +405,15 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
                         sendAndReceive(sourceattackmsg, false); // do not follow redirects
                         LOGGER.debug("Completed WAR/EAR file name [{}]", prefixedUrlfilename);
 
+                        // Skip if attack response is a client/server error
+                        // (zaproxy/zaproxy#9184).
+                        if (isClientOrServerError(sourceattackmsg)) {
+                            LOGGER.debug(
+                                    "Skipping WAR/EAR [{}] due to error response status",
+                                    prefixedUrlfilename);
+                            continue;
+                        }
+
                         // since the WAR/EAR file may be large, and since the LCS does not work well
                         // with such large files, lets just look at the file size,
                         // compared to the original
@@ -447,6 +465,10 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
             LOGGER.debug(
                     "Error scanning parameters for Source Code Disclosure: {}", e.getMessage(), e);
         }
+    }
+
+    private boolean isClientOrServerError(HttpMessage msg) {
+        return isClientError(msg) || isServerError(msg);
     }
 
     private boolean isEmptyOrTooSimilar(HttpMessage msg, int matchPercentage) {

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRuleUnitTest.java
@@ -207,6 +207,19 @@ class SourceCodeDisclosureFileInclusionScanRuleUnitTest
     }
 
     @Test
+    void shouldNotAlertWhenAttackResponseIsClientError() throws IOException {
+        // Given - simulates zaproxy/zaproxy#9184 where attack responses return 4xx
+        String path = "/shouldNotAlertWhenAttackResponseIsClientError";
+        nano.addHandler(new ClientErrorFiHandler(path));
+        HttpMessage msg = this.getHttpMessage("GET", path + "?inc=bar", DEFAULT_RESPONSE_STRING);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, is(empty()));
+    }
+
+    @Test
     void shouldNotAlertWhenConditionsRightAndDisclosureResponseEmpty() throws IOException {
         // Given
         String path = "/empty";
@@ -265,6 +278,39 @@ class SourceCodeDisclosureFileInclusionScanRuleUnitTest
             }
             return newFixedLengthResponse(
                     NanoHTTPD.Response.Status.OK, NanoHTTPD.MIME_HTML, DEFAULT_RESPONSE_STRING);
+        }
+    }
+
+    /**
+     * Handler that simulates zaproxy/zaproxy#9184: returns 200 for the original/random requests but
+     * 404 for attack attempts, causing false positives when body comparison is done without
+     * checking status codes.
+     */
+    private static class ClientErrorFiHandler extends NanoServerHandler {
+
+        public ClientErrorFiHandler(String path) {
+            super(path);
+        }
+
+        @Override
+        protected Response serve(IHTTPSession session) {
+            String pValue = getFirstParamValue(session, "inc");
+
+            // Random param (38 chars): return OK with different body
+            if (pValue.length() == 38) {
+                return newFixedLengthResponse(
+                        Response.Status.OK, NanoHTTPD.MIME_HTML, "different random content");
+            }
+
+            // Original param: return OK with default content
+            if ("bar".equals(pValue)) {
+                return newFixedLengthResponse(
+                        Response.Status.OK, NanoHTTPD.MIME_HTML, DEFAULT_RESPONSE_STRING);
+            }
+
+            // Attack params: return 404 - this should not trigger an alert
+            return newFixedLengthResponse(
+                    Response.Status.NOT_FOUND, NanoHTTPD.MIME_HTML, "Not Found: " + pValue);
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/zaproxy/zaproxy/issues/9184

The `SourceCodeDisclosureFileInclusionScanRule` (ID 43) generates false positives when attack responses return 4xx/5xx status codes. Error pages naturally differ from success pages, and diffing them against the baseline gives misleading match percentages.

### Root cause

The rule sends attack payloads (e.g. path traversal attempts) and compares the response body against a random-parameter baseline using `DiceMatcher`. If the server returns a 4xx error page for the attack (different from the random baseline), the diff exceeds the threshold and the rule falsely flags it as source code disclosure — especially when the URL has no file extension (`dataMatchesExtension` returns `true` when `fileExtension == null`).

**Reported scenario**: A GraphQL endpoint returns 200 for valid queries but 4xx for invalid ones. The rule extracts `graph-ql` from the URL path, sends it as a parameter value, receives a 4xx error page that differs from the baseline, and raises a false positive.

### Fix

Add `isClientError()`/`isServerError()` checks on each attack response, immediately after `sendAndReceive`, in both:
1. The **source file inclusion** loop (line ~311)
2. The **WAR/EAR file inclusion** loop (line ~399)

If the attack response is a 4xx or 5xx, the iteration is skipped (`continue`). This mirrors the existing check on the base message at the start of the `scan()` method.

### Why this is safe

- Real source code disclosure via file inclusion returns **200** (the server successfully served the included file)
- 4xx/5xx means the server **rejected** the request — no file was included
- The rule already applies `isClientError`/`isServerError` to the base message
- All **28 existing tests pass**, plus 1 new test

### New test

`shouldNotAlertWhenAttackResponseIsClientError` — uses a `ClientErrorFiHandler` that returns 200 for original/random requests but 404 for attack payloads, reproducing the exact scenario from the issue.

### Checklist

- [x] Tests pass (28/28 + 1 new)
- [x] Spotless formatting verified
- [x] Minimal change (2 insertion points, same pattern)
- [x] No detection regression