### PR TITLE
Encoder: fix input area squashed at top when opening dialog

### DIFF
--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/EncodeDecodeDialog.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/EncodeDecodeDialog.java
@@ -26,6 +26,8 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
@@ -512,8 +514,17 @@ public class EncodeDecodeDialog extends AbstractFrame implements OptionsChangedL
                     new JSplitPane(
                             JSplitPane.VERTICAL_SPLIT, scrollPanelWithInputField, bottomPanel);
             inputOutputSplitPane.setResizeWeight(initialDividerLocation);
-            inputOutputSplitPane.setDividerLocation(initialDividerLocation);
             inputOutputSplitPane.setOneTouchExpandable(true);
+            inputOutputSplitPane.addComponentListener(
+                    new ComponentAdapter() {
+                        @Override
+                        public void componentResized(ComponentEvent e) {
+                            if (inputOutputSplitPane.getHeight() > 0) {
+                                inputOutputSplitPane.setDividerLocation(initialDividerLocation);
+                                inputOutputSplitPane.removeComponentListener(this);
+                            }
+                        }
+                    });
 
             mainPanel.add(inputOutputSplitPane, BorderLayout.CENTER);
         }


### PR DESCRIPTION
## Overview

Set the split pane divider location after the component has been laid out and has a valid height, using a one-shot ComponentListener. Calling setDividerLocation(double) before layout leaves the top component with no space.

## Related Issues

#7127

---

After rebasing some other changes I have in-bound for encoder I discovered that the dialog might open with the divider smushed to the top.