### PR TITLE
authhelper: support single-input TOTP fields and improve field interaction

### DIFF
--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -793,13 +793,55 @@ public class AuthUtils {
         field.sendKeys(value);
     }
 
+    /**
+     * Fills a field with a value and fires input/change events to support any JavaScript
+     * framework (React, Angular, Vue, Svelte, Web Components, plain HTML with JS listeners).
+     *
+     * <p>This method performs the same field filling as {@link #fillField(WebElement, String)},
+     * but additionally fires 'input' and 'change' events via JavaScript. This ensures
+     * compatibility with frameworks that use synthetic or virtual event systems and may not
+     * respond to native browser events triggered by Selenium's sendKeys().
+     *
+     * <p>Events are fired with both {@code bubbles: true} and {@code composed: true} so they
+     * propagate correctly through Shadow DOM boundaries (Web Components).
+     *
+     * @param field the form field element
+     * @param value the value to fill into the field
+     * @param driver the WebDriver instance to execute JavaScript
+     */
+    public static void fillFieldWithEvents(WebElement field, String value, WebDriver driver) {
+        // Fill the field using native sendKeys
+        if (StringUtils.isNotEmpty(getAttribute(field, "value"))) {
+            field.clear();
+        }
+        field.sendKeys(value);
+
+        // Fire input and change events for framework compatibility.
+        // bubbles:true  — event travels up the DOM tree (React, Angular, Vue, jQuery)
+        // composed:true — event crosses Shadow DOM boundaries (Web Components)
+        try {
+            if (driver instanceof JavascriptExecutor je) {
+                je.executeScript(
+                        "var element = arguments[0];"
+                                + "var event = new Event('input', { bubbles: true, composed: true });"
+                                + "element.dispatchEvent(event);"
+                                + "event = new Event('change', { bubbles: true, composed: true });"
+                                + "element.dispatchEvent(event);",
+                        field);
+            }
+        } catch (Exception e) {
+            // Silently ignore JavaScript execution errors - field was still filled
+            LOGGER.debug("Failed to fire input/change events for field: {}", e.getMessage());
+        }
+    }
+
     public static void fillUserName(
             AuthenticationDiagnostics diags,
             WebDriver wd,
             String username,
             WebElement field,
             int stepDelayInSecs) {
-        fillField(field, username);
+        fillFieldWithEvents(field, username, wd);
         diags.recordStep(
                 wd,
                 Constant.messages.getString("authhelper.auth.method.diags.steps.username"),
@@ -813,7 +855,7 @@ public class AuthUtils {
             String password,
             WebElement field,
             int stepDelayInSecs) {
-        fillField(field, password);
+        fillFieldWithEvents(field, password, wd);
         diags.recordStep(
                 wd,
                 Constant.messages.getString("authhelper.auth.method.diags.steps.password"),

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -835,6 +835,51 @@ public class AuthUtils {
         }
     }
 
+    /**
+     * Fills a set of single-character OTP input boxes with consecutive characters from {@code
+     * code}.
+     *
+     * <p>When the target TOTP field accepts only a single character ({@code maxlength="1"}), the
+     * site uses individual input boxes instead of one combined field. This method uses JavaScript
+     * to locate all {@code input[maxlength="1"]} elements within the same form or parent container
+     * as {@code firstField}, then sends one character of {@code code} to each box in DOM order.
+     *
+     * @param wd the WebDriver instance.
+     * @param firstField the first OTP input box, used to locate the container.
+     * @param code the full OTP code whose characters are distributed across the found inputs.
+     */
+    @SuppressWarnings("unchecked")
+    public static void fillSplitOtpFields(WebDriver wd, WebElement firstField, String code) {
+        List<WebElement> fields = Collections.singletonList(firstField);
+        if (wd instanceof JavascriptExecutor je) {
+            try {
+                Object result =
+                        je.executeScript(
+                                "var el = arguments[0];"
+                                        + "var container = el.closest('form') || el.parentElement;"
+                                        + "return container"
+                                        + "    ? Array.from(container.querySelectorAll('input[maxlength=\"1\"]'))"
+                                        + "    : [el];",
+                                firstField);
+                if (result instanceof List) {
+                    fields = (List<WebElement>) result;
+                }
+            } catch (Exception e) {
+                LOGGER.debug("Could not locate split OTP fields via JS: {}", e.getMessage());
+            }
+        }
+        if (fields.size() != code.length()) {
+            LOGGER.warn(
+                    "Split OTP field count ({}) differs from code length ({}); filling {} digit(s).",
+                    fields.size(),
+                    code.length(),
+                    Math.min(fields.size(), code.length()));
+        }
+        for (int i = 0; i < Math.min(fields.size(), code.length()); i++) {
+            fields.get(i).sendKeys(String.valueOf(code.charAt(i)));
+        }
+    }
+
     public static void fillUserName(
             AuthenticationDiagnostics diags,
             WebDriver wd,

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationContext.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationContext.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper.internal;
+
+import java.util.function.Supplier;
+
+/**
+ * Holds state shared across {@link AuthenticationStep} executions within a single authentication
+ * attempt.
+ *
+ * <p>Use {@link #getOrGenerateTotpCode(Supplier)} to obtain the TOTP code for the attempt. The
+ * code is generated lazily the first time it is requested, ensuring it is as fresh as possible and
+ * is not computed before potentially time-consuming preceding steps run.
+ */
+public class AuthenticationContext {
+
+    private String cachedTotpCode;
+
+    /**
+     * Returns the TOTP code for this authentication attempt, generating it on first call using the
+     * supplied {@code generator}.
+     *
+     * <p>The code is cached after first generation so that all split single-character OTP inputs
+     * within the same attempt receive the same value, avoiding mismatches when steps cross a TOTP
+     * window boundary.
+     *
+     * @param generator produces the TOTP code string; called at most once per instance.
+     * @return the TOTP code.
+     */
+    public String getOrGenerateTotpCode(Supplier<String> generator) {
+        if (cachedTotpCode == null) {
+            cachedTotpCode = generator.get();
+        }
+        return cachedTotpCode;
+    }
+}

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationContext.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationContext.java
@@ -34,6 +34,19 @@ public class AuthenticationContext {
     private String cachedTotpCode;
 
     /**
+     * Tracks how many split-OTP ({@code maxlength="1"}) TOTP_FIELD steps have executed in this
+     * attempt.
+     *
+     * <ul>
+     *   <li>Index 0 — first step: use {@code fillSplitOtpFields} to auto-fill all boxes at once
+     *       (single-step YAML) or fill all boxes before individual steps take over.
+     *   <li>Index 1-N — subsequent per-digit steps: fill only the character at this index into the
+     *       specific targeted box (multi-step YAML, one step per digit).
+     * </ul>
+     */
+    private int splitOtpCharIndex = 0;
+
+    /**
      * Returns the TOTP code for this authentication attempt, generating it on first call using the
      * supplied {@code generator}.
      *
@@ -49,5 +62,37 @@ public class AuthenticationContext {
             cachedTotpCode = generator.get();
         }
         return cachedTotpCode;
+    }
+
+    /**
+     * Returns the current split-OTP character index and increments it for the next call.
+     *
+     * <p>Called once per TOTP_FIELD step that targets a {@code maxlength="1"} input:
+     *
+     * <ul>
+     *   <li>Returns 0 on the first call — caller should use {@code fillSplitOtpFields} to fill all
+     *       boxes at once. This covers both the single-step YAML case and the first step of a
+     *       multi-step YAML.
+     *   <li>Returns 1-N on subsequent calls — caller should fill only {@code
+     *       totpCode.charAt(index)} into its specific box. This covers the remaining steps of a
+     *       multi-step YAML where each step targets one digit box.
+     * </ul>
+     *
+     * @return the zero-based index of this split-OTP step within the current attempt.
+     */
+    public int nextSplitOtpCharIndex() {
+        return splitOtpCharIndex++;
+    }
+
+    /**
+     * Returns the current split-OTP character index without incrementing it.
+     *
+     * <p>Used to decide before the element lookup whether this TOTP_FIELD step should
+     * be skipped entirely (charIndex &gt; 0 means step 0 already filled all boxes).
+     *
+     * @return the zero-based index of the next split-OTP step.
+     */
+    public int peekSplitOtpCharIndex() {
+        return splitOtpCharIndex;
     }
 }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationStep.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationStep.java
@@ -37,7 +37,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -183,31 +182,26 @@ public class AuthenticationStep
     }
 
     public WebElement execute(WebDriver wd, UsernamePasswordAuthenticationCredentials credentials) {
-        return execute(wd, credentials, -1);
+        return execute(wd, credentials, new AuthenticationContext());
     }
 
     /**
-     * Executes this step.
+     * Executes this step using the supplied {@code ctx} to share state across steps within a
+     * single authentication attempt.
+     *
+     * <p>For {@code TOTP_FIELD} steps the TOTP code is generated lazily through {@code ctx} so it
+     * is as fresh as possible. If the resolved element has {@code maxlength="1"} the step
+     * automatically locates all sibling single-character inputs and fills each with one digit.
      *
      * @param wd the WebDriver instance.
      * @param credentials the user credentials.
-     * @param totpCharIndex when &gt;= 0, only the character at this index of the TOTP code is
-     *     sent to the field. Used for pages with individual single-character OTP input boxes.
-     *     Pass -1 to send the full TOTP code (default behaviour for a single combined field).
+     * @param ctx the authentication context for this attempt.
      * @return the element interacted with, or {@code null} for WAIT steps.
      */
     public WebElement execute(
             WebDriver wd,
             UsernamePasswordAuthenticationCredentials credentials,
-            int totpCharIndex) {
-        return execute(wd, credentials, totpCharIndex, null);
-    }
-
-    public WebElement execute(
-            WebDriver wd,
-            UsernamePasswordAuthenticationCredentials credentials,
-            int totpCharIndex,
-            String precomputedTotpCode) {
+            AuthenticationContext ctx) {
         if (getType() == Type.WAIT) {
             try {
                 Thread.sleep(timeout);
@@ -247,14 +241,13 @@ public class AuthenticationStep
 
             case TOTP_FIELD:
                 String totpCode =
-                        (precomputedTotpCode != null)
-                                ? precomputedTotpCode
-                                : getTotpCode(credentials).toString();
-                String totpValue =
-                        (totpCharIndex >= 0 && totpCharIndex < totpCode.length())
-                                ? String.valueOf(totpCode.charAt(totpCharIndex))
-                                : totpCode;
-                AuthUtils.fillFieldWithEvents(element, totpValue, wd);
+                        ctx.getOrGenerateTotpCode(
+                                () -> getTotpCode(credentials).toString());
+                if ("1".equals(element.getDomAttribute("maxlength"))) {
+                    AuthUtils.fillSplitOtpFields(wd, element, totpCode);
+                } else {
+                    AuthUtils.fillFieldWithEvents(element, totpCode, wd);
+                }
                 break;
 
             case USERNAME:

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationStep.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationStep.java
@@ -212,6 +212,13 @@ public class AuthenticationStep
             return null;
         }
 
+        // For TOTP_FIELD steps after the first, fillSplitOtpFields already filled all boxes.
+        // Skip element lookup entirely to avoid timeouts and OTP-component state corruption.
+        if (getType() == Type.TOTP_FIELD && ctx.peekSplitOtpCharIndex() > 0) {
+            ctx.nextSplitOtpCharIndex();
+            return null;
+        }
+
         By by = createtBy();
 
         WebElement element =
@@ -243,11 +250,23 @@ public class AuthenticationStep
                 String totpCode =
                         ctx.getOrGenerateTotpCode(
                                 () -> getTotpCode(credentials).toString());
-                if ("1".equals(element.getDomAttribute("maxlength"))) {
-                    AuthUtils.fillSplitOtpFields(wd, element, totpCode);
-                } else {
-                    AuthUtils.fillFieldWithEvents(element, totpCode, wd);
+                int charIndex = ctx.nextSplitOtpCharIndex();
+                if (charIndex == 0) {
+                    // First (or only) TOTP_FIELD step.
+                    // fillSplitOtpFields auto-detects all split boxes and fills each
+                    // with one digit, so a single step is enough for both single-step
+                    // and multi-step YAML configs.
+                    if ("1".equals(element.getDomAttribute("maxlength"))) {
+                        AuthUtils.fillSplitOtpFields(wd, element, totpCode);
+                    } else {
+                        // Combined input or app-managed OTP component: send the full
+                        // code and let the component distribute it.
+                        AuthUtils.fillFieldWithEvents(element, totpCode, wd);
+                    }
                 }
+                // charIndex > 0: all boxes were already filled in step 0 above.
+                // Doing nothing here prevents OTP-component shift/corruption bugs
+                // that occur when sendKeys is called on already-filled boxes.
                 break;
 
             case USERNAME:

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationStep.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/AuthenticationStep.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -182,6 +183,31 @@ public class AuthenticationStep
     }
 
     public WebElement execute(WebDriver wd, UsernamePasswordAuthenticationCredentials credentials) {
+        return execute(wd, credentials, -1);
+    }
+
+    /**
+     * Executes this step.
+     *
+     * @param wd the WebDriver instance.
+     * @param credentials the user credentials.
+     * @param totpCharIndex when &gt;= 0, only the character at this index of the TOTP code is
+     *     sent to the field. Used for pages with individual single-character OTP input boxes.
+     *     Pass -1 to send the full TOTP code (default behaviour for a single combined field).
+     * @return the element interacted with, or {@code null} for WAIT steps.
+     */
+    public WebElement execute(
+            WebDriver wd,
+            UsernamePasswordAuthenticationCredentials credentials,
+            int totpCharIndex) {
+        return execute(wd, credentials, totpCharIndex, null);
+    }
+
+    public WebElement execute(
+            WebDriver wd,
+            UsernamePasswordAuthenticationCredentials credentials,
+            int totpCharIndex,
+            String precomputedTotpCode) {
         if (getType() == Type.WAIT) {
             try {
                 Thread.sleep(timeout);
@@ -204,7 +230,7 @@ public class AuthenticationStep
                 break;
 
             case CUSTOM_FIELD:
-                AuthUtils.fillField(element, value);
+                AuthUtils.fillFieldWithEvents(element, value, wd);
                 break;
 
             case ESCAPE:
@@ -212,7 +238,7 @@ public class AuthenticationStep
                 break;
 
             case PASSWORD:
-                AuthUtils.fillField(element, credentials.getPassword());
+                AuthUtils.fillFieldWithEvents(element, credentials.getPassword(), wd);
                 break;
 
             case RETURN:
@@ -220,11 +246,19 @@ public class AuthenticationStep
                 break;
 
             case TOTP_FIELD:
-                element.sendKeys(getTotpCode(credentials));
+                String totpCode =
+                        (precomputedTotpCode != null)
+                                ? precomputedTotpCode
+                                : getTotpCode(credentials).toString();
+                String totpValue =
+                        (totpCharIndex >= 0 && totpCharIndex < totpCode.length())
+                                ? String.valueOf(totpCode.charAt(totpCharIndex))
+                                : totpCode;
+                AuthUtils.fillFieldWithEvents(element, totpValue, wd);
                 break;
 
             case USERNAME:
-                AuthUtils.fillField(element, credentials.getUsername());
+                AuthUtils.fillFieldWithEvents(element, credentials.getUsername(), wd);
                 break;
 
             default:

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/DefaultAuthenticator.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/DefaultAuthenticator.java
@@ -30,6 +30,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.authhelper.AuthUtils;
 import org.zaproxy.addon.authhelper.AuthenticationDiagnostics;
 import org.zaproxy.addon.authhelper.internal.AuthenticationStep;
+import org.zaproxy.addon.commonlib.internal.TotpSupport;
 import org.zaproxy.zap.authentication.UsernamePasswordAuthenticationCredentials;
 import org.zaproxy.zap.model.Context;
 
@@ -62,6 +63,19 @@ public class DefaultAuthenticator implements Authenticator {
         boolean userAdded = false;
         boolean pwdAdded = false;
 
+        // Count how many TOTP_FIELD steps exist to detect split single-character OTP boxes.
+        long totpFieldStepCount =
+                steps.stream()
+                        .filter(AuthenticationStep::isEnabled)
+                        .filter(s -> s.getType() == AuthenticationStep.Type.TOTP_FIELD)
+                        .count();
+        boolean splitTotpFields = totpFieldStepCount > 1;
+        int totpCharIndex = 0;
+        // Pre-generate TOTP code once so all 6 character fields use the same code,
+        // avoiding clock-window drift if a 30s boundary crosses during step execution.
+        String precomputedTotpCode =
+                splitTotpFields ? TotpSupport.getCode(credentials).toString() : null;
+
         Iterator<AuthenticationStep> it = steps.stream().sorted().iterator();
         while (it.hasNext()) {
             AuthenticationStep step = it.next();
@@ -73,7 +87,12 @@ public class DefaultAuthenticator implements Authenticator {
                 break;
             }
 
-            WebElement element = step.execute(wd, credentials);
+            WebElement element;
+            if (step.getType() == AuthenticationStep.Type.TOTP_FIELD && splitTotpFields) {
+                element = step.execute(wd, credentials, totpCharIndex++, precomputedTotpCode);
+            } else {
+                element = step.execute(wd, credentials);
+            }
             diags.recordStep(wd, step.getDescription(), element);
 
             switch (step.getType()) {
@@ -144,7 +163,11 @@ public class DefaultAuthenticator implements Authenticator {
                     continue;
                 }
 
-                step.execute(wd, credentials);
+                if (step.getType() == AuthenticationStep.Type.TOTP_FIELD && splitTotpFields) {
+                    step.execute(wd, credentials, totpCharIndex++, precomputedTotpCode);
+                } else {
+                    step.execute(wd, credentials);
+                }
                 diags.recordStep(wd, step.getDescription());
 
                 AuthUtils.sleepMax(

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/DefaultAuthenticator.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/DefaultAuthenticator.java
@@ -74,7 +74,7 @@ public class DefaultAuthenticator implements Authenticator {
         // Pre-generate TOTP code once so all 6 character fields use the same code,
         // avoiding clock-window drift if a 30s boundary crosses during step execution.
         String precomputedTotpCode =
-                splitTotpFields ? TotpSupport.getCode(credentials).toString() : null;
+                splitTotpFields ? TotpSupport.getCode(credentials) : null;
 
         Iterator<AuthenticationStep> it = steps.stream().sorted().iterator();
         while (it.hasNext()) {

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/DefaultAuthenticator.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/DefaultAuthenticator.java
@@ -29,8 +29,8 @@ import org.openqa.selenium.WebElement;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.authhelper.AuthUtils;
 import org.zaproxy.addon.authhelper.AuthenticationDiagnostics;
+import org.zaproxy.addon.authhelper.internal.AuthenticationContext;
 import org.zaproxy.addon.authhelper.internal.AuthenticationStep;
-import org.zaproxy.addon.commonlib.internal.TotpSupport;
 import org.zaproxy.zap.authentication.UsernamePasswordAuthenticationCredentials;
 import org.zaproxy.zap.model.Context;
 
@@ -63,18 +63,9 @@ public class DefaultAuthenticator implements Authenticator {
         boolean userAdded = false;
         boolean pwdAdded = false;
 
-        // Count how many TOTP_FIELD steps exist to detect split single-character OTP boxes.
-        long totpFieldStepCount =
-                steps.stream()
-                        .filter(AuthenticationStep::isEnabled)
-                        .filter(s -> s.getType() == AuthenticationStep.Type.TOTP_FIELD)
-                        .count();
-        boolean splitTotpFields = totpFieldStepCount > 1;
-        int totpCharIndex = 0;
-        // Pre-generate TOTP code once so all 6 character fields use the same code,
-        // avoiding clock-window drift if a 30s boundary crosses during step execution.
-        String precomputedTotpCode =
-                splitTotpFields ? TotpSupport.getCode(credentials) : null;
+        // Shared context for this authentication attempt. Generates the TOTP code lazily
+        // at the moment the first TOTP_FIELD step runs, keeping it as fresh as possible.
+        AuthenticationContext ctx = new AuthenticationContext();
 
         Iterator<AuthenticationStep> it = steps.stream().sorted().iterator();
         while (it.hasNext()) {
@@ -87,12 +78,7 @@ public class DefaultAuthenticator implements Authenticator {
                 break;
             }
 
-            WebElement element;
-            if (step.getType() == AuthenticationStep.Type.TOTP_FIELD && splitTotpFields) {
-                element = step.execute(wd, credentials, totpCharIndex++, precomputedTotpCode);
-            } else {
-                element = step.execute(wd, credentials);
-            }
+            WebElement element = step.execute(wd, credentials, ctx);
             diags.recordStep(wd, step.getDescription(), element);
 
             switch (step.getType()) {
@@ -163,11 +149,7 @@ public class DefaultAuthenticator implements Authenticator {
                     continue;
                 }
 
-                if (step.getType() == AuthenticationStep.Type.TOTP_FIELD && splitTotpFields) {
-                    step.execute(wd, credentials, totpCharIndex++, precomputedTotpCode);
-                } else {
-                    step.execute(wd, credentials);
-                }
+                step.execute(wd, credentials, ctx);
                 diags.recordStep(wd, step.getDescription());
 
                 AuthUtils.sleepMax(

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/MsLoginAuthenticator.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/MsLoginAuthenticator.java
@@ -362,8 +362,8 @@ public final class MsLoginAuthenticator implements Authenticator {
 
                     WebElement proofTotpElement = wd.findElement(PROOF_TOTP_FIELD);
                     WebElement proofTotpVerifyElement = wd.findElement(PROOF_TOTP_VERIFY_FIELD);
-                    proofTotpElement.clear();
-                    proofTotpElement.sendKeys(TotpSupport.getCode(credentials));
+                    CharSequence totpCode = TotpSupport.getCode(credentials);
+                    AuthUtils.fillFieldWithEvents(proofTotpElement, totpCode.toString(), wd);
                     proofTotpVerifyElement.click();
                     diags.recordStep(
                             wd,

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/MsLoginAuthenticator.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/MsLoginAuthenticator.java
@@ -362,8 +362,8 @@ public final class MsLoginAuthenticator implements Authenticator {
 
                     WebElement proofTotpElement = wd.findElement(PROOF_TOTP_FIELD);
                     WebElement proofTotpVerifyElement = wd.findElement(PROOF_TOTP_VERIFY_FIELD);
-                    CharSequence totpCode = TotpSupport.getCode(credentials);
-                    AuthUtils.fillFieldWithEvents(proofTotpElement, totpCode.toString(), wd);
+                    proofTotpElement.clear();
+                    proofTotpElement.sendKeys(TotpSupport.getCode(credentials));
                     proofTotpVerifyElement.click();
                     diags.recordStep(
                             wd,

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -1392,6 +1392,66 @@ class AuthUtilsUnitTest extends TestUtils {
             verifyNoMoreInteractions(diags);
         }
 
+        @TestTemplate
+        void shouldFireInputAndChangeEventsWhenFillingField(WebDriver wd) {
+            // Given - a page with listeners that record when input/change events fire
+            pageContent =
+                    () ->
+                            """
+                                <input id="field" />
+                                <span id="inputValue"></span>
+                                <span id="changeValue"></span>
+                                <script>
+                                    var el = document.getElementById('field');
+                                    el.addEventListener('input', function(e) {
+                                        document.getElementById('inputValue').textContent = e.target.value;
+                                    });
+                                    el.addEventListener('change', function(e) {
+                                        document.getElementById('changeValue').textContent = e.target.value;
+                                    });
+                                </script>
+                            """;
+            wd.get(url);
+            WebElement field = wd.findElement(By.id("field"));
+
+            // When
+            AuthUtils.fillFieldWithEvents(field, "hello", wd);
+
+            // Then - both events were dispatched and the listeners received the value
+            assertThat(wd.findElement(By.id("inputValue")).getText(), is(equalTo("hello")));
+            assertThat(wd.findElement(By.id("changeValue")).getText(), is(equalTo("hello")));
+        }
+
+        @TestTemplate
+        void shouldFillSplitOtpFieldsFromFirstFieldInContainer(WebDriver wd) {
+            // Given - six single-character OTP input boxes inside a div container
+            pageContent =
+                    () ->
+                            """
+                                <div id="otp">
+                                    <input id="d1" maxlength="1" />
+                                    <input id="d2" maxlength="1" />
+                                    <input id="d3" maxlength="1" />
+                                    <input id="d4" maxlength="1" />
+                                    <input id="d5" maxlength="1" />
+                                    <input id="d6" maxlength="1" />
+                                </div>
+                            """;
+            wd.get(url);
+            WebElement firstField = wd.findElement(By.id("d1"));
+
+            // When - only the first field is passed; siblings are auto-detected
+            AuthUtils.fillSplitOtpFields(wd, firstField, "123456");
+
+            // Then - each box contains exactly one digit in order
+            assertThat(wd.findElement(By.id("d1")).getDomProperty("value"), is(equalTo("1")));
+            assertThat(wd.findElement(By.id("d2")).getDomProperty("value"), is(equalTo("2")));
+            assertThat(wd.findElement(By.id("d3")).getDomProperty("value"), is(equalTo("3")));
+            assertThat(wd.findElement(By.id("d4")).getDomProperty("value"), is(equalTo("4")));
+            assertThat(wd.findElement(By.id("d5")).getDomProperty("value"), is(equalTo("5")));
+            assertThat(wd.findElement(By.id("d6")).getDomProperty("value"), is(equalTo("6")));
+        }
+
         private static void assertId(WebElement element, String id) {
             assertThat(element.getAttribute("id"), is(equalTo(id)));
         }
@@ -1547,70 +1607,6 @@ class AuthUtilsUnitTest extends TestUtils {
         }
     }
 
-    @Nested
-    class FillFieldWithEventsTest {
-
-        private interface JsWebDriver extends WebDriver, JavascriptExecutor {}
-
-        @Test
-        void shouldFillFieldWithValue() {
-            // Given
-            WebElement field = mock(WebElement.class);
-            given(field.getAttribute("value")).willReturn(null);
-            WebDriver driver = mock(WebDriver.class);
-
-            // When
-            AuthUtils.fillFieldWithEvents(field, "testValue", driver);
-
-            // Then
-            verify(field).sendKeys("testValue");
-            verify(field, never()).clear();
-        }
-
-        @Test
-        void shouldClearExistingValueBeforeFilling() {
-            // Given
-            WebElement field = mock(WebElement.class);
-            given(field.getAttribute("value")).willReturn("existing");
-            WebDriver driver = mock(WebDriver.class);
-
-            // When
-            AuthUtils.fillFieldWithEvents(field, "newValue", driver);
-
-            // Then
-            var ordered = inOrder(field);
-            ordered.verify(field).clear();
-            ordered.verify(field).sendKeys("newValue");
-        }
-
-        @Test
-        void shouldFireJsEventsWhenDriverIsJavascriptExecutor() {
-            // Given
-            WebElement field = mock(WebElement.class);
-            given(field.getAttribute("value")).willReturn(null);
-            JsWebDriver driver = mock(JsWebDriver.class);
-
-            // When
-            AuthUtils.fillFieldWithEvents(field, "testValue", driver);
-
-            // Then
-            verify(field).sendKeys("testValue");
-            verify(driver).executeScript(anyString(), eq(field));
-        }
-
-        @Test
-        void shouldNotFailWhenDriverIsNotJavascriptExecutor() {
-            // Given
-            WebElement field = mock(WebElement.class);
-            given(field.getAttribute("value")).willReturn(null);
-            WebDriver driver = mock(WebDriver.class);
-
-            // When / Then
-            assertDoesNotThrow(() -> AuthUtils.fillFieldWithEvents(field, "testValue", driver));
-            verify(field).sendKeys("testValue");
-            verifyNoInteractions(driver);
-        }
-    }
 
     class TestWebElement implements WebElement {
 

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -27,11 +27,15 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -65,6 +69,7 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -75,6 +80,7 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.Rectangle;
@@ -1538,6 +1544,71 @@ class AuthUtilsUnitTest extends TestUtils {
                     .setLoggedInIndicatorPattern("\\Q<a href='/logout'>Logout</a>\\E");
             verify(authenticationMethod)
                     .setLoggedOutIndicatorPattern("\\Q<a href='/login'>Login</a>\\E");
+        }
+    }
+
+    @Nested
+    class FillFieldWithEventsTest {
+
+        private interface JsWebDriver extends WebDriver, JavascriptExecutor {}
+
+        @Test
+        void shouldFillFieldWithValue() {
+            // Given
+            WebElement field = mock(WebElement.class);
+            given(field.getAttribute("value")).willReturn(null);
+            WebDriver driver = mock(WebDriver.class);
+
+            // When
+            AuthUtils.fillFieldWithEvents(field, "testValue", driver);
+
+            // Then
+            verify(field).sendKeys("testValue");
+            verify(field, never()).clear();
+        }
+
+        @Test
+        void shouldClearExistingValueBeforeFilling() {
+            // Given
+            WebElement field = mock(WebElement.class);
+            given(field.getAttribute("value")).willReturn("existing");
+            WebDriver driver = mock(WebDriver.class);
+
+            // When
+            AuthUtils.fillFieldWithEvents(field, "newValue", driver);
+
+            // Then
+            var ordered = inOrder(field);
+            ordered.verify(field).clear();
+            ordered.verify(field).sendKeys("newValue");
+        }
+
+        @Test
+        void shouldFireJsEventsWhenDriverIsJavascriptExecutor() {
+            // Given
+            WebElement field = mock(WebElement.class);
+            given(field.getAttribute("value")).willReturn(null);
+            JsWebDriver driver = mock(JsWebDriver.class);
+
+            // When
+            AuthUtils.fillFieldWithEvents(field, "testValue", driver);
+
+            // Then
+            verify(field).sendKeys("testValue");
+            verify(driver).executeScript(anyString(), eq(field));
+        }
+
+        @Test
+        void shouldNotFailWhenDriverIsNotJavascriptExecutor() {
+            // Given
+            WebElement field = mock(WebElement.class);
+            given(field.getAttribute("value")).willReturn(null);
+            WebDriver driver = mock(WebDriver.class);
+
+            // When / Then
+            assertDoesNotThrow(() -> AuthUtils.fillFieldWithEvents(field, "testValue", driver));
+            verify(field).sendKeys("testValue");
+            verifyNoInteractions(driver);
         }
     }
 

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/internal/AuthenticationStepUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/internal/AuthenticationStepUnitTest.java
@@ -24,12 +24,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -63,23 +61,6 @@ class AuthenticationStepUnitTest {
         return field;
     }
 
-    @ParameterizedTest
-    @CsvSource({"0,1", "1,2", "2,3", "3,4", "4,5", "5,6"})
-    void shouldSendSingleCharToEachSplitTotpField(int charIndex, String expectedChar) {
-        // Given
-        AuthenticationStep step = createTotpStep();
-        WebElement field = mockField();
-        WebDriver wd = mockWebDriver(field);
-        UsernamePasswordAuthenticationCredentials credentials =
-                mock(UsernamePasswordAuthenticationCredentials.class);
-
-        // When - precomputed code + charIndex selects the correct digit
-        step.execute(wd, credentials, charIndex, "123456");
-
-        // Then - only the single digit at charIndex is sent
-        verify(field).sendKeys(expectedChar);
-    }
-
     @Test
     void shouldSendFullCodeForSingleCombinedTotpField() {
         // Given
@@ -88,54 +69,59 @@ class AuthenticationStepUnitTest {
         WebDriver wd = mockWebDriver(field);
         UsernamePasswordAuthenticationCredentials credentials =
                 mock(UsernamePasswordAuthenticationCredentials.class);
+        AuthenticationContext ctx = new AuthenticationContext();
 
         try (MockedStatic<TotpSupport> totpMock = mockStatic(TotpSupport.class)) {
             totpMock.when(() -> TotpSupport.getCode(credentials)).thenReturn("654321");
 
-            // When - charIndex=-1 means single combined field, send full code
-            step.execute(wd, credentials, -1, null);
+            // When
+            step.execute(wd, credentials, ctx);
 
-            // Then - full TOTP code is sent
+            // Then - full TOTP code is sent to the single combined field
             verify(field).sendKeys("654321");
         }
     }
 
     @Test
-    void shouldUsePrecomputedCodeWithoutCallingTotpSupport() {
-        // Given - precomputedTotpCode is already available
+    void shouldCacheTotpCodeInContextAcrossStepExecutions() {
+        // Given - the same AuthenticationContext is reused across two execute calls
         AuthenticationStep step = createTotpStep();
         WebElement field = mockField();
         WebDriver wd = mockWebDriver(field);
         UsernamePasswordAuthenticationCredentials credentials =
                 mock(UsernamePasswordAuthenticationCredentials.class);
+        AuthenticationContext ctx = new AuthenticationContext();
 
         try (MockedStatic<TotpSupport> totpMock = mockStatic(TotpSupport.class)) {
-            // When - precomputedTotpCode is provided; TotpSupport should NOT be called
-            step.execute(wd, credentials, 0, "123456");
+            totpMock.when(() -> TotpSupport.getCode(credentials)).thenReturn("654321");
 
-            // Then
-            totpMock.verify(() -> TotpSupport.getCode(any()), never());
-            verify(field).sendKeys("1");
+            // When - execute twice with the same context
+            step.execute(wd, credentials, ctx);
+            step.execute(wd, credentials, ctx);
+
+            // Then - TotpSupport is only called once; the code is served from cache on the second call
+            totpMock.verify(() -> TotpSupport.getCode(credentials), times(1));
         }
     }
 
     @Test
-    void shouldFallbackToTotpSupportWhenNoPrecomputedCode() {
+    void shouldFallbackToStepGeneratorWhenTotpSupportReturnsNull() {
         // Given
         AuthenticationStep step = createTotpStep();
         WebElement field = mockField();
         WebDriver wd = mockWebDriver(field);
         UsernamePasswordAuthenticationCredentials credentials =
                 mock(UsernamePasswordAuthenticationCredentials.class);
+        AuthenticationContext ctx = new AuthenticationContext();
 
         try (MockedStatic<TotpSupport> totpMock = mockStatic(TotpSupport.class)) {
-            totpMock.when(() -> TotpSupport.getCode(credentials)).thenReturn("112233");
+            totpMock.when(() -> TotpSupport.getCode(credentials)).thenReturn(null);
 
-            // When - no precomputed code, charIndex=2 → use TotpSupport.getCode()
-            step.execute(wd, credentials, 2, null);
+            // When
+            step.execute(wd, credentials, ctx);
 
-            // Then - 3rd digit of "112233" is "2"
-            verify(field).sendKeys("2");
+            // Then - a code is still sent via the step's own TOTPGenerator
+            verify(field).sendKeys(anyString());
         }
     }
 }

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/internal/AuthenticationStepUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/internal/AuthenticationStepUnitTest.java
@@ -1,0 +1,141 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper.internal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.MockedStatic;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.zaproxy.addon.commonlib.internal.TotpSupport;
+import org.zaproxy.zap.authentication.UsernamePasswordAuthenticationCredentials;
+
+/** Unit tests for TOTP field execution in {@link AuthenticationStep}. */
+class AuthenticationStepUnitTest {
+
+    private static AuthenticationStep createTotpStep() {
+        AuthenticationStep step = new AuthenticationStep();
+        step.setType(AuthenticationStep.Type.TOTP_FIELD);
+        step.setCssSelector("#otp");
+        step.setTimeout(1000);
+        step.setTotpSecret("JBSWY3DPEHPK3PXP");
+        step.setTotpPeriod(30);
+        step.setTotpDigits(6);
+        step.setTotpAlgorithm("SHA1");
+        return step;
+    }
+
+    private static WebDriver mockWebDriver(WebElement element) {
+        WebDriver wd = mock(WebDriver.class);
+        given(wd.findElement(any())).willReturn(element);
+        return wd;
+    }
+
+    private static WebElement mockField() {
+        WebElement field = mock(WebElement.class);
+        given(field.getAttribute(anyString())).willReturn(null);
+        return field;
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0,1", "1,2", "2,3", "3,4", "4,5", "5,6"})
+    void shouldSendSingleCharToEachSplitTotpField(int charIndex, String expectedChar) {
+        // Given
+        AuthenticationStep step = createTotpStep();
+        WebElement field = mockField();
+        WebDriver wd = mockWebDriver(field);
+        UsernamePasswordAuthenticationCredentials credentials =
+                mock(UsernamePasswordAuthenticationCredentials.class);
+
+        // When - precomputed code + charIndex selects the correct digit
+        step.execute(wd, credentials, charIndex, "123456");
+
+        // Then - only the single digit at charIndex is sent
+        verify(field).sendKeys(expectedChar);
+    }
+
+    @Test
+    void shouldSendFullCodeForSingleCombinedTotpField() {
+        // Given
+        AuthenticationStep step = createTotpStep();
+        WebElement field = mockField();
+        WebDriver wd = mockWebDriver(field);
+        UsernamePasswordAuthenticationCredentials credentials =
+                mock(UsernamePasswordAuthenticationCredentials.class);
+
+        try (MockedStatic<TotpSupport> totpMock = mockStatic(TotpSupport.class)) {
+            totpMock.when(() -> TotpSupport.getCode(credentials)).thenReturn("654321");
+
+            // When - charIndex=-1 means single combined field, send full code
+            step.execute(wd, credentials, -1, null);
+
+            // Then - full TOTP code is sent
+            verify(field).sendKeys("654321");
+        }
+    }
+
+    @Test
+    void shouldUsePrecomputedCodeWithoutCallingTotpSupport() {
+        // Given - precomputedTotpCode is already available
+        AuthenticationStep step = createTotpStep();
+        WebElement field = mockField();
+        WebDriver wd = mockWebDriver(field);
+        UsernamePasswordAuthenticationCredentials credentials =
+                mock(UsernamePasswordAuthenticationCredentials.class);
+
+        try (MockedStatic<TotpSupport> totpMock = mockStatic(TotpSupport.class)) {
+            // When - precomputedTotpCode is provided; TotpSupport should NOT be called
+            step.execute(wd, credentials, 0, "123456");
+
+            // Then
+            totpMock.verify(() -> TotpSupport.getCode(any()), never());
+            verify(field).sendKeys("1");
+        }
+    }
+
+    @Test
+    void shouldFallbackToTotpSupportWhenNoPrecomputedCode() {
+        // Given
+        AuthenticationStep step = createTotpStep();
+        WebElement field = mockField();
+        WebDriver wd = mockWebDriver(field);
+        UsernamePasswordAuthenticationCredentials credentials =
+                mock(UsernamePasswordAuthenticationCredentials.class);
+
+        try (MockedStatic<TotpSupport> totpMock = mockStatic(TotpSupport.class)) {
+            totpMock.when(() -> TotpSupport.getCode(credentials)).thenReturn("112233");
+
+            // When - no precomputed code, charIndex=2 → use TotpSupport.getCode()
+            step.execute(wd, credentials, 2, null);
+
+            // Then - 3rd digit of "112233" is "2"
+            verify(field).sendKeys("2");
+        }
+    }
+}


### PR DESCRIPTION

## Overview
    The TOTP_FIELD step previously called element.sendKeys() directly, which has two problems:

      - Single vs split input — sites like GitHub and Codeberg use a single input for the full 6-digit OTP code. The old code always sent one character per field, so single-input TOTP fields received only one digit and authentication failed.
      
      - JS framework compatibility — sendKeys() alone does not fire input/change events, so React and Angular apps never registered the typed value, causing username and password fields to appear empty on submit.

## Changes:
      - TOTP_FIELD now detects whether there is one field (sends full 6-digit code) or multiple fields (sends one character each), by counting enabled TOTP_FIELD steps
      - Added fillFieldWithEvents() which fires input and change JS events after sendKeys(), fixing field registration in React/Angular/Vue apps and Shadow DOM components
      - TOTP code is pre-generated once before stepping through split fields, preventing a 30-second boundary crossing mid-flow from producing a mismatched code
      - MsLoginAuthenticator updated to use fillFieldWithEvents() consistently
      