### PR TITLE
client: add hook for browser closing

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a button in the Client History tab to clear the history from both the GUI and session.
 
 ### Changed
+- Allow callback implementors to handle browsers closing.
 - Depend on Database add-on.
 
 ## [0.21.0] - 2026-03-31

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientCallBackUtils.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientCallBackUtils.java
@@ -19,33 +19,24 @@
  */
 package org.zaproxy.addon.client;
 
-import org.parosproxy.paros.network.HttpMessage;
+import java.util.UUID;
+import lombok.Getter;
 import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 
 /**
- * @since 0.21.0
+ * @since 0.22.0
  */
-public interface ClientCallBackImplementor {
+public class ClientCallBackUtils extends SeleniumScriptUtils {
 
-    String getImplementorName();
+    @Getter private final UUID uuid;
 
-    String handleCallBack(HttpMessage msg);
-
-    /**
-     * This method will be removed soon.
-     *
-     * @deprecated
-     */
-    @Deprecated
-    default void browserLaunched(SeleniumScriptUtils ssutils) {}
-
-    @SuppressWarnings("deprecation")
-    default void browserLaunched(ClientCallBackUtils ccbutils) {
-        browserLaunched((SeleniumScriptUtils) ccbutils);
+    public ClientCallBackUtils(SeleniumScriptUtils ssu, UUID uuid) {
+        super(
+                ssu.getWebDriver(),
+                ssu.getRequester(),
+                ssu.getBrowserId(),
+                ssu.getProxyAddress(),
+                ssu.getProxyPort());
+        this.uuid = uuid;
     }
-
-    /**
-     * @since 0.22.0
-     */
-    default void browserClosing(ClientCallBackUtils ccbutils) {}
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
@@ -33,6 +33,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -46,7 +47,6 @@ import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiResponse;
 import org.zaproxy.zap.extension.api.ApiResponseElement;
-import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 
 public class ClientIntegrationAPI extends ApiImplementor {
     private static final String PREFIX = "client";
@@ -70,6 +70,9 @@ public class ClientIntegrationAPI extends ApiImplementor {
     private String callbackUrl;
 
     private Map<String, ClientCallBackImplementor> clientCallBacks =
+            Collections.synchronizedMap(new HashMap<>());
+
+    private Map<WebDriver, ClientCallBackUtils> wdMap =
             Collections.synchronizedMap(new HashMap<>());
 
     public ClientIntegrationAPI(ExtensionClientIntegration extension) {
@@ -293,14 +296,34 @@ public class ClientIntegrationAPI extends ApiImplementor {
         this.clientCallBacks.remove(callback.getImplementorName());
     }
 
-    protected void browserLaunched(SeleniumScriptUtils ssutils) {
+    protected void browserLaunched(ClientCallBackUtils ccbu) {
+        wdMap.put(ccbu.getWebDriver(), ccbu);
         this.clientCallBacks.forEach(
                 (n, callback) -> {
                     try {
-                        callback.browserLaunched(ssutils);
+                        callback.browserLaunched(ccbu);
                     } catch (Exception e) {
                         LOGGER.error(e.getMessage(), e);
                     }
                 });
+    }
+
+    void browserClosing(WebDriver wd) {
+        if (!wdMap.containsKey(wd)) {
+            return;
+        }
+        ClientCallBackUtils ccbu = wdMap.remove(wd);
+        this.clientCallBacks.forEach(
+                (n, callback) -> {
+                    try {
+                        callback.browserClosing(ccbu);
+                    } catch (Exception e) {
+                        LOGGER.error(e.getMessage(), e);
+                    }
+                });
+    }
+
+    void clear() {
+        this.wdMap.clear();
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -45,6 +45,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -875,6 +876,10 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
             spiderScanController.stopAllScans();
             spiderScanController.reset();
 
+            if (api != null) {
+                api.clear();
+            }
+
             if (hasView()) {
                 getClientSpiderPanel().reset();
                 if (spiderDialog != null) {
@@ -961,6 +966,10 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
      */
     public void unregisterClientCallBack(ClientCallBackImplementor callback) {
         this.api.unregisterClientCallBack(callback);
+    }
+
+    public void browserClosing(WebDriver wd) {
+        this.api.browserClosing(wd);
     }
 
     private class ClientPassiveScanRuleProvider implements PassiveScanRuleProvider {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/RedirectScript.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/RedirectScript.java
@@ -49,13 +49,14 @@ public class RedirectScript implements BrowserHook {
             sb.append("&zaprecord=true");
         }
         sb.append("&zapid=");
-        sb.append(UUID.randomUUID());
+        UUID uuid = UUID.randomUUID();
+        sb.append(uuid);
         String zapurl = sb.toString();
         ssutils.getWebDriver().get(zapurl);
         JavascriptExecutor jsExecutor = (JavascriptExecutor) ssutils.getWebDriver();
         jsExecutor.executeScript("localStorage.setItem('localzapurl', '" + apiurl + "')");
         // The second refresh seems to be needed sometimes - could be a browser timing issue?
         ssutils.getWebDriver().get(zapurl);
-        api.browserLaunched(ssutils);
+        api.browserLaunched(new ClientCallBackUtils(ssutils, uuid));
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -339,7 +339,11 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
                 try {
                     wdp =
                             new WebDriverProcess(
-                                    extensionNetwork, extSelenium, new ProxyHandler(), options);
+                                    extClient,
+                                    extensionNetwork,
+                                    extSelenium,
+                                    new ProxyHandler(),
+                                    options);
                 } catch (IOException e) {
                     throw new RuntimeException("Failed to create WebDriver process:", e);
                 }
@@ -803,13 +807,16 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
 
         private Server proxy;
         private WebDriver webDriver;
+        private ExtensionClientIntegration extClient;
 
         private WebDriverProcess(
+                ExtensionClientIntegration extensionClient,
                 ExtensionNetwork extensionNetwork,
                 ExtensionSelenium extensionSelenium,
                 ProxyHandler proxyHandler,
                 ClientOptions options)
                 throws IOException {
+            extClient = extensionClient;
             proxy =
                     extensionNetwork.createHttpServer(
                             HttpServerConfig.builder()
@@ -830,6 +837,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
         private void shutdown() {
             if (webDriver != null) {
                 try {
+                    extClient.browserClosing(webDriver);
                     webDriver.quit();
                 } catch (Exception e) {
                     LOGGER.debug("An error occurred while quitting the browser.", e);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientIntegrationAPIUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientIntegrationAPIUnitTest.java
@@ -21,14 +21,20 @@ package org.zaproxy.addon.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
+import java.util.UUID;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link ClientIntegrationAPI}. */
@@ -145,11 +151,139 @@ class ClientIntegrationAPIUnitTest extends TestUtils {
         assertThat(resp4, is(""));
     }
 
+    @Test
+    void shouldCallBrowserLaunchedOnRegisteredCallbacks() {
+        // Given
+        BrowserEventCallBackImp callback = new BrowserEventCallBackImp("test");
+        api.registerClientCallBack(callback);
+        ClientCallBackUtils ccbu = createClientCallBackUtils();
+
+        // When
+        api.browserLaunched(ccbu);
+
+        // Then
+        assertThat(callback.launchedCcbu, is(sameInstance(ccbu)));
+    }
+
+    @Test
+    void shouldNotCallBrowserLaunchedOnUnregisteredCallbacks() {
+        // Given
+        BrowserEventCallBackImp callback = new BrowserEventCallBackImp("test");
+        api.registerClientCallBack(callback);
+        api.unregisterClientCallBack(callback);
+        ClientCallBackUtils ccbu = createClientCallBackUtils();
+
+        // When
+        api.browserLaunched(ccbu);
+
+        // Then
+        assertThat(callback.launchedCcbu, is(nullValue()));
+    }
+
+    @Test
+    void shouldCallBrowserClosingOnRegisteredCallbacksWithSameCcbu() {
+        // Given
+        BrowserEventCallBackImp callback = new BrowserEventCallBackImp("test");
+        api.registerClientCallBack(callback);
+        ClientCallBackUtils ccbu = createClientCallBackUtils();
+        api.browserLaunched(ccbu);
+
+        // When
+        api.browserClosing(ccbu.getWebDriver());
+
+        // Then
+        assertThat(callback.closingCcbu, is(sameInstance(ccbu)));
+    }
+
+    @Test
+    void shouldNotCallBrowserClosingForUnknownWebDriver() {
+        // Given
+        BrowserEventCallBackImp callback = new BrowserEventCallBackImp("test");
+        api.registerClientCallBack(callback);
+        WebDriver unknownWd = mock(WebDriver.class);
+
+        // When
+        api.browserClosing(unknownWd);
+
+        // Then
+        assertThat(callback.closingCcbu, is(nullValue()));
+    }
+
+    @Test
+    void shouldNotCallBrowserClosingTwiceForSameWebDriver() {
+        // Given
+        BrowserEventCallBackImp callback = new BrowserEventCallBackImp("test");
+        api.registerClientCallBack(callback);
+        ClientCallBackUtils ccbu = createClientCallBackUtils();
+        api.browserLaunched(ccbu);
+        api.browserClosing(ccbu.getWebDriver());
+        callback.closingCcbu = null;
+
+        // When
+        api.browserClosing(ccbu.getWebDriver());
+
+        // Then
+        assertThat(callback.closingCcbu, is(nullValue()));
+    }
+
+    @Test
+    void shouldNotCallBrowserClosingAfterClear() {
+        // Given
+        BrowserEventCallBackImp callback = new BrowserEventCallBackImp("test");
+        api.registerClientCallBack(callback);
+        ClientCallBackUtils ccbu = createClientCallBackUtils();
+        api.browserLaunched(ccbu);
+
+        // When
+        api.clear();
+        api.browserClosing(ccbu.getWebDriver());
+
+        // Then
+        assertThat(callback.closingCcbu, is(nullValue()));
+    }
+
+    private static ClientCallBackUtils createClientCallBackUtils() {
+        WebDriver wd = mock(WebDriver.class);
+        SeleniumScriptUtils ssu = new SeleniumScriptUtils(wd, 0, "firefox", "localhost", 8080);
+        return new ClientCallBackUtils(ssu, UUID.randomUUID());
+    }
+
     private HttpMessage getMsg(String method, String url) throws Exception {
         HttpMessage msg = new HttpMessage();
         URI uri = new URI(url, true);
         msg.setRequestHeader(new HttpRequestHeader(method, uri, HttpHeader.HTTP11));
         return msg;
+    }
+
+    static class BrowserEventCallBackImp implements ClientCallBackImplementor {
+
+        private final String name;
+        ClientCallBackUtils launchedCcbu;
+        ClientCallBackUtils closingCcbu;
+
+        BrowserEventCallBackImp(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getImplementorName() {
+            return name;
+        }
+
+        @Override
+        public String handleCallBack(HttpMessage msg) {
+            return "";
+        }
+
+        @Override
+        public void browserLaunched(ClientCallBackUtils ccbu) {
+            this.launchedCcbu = ccbu;
+        }
+
+        @Override
+        public void browserClosing(ClientCallBackUtils ccbu) {
+            this.closingCcbu = ccbu;
+        }
     }
 
     static class CallBackImp implements ClientCallBackImplementor {

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/RedirectScriptUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/RedirectScriptUnitTest.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.addon.client;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -78,6 +80,26 @@ class RedirectScriptUnitTest {
         verify(wd, times(2)).get(urlCaptor.capture());
         assertUrlsHavePrefixAndValidZapid(
                 urlCaptor, "callback-url?zapenable=true&zaprecord=true&zapid=");
+    }
+
+    @Test
+    void shouldPassMatchingUuidToUrlAndClientCallBackUtils() {
+        // Given
+        given(ssutils.getRequester()).willReturn(HttpSender.PROXY_INITIATOR);
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<ClientCallBackUtils> ccbuCaptor =
+                ArgumentCaptor.forClass(ClientCallBackUtils.class);
+
+        // When
+        script.browserLaunched(ssutils);
+
+        // Then
+        verify(wd, times(2)).get(urlCaptor.capture());
+        verify(api).browserLaunched(ccbuCaptor.capture());
+
+        String url = urlCaptor.getAllValues().get(0);
+        String uuidInUrl = url.substring(url.indexOf("zapid=") + "zapid=".length());
+        assertThat(ccbuCaptor.getValue().getUuid().toString(), is(uuidInUrl));
     }
 
     private static void assertUrlsHavePrefixAndValidZapid(


### PR DESCRIPTION
Adds a new interface for client callback implementors which allows them to be notified when the browser is closing.
Also shared the UUID on launch and exit.
Initially for PTK integration, but other add-ons may well find it useful in the future.