### PR TITLE
scripts: prevent engine closure during scan rule metadata registration

### DIFF
--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRule.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRule.java
@@ -48,7 +48,7 @@ public class ActiveScriptScanRule extends ActiveScriptHelper {
     private ScanRuleMetadata metadata;
 
     // Prevents GraalJS ScriptEngineCleaner from GC'ing the engine. Issue #9297.
-    Object engineRef;
+    ScanRuleMetadataProvider engineRef;
 
     /** Used via reflection in {@link org.parosproxy.paros.core.scanner.PluginFactory} */
     public ActiveScriptScanRule() {}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRule.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptScanRule.java
@@ -47,6 +47,9 @@ public class ActiveScriptScanRule extends ActiveScriptHelper {
     private CachedScriptInterfaces cachedScriptInterfaces;
     private ScanRuleMetadata metadata;
 
+    // Prevents GraalJS ScriptEngineCleaner from GC'ing the engine. Issue #9297.
+    Object engineRef;
+
     /** Used via reflection in {@link org.parosproxy.paros.core.scanner.PluginFactory} */
     public ActiveScriptScanRule() {}
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptSynchronizer.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ActiveScriptSynchronizer.java
@@ -39,8 +39,8 @@ public class ActiveScriptSynchronizer {
         try {
             ActiveScriptScanRule scanRule = scriptToScanRuleMap.get(script);
 
-            var metadata = ScriptSynchronizerUtils.getMetadataForScript(script);
-            if (metadata == null) {
+            var metadataResult = ScriptSynchronizerUtils.getMetadataForScript(script);
+            if (metadataResult == null) {
                 if (scanRule != null) {
                     // The metadata function was removed from the script
                     scriptRemoved(script);
@@ -48,9 +48,12 @@ public class ActiveScriptSynchronizer {
                 return;
             }
 
+            var metadata = metadataResult.metadata;
+
             if (scanRule != null) {
                 if (scanRule.getId() == metadata.getId()) {
                     scanRule.setMetadata(metadata);
+                    scanRule.engineRef = metadataResult.providerRef;
                     return;
                 }
                 if (unloadScanRule(scanRule)) {
@@ -69,6 +72,7 @@ public class ActiveScriptSynchronizer {
                 return;
             }
             scriptToScanRuleMap.put(script, scanRule);
+            scanRule.engineRef = metadataResult.providerRef;
         } catch (Exception e) {
             getExtScript().handleScriptException(script, e);
         }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRule.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRule.java
@@ -41,6 +41,9 @@ public class PassiveScriptScanRule extends PassiveScriptHelper {
     private CachedScriptInterfaces cachedScriptInterfaces;
     private ScanRuleMetadata metadata;
 
+    // Prevents GraalJS ScriptEngineCleaner from GC'ing the engine. Issue #9297.
+    Object engineRef;
+
     public PassiveScriptScanRule(ScriptWrapper script, ScanRuleMetadata metadata) {
         this.script = script;
         cachedScriptInterfaces = new CachedScriptInterfaces(script);

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRule.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptScanRule.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadata;
+import org.zaproxy.addon.commonlib.scanrules.ScanRuleMetadataProvider;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -42,7 +43,7 @@ public class PassiveScriptScanRule extends PassiveScriptHelper {
     private ScanRuleMetadata metadata;
 
     // Prevents GraalJS ScriptEngineCleaner from GC'ing the engine. Issue #9297.
-    Object engineRef;
+    ScanRuleMetadataProvider engineRef;
 
     public PassiveScriptScanRule(ScriptWrapper script, ScanRuleMetadata metadata) {
         this.script = script;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptSynchronizer.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/PassiveScriptSynchronizer.java
@@ -43,8 +43,8 @@ public class PassiveScriptSynchronizer {
         try {
             PassiveScriptScanRule scanRule = scriptToScanRuleMap.get(script);
 
-            var metadata = ScriptSynchronizerUtils.getMetadataForScript(script);
-            if (metadata == null) {
+            var metadataResult = ScriptSynchronizerUtils.getMetadataForScript(script);
+            if (metadataResult == null) {
                 if (scanRule != null) {
                     // The metadata function was removed from the script
                     scriptRemoved(script);
@@ -52,9 +52,12 @@ public class PassiveScriptSynchronizer {
                 return;
             }
 
+            var metadata = metadataResult.metadata;
+
             if (scanRule != null) {
                 if (scanRule.getPluginId() == metadata.getId()) {
                     scanRule.setMetadata(metadata);
+                    scanRule.engineRef = metadataResult.providerRef;
                     return;
                 }
                 if (unloadScanRule(scanRule)) {
@@ -84,6 +87,7 @@ public class PassiveScriptSynchronizer {
                 return;
             }
             scriptToScanRuleMap.put(script, scanRule);
+            scanRule.engineRef = metadataResult.providerRef;
         } catch (Exception e) {
             getExtScript().handleScriptException(script, e);
         }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptSynchronizerUtils.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptSynchronizerUtils.java
@@ -44,9 +44,9 @@ class ScriptSynchronizerUtils {
      */
     static class MetadataResult {
         final ScanRuleMetadata metadata;
-        final Object providerRef;
+        final ScanRuleMetadataProvider providerRef;
 
-        MetadataResult(ScanRuleMetadata metadata, Object providerRef) {
+        MetadataResult(ScanRuleMetadata metadata, ScanRuleMetadataProvider providerRef) {
             this.metadata = metadata;
             this.providerRef = providerRef;
         }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptSynchronizerUtils.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/scanrules/ScriptSynchronizerUtils.java
@@ -34,14 +34,43 @@ class ScriptSynchronizerUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(ScriptSynchronizerUtils.class);
 
-    static ScanRuleMetadata getMetadataForScript(ScriptWrapper script) throws Exception {
+    /**
+     * Bundles metadata with a strong reference to the provider proxy. The caller MUST store {@code
+     * providerRef} for as long as the scan rule is registered — if the proxy is GC'd, the GraalJS
+     * {@code ScriptEngineCleaner} closes the engine and permanently poisons {@code
+     * ScanRuleMetadata} class init for the JVM process.
+     *
+     * @see <a href="https://github.com/zaproxy/zaproxy/issues/9297">Issue 9297</a>
+     */
+    static class MetadataResult {
+        final ScanRuleMetadata metadata;
+        final Object providerRef;
+
+        MetadataResult(ScanRuleMetadata metadata, Object providerRef) {
+            this.metadata = metadata;
+            this.providerRef = providerRef;
+        }
+    }
+
+    /**
+     * Returns metadata and the provider proxy in a single result. These MUST be obtained from a
+     * single {@code getInterface()} call — splitting into two calls creates a window where the
+     * first proxy can be GC'd before the caller stores it.
+     */
+    static MetadataResult getMetadataForScript(ScriptWrapper script) throws Exception {
         var metadataProvider = getExtScript().getInterface(script, ScanRuleMetadataProvider.class);
         if (metadataProvider != null) {
-            return ScriptScanRuleUtils.callOptionalScriptMethod(metadataProvider::getMetadata);
+            var metadata =
+                    ScriptScanRuleUtils.callOptionalScriptMethod(metadataProvider::getMetadata);
+            if (metadata != null) {
+                return new MetadataResult(metadata, metadataProvider);
+            }
         }
         return null;
     }
 
+    // Unlike getMetadataForScript(), this intentionally does NOT retain the provider reference.
+    // It's only a probe — engine closure here does not affect scan rule registration.
     static boolean providesMetadata(ScriptWrapper script) {
         try {
             var metadataProvider =


### PR DESCRIPTION
## Summary

Ref zaproxy/zaproxy#9297 — the `ScriptEngineCleaner` introduced in graaljs 0.13.0 intermittently breaks `getMetadata()` for script scan rules by closing the engine when GC collects the metadata provider proxy.

## Root Cause

`ScriptSynchronizerUtils.getMetadataForScript()` calls `getInterface()` to get a `ScanRuleMetadataProvider` proxy from the GraalJS engine. This proxy is tracked by the `ScriptEngineCleaner`. When the method returns, the proxy goes out of scope → GC collects it → Cleaner fires → engine closes → `ScanRuleMetadata` class init fails permanently for the JVM.

## Fix

1. **`ScriptSynchronizerUtils`**: New `MetadataResult` class bundles metadata + provider proxy from a single `getInterface()` call (atomicity prevents a GC race between two separate calls)
2. **`ActiveScriptScanRule` / `PassiveScriptScanRule`**: New `Object engineRef` field serves as a GC anchor — the reference lives as long as the scan rule
3. **`ActiveScriptSynchronizer` / `PassiveScriptSynchronizer`**: Set `scanRule.engineRef` on all registration paths (new, update, ID-change)

No manual cleanup needed — when a scan rule is unloaded, `engineRef` dies with it.

## Design Decisions

- **`MetadataResult` instead of two `getInterface()` calls**: Splitting into two calls creates a GC window where the first proxy can be collected before the caller stores it — the exact race we're fixing.
- **`engineRef` field on scan rule instead of parallel map**: Ties the reference lifetime to the scan rule automatically. No `.remove()` / `.clear()` needed.
- **`Object` type instead of `ScanRuleMetadataProvider`**: The reference is never called — it only exists to prevent GC. Using `Object` makes the intent explicit.
- **`providesMetadata()` intentionally not fixed**: This method also evaluates `getMetadata()` but is only a probe — engine closure here does not affect scan rule registration.

## Approach

Matches the pattern from zaproxy/zaproxy#9236 which solved a similar Cleaner side-effect by retaining a strong reference to prevent GC.

## Files Changed

| File | Change |
|---|---|
| `ScriptSynchronizerUtils.java` | New `MetadataResult` class; `getMetadataForScript()` returns provider ref atomically with metadata |
| `ActiveScriptScanRule.java` | `Object engineRef` field |
| `PassiveScriptScanRule.java` | `Object engineRef` field |
| `ActiveScriptSynchronizer.java` | Uses `MetadataResult`; sets `engineRef` on new + update paths |
| `PassiveScriptSynchronizer.java` | Same pattern |

## Testing

This is a race condition dependent on GC/Cleaner timing. The fix can be verified by running ZAP daemon with `-addoninstall communityScripts` repeatedly — `Find Emails.js` and `SwaggerSecretDetector.js` should consistently register with `error: false`.