### PR TITLE
ascanrules: Add Example Alerts for Time Based SQLi rules

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- The Cross Site Scripting (Persistent) rule now includes example alert functionality for documentation generation purposes (Issue 6119) and alert references (Issue 7100).
+- The following scan rules now include example alert functionality for documentation generation purposes (Issue 6119):
+    - SQL Injection - Hypersonic SQL (Time Based)
+    - SQL Injection - MsSQL (Time Based)
+    - SQL Injection - MySQL (Time Based)
+    - SQL Injection - Oracle (Time Based)
+    - SQL Injection - PostgreSQL (Time Based)
+    - Cross Site Scripting (Persistent) (Also now includes alert references (Issue 7100))
 
 ## [81] - 2026-04-14
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicTimingScanRule.java
@@ -298,13 +298,7 @@ public class SqlInjectionHypersonicTimingScanRule extends AbstractAppParamPlugin
                         message.compareAndSet(null, msg);
 
                         String finalPayload =
-                                sleepPayload
-                                        .replace(ORIG_VALUE_TOKEN, paramValue)
-                                        // Time in milliseconds for the SQL function.
-                                        .replace(
-                                                SLEEP_TOKEN,
-                                                String.valueOf(
-                                                        TimeUnit.SECONDS.toMillis((long) x)));
+                                assembleTimingPayload(sleepPayload, paramValue, (long) x);
 
                         setParameter(msg, paramName, finalPayload);
                         LOGGER.debug("Testing [{}] = [{}]", paramName, finalPayload);
@@ -329,18 +323,13 @@ public class SqlInjectionHypersonicTimingScanRule extends AbstractAppParamPlugin
                             paramName,
                             attack.get());
 
-                    newAlert()
-                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
-                            .setParam(paramName)
-                            .setAttack(attack.get())
-                            .setOtherInfo(
-                                    Constant.messages.getString(
-                                            "ascanrules.sqlinjection.alert.timebased.extrainfo",
-                                            attack.get(),
-                                            message.get().getTimeElapsedMillis(),
-                                            paramValue,
-                                            getBaseMsg().getTimeElapsedMillis()))
+                    buildAlert(
+                                    getBaseMsg().getRequestHeader().getURI().toString(),
+                                    paramName,
+                                    paramValue,
+                                    attack.get(),
+                                    message.get().getTimeElapsedMillis(),
+                                    getBaseMsg().getTimeElapsedMillis())
                             .setMessage(message.get())
                             .raise();
                     break;
@@ -359,6 +348,49 @@ public class SqlInjectionHypersonicTimingScanRule extends AbstractAppParamPlugin
                         ex);
             }
         }
+    }
+
+    private static String assembleTimingPayload(
+            String template, String paramValue, long sleepSeconds) {
+        return template.replace(ORIG_VALUE_TOKEN, paramValue)
+                .replace(SLEEP_TOKEN, String.valueOf(TimeUnit.SECONDS.toMillis(sleepSeconds)));
+    }
+
+    private AlertBuilder buildAlert(
+            String uri,
+            String paramName,
+            String paramValue,
+            String attackValue,
+            long attackElapsedMillis,
+            long originalElapsedMillis) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setUri(uri)
+                .setParam(paramName)
+                .setAttack(attackValue)
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                "ascanrules.sqlinjection.alert.timebased.extrainfo",
+                                attackValue,
+                                attackElapsedMillis,
+                                paramValue,
+                                originalElapsedMillis));
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildAlert(
+                                "https://example.com/?name=test",
+                                "name",
+                                "test",
+                                assembleTimingPayload(
+                                        SQL_HYPERSONIC_TIME_REPLACEMENTS.get(3),
+                                        "test",
+                                        DEFAULT_SLEEP_TIME),
+                                TimeUnit.SECONDS.toMillis(DEFAULT_SLEEP_TIME),
+                                100L)
+                        .build());
     }
 
     void setTimeSleepSeconds(int timeSleepSeconds) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlTimingScanRule.java
@@ -243,9 +243,7 @@ public class SqlInjectionMsSqlTimingScanRule extends AbstractAppParamPlugin
                         message.compareAndSet(null, msg);
 
                         String finalPayload =
-                                sleepPayload
-                                        .replace(ORIG_VALUE_TOKEN, paramValue)
-                                        .replace(SLEEP_TOKEN, getSleepToken((int) x));
+                                assembleTimingPayload(sleepPayload, paramValue, (int) x);
 
                         setParameter(msg, paramName, finalPayload);
                         LOGGER.debug("Testing [{}] = [{}]", paramName, finalPayload);
@@ -270,20 +268,13 @@ public class SqlInjectionMsSqlTimingScanRule extends AbstractAppParamPlugin
                             paramName,
                             attack.get());
 
-                    String extraInfo =
-                            Constant.messages.getString(
-                                    "ascanrules.sqlinjection.mssql.alert.timebased.extrainfo",
+                    buildAlert(
+                                    getBaseMsg().getRequestHeader().getURI().toString(),
+                                    paramName,
+                                    paramValue,
                                     attack.get(),
                                     message.get().getTimeElapsedMillis(),
-                                    paramValue,
-                                    getBaseMsg().getTimeElapsedMillis());
-
-                    newAlert()
-                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
-                            .setParam(paramName)
-                            .setAttack(attack.get())
-                            .setOtherInfo(extraInfo)
+                                    getBaseMsg().getTimeElapsedMillis())
                             .setMessage(message.get())
                             .raise();
                     break;
@@ -302,6 +293,49 @@ public class SqlInjectionMsSqlTimingScanRule extends AbstractAppParamPlugin
                         ex);
             }
         }
+    }
+
+    private static String assembleTimingPayload(
+            String template, String paramValue, int sleepSeconds) {
+        return template.replace(ORIG_VALUE_TOKEN, paramValue)
+                .replace(SLEEP_TOKEN, getSleepToken(sleepSeconds));
+    }
+
+    private AlertBuilder buildAlert(
+            String uri,
+            String paramName,
+            String paramValue,
+            String attackValue,
+            long attackElapsedMillis,
+            long originalElapsedMillis) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setUri(uri)
+                .setParam(paramName)
+                .setAttack(attackValue)
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                "ascanrules.sqlinjection.mssql.alert.timebased.extrainfo",
+                                attackValue,
+                                attackElapsedMillis,
+                                paramValue,
+                                originalElapsedMillis));
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildAlert(
+                                "https://example.com/?name=test",
+                                "name",
+                                "test",
+                                assembleTimingPayload(
+                                        SQL_MSSQL_TIME_REPLACEMENTS.get(4),
+                                        "test",
+                                        DEFAULT_SLEEP_TIME),
+                                TimeUnit.SECONDS.toMillis(DEFAULT_SLEEP_TIME),
+                                100L)
+                        .build());
     }
 
     private static String getSleepToken(int totalTimeInSeconds) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMySqlTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMySqlTimingScanRule.java
@@ -304,9 +304,7 @@ public class SqlInjectionMySqlTimingScanRule extends AbstractAppParamPlugin
                         message.compareAndSet(null, msg);
 
                         String finalPayload =
-                                sleepPayload
-                                        .replace(ORIG_VALUE_TOKEN, originalParamValue)
-                                        .replace(SLEEP_TOKEN, Integer.toString((int) x));
+                                assembleTimingPayload(sleepPayload, originalParamValue, (int) x);
 
                         setParameter(msg, paramName, finalPayload);
                         LOGGER.debug("Testing [{}] = [{}]", paramName, finalPayload);
@@ -331,18 +329,13 @@ public class SqlInjectionMySqlTimingScanRule extends AbstractAppParamPlugin
                             paramName,
                             attack.get());
 
-                    newAlert()
-                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
-                            .setParam(paramName)
-                            .setAttack(attack.get())
-                            .setOtherInfo(
-                                    Constant.messages.getString(
-                                            "ascanrules.sqlinjection.alert.timebased.extrainfo",
-                                            attack.get(),
-                                            message.get().getTimeElapsedMillis(),
-                                            originalParamValue,
-                                            getBaseMsg().getTimeElapsedMillis()))
+                    buildAlert(
+                                    getBaseMsg().getRequestHeader().getURI().toString(),
+                                    paramName,
+                                    originalParamValue,
+                                    attack.get(),
+                                    message.get().getTimeElapsedMillis(),
+                                    getBaseMsg().getTimeElapsedMillis())
                             .setMessage(message.get())
                             .raise();
                     break;
@@ -361,6 +354,49 @@ public class SqlInjectionMySqlTimingScanRule extends AbstractAppParamPlugin
                         ex);
             }
         }
+    }
+
+    private static String assembleTimingPayload(
+            String template, String paramValue, int sleepSeconds) {
+        return template.replace(ORIG_VALUE_TOKEN, paramValue)
+                .replace(SLEEP_TOKEN, Integer.toString(sleepSeconds));
+    }
+
+    private AlertBuilder buildAlert(
+            String uri,
+            String paramName,
+            String paramValue,
+            String attackValue,
+            long attackElapsedMillis,
+            long originalElapsedMillis) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setUri(uri)
+                .setParam(paramName)
+                .setAttack(attackValue)
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                "ascanrules.sqlinjection.alert.timebased.extrainfo",
+                                attackValue,
+                                attackElapsedMillis,
+                                paramValue,
+                                originalElapsedMillis));
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildAlert(
+                                "https://example.com/?name=test",
+                                "name",
+                                "test",
+                                assembleTimingPayload(
+                                        SQL_MYSQL_TIME_REPLACEMENTS.get(1),
+                                        "test",
+                                        DEFAULT_SLEEP_TIME),
+                                TimeUnit.SECONDS.toMillis(DEFAULT_SLEEP_TIME),
+                                100L)
+                        .build());
     }
 
     public void setSleepInSeconds(int sleep) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionOracleTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionOracleTimingScanRule.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.ascanrules;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -224,13 +225,13 @@ public class SqlInjectionOracleTimingScanRule extends AbstractAppParamPlugin
                 return;
             }
             AtomicReference<HttpMessage> message = new AtomicReference<>();
-            String payloadValue = PAYLOADS[payloadIndex].replace(ORIG_VALUE_TOKEN, paramValue);
+            String payloadTemplate = PAYLOADS[payloadIndex];
             TimingUtils.RequestSender requestSender =
                     x -> {
                         HttpMessage timedMsg = getNewMsg();
                         message.compareAndSet(null, timedMsg);
                         String finalPayload =
-                                payloadValue.replace(SLEEP_TOKEN, String.valueOf((int) x));
+                                assembleTimingPayload(payloadTemplate, paramValue, (int) x);
                         setParameter(timedMsg, paramName, finalPayload);
                         sendAndReceive(timedMsg, false); // do not follow redirects
                         return TimeUnit.MILLISECONDS.toSeconds(timedMsg.getTimeElapsedMillis());
@@ -256,29 +257,64 @@ public class SqlInjectionOracleTimingScanRule extends AbstractAppParamPlugin
 
             if (isInjectable) {
                 String finalPayloadValue =
-                        payloadValue.replace(SLEEP_TOKEN, String.valueOf(sleepInSeconds));
+                        assembleTimingPayload(payloadTemplate, paramValue, sleepInSeconds);
                 LOGGER.debug(
                         "Time Based Oracle SQL Injection - Found on parameter [{}] with value [{}]",
                         paramName,
                         paramValue);
 
-                newAlert()
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setUri(getBaseMsg().getRequestHeader().getURI().toString())
-                        .setParam(paramName)
-                        .setAttack(finalPayloadValue)
+                buildAlert(
+                                getBaseMsg().getRequestHeader().getURI().toString(),
+                                paramName,
+                                paramValue,
+                                finalPayloadValue,
+                                message.get().getTimeElapsedMillis(),
+                                getBaseMsg().getTimeElapsedMillis())
                         .setMessage(message.get())
-                        .setOtherInfo(
-                                Constant.messages.getString(
-                                        "ascanrules.sqlinjection.alert.timebased.extrainfo",
-                                        finalPayloadValue,
-                                        message.get().getTimeElapsedMillis(),
-                                        paramValue,
-                                        getBaseMsg().getTimeElapsedMillis()))
                         .raise();
                 return;
             }
         }
+    }
+
+    private static String assembleTimingPayload(
+            String template, String paramValue, int sleepSeconds) {
+        return template.replace(ORIG_VALUE_TOKEN, paramValue)
+                .replace(SLEEP_TOKEN, String.valueOf(sleepSeconds));
+    }
+
+    private AlertBuilder buildAlert(
+            String uri,
+            String paramName,
+            String paramValue,
+            String attackValue,
+            long attackElapsedMillis,
+            long originalElapsedMillis) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setUri(uri)
+                .setParam(paramName)
+                .setAttack(attackValue)
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                "ascanrules.sqlinjection.alert.timebased.extrainfo",
+                                attackValue,
+                                attackElapsedMillis,
+                                paramValue,
+                                originalElapsedMillis));
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildAlert(
+                                "https://example.com/?name=test",
+                                "name",
+                                "test",
+                                assembleTimingPayload(PAYLOADS[1], "test", DEFAULT_TIME_SLEEP_SEC),
+                                TimeUnit.SECONDS.toMillis(DEFAULT_TIME_SLEEP_SEC),
+                                100L)
+                        .build());
     }
 
     public void setSleepInSeconds(int sleep) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionPostgreSqlTimingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionPostgreSqlTimingScanRule.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.SocketException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -264,15 +265,13 @@ public class SqlInjectionPostgreSqlTimingScanRule extends AbstractAppParamPlugin
                             && countTimeBasedRequests < doTimeMaxRequests;
                     timeBasedSQLindex++, countTimeBasedRequests++) {
                 AtomicReference<HttpMessage> message = new AtomicReference<>();
-                String payloadValue =
-                        SQL_POSTGRES_TIME_REPLACEMENTS[timeBasedSQLindex].replace(
-                                ORIG_VALUE_TOKEN, paramValue);
+                String payloadTemplate = SQL_POSTGRES_TIME_REPLACEMENTS[timeBasedSQLindex];
                 TimingUtils.RequestSender requestSender =
                         x -> {
                             HttpMessage timedMsg = getNewMsg();
                             message.compareAndSet(null, timedMsg);
                             String finalPayload =
-                                    payloadValue.replace(SLEEP_TOKEN, String.valueOf(x));
+                                    assembleTimingPayload(payloadTemplate, paramValue, x);
                             setParameter(timedMsg, paramName, finalPayload);
                             sendAndReceive(timedMsg, false); // do not follow redirects
                             return TimeUnit.MILLISECONDS.toSeconds(timedMsg.getTimeElapsedMillis());
@@ -299,25 +298,20 @@ public class SqlInjectionPostgreSqlTimingScanRule extends AbstractAppParamPlugin
 
                     if (isInjectable) {
                         String finalPayloadValue =
-                                payloadValue.replace(SLEEP_TOKEN, String.valueOf(sleepInSeconds));
+                                assembleTimingPayload(payloadTemplate, paramValue, sleepInSeconds);
                         LOGGER.debug(
                                 "[Time Based Postrgres SQL Injection - Found] on parameter [{}] with value [{}]",
                                 paramName,
                                 paramValue);
 
-                        newAlert()
-                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                .setUri(getBaseMsg().getRequestHeader().getURI().toString())
-                                .setParam(paramName)
-                                .setAttack(finalPayloadValue)
+                        buildAlert(
+                                        getBaseMsg().getRequestHeader().getURI().toString(),
+                                        paramName,
+                                        paramValue,
+                                        finalPayloadValue,
+                                        message.get().getTimeElapsedMillis(),
+                                        getBaseMsg().getTimeElapsedMillis())
                                 .setMessage(message.get())
-                                .setOtherInfo(
-                                        Constant.messages.getString(
-                                                "ascanrules.sqlinjection.alert.timebased.extrainfo",
-                                                finalPayloadValue,
-                                                message.get().getTimeElapsedMillis(),
-                                                paramValue,
-                                                getBaseMsg().getTimeElapsedMillis()))
                                 .raise();
                         return;
                     }
@@ -335,6 +329,49 @@ public class SqlInjectionPostgreSqlTimingScanRule extends AbstractAppParamPlugin
                     "An error occurred checking a URL for Postgres SQL Injection vulnerabilities",
                     e);
         }
+    }
+
+    private static String assembleTimingPayload(
+            String template, String paramValue, Number sleepArg) {
+        return template.replace(ORIG_VALUE_TOKEN, paramValue)
+                .replace(SLEEP_TOKEN, String.valueOf(sleepArg));
+    }
+
+    private AlertBuilder buildAlert(
+            String uri,
+            String paramName,
+            String paramValue,
+            String attackValue,
+            long attackElapsedMillis,
+            long originalElapsedMillis) {
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setUri(uri)
+                .setParam(paramName)
+                .setAttack(attackValue)
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                "ascanrules.sqlinjection.alert.timebased.extrainfo",
+                                attackValue,
+                                attackElapsedMillis,
+                                paramValue,
+                                originalElapsedMillis));
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildAlert(
+                                "https://example.com/?name=test",
+                                "name",
+                                "test",
+                                assembleTimingPayload(
+                                        SQL_POSTGRES_TIME_REPLACEMENTS[11],
+                                        "test",
+                                        DEFAULT_TIME_SLEEP_SEC),
+                                TimeUnit.SECONDS.toMillis(DEFAULT_TIME_SLEEP_SEC),
+                                100L)
+                        .build());
     }
 
     public void setSleepInSeconds(int sleep) {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicTimingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionHypersonicTimingScanRuleUnitTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,6 +56,17 @@ class SqlInjectionHypersonicTimingScanRuleUnitTest
         boolean targets = rule.targets(techSet);
         // Then
         assertThat(targets, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
     @Test

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlTimingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMsSqlTimingScanRuleUnitTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,6 +56,17 @@ class SqlInjectionMsSqlTimingScanRuleUnitTest
         boolean targets = rule.targets(techSet);
         // Then
         assertThat(targets, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
     @Test

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMySqlTimingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionMySqlTimingScanRuleUnitTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,6 +56,17 @@ class SqlInjectionMySqlTimingScanRuleUnitTest
         boolean targets = rule.targets(techSet);
         // Then
         assertThat(targets, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
     @Test

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionOracleTimingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionOracleTimingScanRuleUnitTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.is;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +60,17 @@ class SqlInjectionOracleTimingScanRuleUnitTest
         boolean targets = rule.targets(techSet);
         // Then
         assertThat(targets, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
     @Test

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionPostgreSqlTimingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionPostgreSqlTimingScanRuleUnitTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.is;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -58,6 +59,17 @@ class SqlInjectionPostgreSqlTimingScanRuleUnitTest
         boolean targets = rule.targets(techSet);
         // Then
         assertThat(targets, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        Alert alert = alerts.get(0);
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
     @Test


### PR DESCRIPTION
## Overview

-  Scan Rules > Added example alert handling.
-  Unit Tests > Added tests for the example alerts and references.
-  CHANGELOG > Added change note.

## Related Issues
- zaproxy/zaproxy#6119
