### PR TITLE
insights: allow exitAutoOnHigh to detect persistent auth failures

### DIFF
--- a/addOns/insights/CHANGELOG.md
+++ b/addOns/insights/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Elevated insight.auth.failure from Medium to High severity so that exitAutoOnHigh can stop scans with persistent auth failures.
+- Reduced minimum auth request threshold from 10 to 5 to detect browser-based auth failures earlier.
 
 ## [0.3.0] - 2026-03-31
 ### Fixed

--- a/addOns/insights/src/main/java/org/zaproxy/addon/insights/internal/StatsMonitor.java
+++ b/addOns/insights/src/main/java/org/zaproxy/addon/insights/internal/StatsMonitor.java
@@ -63,7 +63,7 @@ public class StatsMonitor implements StatsListener, EventConsumer {
     private static final String STATS_RESPONSE_TIME_PREFIX = "stats.responseTime.";
 
     private static final int MIN_NUMBER_OF_REQS = 1000;
-    private static final int MIN_NUMBER_OF_AUTH = 10;
+    private static final int MIN_NUMBER_OF_AUTH = 5;
 
     private static final long MEM_GC_CHECK_MSEC = TimeUnit.MINUTES.toMillis(1);
 
@@ -328,7 +328,7 @@ public class StatsMonitor implements StatsListener, EventConsumer {
             }
             recordMessageInsightWithLimits(
                     Insight.Level.LOW,
-                    Insight.Level.MEDIUM,
+                    Insight.Level.HIGH,
                     site,
                     "insight.auth.failure",
                     MIN_NUMBER_OF_AUTH,

--- a/addOns/insights/src/main/javahelp/org/zaproxy/addon/insights/resources/help/contents/insights-list.html
+++ b/addOns/insights/src/main/javahelp/org/zaproxy/addon/insights/resources/help/contents/insights-list.html
@@ -74,7 +74,7 @@ This is the full set of Insights currently supported:
 <td>Yes
 <td>Msg
 <td>Low
-<td> Med
+<td>High
 
 <tr>
 <td>insight.code.Xxx

--- a/addOns/insights/src/test/java/org/zaproxy/addon/insights/ExtensionInsightsUnitTest.java
+++ b/addOns/insights/src/test/java/org/zaproxy/addon/insights/ExtensionInsightsUnitTest.java
@@ -237,7 +237,7 @@ class ExtensionInsightsUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldRecordWarningOnAuthMediumStats() {
+    void shouldRecordWarningOnAuthHighStats() {
         // Given
         Stats.incCounter(EXAMPLE_COM, "stats.auth.success", 1000);
         Stats.incCounter(EXAMPLE_COM, "stats.auth.failure", 3000);
@@ -249,7 +249,7 @@ class ExtensionInsightsUnitTest extends TestUtils {
         assertThat(ext.getInsights().size(), is(equalTo(1)));
         assertInsight(
                 0,
-                Insight.Level.MEDIUM,
+                Insight.Level.HIGH,
                 Insight.Reason.EXCEEDED_HIGH,
                 EXAMPLE_COM,
                 "insight.auth.failure",


### PR DESCRIPTION
## Summary

This PR makes two small changes to `StatsMonitor.java` so that `exitAutoOnHigh` can detect and stop scans with persistent authentication failures.

## Context

In zaproxy/zaproxy#9298 I proposed adding a `maxAuthRetries` limit to `AuthenticationMethod`. @psiinon pointed out that the Insights addon should handle this — the `exitAutoOnHigh` mechanism should detect auth failures and stop the scan.

After looking into it, I found that `insight.auth.failure` currently caps at `Insight.Level.MEDIUM`, but `exitAutoOnHigh` only triggers on `Insight.Level.HIGH`. So auth failures can never actually stop a scan via Insights.

### Changes

- **Elevate `insight.auth.failure` high level from `MEDIUM` to `HIGH`** — so `exitAutoOnHigh` can catch persistent auth failures, matching `insight.code.5xx` which already uses `HIGH`
- **Reduce `MIN_NUMBER_OF_AUTH` from 10 to 5** — with browser-based auth (Selenium/Chrome), each retry involves page loads, form interaction, and timeouts, so waiting for 10 attempts before escalating delays detection significantly

### Question

Would it make sense to make `MIN_NUMBER_OF_AUTH` configurable via the Automation Framework YAML (similar to `messagesHighThreshold`)? Browser-based auth retries are much more expensive than form/JSON auth, so different setups would benefit from different thresholds. Happy to do this in a follow-up if useful.