### PR TITLE
ascanrulesAlpha: Add getExampleAlerts to LDAP Injection scan rule

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The LDAP Injection scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
 
 ## [56] - 2026-04-14
 ### Changed

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- The LDAP Injection scan rule now includes example alert functionality for documentation generation purposes (Issue 6119).
+- The LDAP Injection scan rule now includes example alert functionality for documentation generation purposes (Issue 6119) and alert references (Issue 7100).
 
 ## [56] - 2026-04-14
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -395,17 +395,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                             appendTrueAttack);
                     LOGGER.debug("We found an LDAP injection");
 
-                    buildBooleanBasedAlert(
-                                    paramname,
-                                    getBaseMsg().getRequestHeader().getMethod(),
-                                    getBaseMsg().getRequestHeader().getURI().toString(),
-                                    appendTrueAttack,
-                                    randomparameterAttack)
-                            .setMessage(getBaseMsg())
-                            .raise();
-
-                    logBooleanInjection(
-                            getBaseMsg(), paramname, appendTrueAttack, randomparameterAttack);
+                    raiseBooleanBasedAlert(paramname, appendTrueAttack, randomparameterAttack);
 
                     // all done for this parameter. return.
                     return;
@@ -468,17 +458,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                             hopefullyTrueAttack);
                     LOGGER.debug("We found an LDAP injection");
 
-                    buildBooleanBasedAlert(
-                                    paramname,
-                                    getBaseMsg().getRequestHeader().getMethod(),
-                                    getBaseMsg().getRequestHeader().getURI().toString(),
-                                    hopefullyTrueAttack,
-                                    randomparameterAttack)
-                            .setMessage(getBaseMsg())
-                            .raise();
-
-                    logBooleanInjection(
-                            getBaseMsg(), paramname, hopefullyTrueAttack, randomparameterAttack);
+                    raiseBooleanBasedAlert(paramname, hopefullyTrueAttack, randomparameterAttack);
 
                     // all done for this parameter. return.
                     return;
@@ -639,6 +619,19 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                 .setOtherInfo(extraInfo)
                 .setEvidence("")
                 .setAlertRef(getId() + "-2");
+    }
+
+    private void raiseBooleanBasedAlert(String paramName, String trueAttack, String randomAttack) {
+        buildBooleanBasedAlert(
+                        paramName,
+                        getBaseMsg().getRequestHeader().getMethod(),
+                        getBaseMsg().getRequestHeader().getURI().toString(),
+                        trueAttack,
+                        randomAttack)
+                .setMessage(getBaseMsg())
+                .raise();
+
+        logBooleanInjection(getBaseMsg(), paramName, trueAttack, randomAttack);
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -395,7 +395,17 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                             appendTrueAttack);
                     LOGGER.debug("We found an LDAP injection");
 
-                    raiseBooleanBasedAlert(paramname, appendTrueAttack, randomparameterAttack);
+                    buildBooleanBasedAlert(
+                                    paramname,
+                                    getBaseMsg().getRequestHeader().getMethod(),
+                                    getBaseMsg().getRequestHeader().getURI().toString(),
+                                    appendTrueAttack,
+                                    randomparameterAttack)
+                            .setMessage(getBaseMsg())
+                            .raise();
+
+                    logBooleanInjection(
+                            getBaseMsg(), paramname, appendTrueAttack, randomparameterAttack);
 
                     // all done for this parameter. return.
                     return;
@@ -458,7 +468,17 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                             hopefullyTrueAttack);
                     LOGGER.debug("We found an LDAP injection");
 
-                    raiseBooleanBasedAlert(paramname, hopefullyTrueAttack, randomparameterAttack);
+                    buildBooleanBasedAlert(
+                                    paramname,
+                                    getBaseMsg().getRequestHeader().getMethod(),
+                                    getBaseMsg().getRequestHeader().getURI().toString(),
+                                    hopefullyTrueAttack,
+                                    randomparameterAttack)
+                            .setMessage(getBaseMsg())
+                            .raise();
+
+                    logBooleanInjection(
+                            getBaseMsg(), paramname, hopefullyTrueAttack, randomparameterAttack);
 
                     // all done for this parameter. return.
                     return;
@@ -547,8 +567,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                                 parameterName,
                                 getBaseMsg().getRequestHeader().getMethod(),
                                 getBaseMsg().getRequestHeader().getURI().toString(),
-                                LDAP_ERRORS.get(errorPattern),
-                                errorPattern.toString())
+                                errorPattern)
                         .setMessage(attackMessage)
                         .raise();
 
@@ -574,11 +593,8 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
     }
 
     private AlertBuilder buildErrorBasedAlert(
-            String param,
-            String method,
-            String uri,
-            String ldapImplementation,
-            String errorPattern) {
+            String param, String method, String uri, Pattern errorPattern) {
+        String ldapImplementation = LDAP_ERRORS.get(errorPattern);
         String attack =
                 Constant.messages.getString(
                         I18N_PREFIX + "ldapinjection.alert.attack", param, errorAttack);
@@ -590,14 +606,14 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                         uri,
                         errorAttack,
                         ldapImplementation,
-                        errorPattern);
+                        errorPattern.toString());
         return newAlert()
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setName(getName() + " - " + ldapImplementation)
                 .setParam(param)
                 .setAttack(attack)
                 .setOtherInfo(extraInfo)
-                .setEvidence(errorPattern)
+                .setEvidence(errorPattern.toString())
                 .setAlertRef(getId() + "-1");
     }
 
@@ -625,24 +641,21 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                 .setAlertRef(getId() + "-2");
     }
 
-    private void raiseBooleanBasedAlert(String paramName, String trueAttack, String randomAttack) {
-        buildBooleanBasedAlert(
-                        paramName,
-                        getBaseMsg().getRequestHeader().getMethod(),
-                        getBaseMsg().getRequestHeader().getURI().toString(),
-                        trueAttack,
-                        randomAttack)
-                .setMessage(getBaseMsg())
-                .raise();
-
-        logBooleanInjection(getBaseMsg(), paramName, trueAttack, randomAttack);
-    }
-
     @Override
     public List<Alert> getExampleAlerts() {
         return List.of(
-                buildErrorBasedAlert("param", "", "", "openldap", "Invalid credentials").build(),
-                buildBooleanBasedAlert("param", "", "", "test)(objectClass=*", "randomvalue")
+                buildErrorBasedAlert(
+                                "param",
+                                "GET",
+                                "https://example.com/",
+                                LDAP_ERRORS.keySet().iterator().next())
+                        .build(),
+                buildBooleanBasedAlert(
+                                "param",
+                                "GET",
+                                "https://example.com/",
+                                "test)(objectClass=*",
+                                "randomvalue")
                         .build());
     }
 

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -24,6 +24,7 @@ import java.net.UnknownHostException;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.regex.Matcher;
@@ -394,44 +395,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                             appendTrueAttack);
                     LOGGER.debug("We found an LDAP injection");
 
-                    String extraInfo =
-                            Constant.messages.getString(
-                                    I18N_PREFIX + "ldapinjection.booleanbased.alert.extrainfo",
-                                    paramname,
-                                    getBaseMsg().getRequestHeader().getMethod(),
-                                    getBaseMsg().getRequestHeader().getURI(),
-                                    appendTrueAttack,
-                                    randomparameterAttack);
-
-                    String vulnevidence =
-                            ""; // there is no String to search for in the original output.  all
-                    // extra info is in extra info field. ahem!
-                    String attack =
-                            Constant.messages.getString(
-                                    I18N_PREFIX + "ldapinjection.booleanbased.alert.attack",
-                                    appendTrueAttack,
-                                    randomparameterAttack);
-                    String vulnname =
-                            Constant.messages.getString(I18N_PREFIX + "ldapinjection.name");
-                    String vulndesc =
-                            Constant.messages.getString(I18N_PREFIX + "ldapinjection.desc");
-                    String vulnsoln =
-                            Constant.messages.getString(I18N_PREFIX + "ldapinjection.soln");
-
-                    newAlert()
-                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setName(vulnname)
-                            .setDescription(vulndesc)
-                            .setParam(paramname)
-                            .setAttack(attack)
-                            .setOtherInfo(extraInfo)
-                            .setSolution(vulnsoln)
-                            .setEvidence(vulnevidence)
-                            .setMessage(getBaseMsg())
-                            .raise();
-
-                    logBooleanInjection(
-                            getBaseMsg(), paramname, appendTrueAttack, randomparameterAttack);
+                    raiseBooleanBasedAlert(paramname, appendTrueAttack, randomparameterAttack);
 
                     // all done for this parameter. return.
                     return;
@@ -494,44 +458,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                             hopefullyTrueAttack);
                     LOGGER.debug("We found an LDAP injection");
 
-                    String extraInfo =
-                            Constant.messages.getString(
-                                    I18N_PREFIX + "ldapinjection.booleanbased.alert.extrainfo",
-                                    paramname,
-                                    getBaseMsg().getRequestHeader().getMethod(),
-                                    getBaseMsg().getRequestHeader().getURI(),
-                                    hopefullyTrueAttack,
-                                    randomparameterAttack);
-
-                    String vulnevidence =
-                            ""; // there is no String to search for in the original output.  all
-                    // extra info is in extra info field. ahem!
-                    String attack =
-                            Constant.messages.getString(
-                                    I18N_PREFIX + "ldapinjection.booleanbased.alert.attack",
-                                    hopefullyTrueAttack,
-                                    randomparameterAttack);
-                    String vulnname =
-                            Constant.messages.getString(I18N_PREFIX + "ldapinjection.name");
-                    String vulndesc =
-                            Constant.messages.getString(I18N_PREFIX + "ldapinjection.desc");
-                    String vulnsoln =
-                            Constant.messages.getString(I18N_PREFIX + "ldapinjection.soln");
-
-                    newAlert()
-                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setName(vulnname)
-                            .setDescription(vulndesc)
-                            .setParam(paramname)
-                            .setAttack(attack)
-                            .setOtherInfo(extraInfo)
-                            .setSolution(vulnsoln)
-                            .setEvidence(vulnevidence)
-                            .setMessage(getBaseMsg())
-                            .raise();
-
-                    logBooleanInjection(
-                            getBaseMsg(), paramname, hopefullyTrueAttack, randomparameterAttack);
+                    raiseBooleanBasedAlert(paramname, hopefullyTrueAttack, randomparameterAttack);
 
                     // all done for this parameter. return.
                     return;
@@ -624,26 +551,13 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                                 LDAP_ERRORS.get(errorPattern),
                                 errorPattern);
 
-                String attack =
-                        Constant.messages.getString(
-                                I18N_PREFIX + "ldapinjection.alert.attack",
-                                parameterName,
-                                errorAttack);
-                String vulnname = Constant.messages.getString(I18N_PREFIX + "ldapinjection.name");
-                String vulndesc = Constant.messages.getString(I18N_PREFIX + "ldapinjection.desc");
-                String vulnsoln = Constant.messages.getString(I18N_PREFIX + "ldapinjection.soln");
-
                 // we know the LDAP implementation, so put it in the title, where it will be
                 // obvious.
-                newAlert()
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setName(vulnname + " - " + LDAP_ERRORS.get(errorPattern))
-                        .setDescription(vulndesc)
-                        .setParam(parameterName)
-                        .setAttack(attack)
+                buildErrorBasedAlert(
+                                parameterName,
+                                LDAP_ERRORS.get(errorPattern),
+                                errorPattern.toString())
                         .setOtherInfo(extraInfo)
-                        .setSolution(vulnsoln)
-                        .setEvidence(errorPattern.toString())
                         .setMessage(attackMessage)
                         .raise();
 
@@ -666,6 +580,60 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
         } // for each error message for the given LDAP implementation
 
         return false; // did not throw an alert
+    }
+
+    private AlertBuilder buildErrorBasedAlert(
+            String param, String ldapImplementation, String errorPattern) {
+        String attack =
+                Constant.messages.getString(
+                        I18N_PREFIX + "ldapinjection.alert.attack", param, errorAttack);
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setName(getName() + " - " + ldapImplementation)
+                .setParam(param)
+                .setAttack(attack)
+                .setEvidence(errorPattern)
+                .setAlertRef(getId() + "-1");
+    }
+
+    private AlertBuilder buildBooleanBasedAlert(
+            String param, String trueAttack, String randomAttack) {
+        String attack =
+                Constant.messages.getString(
+                        I18N_PREFIX + "ldapinjection.booleanbased.alert.attack",
+                        trueAttack,
+                        randomAttack);
+        return newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setParam(param)
+                .setAttack(attack)
+                .setEvidence("")
+                .setAlertRef(getId() + "-2");
+    }
+
+    private void raiseBooleanBasedAlert(String paramName, String trueAttack, String randomAttack) {
+        String extraInfo =
+                Constant.messages.getString(
+                        I18N_PREFIX + "ldapinjection.booleanbased.alert.extrainfo",
+                        paramName,
+                        getBaseMsg().getRequestHeader().getMethod(),
+                        getBaseMsg().getRequestHeader().getURI(),
+                        trueAttack,
+                        randomAttack);
+
+        buildBooleanBasedAlert(paramName, trueAttack, randomAttack)
+                .setOtherInfo(extraInfo)
+                .setMessage(getBaseMsg())
+                .raise();
+
+        logBooleanInjection(getBaseMsg(), paramName, trueAttack, randomAttack);
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return List.of(
+                buildErrorBasedAlert("param", "openldap", "Invalid credentials").build(),
+                buildBooleanBasedAlert("param", "test)(objectClass=*", "randomvalue").build());
     }
 
     /**

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -541,23 +541,14 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
                 // does not trigger the same effect.
                 // so raise the error, and move on to the next parameter
 
-                String extraInfo =
-                        Constant.messages.getString(
-                                I18N_PREFIX + "ldapinjection.alert.extrainfo",
-                                parameterName,
-                                getBaseMsg().getRequestHeader().getMethod(),
-                                getBaseMsg().getRequestHeader().getURI(),
-                                errorAttack,
-                                LDAP_ERRORS.get(errorPattern),
-                                errorPattern);
-
                 // we know the LDAP implementation, so put it in the title, where it will be
                 // obvious.
                 buildErrorBasedAlert(
                                 parameterName,
+                                getBaseMsg().getRequestHeader().getMethod(),
+                                getBaseMsg().getRequestHeader().getURI().toString(),
                                 LDAP_ERRORS.get(errorPattern),
                                 errorPattern.toString())
-                        .setOtherInfo(extraInfo)
                         .setMessage(attackMessage)
                         .raise();
 
@@ -583,46 +574,64 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
     }
 
     private AlertBuilder buildErrorBasedAlert(
-            String param, String ldapImplementation, String errorPattern) {
+            String param,
+            String method,
+            String uri,
+            String ldapImplementation,
+            String errorPattern) {
         String attack =
                 Constant.messages.getString(
                         I18N_PREFIX + "ldapinjection.alert.attack", param, errorAttack);
+        String extraInfo =
+                Constant.messages.getString(
+                        I18N_PREFIX + "ldapinjection.alert.extrainfo",
+                        param,
+                        method,
+                        uri,
+                        errorAttack,
+                        ldapImplementation,
+                        errorPattern);
         return newAlert()
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setName(getName() + " - " + ldapImplementation)
                 .setParam(param)
                 .setAttack(attack)
+                .setOtherInfo(extraInfo)
                 .setEvidence(errorPattern)
                 .setAlertRef(getId() + "-1");
     }
 
     private AlertBuilder buildBooleanBasedAlert(
-            String param, String trueAttack, String randomAttack) {
+            String param, String method, String uri, String trueAttack, String randomAttack) {
         String attack =
                 Constant.messages.getString(
                         I18N_PREFIX + "ldapinjection.booleanbased.alert.attack",
+                        trueAttack,
+                        randomAttack);
+        String extraInfo =
+                Constant.messages.getString(
+                        I18N_PREFIX + "ldapinjection.booleanbased.alert.extrainfo",
+                        param,
+                        method,
+                        uri,
                         trueAttack,
                         randomAttack);
         return newAlert()
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setParam(param)
                 .setAttack(attack)
+                .setOtherInfo(extraInfo)
                 .setEvidence("")
                 .setAlertRef(getId() + "-2");
     }
 
     private void raiseBooleanBasedAlert(String paramName, String trueAttack, String randomAttack) {
-        String extraInfo =
-                Constant.messages.getString(
-                        I18N_PREFIX + "ldapinjection.booleanbased.alert.extrainfo",
+        buildBooleanBasedAlert(
                         paramName,
                         getBaseMsg().getRequestHeader().getMethod(),
-                        getBaseMsg().getRequestHeader().getURI(),
+                        getBaseMsg().getRequestHeader().getURI().toString(),
                         trueAttack,
-                        randomAttack);
-
-        buildBooleanBasedAlert(paramName, trueAttack, randomAttack)
-                .setOtherInfo(extraInfo)
+                        randomAttack)
                 .setMessage(getBaseMsg())
                 .raise();
 
@@ -632,8 +641,9 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
     @Override
     public List<Alert> getExampleAlerts() {
         return List.of(
-                buildErrorBasedAlert("param", "openldap", "Invalid credentials").build(),
-                buildBooleanBasedAlert("param", "test)(objectClass=*", "randomvalue").build());
+                buildErrorBasedAlert("param", "", "", "openldap", "Invalid credentials").build(),
+                buildBooleanBasedAlert("param", "", "", "test)(objectClass=*", "randomvalue")
+                        .build());
     }
 
     /**

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
@@ -22,10 +22,12 @@ package org.zaproxy.zap.extension.ascanrulesAlpha;
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
@@ -182,14 +184,16 @@ class LdapInjectionScanRuleUnitTest extends ActiveScannerTest<LdapInjectionScanR
         assertThat(alerts, hasSize(2));
 
         Alert errorBasedAlert = alerts.get(0);
-        assertThat(errorBasedAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(errorBasedAlert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
         assertThat(errorBasedAlert.getAlertRef(), is(equalTo(rule.getId() + "-1")));
+        assertThat(errorBasedAlert.getOtherInfo(), is(notNullValue()));
+        assertThat(errorBasedAlert.getOtherInfo(), is(not(emptyString())));
 
         Alert booleanBasedAlert = alerts.get(1);
-        assertThat(booleanBasedAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(booleanBasedAlert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
         assertThat(booleanBasedAlert.getAlertRef(), is(equalTo(rule.getId() + "-2")));
+        assertThat(booleanBasedAlert.getOtherInfo(), is(notNullValue()));
+        assertThat(booleanBasedAlert.getOtherInfo(), is(not(emptyString())));
     }
 
     private static HttpMessage createMessage(String path) {

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
@@ -23,6 +23,7 @@ import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
@@ -30,12 +31,14 @@ import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.ScannerParam;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -169,6 +172,24 @@ class LdapInjectionScanRuleUnitTest extends ActiveScannerTest<LdapInjectionScanR
         // Then
         assertThat(alertsRaised, is(empty()));
         assertThat(httpMessagesSent, is(not(empty())));
+    }
+
+    @Test
+    void shouldHaveExpectedExampleAlerts() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        // Then
+        assertThat(alerts, hasSize(2));
+
+        Alert errorBasedAlert = alerts.get(0);
+        assertThat(errorBasedAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(errorBasedAlert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(errorBasedAlert.getAlertRef(), is(equalTo(rule.getId() + "-1")));
+
+        Alert booleanBasedAlert = alerts.get(1);
+        assertThat(booleanBasedAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(booleanBasedAlert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(booleanBasedAlert.getAlertRef(), is(equalTo(rule.getId() + "-2")));
     }
 
     private static HttpMessage createMessage(String path) {

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
@@ -184,15 +183,13 @@ class LdapInjectionScanRuleUnitTest extends ActiveScannerTest<LdapInjectionScanR
         assertThat(alerts, hasSize(2));
 
         Alert errorBasedAlert = alerts.get(0);
+        assertThat(errorBasedAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(errorBasedAlert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        assertThat(errorBasedAlert.getAlertRef(), is(equalTo(rule.getId() + "-1")));
-        assertThat(errorBasedAlert.getOtherInfo(), is(notNullValue()));
         assertThat(errorBasedAlert.getOtherInfo(), is(not(emptyString())));
 
         Alert booleanBasedAlert = alerts.get(1);
+        assertThat(booleanBasedAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(booleanBasedAlert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        assertThat(booleanBasedAlert.getAlertRef(), is(equalTo(rule.getId() + "-2")));
-        assertThat(booleanBasedAlert.getOtherInfo(), is(notNullValue()));
         assertThat(booleanBasedAlert.getOtherInfo(), is(not(emptyString())));
     }
 


### PR DESCRIPTION
## Summary
- Add `getExampleAlerts()` to `LdapInjectionScanRule` (plugin 40015) returning 2 example alerts: error-based and boolean-based variants
- Extract `buildErrorBasedAlert()` and `buildBooleanBasedAlert()` helpers from existing alert-raising code, with `alertRef` suffixes (`-1`, `-2`)
- Add `raiseBooleanBasedAlert()` to deduplicate the two identical boolean-based call sites
- Remove redundant `setName()`, `setDescription()`, `setSolution()` calls (already handled by `newAlert()`)

Ref zaproxy/zaproxy#6119

## Test plan
- [x] `shouldHaveExpectedExampleAlerts` - verifies 2 alerts with correct risk, confidence, and alertRef
- [x] All existing LDAP injection tests pass
- [x] `./gradlew :addOns:ascanrulesAlpha:spotlessApply` clean
- [x] `./gradlew :addOns:ascanrulesAlpha:test --no-parallel` passes