### PR TITLE
reports: correct systemic state in JSON/XML reports

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- The alert's systemic flag in JSON and XML reports now correctly reflects its state (Issue 9254).
+
 ### Changed
 - Update dependency.
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportHelper.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportHelper.java
@@ -195,23 +195,30 @@ public class ReportHelper {
     public static List<Alert> getAlertInstancesForSite(
             AlertNode rootNode, String site, String alertName, int alertRisk) {
         List<Alert> list = new ArrayList<>();
-
-        for (int alertIndex = 0; alertIndex < rootNode.getChildCount(); alertIndex++) {
-            AlertNode alertNode = rootNode.getChildAt(alertIndex);
-            // Only the instances have userObjects, not the top level nodes :/
-            if (alertNode.getChildAt(0) != null
-                    && alertNode.getRisk() == alertRisk
-                    && alertNode.getChildAt(0).getUserObject().getName().equals(alertName)) {
-                for (int instIndex = 0; instIndex < alertNode.getChildCount(); instIndex++) {
-                    AlertNode instanceNode = alertNode.getChildAt(instIndex);
-                    if (instanceNode.getUserObject().getUri().startsWith(site)) {
-                        list.add(instanceNode.getUserObject());
-                    }
+        AlertNode alertNode = findAlertNode(rootNode, alertName, alertRisk);
+        if (alertNode != null) {
+            for (int instIndex = 0; instIndex < alertNode.getChildCount(); instIndex++) {
+                AlertNode instanceNode = alertNode.getChildAt(instIndex);
+                if (instanceNode.getUserObject().getUri().startsWith(site)) {
+                    list.add(instanceNode.getUserObject());
                 }
-                break;
             }
         }
         return list;
+    }
+
+    private static AlertNode findAlertNode(AlertNode rootNode, String alertName, int alertRisk) {
+        for (int i = 0; i < rootNode.getChildCount(); i++) {
+            AlertNode alertNode = rootNode.getChildAt(i);
+            // Only the instances have userObjects, not the top level nodes :/
+            AlertNode firstChild = alertNode.getChildAt(0);
+            if (firstChild != null
+                    && alertNode.getRisk() == alertRisk
+                    && firstChild.getUserObject().getName().equals(alertName)) {
+                return alertNode;
+            }
+        }
+        return null;
     }
 
     public static List<AlertNode> getChildren(AlertNode node, boolean incLeaves) {
@@ -328,14 +335,15 @@ public class ReportHelper {
     }
 
     /**
-     * Returns whether the alert node is systemic.
+     * Returns whether the alert is systemic, by locating the matching {@link AlertNode} in the
+     * alert tree and checking the instance count against the systemic threshold.
      *
-     * @since 0.42.0
+     * @since 0.45.0
      */
-    public static boolean isSystemic(Alert alert) {
-        if (alert == null) {
+    public static boolean isSystemic(AlertNode rootNode, String alertName, int alertRisk) {
+        if (rootNode == null) {
             return false;
         }
-        return alert.isSystemic();
+        return isSystemic(findAlertNode(rootNode, alertName, alertRisk));
     }
 }

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/report.json
@@ -46,7 +46,7 @@
                         }[/th:block]
                     ],
                     "count": "[(${instances.size})]",
-                    "systemic": [[${helper.isSystemic(alert)}]],
+                    "systemic": [[${helper.isSystemic(alertTree, alert.name, alert.risk)}]],
                     "solution": "[(${helper.legacyEscapeParagraph(alert.solution, true)})]",
                     "otherinfo": "[(${helper.legacyEscapeParagraph(alert.otherinfo, true)})]",
                     "reference": "[(${helper.legacyEscapeParagraph(alert.reference, true)})]",

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json/report.json
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json/report.json
@@ -42,7 +42,7 @@
 						}[/th:block]
 					],
 					"count": "[(${instances.size})]",
-					"systemic": [[${helper.isSystemic(alert)}]],
+					"systemic": [[${helper.isSystemic(alertTree, alert.name, alert.risk)}]],
 					"solution": "[(${helper.legacyEscapeParagraph(alert.solution, true)})]",
 					"otherinfo": "[(${helper.legacyEscapeParagraph(alert.otherinfo, true)})]",
 					"reference": "[(${helper.legacyEscapeParagraph(alert.reference, true)})]",

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml-plus/report.xml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml-plus/report.xml
@@ -42,7 +42,8 @@
 							</th:block>
 						</instances>
 						<count th:text="${instances.size()}"></count>
-						<systemic th:text="${helper.isSystemic(alert)}"></systemic>
+						<systemic
+							th:text="${helper.isSystemic(alertTree, alert.name, alert.risk)}"></systemic>
 						<solution th:text="${alert.solution}"></solution>
 						<otherinfo th:text="${alert.otherinfo}"></otherinfo>
 						<reference th:text="${alert.reference}"></reference>

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
@@ -35,7 +35,8 @@
 							</th:block>
 						</instances>
 						<count th:text="${instances.size()}"></count>
-						<systemic th:text="${helper.isSystemic(alert)}"></systemic>
+						<systemic
+							th:text="${helper.isSystemic(alertTree, alert.name, alert.risk)}"></systemic>
 						<solution
 							th:text="${helper.legacyEscapeParagraph(alert.solution)}"></solution>
 						<otherinfo

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsJsonUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsJsonUnitTest.java
@@ -758,4 +758,21 @@ class ExtensionReportsJsonUnitTest extends TestUtils {
         assertThat(tags.getJSONObject(0).getString("tag"), is(equalTo("tagkey")));
         assertThat(tags.getJSONObject(0).getString("link"), is(equalTo("tagvalue")));
     }
+
+    @Test
+    void shouldNotMarkSystemicWhenInstancesBelowThresholdEvenWithSystemicTag() throws Exception {
+        // Given
+        Template template = ReportTestUtils.getTemplateFromYamlFile("traditional-json");
+        File f = File.createTempFile("systemic-tag-json", template.getExtension());
+
+        // When
+        File r = ReportTestUtils.generateReportWithSystemicTaggedAlert(template, f);
+        String report = new String(Files.readAllBytes(r.toPath()));
+        JSONObject json = JSONObject.fromObject(report);
+        JSONArray site = json.getJSONArray("site");
+        JSONArray alerts = site.getJSONObject(0).getJSONArray("alerts");
+
+        // Then
+        assertThat(alerts.getJSONObject(0).getBoolean("systemic"), is(equalTo(false)));
+    }
 }

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsXmlUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsXmlUnitTest.java
@@ -59,6 +59,7 @@ import org.zaproxy.zap.extension.sequence.automation.SequenceAScanJobResultData;
 import org.zaproxy.zap.extension.stats.ExtensionStats;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.XmlUtils;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 class ExtensionReportsXmlUnitTest extends TestUtils {
@@ -496,5 +497,22 @@ class ExtensionReportsXmlUnitTest extends TestUtils {
 
         assertThat(insightNode.getChildNodes().item(11).getNodeName(), is(equalTo("statistic")));
         assertThat(insightNode.getChildNodes().item(11).getTextContent(), is(equalTo(stat)));
+    }
+
+    @Test
+    void shouldNotMarkSystemicWhenInstancesBelowThresholdEvenWithSystemicTag() throws Exception {
+        // Given
+        Template template = ReportTestUtils.getTemplateFromYamlFile("traditional-xml");
+        File f = File.createTempFile("systemic-tag-xml", template.getExtension());
+        DocumentBuilder db = XmlUtils.newXxeDisabledDocumentBuilderFactory().newDocumentBuilder();
+
+        // When
+        File r = ReportTestUtils.generateReportWithSystemicTaggedAlert(template, f);
+        Document doc = db.parse(r);
+
+        // Then
+        NodeList systemicNodes = doc.getElementsByTagName("systemic");
+        assertThat(systemicNodes.getLength(), is(equalTo(1)));
+        assertThat(systemicNodes.item(0).getTextContent(), is(equalTo("false")));
     }
 }

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportTestUtils.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportTestUtils.java
@@ -31,6 +31,7 @@ import org.apache.commons.httpclient.URIException;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.insights.internal.Insight;
 import org.zaproxy.addon.insights.report.ExtensionInsightsReport;
 import org.zaproxy.zap.extension.alert.AlertNode;
@@ -76,6 +77,31 @@ public class ReportTestUtils {
         AlertNode node = new AlertNode(risk, name);
         Alert alert1 = createAlertNode(name, desc, risk, confidence, "");
         Alert alert2 = createAlertNode(name, desc, risk, confidence, "Another ");
+        node.setUserObject(alert1);
+
+        AlertNode instance1 = new AlertNode(0, name);
+        instance1.setUserObject(alert1);
+
+        AlertNode instance2 = new AlertNode(0, name);
+        instance2.setUserObject(alert2);
+
+        node.add(instance1);
+        node.add(instance2);
+
+        return node;
+    }
+
+    static AlertNode getSystemicTaggedAlertNode(String name, String desc, int risk, int confidence)
+            throws URIException, HttpMalformedHeaderException {
+        AlertNode node = new AlertNode(risk, name);
+        Alert alert1 = createAlertNode(name, desc, risk, confidence, "");
+        Alert alert2 = createAlertNode(name, desc, risk, confidence, "Another ");
+
+        Map<String, String> systemicTags = new HashMap<>();
+        systemicTags.put(CommonAlertTag.SYSTEMIC.getTag(), CommonAlertTag.SYSTEMIC.getValue());
+        alert1.setTags(systemicTags);
+        alert2.setTags(systemicTags);
+
         node.setUserObject(alert1);
 
         AlertNode instance1 = new AlertNode(0, name);
@@ -181,6 +207,26 @@ public class ReportTestUtils {
         ExtensionReports extRep = new ExtensionReports();
         ReportData reportData = getTestReportDataWithAlerts();
         reportData.setSections(template.getSections());
+        return extRep.generateReport(reportData, template, f.getAbsolutePath(), false);
+    }
+
+    static File generateReportWithSystemicTaggedAlert(Template template, File f)
+            throws IOException, DocumentException, URIException, HttpMalformedHeaderException {
+        ExtensionReports extRep = new ExtensionReports();
+        ReportData reportData = new ReportData("test");
+        reportData.setTitle("Test Title");
+        reportData.setDescription("Test Description");
+        reportData.setIncludeAllConfidences(true);
+        reportData.setIncludeAllRisks(true);
+        reportData.setSections(template.getSections());
+
+        AlertNode root = new AlertNode(0, "Test");
+        root.add(
+                getSystemicTaggedAlertNode(
+                        "XSS", "XSS Description", Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+        reportData.setAlertTreeRootNode(root);
+        addSites(reportData);
+
         return extRep.generateReport(reportData, template, f.getAbsolutePath(), false);
     }
 


### PR DESCRIPTION
Fixes zaproxy/zaproxy#9254

## Root Cause
Alert.isSystemic() checks if the scan rule has the SYSTEMIC tag — a rule-level 
property set by scan rule authors. AlertNode.isSystemic() checks if the instance 
count >= systemic-limit — the correct check for reports.

The JSON and XML templates were calling helper.isSystemic(alert) with an Alert 
object, producing systemic=true whenever a rule had the SYSTEMIC tag, regardless 
of instance count. The HTML report was already correct because it operates on 
AlertNode objects directly.

## Changes
- Added ReportHelper.isSystemic(AlertNode, String, int) that locates the matching 
  AlertNode in the alert tree and delegates to AlertNode.isSystemic()
- Deprecated old isSystemic(Alert) overload
- Updated 4 templates: traditional-json, traditional-json-plus, traditional-xml, 
  traditional-xml-plus
- Added regression tests for JSON and XML reports
- Updated CHANGELOG.md