### PR TITLE
openapi: address NPE importing definition

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Dependency update.
 
+### Fixed
+- Address exception importing definition with indirect `additionalProperties` referencing an `oneOf` (Issue 9305).
+
 ## [54] - 2026-04-14
 ### Changed
 - Dependency update to fix stack overflows when importing the definitions.

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/MapGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/MapGenerator.java
@@ -45,7 +45,8 @@ public class MapGenerator {
      */
     public String generate(Map<String, String> types, Schema<?> property) {
         Schema<?> schema = (Schema<?>) property.getAdditionalProperties();
-        String type = types.get(OpenApiSchemaTypeUtils.getType(schema));
+        String schemaType = OpenApiSchemaTypeUtils.getType(schema);
+        String type = schemaType != null ? types.get(schemaType) : null;
         String value = type != null ? type : bodyGenerator.generate(schema);
         String defaultKey = types.get(OpenApiSchemaTypeUtils.TYPE_STRING);
         return OBJECT_BEGIN + defaultKey + INNER_SEPARATOR + value + OBJECT_END;

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -842,6 +842,24 @@ class BodyGeneratorUnitTest extends TestUtils {
         assertEquals("{\"items\":[[1.2]]}", request);
     }
 
+    @Test
+    void shouldGenerateBodyOfObjectWithAdditionalPropertiesAndOneOf() throws IOException {
+        // Given
+        OpenAPI openAPI = parseResource("openapi_30_composed_oneof.json");
+        // When
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/things",
+                                        openAPI.getPaths().get("/things").getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+        // Then
+        assertEquals("{\"props\":{\"John Doe\":{\"a\":\"John Doe\"}}}", request);
+    }
+
     private OpenAPI parseResource(String fileName) throws IOException {
         ParseOptions options = new ParseOptions();
         options.setResolveFully(true);

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/openapi_30_composed_oneof.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/openapi_30_composed_oneof.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.3",
+  "info": {"title": "repro", "version": "1.0.0"},
+  "paths": {
+    "/things": {
+      "post": {
+        "requestBody": {
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateRequest"}}}
+        },
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateRequest": {
+        "type": "object",
+        "properties": {"props": {"$ref": "#/components/schemas/PropsMap"}}
+      },
+      "PropsMap": {
+        "type": "object",
+        "additionalProperties": {"$ref": "#/components/schemas/OneOfProp"}
+      },
+      "OneOfProp": {
+        "oneOf": [
+          {"$ref": "#/components/schemas/A"},
+          {"$ref": "#/components/schemas/B"}
+        ]
+      },
+      "A": {"type": "object", "properties": {"a": {"type": "string"}}},
+      "B": {"type": "object", "properties": {"b": {"type": "string"}}}
+    }
+  }
+}


### PR DESCRIPTION
Handle null explicitly when getting default values, since the map now used (`Map.of(…)`) does not handle nulls.

Fix zaproxy/zaproxy#9305