### PR TITLE
quickstart: Add Scan Policy option to Automated Scan panel

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Add Scan Policy option to the Automated Scan panel.
 
 
 ## [55] - 2026-03-09

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -188,8 +188,19 @@ public class AttackPanel extends QuickStartSubPanel {
                             .getExtensionLoader()
                             .getExtension(ExtensionActiveScan.class);
             if (extAscan != null) {
+                String savedPolicy =
+                        getExtensionQuickStart().getQuickStartParam().getScanPolicyName();
+                String defaultPolicy = null;
                 for (String name : extAscan.getPolicyManager().getAllPolicyNames()) {
                     policyField.addItem(name);
+                    if ("Dev Standard".equals(name)) {
+                        defaultPolicy = name;
+                    }
+                }
+                if (savedPolicy != null && !savedPolicy.isEmpty()) {
+                    policyField.setSelectedItem(savedPolicy);
+                } else if (defaultPolicy != null) {
+                    policyField.setSelectedItem(defaultPolicy);
                 }
             }
         }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -39,6 +39,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+import org.zaproxy.zap.extension.ascan.PolicyManager;
 import org.zaproxy.zap.extension.search.SearchPanel;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
@@ -49,6 +50,7 @@ public class AttackPanel extends QuickStartSubPanel {
     private static final long serialVersionUID = 1L;
 
     private static final String DEFAULT_VALUE_URL_FIELD = "http://";
+    private static final String DEFAULT_SCAN_POLICY = "Dev Standard";
 
     private ImageIcon icon;
     private JButton attackButton;
@@ -193,11 +195,11 @@ public class AttackPanel extends QuickStartSubPanel {
                 String defaultPolicy = null;
                 for (String name : extAscan.getPolicyManager().getAllPolicyNames()) {
                     policyField.addItem(name);
-                    if ("Dev Standard".equals(name)) {
+                    if (DEFAULT_SCAN_POLICY.equals(name)) {
                         defaultPolicy = name;
                     }
                 }
-                if (savedPolicy != null && !savedPolicy.isEmpty()) {
+                if (savedPolicy != null && PolicyManager.policyExists(savedPolicy)) {
                     policyField.setSelectedItem(savedPolicy);
                 } else if (defaultPolicy != null) {
                     policyField.setSelectedItem(defaultPolicy);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -188,8 +188,7 @@ public class AttackPanel extends QuickStartSubPanel {
                             .getExtensionLoader()
                             .getExtension(ExtensionActiveScan.class);
             if (extAscan != null) {
-                List<String> policyNames = extAscan.getPolicyManager().getAllPolicyNames();
-                for (String name : policyNames) {
+                for (String name : extAscan.getPolicyManager().getAllPolicyNames()) {
                     policyField.addItem(name);
                 }
             }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -433,6 +433,7 @@ public class AttackPanel extends QuickStartSubPanel {
             return false;
         }
         this.getExtensionQuickStart().getQuickStartParam().addRecentUrl(urlStr);
+        this.getExtensionQuickStart().getQuickStartParam().setScanPolicyName(getSelectedPolicy());
         getAttackButton().setEnabled(false);
         getStopButton().setEnabled(true);
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -184,10 +184,9 @@ public class AttackPanel extends QuickStartSubPanel {
         if (policyField == null) {
             policyField = new JComboBox<>();
             ExtensionActiveScan extAscan =
-                    (ExtensionActiveScan)
-                            Control.getSingleton()
-                                    .getExtensionLoader()
-                                    .getExtension(ExtensionActiveScan.class);
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionActiveScan.class);
             if (extAscan != null) {
                 List<String> policyNames = extAscan.getPolicyManager().getAllPolicyNames();
                 for (String name : policyNames) {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -187,7 +187,7 @@ public class AttackPanel extends QuickStartSubPanel {
                     (ExtensionActiveScan)
                             Control.getSingleton()
                                     .getExtensionLoader()
-                                    .getExtension(ExtensionActiveScan.NAME);
+                                    .getExtension(ExtensionActiveScan.class);
             if (extAscan != null) {
                 List<String> policyNames = extAscan.getPolicyManager().getAllPolicyNames();
                 for (String name : policyNames) {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
+import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.search.SearchPanel;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
@@ -52,6 +53,7 @@ public class AttackPanel extends QuickStartSubPanel {
     private ImageIcon icon;
     private JButton attackButton;
     private JButton stopButton;
+    private JComboBox<String> policyField;
     private JComboBox<String> urlField;
     private DefaultComboBoxModel<String> urlModel;
     private JButton selectButton;
@@ -149,6 +151,11 @@ public class AttackPanel extends QuickStartSubPanel {
             urlSelectPanel.add(this.getUrlField(), LayoutHelper.getGBC(0, 0, 1, 0.5D));
             urlSelectPanel.add(selectButton, LayoutHelper.getGBC(1, 0, 1, 0.0D));
             contentPanel.add(urlSelectPanel, LayoutHelper.getGBC(2, formPanelY, 3, 0.25D));
+            contentPanel.add(
+                    new JLabel(Constant.messages.getString("quickstart.label.policy")),
+                    LayoutHelper.getGBC(
+                            1, ++formPanelY, 1, 0.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));
+            contentPanel.add(getPolicyField(), LayoutHelper.getGBC(2, formPanelY, 1, 0.25D));
 
             traditionalSpiderY = ++formPanelY;
             plugableSpiderY = ++formPanelY;
@@ -171,6 +178,30 @@ public class AttackPanel extends QuickStartSubPanel {
         }
 
         return contentPanel;
+    }
+
+    private JComboBox<String> getPolicyField() {
+        if (policyField == null) {
+            policyField = new JComboBox<>();
+            ExtensionActiveScan extAscan =
+                    (ExtensionActiveScan)
+                            Control.getSingleton()
+                                    .getExtensionLoader()
+                                    .getExtension(ExtensionActiveScan.NAME);
+            if (extAscan != null) {
+                List<String> policyNames = extAscan.getPolicyManager().getAllPolicyNames();
+                for (String name : policyNames) {
+                    policyField.addItem(name);
+                }
+            }
+        }
+        return policyField;
+    }
+
+    public String getSelectedPolicy() {
+        if (policyField == null) return null;
+        Object selected = policyField.getSelectedItem();
+        return selected != null ? selected.toString() : null;
     }
 
     private JLabel getProgressLabel() {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -198,7 +198,9 @@ public class AttackPanel extends QuickStartSubPanel {
     }
 
     public String getSelectedPolicy() {
-        if (policyField == null) return null;
+        if (policyField == null) {
+            return null;
+        }
         Object selected = policyField.getSelectedItem();
         return selected != null ? selected.toString() : null;
     }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -191,24 +191,24 @@ public class AttackPanel extends QuickStartSubPanel {
                             .getExtension(ExtensionActiveScan.class);
             if (extAscan != null) {
                 extAscan.getPolicyManager().getAllPolicyNames().forEach(policyField::addItem);
-                if (PolicyManager.policyExists(
-                        getExtensionQuickStart().getQuickStartParam().getScanPolicyName())) {
-                    policyField.setSelectedItem(
-                            getExtensionQuickStart().getQuickStartParam().getScanPolicyName());
-                } else if (PolicyManager.policyExists(DEFAULT_SCAN_POLICY)) {
-                    policyField.setSelectedItem(DEFAULT_SCAN_POLICY);
-                }
             }
         }
         return policyField;
     }
 
-    public String getSelectedPolicy() {
-        if (policyField == null) {
-            return null;
+    private void selectScanPolicy() {
+        String savedPolicy = getExtensionQuickStart().getQuickStartParam().getScanPolicyName();
+        if (!setPolicy(savedPolicy)) {
+            setPolicy(DEFAULT_SCAN_POLICY);
         }
-        Object selected = policyField.getSelectedItem();
-        return selected != null ? selected.toString() : null;
+    }
+
+    private boolean setPolicy(String policyName) {
+        if (policyName != null && PolicyManager.policyExists(policyName)) {
+            policyField.setSelectedItem(policyName);
+            return true;
+        }
+        return false;
     }
 
     private JLabel getProgressLabel() {
@@ -439,13 +439,17 @@ public class AttackPanel extends QuickStartSubPanel {
             this.getUrlField().requestFocusInWindow();
             return false;
         }
+        String selectedPolicy = (String) policyField.getSelectedItem();
+        getExtensionQuickStart().getQuickStartParam().setScanPolicyName(selectedPolicy);
         this.getExtensionQuickStart().getQuickStartParam().addRecentUrl(urlStr);
-        this.getExtensionQuickStart().getQuickStartParam().setScanPolicyName(getSelectedPolicy());
         getAttackButton().setEnabled(false);
         getStopButton().setEnabled(true);
 
         getExtensionQuickStart()
-                .attack(url, traditionalSpider != null && traditionalSpider.isSelected());
+                .attack(
+                        url,
+                        traditionalSpider != null && traditionalSpider.isSelected(),
+                        selectedPolicy);
         setSpiderButtonsEnabled(false);
         return true;
     }
@@ -504,10 +508,11 @@ public class AttackPanel extends QuickStartSubPanel {
 
     public void optionsLoaded(QuickStartParam quickStartParam) {
         setRecentUrls();
+        selectScanPolicy();
     }
 
     public void optionsChanged(OptionsParam optionsParam) {
-        setRecentUrls();
+        optionsLoaded(optionsParam.getParamSet(QuickStartParam.class));
     }
 
     @Override

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -193,11 +193,9 @@ public class AttackPanel extends QuickStartSubPanel {
                 String savedPolicy =
                         getExtensionQuickStart().getQuickStartParam().getScanPolicyName();
                 String defaultPolicy = null;
-                for (String name : extAscan.getPolicyManager().getAllPolicyNames()) {
-                    policyField.addItem(name);
-                    if (DEFAULT_SCAN_POLICY.equals(name)) {
-                        defaultPolicy = name;
-                    }
+                extAscan.getPolicyManager().getAllPolicyNames().forEach(policyField::addItem);
+                if (PolicyManager.policyExists(DEFAULT_SCAN_POLICY)) {
+                    defaultPolicy = DEFAULT_SCAN_POLICY;
                 }
                 if (savedPolicy != null && PolicyManager.policyExists(savedPolicy)) {
                     policyField.setSelectedItem(savedPolicy);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -190,17 +190,13 @@ public class AttackPanel extends QuickStartSubPanel {
                             .getExtensionLoader()
                             .getExtension(ExtensionActiveScan.class);
             if (extAscan != null) {
-                String savedPolicy =
-                        getExtensionQuickStart().getQuickStartParam().getScanPolicyName();
-                String defaultPolicy = null;
                 extAscan.getPolicyManager().getAllPolicyNames().forEach(policyField::addItem);
-                if (PolicyManager.policyExists(DEFAULT_SCAN_POLICY)) {
-                    defaultPolicy = DEFAULT_SCAN_POLICY;
-                }
-                if (savedPolicy != null && PolicyManager.policyExists(savedPolicy)) {
-                    policyField.setSelectedItem(savedPolicy);
-                } else if (defaultPolicy != null) {
-                    policyField.setSelectedItem(defaultPolicy);
+                if (PolicyManager.policyExists(
+                        getExtensionQuickStart().getQuickStartParam().getScanPolicyName())) {
+                    policyField.setSelectedItem(
+                            getExtensionQuickStart().getQuickStartParam().getScanPolicyName());
+                } else if (PolicyManager.policyExists(DEFAULT_SCAN_POLICY)) {
+                    policyField.setSelectedItem(DEFAULT_SCAN_POLICY);
                 }
             }
         }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -204,8 +204,7 @@ public class AttackThread extends Thread {
                     } catch (Exception ex) {
                         LOGGER.warn("Failed to load policy {}, using default", scanPolicyName);
                     }
-                }
-                if (scanPolicy == null) {
+                } else {
                     scanPolicy = extAscan.getPolicyManager().getDefaultScanPolicy();
                 }
                 scanId = extAscan.startScan(target, null, new Object[] {scanPolicy});

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+import org.zaproxy.zap.extension.ascan.ScanPolicy;
 import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.utils.Stats;
@@ -52,6 +53,7 @@ public class AttackThread extends Thread {
     private PlugableSpider plugableSpider;
     private boolean stopAttack = false;
     private boolean useStdSpider;
+    private String scanPolicyName;
 
     private static final Logger LOGGER = LogManager.getLogger(AttackThread.class);
 
@@ -70,6 +72,10 @@ public class AttackThread extends Thread {
 
     public void setTraditionalSpider(TraditionalSpider traditionalSpider) {
         this.traditionalSpider = traditionalSpider;
+    }
+
+    public void setScanPolicyName(String scanPolicyName) {
+        this.scanPolicyName = scanPolicyName;
     }
 
     public void setPlugableSpider(PlugableSpider plugableSpider) {
@@ -191,7 +197,18 @@ public class AttackThread extends Thread {
                 return;
             } else {
                 extension.notifyProgress(Progress.ascan);
-                scanId = extAscan.startScan(target);
+                ScanPolicy scanPolicy = null;
+                if (scanPolicyName != null && !scanPolicyName.isEmpty()) {
+                    try {
+                        scanPolicy = extAscan.getPolicyManager().getPolicy(scanPolicyName);
+                    } catch (Exception ex) {
+                        LOGGER.warn("Failed to load policy {}, using default", scanPolicyName);
+                    }
+                }
+                if (scanPolicy == null) {
+                    scanPolicy = extAscan.getPolicyManager().getDefaultScanPolicy();
+                }
+                scanId = extAscan.startScan(target, null, new Object[] {scanPolicy});
             }
 
             try {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -203,9 +203,9 @@ public class AttackThread extends Thread {
                         scanPolicy = extAscan.getPolicyManager().getPolicy(scanPolicyName);
                     } catch (Exception ex) {
                         LOGGER.warn("Failed to load policy {}, using default", scanPolicyName);
-                        scanPolicy = extAscan.getPolicyManager().getDefaultScanPolicy();
                     }
-                } else {
+                }
+                if (scanPolicy == null) {
                     scanPolicy = extAscan.getPolicyManager().getDefaultScanPolicy();
                 }
                 scanId = extAscan.startScan(target, null, new Object[] {scanPolicy});

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -203,6 +203,7 @@ public class AttackThread extends Thread {
                         scanPolicy = extAscan.getPolicyManager().getPolicy(scanPolicyName);
                     } catch (Exception ex) {
                         LOGGER.warn("Failed to load policy {}, using default", scanPolicyName);
+                        scanPolicy = extAscan.getPolicyManager().getDefaultScanPolicy();
                     }
                 } else {
                     scanPolicy = extAscan.getPolicyManager().getDefaultScanPolicy();

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -312,6 +312,10 @@ public class ExtensionQuickStart extends ExtensionAdaptor
     }
 
     public void attack(URL url, boolean useStdSpider) {
+        attack(url, useStdSpider, null);
+    }
+
+    public void attack(URL url, boolean useStdSpider, String policyName) {
         if (attackThread != null && attackThread.isAlive()) {
             return;
         }
@@ -319,12 +323,7 @@ public class ExtensionQuickStart extends ExtensionAdaptor
         attackThread.setURL(url);
         attackThread.setTraditionalSpider(traditionalSpider);
         attackThread.setPlugableSpider(plugableSpider);
-        if (hasView()) {
-            attackThread.setScanPolicyName(
-                    getQuickStartPanel().getAttackPanel().getSelectedPolicy());
-        } else {
-            attackThread.setScanPolicyName(getQuickStartParam().getScanPolicyName());
-        }
+        attackThread.setScanPolicyName(policyName);
         attackThread.start();
     }
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -319,7 +319,12 @@ public class ExtensionQuickStart extends ExtensionAdaptor
         attackThread.setURL(url);
         attackThread.setTraditionalSpider(traditionalSpider);
         attackThread.setPlugableSpider(plugableSpider);
-        attackThread.setScanPolicyName(getQuickStartPanel().getAttackPanel().getSelectedPolicy());
+        if (hasView()) {
+            attackThread.setScanPolicyName(
+                    getQuickStartPanel().getAttackPanel().getSelectedPolicy());
+        } else {
+            attackThread.setScanPolicyName(getQuickStartParam().getScanPolicyName());
+        }
         attackThread.start();
     }
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -319,6 +319,7 @@ public class ExtensionQuickStart extends ExtensionAdaptor
         attackThread.setURL(url);
         attackThread.setTraditionalSpider(traditionalSpider);
         attackThread.setPlugableSpider(plugableSpider);
+        attackThread.setScanPolicyName(getQuickStartPanel().getAttackPanel().getSelectedPolicy());
         attackThread.start();
     }
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartParam.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartParam.java
@@ -141,6 +141,11 @@ public class QuickStartParam extends VersionedAbstractParam {
         } catch (Exception e) {
             LOGGER.error("Failed to load the cleared news item configuration", e);
         }
+        try {
+            scanPolicyName = getConfig().getString(PARAM_SCAN_POLICY_NAME, "");
+        } catch (Exception e) {
+            LOGGER.error("Failed to load the cleared news item configuration", e);
+        }
     }
 
     @Override

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartParam.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartParam.java
@@ -63,6 +63,8 @@ public class QuickStartParam extends VersionedAbstractParam {
 
     private static final String PARAM_CLEARED_NEWS_ITEM = PARAM_BASE_KEY + ".clearedNews";
 
+    private static final String PARAM_SCAN_POLICY_NAME = PARAM_BASE_KEY + ".scanPolicyName";
+
     /**
      * The current version of the configurations. Used to keep track of configuration changes
      * between releases, in case changes/updates are needed.
@@ -90,6 +92,7 @@ public class QuickStartParam extends VersionedAbstractParam {
     private String ajaxSpiderSelection;
     private String ajaxSpiderDefaultBrowser;
     private String clearedNewsItem;
+    private String scanPolicyName;
 
     @Override
     protected void parseImpl() {
@@ -248,6 +251,15 @@ public class QuickStartParam extends VersionedAbstractParam {
         }
         getConfig().setProperty(PARAM_RECENT_URLS, this.recentUrls);
         QuickStartHelper.raiseOptionsChangedEvent();
+    }
+
+    public String getScanPolicyName() {
+        return scanPolicyName;
+    }
+
+    public void setScanPolicyName(String scanPolicyName) {
+        this.scanPolicyName = scanPolicyName;
+        getConfig().setProperty(PARAM_SCAN_POLICY_NAME, scanPolicyName);
     }
 
     public String getClearedNewsItem() {

--- a/addOns/quickstart/src/main/javahelp/org/zaproxy/zap/extension/quickstart/resources/help/contents/quickstart.html
+++ b/addOns/quickstart/src/main/javahelp/org/zaproxy/zap/extension/quickstart/resources/help/contents/quickstart.html
@@ -29,6 +29,12 @@ ZAP will crawl from the URL specified but will remove a trailing slash from the 
 This is because https://example.com/test/ is treated as a leaf node internally, which would mean that ZAP would not attack
 URLs like https://example.com/test/1 etc.
 
+<H3>Scan Policy</H3>
+
+The scan policy to use when performing the active scan.
+The last chosen policy will be used by default.
+<br><br>
+
 <H3>Use traditional spider</H3>
 
 The traditional spider explores the application by finding links in HTML pages. 

--- a/addOns/quickstart/src/main/javahelp/org/zaproxy/zap/extension/quickstart/resources/help/contents/quickstart.html
+++ b/addOns/quickstart/src/main/javahelp/org/zaproxy/zap/extension/quickstart/resources/help/contents/quickstart.html
@@ -33,7 +33,6 @@ URLs like https://example.com/test/1 etc.
 
 The scan policy to use when performing the active scan.
 Note that the policies will not be shown dynamically, any added/removed policies will be missing until a restart is done.
-<br><br>
 
 <H3>Use traditional spider</H3>
 

--- a/addOns/quickstart/src/main/javahelp/org/zaproxy/zap/extension/quickstart/resources/help/contents/quickstart.html
+++ b/addOns/quickstart/src/main/javahelp/org/zaproxy/zap/extension/quickstart/resources/help/contents/quickstart.html
@@ -32,7 +32,7 @@ URLs like https://example.com/test/1 etc.
 <H3>Scan Policy</H3>
 
 The scan policy to use when performing the active scan.
-The last chosen policy will be used by default.
+Note that the policies will not be shown dynamically, any added/removed policies will be missing until a restart is done.
 <br><br>
 
 <H3>Use traditional spider</H3>

--- a/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
+++ b/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
@@ -87,6 +87,7 @@ quickstart.label.exploreurl = URL to explore:
 quickstart.label.hud = Enable HUD:
 quickstart.label.hud.warn.scope = Warning: the HUD is only enabled for URLs in scope
 quickstart.label.news = News
+quickstart.label.policy = Scan Policy:
 quickstart.label.progress = Progress:
 quickstart.label.show = Show this tab on start up:
 quickstart.label.tradspider = Use traditional spider:

--- a/addOns/quickstart/src/test/java/org/zaproxy/zap/extension/quickstart/QuickStartParamUnitTest.java
+++ b/addOns/quickstart/src/test/java/org/zaproxy/zap/extension/quickstart/QuickStartParamUnitTest.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.quickstart;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link QuickStartParam}. */
+class QuickStartParamUnitTest {
+
+    private QuickStartParam param;
+    private ZapXmlConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        param = new QuickStartParam();
+        configuration = new ZapXmlConfiguration();
+        param.load(configuration);
+    }
+
+    @Test
+    void shouldDefaultScanPolicyNameToEmpty() {
+        assertThat(param.getScanPolicyName(), is(equalTo("")));
+    }
+
+    @Test
+    void shouldSaveScanPolicyName() {
+        // Given
+        String policyName = "Test Policy";
+        // When
+        param.setScanPolicyName(policyName);
+        // Then
+        assertThat(param.getScanPolicyName(), is(equalTo(policyName)));
+    }
+
+    @Test
+    void shouldLoadScanPolicyNameFromConfig() {
+        // Given
+        configuration.setProperty("quickstart.scanPolicyName", "My Policy");
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getScanPolicyName(), is(equalTo("My Policy")));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.caching=true
+org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2g

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,1 @@
 org.gradle.caching=true
-org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
Fixes zaproxy/zaproxy#9291

Added a Scan Policy dropdown to the Quick Start Automated Scan panel.

Changes:
- AttackPanel.java: Added policy JComboBox populated from PolicyManager
- AttackThread.java: Added scanPolicyName field and passes selected policy to active scanner
- ExtensionQuickStart.java: Passes selected policy from panel to attack thread
- Messages.properties: Added quickstart.label.policy label