### PR TITLE
authhelper: limit body size for session tokens

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Do not attempt to extract session tokens from big responses, to reduce memory usage, which are more likely to represent application data rather than having session tokens.
+
 ### Fixed
 - Improve detection of finished Microsoft login.
 

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -202,6 +202,8 @@ public class AuthUtils {
 
     private static ExecutorService executorService;
 
+    private static final int MAX_LENGTH_RESPONSE_BODY = 2_000_000;
+
     private static long timeToWaitMs = TimeUnit.SECONDS.toMillis(5);
 
     @Setter
@@ -1006,27 +1008,15 @@ public class AuthUtils {
                 && StringUtils.isNotBlank(responseData)
                 && !extractJsonString(map, responseData)) {
             Map<String, SessionToken> tokens = new HashMap<>();
-            try {
-                try {
-                    AuthUtils.extractJsonTokens(JSONObject.fromObject(responseData), "", tokens);
-                } catch (JSONException e) {
-                    AuthUtils.extractJsonTokens(JSONArray.fromObject(responseData), "", tokens);
-                }
-                for (SessionToken token : tokens.values()) {
-                    String tokenLc = token.getKey().toLowerCase(Locale.ROOT);
-                    for (String id : JSON_IDS) {
-                        if (tokenLc.equals(id) || tokenLc.endsWith("." + id)) {
-                            addToMap(map, token);
-                            break;
-                        }
+            addResponseBodyTokens(msg, tokens);
+            for (SessionToken token : tokens.values()) {
+                String tokenLc = token.getKey().toLowerCase(Locale.ROOT);
+                for (String id : JSON_IDS) {
+                    if (tokenLc.equals(id) || tokenLc.endsWith("." + id)) {
+                        addToMap(map, token);
+                        break;
                     }
                 }
-            } catch (JSONException | ClassCastException e) {
-                LOGGER.debug(
-                        "Unable to parse authentication response body from {} as JSON: {} ",
-                        msg.getRequestHeader().getURI(),
-                        responseData,
-                        e);
             }
         }
         if (!map.isEmpty()) {
@@ -1099,24 +1089,7 @@ public class AuthUtils {
 
     public static Map<String, SessionToken> getAllTokens(HttpMessage msg, boolean incReqCookies) {
         Map<String, SessionToken> tokens = new HashMap<>();
-        String responseData = msg.getResponseBody().toString();
-        if (msg.getResponseHeader().isJson()
-                && StringUtils.isNotBlank(responseData)
-                && !extractJsonString(tokens, responseData)) {
-            // Extract json response data
-            try {
-                try {
-                    AuthUtils.extractJsonTokens(JSONObject.fromObject(responseData), "", tokens);
-                } catch (JSONException e) {
-                    AuthUtils.extractJsonTokens(JSONArray.fromObject(responseData), "", tokens);
-                }
-            } catch (JSONException e) {
-                LOGGER.debug(
-                        "Unable to parse authentication response body from {} as JSON: {}",
-                        msg.getRequestHeader().getURI(),
-                        responseData);
-            }
-        }
+        addResponseBodyTokens(msg, tokens);
         // Add response headers
         msg.getResponseHeader()
                 .getHeaders()
@@ -1164,6 +1137,37 @@ public class AuthUtils {
                                                 c.getValue())));
 
         return tokens;
+    }
+
+    private static void addResponseBodyTokens(HttpMessage msg, Map<String, SessionToken> tokens) {
+        if (msg.getResponseBody().length() > MAX_LENGTH_RESPONSE_BODY) {
+            LOGGER.debug(
+                    "Skipping extraction of session tokens in {} Response body deemed too big {} > {}",
+                    msg.getRequestHeader().getURI(),
+                    msg.getResponseBody().length(),
+                    MAX_LENGTH_RESPONSE_BODY);
+            return;
+        }
+
+        String responseData = msg.getResponseBody().toString();
+        if (msg.getResponseHeader().isJson()
+                && StringUtils.isNotBlank(responseData)
+                && !extractJsonString(tokens, responseData)) {
+            // Extract json response data
+            try {
+                try {
+                    AuthUtils.extractJsonTokens(JSONObject.fromObject(responseData), "", tokens);
+                } catch (JSONException e) {
+                    AuthUtils.extractJsonTokens(JSONArray.fromObject(responseData), "", tokens);
+                }
+            } catch (JSONException e) {
+                LOGGER.debug(
+                        "Unable to parse authentication response body from {} as JSON: {}",
+                        msg.getRequestHeader().getURI(),
+                        responseData,
+                        e);
+            }
+        }
     }
 
     /**

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -398,6 +398,24 @@ class AuthUtilsUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldNotExtractJsonSessionTokensFromTooLargeBody() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage(new URI("https://example.com/test", true));
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        msg.getResponseBody().setBody(getBigJsonBodyWithToken());
+
+        // When
+        Map<String, SessionToken> tokens = AuthUtils.getResponseSessionTokens(msg);
+
+        // Then
+        assertThat(tokens.size(), is(equalTo(0)));
+    }
+
+    private static String getBigJsonBodyWithToken() {
+        return "{\"accessToken\": \"%s\"}".formatted("a".repeat(2_000_000));
+    }
+
+    @Test
     void shouldExtractJsonSessionTokenInString() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage(new URI("https://example.com/test", true));
@@ -556,6 +574,23 @@ class AuthUtilsUnitTest extends TestUtils {
         assertThat(
                 tokens.get("json:wrapper1.wrapper2.array[1].att4").getValue(), is(equalTo("val7")));
         assertThat(tokens.get("header:Content-Type").getValue(), is(equalTo("application/json")));
+    }
+
+    @Test
+    void shouldNotExtractJsonTokensFromTooLargeBody() throws Exception {
+        // Given
+        HttpMessage msg =
+                new HttpMessage(
+                        new HttpRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"),
+                        new HttpRequestBody("Request Body"),
+                        new HttpResponseHeader(
+                                "HTTP/1.1 200 OK\r\n" + "Content-Type: application/json"),
+                        new HttpResponseBody(getBigJsonBodyWithToken()));
+        // When
+        Map<String, SessionToken> tokens = AuthUtils.getAllTokens(msg, false);
+
+        // Then
+        assertThat(tokens.get("json:accessToken"), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
Do not attempt to parse the body of too big responses since those are unlikely to be source of tokens, more likely application data.
Deduplicate the code that was extracting the tokens from the body.