### PR TITLE
network: Add authority key identifer to generated server certificates

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update dependencies.
+- Include the Authority Key Identifier in generated server certificates per RFC 5280 (Issue 9301).
 
 ## [0.26.0] - 2026-03-19
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
@@ -59,6 +59,7 @@ import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.DistributionPoint;
@@ -302,6 +303,10 @@ public final class CertificateUtils {
                 Extension.subjectKeyIdentifier,
                 false,
                 new SubjectKeyIdentifier(publicKey.getEncoded()));
+        certGen.addExtension(
+                Extension.authorityKeyIdentifier,
+                false,
+                new AuthorityKeyIdentifier(rootCaPublicKey.getEncoded()));
         certGen.addExtension(Extension.basicConstraints, false, new BasicConstraints(false));
         certGen.addExtension(
                 Extension.extendedKeyUsage,

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
@@ -41,6 +41,9 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
+import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -147,6 +150,33 @@ class CertificateUtilsUnitTest {
         Date certExpiredDate =
                 new Date(System.currentTimeMillis() + validity.plusDays(1L).toMillis());
         assertThat(certNotAfter.before(certExpiredDate), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldCreateServerCertificateWithAuthorityKeyIdentifier() throws Exception {
+        // Given
+        CertConfig config = new CertConfig(Duration.ofDays(60));
+        KeyStore rootCaKeyStore =
+                CertificateUtils.stringToKeystore(NetworkTestUtils.FISH_CERT_BASE64_STR);
+        X509Certificate rootCaCert = CertificateUtils.getCertificate(rootCaKeyStore);
+        PublicKey rootCaPublicKey = rootCaCert.getPublicKey();
+        PrivateKey rooCaPrivateKey = CertificateUtils.getPrivateKey(rootCaKeyStore);
+        CertData certData = new CertData("example.org");
+        // When
+        KeyStore keyStore =
+                CertificateUtils.createServerKeyStore(
+                        rootCaCert, rootCaPublicKey, rooCaPrivateKey, certData, 1L, config);
+        // Then
+        assertThat(keyStore, is(notNullValue()));
+        X509Certificate cert = CertificateUtils.getCertificate(keyStore);
+        byte[] actualExtensionValue =
+                cert.getExtensionValue(Extension.authorityKeyIdentifier.getId());
+        AuthorityKeyIdentifier actualAki =
+                AuthorityKeyIdentifier.getInstance(
+                        JcaX509ExtensionUtils.parseExtensionValue(actualExtensionValue));
+        AuthorityKeyIdentifier expectedAki =
+                new AuthorityKeyIdentifier(rootCaPublicKey.getEncoded());
+        assertThat(actualAki.getEncoded(), is(equalTo(expectedAki.getEncoded())));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/zaproxy/zaproxy/issues/9301

Added Authority Key Identifier extension to server certificates.

Changes:
- CertificateUtils.java: Added authority key identifier extension to the cert generation
- CertificateUtilsUnitTest.java: Added test to verify existence of authority key identifier extension. I wrote the extension value outright instead of importing org.bouncycastle.asn1.x509.Extension into the test file
