### PR TITLE
Use object-literal form for GraalJS Java.extend adapters

### DIFF
--- a/addOns/mcp/CHANGELOG.md
+++ b/addOns/mcp/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.0.1] - 2026-04-02
 

--- a/addOns/mcp/src/main/zapHomeFiles/scripts/templates/extender/Add MCP resource.js
+++ b/addOns/mcp/src/main/zapHomeFiles/scripts/templates/extender/Add MCP resource.js
@@ -15,7 +15,7 @@ const RESOURCE_URI = "zap://example-resource";
 const NAME = "example-resource";
 
 function newResource() {
-  return new (Java.extend(McpResource)) {
+  return new (Java.extend(McpResource))({
     getUri: function() {
       return RESOURCE_URI;
     },
@@ -37,7 +37,7 @@ function newResource() {
       content.put("timestamp", new Date().toISOString());
       return content.toString();
     }
-  };
+  });
 }
 
 /**

--- a/addOns/mcp/src/main/zapHomeFiles/scripts/templates/extender/Add MCP tool.js
+++ b/addOns/mcp/src/main/zapHomeFiles/scripts/templates/extender/Add MCP tool.js
@@ -20,7 +20,7 @@ const ArrayList = Java.type("java.util.ArrayList");
 const NAME = "example-tool";
 
 function newTool() {
-  return new (Java.extend(McpTool)) {
+  return new (Java.extend(McpTool))({
     getName: function() {
       return NAME;
     },
@@ -44,7 +44,7 @@ function newTool() {
       }
       return McpToolResult.success("Echo: " + message);
     }
-  };
+  });
 }
 
 /**

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update dependency.
 - Revised error handling for chained scripts, output is now more detailed/specific.
+- Maintenance changes.
 
 ## [45.18.0] - 2026-03-31
 ### Changed

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add api call.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add api call.js
@@ -7,7 +7,7 @@
 
 // Script variable to use when uninstalling
 var apiimpltype = Java.type("org.zaproxy.zap.extension.api.ApiImplementor");
-var apiimpl = new apiimpltype() {
+var apiimpl = new (Java.extend(apiimpltype))({
   getPrefix: function() {
     return "extenderApiExample";
   },
@@ -29,7 +29,7 @@ var apiimpl = new apiimpltype() {
       return Java.super(this).handleApiAction(name, params);
     }
   }
-};
+});
 apiimpl.addApiView(new org.zaproxy.zap.extension.api.ApiView("exampleView", ["mandParam"], ["optParam1", "optParam2"]));
 apiimpl.addApiAction(new org.zaproxy.zap.extension.api.ApiAction("exampleAction", ["mandParam"], ["optParam1", "optParam2"]));
 

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add history record menu.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add history record menu.js
@@ -6,13 +6,13 @@
 
 // Script variable to use when uninstalling
 var popupmenuitemtype = Java.extend(Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer"));
-var menuitem = new popupmenuitemtype("Example history reference menu") {
+var menuitem = new popupmenuitemtype("Example history reference menu", {
       performAction: function(href) {
         print("Example menu called with " + href.getHttpMessage().getRequestHeader().getURI().toString());
         view.showMessageDialog(
           "Example menu called with " + href.getHttpMessage().getRequestHeader().getURI().toString());
       }
-    }
+    });
 
 // View to be used in the menu item (initialised when installing the script).
 var view;

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add toolbar button.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Add toolbar button.js
@@ -25,11 +25,9 @@ function install(helper) {
     button.setIcon(org.zaproxy.zap.utils.DisplayUtils.getScaledIcon(
        new imageicon(org.zaproxy.zap.ZAP.class.getResource("/resource/icon/16/035.png"))));
     button.setToolTipText("An example button");
-    button.addActionListener(new java.awt.event.ActionListener() {
-        actionPerformed: function(event) {
-            print("Example button pressed");
-            create_window();
-        }
+    button.addActionListener(function(event) {
+      print("Example button pressed");
+      create_window();
     });
     helper.getView().addMainToolbarButton(button)
   }

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
@@ -5,7 +5,7 @@
 
 // Script variable to use when uninstalling
 var popupmenuitemtype = Java.extend(Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer"));
-var curlmenuitem = new popupmenuitemtype("Copy as curl Command") {
+var curlmenuitem = new popupmenuitemtype("Copy as curl Command", {
 	performAction: function(href) {
 		invokeWith(href.getHttpMessage());
 	},
@@ -15,7 +15,7 @@ var curlmenuitem = new popupmenuitemtype("Copy as curl Command") {
 	isSafe: function() {
 		return true;
 	}
-}
+});
 
 /**
  * This function is called when the script is enabled.


### PR DESCRIPTION
## Overview

Rhino-style new Type() { } / new (Java.extend(...)) { } is not valid JS for Prettier; pass a single parenthesized object literal instead so templates parse and behavior stays the same for GraalJS.

## Related Issues

- zaproxy/community-scripts#170
- zaproxy/zap-extensions#7312

## AI Disclosure

Cursor was used in creation of this change.
