### PR TITLE
client: centralize client map logic

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.Validate;
@@ -37,10 +36,7 @@ import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
-import org.zaproxy.addon.client.internal.ClientNode;
-import org.zaproxy.addon.client.internal.ClientSideComponent;
-import org.zaproxy.addon.client.internal.ReportedElement;
-import org.zaproxy.addon.client.internal.ReportedEvent;
+import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.api.ApiAction;
 import org.zaproxy.zap.extension.api.ApiException;
@@ -66,6 +62,7 @@ public class ClientIntegrationAPI extends ApiImplementor {
     private static final Logger LOGGER = LogManager.getLogger(ClientIntegrationAPI.class);
 
     private ExtensionClientIntegration extension;
+    private ClientMap clientMap;
 
     private String callbackUrl;
 
@@ -75,8 +72,9 @@ public class ClientIntegrationAPI extends ApiImplementor {
     private Map<WebDriver, ClientCallBackUtils> wdMap =
             Collections.synchronizedMap(new HashMap<>());
 
-    public ClientIntegrationAPI(ExtensionClientIntegration extension) {
+    public ClientIntegrationAPI(ExtensionClientIntegration extension, ClientMap clientMap) {
         this.extension = extension;
+        this.clientMap = clientMap;
 
         this.addApiAction(new ApiAction(ACTION_REPORT_OBJECT, new String[] {PARAM_OBJECT_JSON}));
         this.addApiAction(new ApiAction(ACTION_REPORT_EVENT, new String[] {PARAM_EVENT_JSON}));
@@ -102,57 +100,15 @@ public class ClientIntegrationAPI extends ApiImplementor {
         return callbackUrl;
     }
 
-    private void handleReportObject(String jsonStr) {
-        LOGGER.debug("Got object: {}", jsonStr);
-        JSONObject json = JSONObject.fromObject(jsonStr);
-        ReportedElement rnode = new ReportedElement(json);
-        if (!"A".equals(rnode.getNodeName())) {
-            // Dont add links - they flood the table
-            this.extension.addReportedObject(rnode);
-        }
-        Object url = json.get("url");
-        if (url instanceof String) {
-            String urlStr = (String) url;
-            if (!ExtensionClientIntegration.isApiUrl(urlStr)) {
-                ClientNode node = this.extension.getOrAddClientNode(urlStr, false, false);
-                ClientSideComponent component = new ClientSideComponent(json);
-                extension.addComponentToNode(node, component);
-                if (component.isStorageEvent()) {
-                    String storageUrl = node.getSite() + component.getTypeForDisplay();
-                    extension.addComponentToNode(
-                            this.extension.getOrAddClientNode(storageUrl, false, true), component);
-                }
-            }
-        } else {
-            LOGGER.debug("Not got url:(: {}", url);
-        }
-        Object href = json.get("href");
-        if (href instanceof String && ((String) href).toLowerCase(Locale.ROOT).startsWith("http")) {
-            extension.getOrAddClientNode((String) href, false, false);
-        }
-    }
-
-    private void handleReportEvent(String jsonStr) {
-        LOGGER.debug("Got event: {}", jsonStr);
-        JSONObject json = JSONObject.fromObject(jsonStr);
-        ReportedEvent event = new ReportedEvent(json);
-        if (event.getUrl() == null || !ExtensionClientIntegration.isApiUrl(event.getUrl())) {
-            this.extension.addReportedObject(event);
-            if (event.getUrl() != null) {
-                extension.setVisited(event.getUrl());
-            }
-        }
-    }
-
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
         try {
             switch (name) {
                 case ACTION_REPORT_OBJECT ->
-                        handleReportObject(this.getParam(params, PARAM_OBJECT_JSON, ""));
+                        clientMap.handleReportObject(this.getParam(params, PARAM_OBJECT_JSON, ""));
 
                 case ACTION_REPORT_EVENT ->
-                        handleReportEvent(this.getParam(params, PARAM_EVENT_JSON, ""));
+                        clientMap.handleReportEvent(this.getParam(params, PARAM_EVENT_JSON, ""));
 
                 case ACTION_REPORT_ZEST_STATEMENT ->
                         this.extension.addZestStatement(
@@ -220,10 +176,11 @@ public class ClientIntegrationAPI extends ApiImplementor {
         if (HttpRequestHeader.POST.equals(msg.getRequestHeader().getMethod())) {
             String body = msg.getRequestBody().toString();
 
+            int source = msg.getRequestHeader().getLocalAddress().getPort();
             if (body.startsWith(PARAM_OBJECT_JSON + "=")) {
-                handleReportObject(decodeParamString(body, PARAM_OBJECT_JSON));
+                clientMap.handleReportObject(decodeParamString(body, PARAM_OBJECT_JSON), source);
             } else if (body.startsWith(PARAM_EVENT_JSON)) {
-                handleReportEvent(decodeParamString(body, PARAM_EVENT_JSON));
+                clientMap.handleReportEvent(decodeParamString(body, PARAM_EVENT_JSON), source);
             } else if (body.startsWith(PARAM_STATEMENT_JSON)) {
                 try {
                     this.extension.addZestStatement(decodeParamString(body, PARAM_STATEMENT_JSON));

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -70,8 +70,6 @@ import org.zaproxy.addon.client.internal.ClientMapWriter;
 import org.zaproxy.addon.client.internal.ClientNode;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.ClientSideDetails;
-import org.zaproxy.addon.client.internal.ReportedElement;
-import org.zaproxy.addon.client.internal.ReportedEvent;
 import org.zaproxy.addon.client.internal.ReportedObject;
 import org.zaproxy.addon.client.internal.db.ClientHistoryDao;
 import org.zaproxy.addon.client.internal.db.TableJdo;
@@ -105,7 +103,6 @@ import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.selenium.ProfileManager;
@@ -186,9 +183,11 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
                                 new ClientSideDetails(
                                         Constant.messages.getString("client.tree.title"), null),
                                 this.getModel().getSession()));
+        clientTree.setReportedObjectConsumer(this::addReportedObject);
         spiderScanController =
                 new SpiderScanController(
                         this,
+                        clientTree,
                         Control.getSingleton()
                                 .getExtensionLoader()
                                 .getExtension(ExtensionCommonlib.class)
@@ -208,7 +207,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
 
-        this.api = new ClientIntegrationAPI(this);
+        this.api = new ClientIntegrationAPI(this, clientTree);
 
         extensionHook.addSessionListener(new SessionChangedListenerImpl());
         extensionHook.addOptionsParamSet(getClientParam());
@@ -532,59 +531,8 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
         }
     }
 
-    public ClientNode getOrAddClientNode(String url, boolean visited, boolean storage) {
-        return this.clientTree.getOrAddNode(url, visited, storage);
-    }
-
-    public ClientNode getClientNode(String url, boolean visited, boolean storage) {
-        return this.clientTree.getNode(url, visited, storage);
-    }
-
     public void clientNodeSelected(ClientNode node) {
         getClientDetailsPanel().setClientNode(node);
-    }
-
-    private void clientNodeChanged(ClientNode node) {
-        if (!hasView()) {
-            return;
-        }
-
-        ThreadUtils.invokeAndWaitHandled(() -> clientTree.nodeChanged(node));
-    }
-
-    public boolean addComponentToNode(ClientNode node, ClientSideComponent component) {
-        if (this.clientTree.addComponentToNode(node, component)) {
-            this.clientNodeChanged(node);
-            return true;
-        }
-        return false;
-    }
-
-    public boolean setRedirect(String originalUrl, String redirectedUrl) {
-        ClientNode node = this.clientTree.setRedirect(originalUrl, redirectedUrl);
-        if (node != null) {
-            this.clientNodeChanged(node);
-            return true;
-        }
-        return false;
-    }
-
-    public boolean setVisited(String url) {
-        ClientNode node = this.clientTree.setVisited(url);
-        if (node != null) {
-            this.clientNodeChanged(node);
-            return true;
-        }
-        return false;
-    }
-
-    public boolean setContentLoaded(String url) {
-        ClientNode node = clientTree.setContentLoaded(url);
-        if (node != null) {
-            clientNodeChanged(node);
-            return true;
-        }
-        return false;
     }
 
     public void deleteNodes(List<ClientNode> nodes) {
@@ -634,22 +582,12 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
         }
     }
 
-    public void addReportedObject(ReportedObject obj) {
-        if (obj instanceof ReportedEvent) {
-            ReportedEvent ev = (ReportedEvent) obj;
-            String url = ev.getUrl();
-            if (url != null && isApiUrl(url)) {
-                // Don't record ZAP API calls
-                return;
-            }
-        } else if (obj instanceof ReportedElement) {
-            ReportedElement rn = (ReportedElement) obj;
-            String url = rn.getUrl();
-            if (url != null && isApiUrl(url)) {
-                // Don't record ZAP API calls
-                return;
-            }
+    private void addReportedObject(ReportedObject obj) {
+        if ("A".equals(obj.getNodeName())) {
+            // Dont add links - they flood the table
+            return;
         }
+
         this.clientHistoryTableModel.addReportedObject(obj);
         ClientHistoryDao.persist(obj);
         incPscanCount();
@@ -719,10 +657,6 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
 
     public ClientZestRecorder getClientRecorderHelper() {
         return clientHandler;
-    }
-
-    protected static boolean isApiUrl(String url) {
-        return url.startsWith(API.API_URL) || url.startsWith(API.API_URL_S);
     }
 
     @Override

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMap.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMap.java
@@ -22,16 +22,22 @@ package org.zaproxy.addon.client.internal;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Consumer;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
+import net.sf.json.JSONObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.client.ClientUtils;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.eventBus.EventPublisher;
+import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.model.Target;
+import org.zaproxy.zap.utils.ThreadUtils;
 
 @SuppressWarnings("serial")
 public class ClientMap extends SortedTreeModel implements EventPublisher {
@@ -41,10 +47,12 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
     public static final String DEPTH_KEY = "depth";
     public static final String SIBLINGS_KEY = "siblings";
     public static final String URL_KEY = "url";
+    public static final String MESSAGE_UUID_KEY = "client.message.uuid";
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LogManager.getLogger(ClientMap.class);
     private ClientNode root;
+    private Consumer<ReportedObject> reportedObjectConsumer;
 
     public ClientMap(ClientNode root) {
         super(root);
@@ -159,6 +167,22 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
         return this.getClass().getCanonicalName();
     }
 
+    private void notifyNodeChanged(ClientNode node) {
+        if (!View.isInitialised()) {
+            return;
+        }
+        ThreadUtils.invokeAndWaitHandled(() -> nodeChanged(node));
+    }
+
+    public void addComponent(String url, ClientSideComponent component) {
+        ClientNode node = getOrAddNode(url, false, false);
+        addComponentToNode(node, component);
+        if (component.isStorageEvent()) {
+            String storageUrl = node.getSite() + component.getTypeForDisplay();
+            addComponentToNode(getOrAddNode(storageUrl, false, true), component);
+        }
+    }
+
     public boolean addComponentToNode(ClientNode node, ClientSideComponent component) {
         ClientSideDetails details = node.getUserObject();
         boolean wasVisited = details.isVisited();
@@ -172,6 +196,7 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
             ZAP.getEventBus()
                     .publishSyncEvent(
                             this, new Event(this, MAP_COMPONENT_ADDED_EVENT, new Target(), map));
+            notifyNodeChanged(node);
         }
         return componentAdded;
     }
@@ -193,6 +218,7 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
                                     ClientSideComponent.Type.REDIRECT,
                                     null,
                                     -1));
+            notifyNodeChanged(node);
             return node;
         }
         LOGGER.debug("setRedirect, no node for URL {}", originalUrl);
@@ -203,6 +229,7 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
         ClientNode node = getNode(url, false, false);
         if (node != null && !node.getUserObject().isVisited()) {
             node.getUserObject().setVisited(true);
+            notifyNodeChanged(node);
             return node;
         }
         LOGGER.debug("setVisited, no node for URL or already visited {}", url);
@@ -228,8 +255,64 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
                                 ClientSideComponent.Type.CONTENT_LOADED,
                                 null,
                                 -1));
-
+        notifyNodeChanged(node);
         return node;
+    }
+
+    public void setReportedObjectConsumer(Consumer<ReportedObject> consumer) {
+        this.reportedObjectConsumer = consumer;
+    }
+
+    public void handleReportObject(String jsonStr) {
+        handleReportObject(jsonStr, 0);
+    }
+
+    public void handleReportObject(String jsonStr, int source) {
+        LOGGER.debug("Got object: {}", jsonStr);
+        JSONObject json = JSONObject.fromObject(jsonStr);
+        ReportedElement rnode = new ReportedElement(json);
+        notifyReportedObjectConsumer(rnode);
+        String url = rnode.getUrl();
+        if (url != null) {
+            if (!isApiUrl(url)) {
+                addComponent(url, new ClientSideComponent(json));
+            }
+        } else {
+            LOGGER.debug("Not got url:(: {}", url);
+        }
+        String href = rnode.getHref();
+        if (href != null && href.toLowerCase(Locale.ROOT).startsWith("http")) {
+            getOrAddNode(href, false, false);
+        }
+    }
+
+    public void handleReportEvent(String jsonStr) {
+        handleReportEvent(jsonStr, 0);
+    }
+
+    public void handleReportEvent(String jsonStr, int source) {
+        LOGGER.debug("Got event: {}", jsonStr);
+        JSONObject json = JSONObject.fromObject(jsonStr);
+        ReportedEvent event = new ReportedEvent(json);
+        notifyReportedObjectConsumer(event);
+        String url = event.getUrl();
+        if (url != null && !isApiUrl(url)) {
+            setVisited(url);
+        }
+    }
+
+    private void notifyReportedObjectConsumer(ReportedObject reportObject) {
+        if (isApiUrl(reportObject.getUrl())) {
+            return;
+        }
+
+        if (reportedObjectConsumer != null) {
+            reportedObjectConsumer.accept(reportObject);
+        }
+    }
+
+    private static boolean isApiUrl(String url) {
+        return url != null && (url.startsWith(API.API_URL) || url.startsWith(API.API_URL_S));
     }
 }
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -134,6 +134,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
     private final Context context;
     private final User user;
     private ExtensionClientIntegration extClient;
+    private final ClientMap clientMap;
     private final ExtensionSelenium extSelenium;
     private final ExtensionNetwork extensionNetwork;
 
@@ -163,6 +164,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
 
     public ClientSpider(
             ExtensionClientIntegration extClient,
+            ClientMap clientMap,
             String displayName,
             String targetUrl,
             ClientOptions options,
@@ -172,6 +174,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
             boolean subtreeOnly,
             ValueProvider valueProvider) {
         this.extClient = extClient;
+        this.clientMap = clientMap;
         session = extClient.getModel().getSession();
         this.displayName = displayName;
         this.targetUrl = targetUrl;
@@ -237,15 +240,6 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
         outOfScopeResponseHeader = responseHeader;
     }
 
-    public ClientSpider(
-            ExtensionClientIntegration extClient,
-            String displayName,
-            String targetUrl,
-            ClientOptions options,
-            int id) {
-        this(extClient, displayName, targetUrl, options, id, null, null, false, null);
-    }
-
     @Override
     public void run() {
         startTime = System.currentTimeMillis();
@@ -309,7 +303,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
 
     private List<String> getUnvisitedUrls() {
         List<String> urls = new ArrayList<>();
-        ClientNode targetNode = extClient.getClientNode(targetUrl, false, false);
+        ClientNode targetNode = clientMap.getNode(targetUrl, false, false);
         if (targetUrl.endsWith("/") && targetNode != null) {
             // Start up one level as "/" will be a leaf node
             getUnvisitedUrls(targetNode.getParent(), urls);
@@ -584,7 +578,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
     }
 
     protected void setRedirect(String originalUrl, String redirectedUrl) {
-        ThreadUtils.invokeLater(() -> extClient.setRedirect(originalUrl, redirectedUrl));
+        ThreadUtils.invokeLater(() -> clientMap.setRedirect(originalUrl, redirectedUrl));
     }
 
     @Override
@@ -677,7 +671,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
 
         int contentLoaded = 0;
         for (String url : crawledUrls) {
-            if (extClient.setContentLoaded(url)) {
+            if (clientMap.setContentLoaded(url) != null) {
                 contentLoaded++;
             }
         }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/SpiderScanController.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/SpiderScanController.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
+import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ScanController;
@@ -42,6 +43,8 @@ public class SpiderScanController implements ScanController<ClientSpider> {
     private static final Logger LOGGER = LogManager.getLogger(SpiderScanController.class);
 
     private ExtensionClientIntegration extension;
+
+    private final ClientMap clientMap;
 
     private final ValueProvider valueProvider;
 
@@ -85,9 +88,13 @@ public class SpiderScanController implements ScanController<ClientSpider> {
      */
     private List<ClientSpider> clientSpiderList;
 
-    public SpiderScanController(ExtensionClientIntegration extension, ValueProvider valueProvider) {
+    public SpiderScanController(
+            ExtensionClientIntegration extension,
+            ClientMap clientMap,
+            ValueProvider valueProvider) {
         this.clientSpidersLock = new ReentrantLock();
         this.extension = extension;
+        this.clientMap = clientMap;
         this.valueProvider = valueProvider;
         this.clientSpiderMap = new HashMap<>();
         this.clientSpiderList = new ArrayList<>();
@@ -130,6 +137,7 @@ public class SpiderScanController implements ScanController<ClientSpider> {
             ClientSpider scan =
                     new ClientSpider(
                             extension,
+                            clientMap,
                             name,
                             startUri.toString(),
                             clientOptions,

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientIntegrationAPIUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientIntegrationAPIUnitTest.java
@@ -25,8 +25,13 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import java.net.InetSocketAddress;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,17 +39,22 @@ import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link ClientIntegrationAPI}. */
 class ClientIntegrationAPIUnitTest extends TestUtils {
 
+    private ExtensionClientIntegration extension;
+    private ClientMap clientMap;
     private ClientIntegrationAPI api;
 
     @BeforeEach
     void setUp() {
-        api = new ClientIntegrationAPI(null);
+        extension = mock(ExtensionClientIntegration.class);
+        clientMap = mock(ClientMap.class);
+        api = new ClientIntegrationAPI(extension, clientMap);
     }
 
     @Test
@@ -242,16 +252,87 @@ class ClientIntegrationAPIUnitTest extends TestUtils {
         assertThat(callback.closingCcbu, is(nullValue()));
     }
 
+    @Test
+    void shouldDelegateReportObject() throws Exception {
+        // Given
+        String reportedObject = "ReportedObject";
+        JSONObject params = new JSONObject();
+        params.put("objectJson", reportedObject);
+
+        // When
+        api.handleApiAction("reportObject", params);
+
+        // Then
+        verify(clientMap).handleReportObject(reportedObject);
+    }
+
+    @Test
+    void shouldDelegateReportEvent() throws Exception {
+        // Given
+        String reportedEvent = "ReportedEvent";
+        JSONObject params = new JSONObject();
+        params.put("eventJson", reportedEvent);
+
+        // When
+        api.handleApiAction("reportEvent", params);
+
+        // Then
+        verify(clientMap).handleReportEvent(reportedEvent);
+    }
+
+    @Test
+    void shouldDelegateReportObjectViaCallback() throws Exception {
+        // Given
+        String reportedObject = "ReportedObject";
+        int localPort = 1234;
+        HttpMessage msg =
+                getPostMsg(
+                        api.getCallbackUrl(),
+                        "objectJson=" + URLEncoder.encode(reportedObject, StandardCharsets.UTF_8),
+                        localPort);
+
+        // When
+        api.handleCallBack(msg);
+
+        // Then
+        verify(clientMap).handleReportObject(reportedObject, localPort);
+    }
+
+    @Test
+    void shouldDelegateReportEventViaCallback() throws Exception {
+        // Given
+        String reportedEvent = "ReportedEvent";
+        int localPort = 4321;
+        HttpMessage msg =
+                getPostMsg(
+                        api.getCallbackUrl(),
+                        "eventJson=" + URLEncoder.encode(reportedEvent, StandardCharsets.UTF_8),
+                        localPort);
+
+        // When
+        api.handleCallBack(msg);
+
+        // Then
+        verify(clientMap).handleReportEvent(reportedEvent, localPort);
+    }
+
     private static ClientCallBackUtils createClientCallBackUtils() {
         WebDriver wd = mock(WebDriver.class);
         SeleniumScriptUtils ssu = new SeleniumScriptUtils(wd, 0, "firefox", "localhost", 8080);
         return new ClientCallBackUtils(ssu, UUID.randomUUID());
     }
 
-    private HttpMessage getMsg(String method, String url) throws Exception {
+    private static HttpMessage getMsg(String method, String url) throws Exception {
         HttpMessage msg = new HttpMessage();
         URI uri = new URI(url, true);
         msg.setRequestHeader(new HttpRequestHeader(method, uri, HttpHeader.HTTP11));
+        return msg;
+    }
+
+    private static HttpMessage getPostMsg(String url, String body, int localPort) throws Exception {
+        HttpMessage msg = getMsg(HttpRequestHeader.POST, url);
+        msg.getRequestHeader().setLocalAddress(new InetSocketAddress(localPort));
+        msg.setRequestBody(body);
         return msg;
     }
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ExtensionClientIntegrationUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ExtensionClientIntegrationUnitTest.java
@@ -22,6 +22,8 @@ package org.zaproxy.addon.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -34,13 +36,12 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.quality.Strictness;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.client.spider.ClientSpider;
@@ -49,11 +50,44 @@ import org.zaproxy.addon.pscan.ExtensionPassiveScan2;
 import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.selenium.internal.FirefoxProfileManager;
+import org.zaproxy.zap.model.StandardParameterParser;
 import org.zaproxy.zap.testutils.TestUtils;
-import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 class ExtensionClientIntegrationUnitTest extends TestUtils {
+
+    private ExtensionClientIntegration extClient;
+
+    @BeforeEach
+    void setUp() {
+        extClient = new ExtensionClientIntegration();
+        mockMessages(extClient);
+
+        Model model = mock(Model.class, withSettings().strictness(Strictness.LENIENT));
+
+        Session session = mock(Session.class, withSettings().strictness(Strictness.LENIENT));
+        lenient()
+                .when(session.getUrlParamParser(any(String.class)))
+                .thenReturn(new StandardParameterParser());
+        when(model.getSession()).thenReturn(session);
+
+        ExtensionLoader extensionLoader =
+                mock(ExtensionLoader.class, withSettings().strictness(Strictness.LENIENT));
+        when(extensionLoader.getExtension(ExtensionCommonlib.class))
+                .thenReturn(mock(ExtensionCommonlib.class));
+        when(extensionLoader.getExtension(ExtensionPassiveScan2.class))
+                .thenReturn(mock(ExtensionPassiveScan2.class));
+
+        Control.initSingletonForTesting(model, extensionLoader);
+
+        extClient.init();
+        extClient.initModel(model);
+    }
+
+    @AfterEach
+    void tearDown() {
+        extClient.unload();
+    }
 
     @Test
     void shouldCreateFirefoxPrefFile() throws IOException {
@@ -70,8 +104,6 @@ class ExtensionClientIntegrationUnitTest extends TestUtils {
         Path path = Files.createTempDirectory("zap-browser-test");
         when(fpm.getOrCreateProfile(ExtensionClientIntegration.ZAP_FIREFOX_PROFILE_NAME))
                 .thenReturn(path);
-
-        ExtensionClientIntegration extClient = new ExtensionClientIntegration();
 
         // When
         extClient.postInit();
@@ -92,7 +124,6 @@ class ExtensionClientIntegrationUnitTest extends TestUtils {
                         "Path=" + Path.of("Profiles/abcd1234.zap-client-profile"));
         Path iniPath = Files.createTempFile("fx-profiles", ".ini");
         Files.write(iniPath, validProfiles, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
-        ExtensionClientIntegration extClient = new ExtensionClientIntegration();
 
         // When
         extClient.checkFirefoxProfilesFile(iniPath, Path.of("ignored"));
@@ -125,7 +156,6 @@ class ExtensionClientIntegrationUnitTest extends TestUtils {
 
         Path iniPath = Files.createTempFile("fx-profiles", ".ini");
         Files.write(iniPath, validProfiles, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
-        ExtensionClientIntegration extClient = new ExtensionClientIntegration();
 
         // When
         extClient.checkFirefoxProfilesFile(iniPath, zapProfilePath);
@@ -138,40 +168,17 @@ class ExtensionClientIntegrationUnitTest extends TestUtils {
     @Test
     void shouldStartSpider() throws IOException {
         // Given
-        Constant.messages = new I18N(Locale.ENGLISH);
-        ExtensionLoader extensionLoader =
-                mock(ExtensionLoader.class, withSettings().strictness(Strictness.LENIENT));
-        Model model = mock(Model.class);
-        Session session = mock(Session.class);
-        when(model.getSession()).thenReturn(session);
-        Control.initSingletonForTesting(model, extensionLoader);
-        when(extensionLoader.getExtension(ExtensionHistory.class))
-                .thenReturn(mock(ExtensionHistory.class));
-        when(extensionLoader.getExtension(ExtensionSelenium.class))
-                .thenReturn(mock(ExtensionSelenium.class));
-        when(extensionLoader.getExtension(ExtensionCommonlib.class))
-                .thenReturn(mock(ExtensionCommonlib.class));
-        when(extensionLoader.getExtension(ExtensionPassiveScan2.class))
-                .thenReturn(mock(ExtensionPassiveScan2.class));
-        ExtensionClientIntegration extClient = new ExtensionClientIntegration();
-        extClient.initModel(model);
-        extClient.init();
         ClientOptions options = new ClientOptions();
         options.load(new ZapXmlConfiguration());
         options.setThreadCount(1);
 
-        try {
-            // When
-            int spiderId =
-                    extClient.startScan("https://www.example.com", options, null, null, false);
-            ClientSpider spider = extClient.getScan(spiderId);
-            boolean isRunning = spider.isRunning();
-            spider.stopScan();
+        // When
+        int spiderId = extClient.startScan("https://www.example.com", options, null, null, false);
+        ClientSpider spider = extClient.getScan(spiderId);
+        boolean isRunning = spider.isRunning();
+        spider.stopScan();
 
-            // Then
-            assertEquals(true, isRunning);
-        } finally {
-            extClient.unload();
-        }
+        // Then
+        assertEquals(true, isRunning);
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
@@ -21,22 +21,65 @@ package org.zaproxy.addon.client.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.model.Session;
+import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.model.StandardParameterParser;
+import org.zaproxy.zap.testutils.TestUtils;
 
-class ClientMapUnitTest {
+class ClientMapUnitTest extends TestUtils {
+
+    private static final String REPORTED_OBJECT_JSON =
+            """
+            {
+              "tagName": "INPUT",
+              "id": "",
+              "type": "input",
+              "url": "%s",
+              "href": %s,
+              "nodeName": "INPUT",
+              "timestamp": 0
+            }""";
+
+    private static final String REPORTED_EVENT_JSON =
+            """
+            {
+              "eventName": "pageLoad",
+              "url": "%s",
+              "count": 1,
+              "id": "",
+              "tagName": "",
+              "nodeName": "",
+              "type": "",
+              "xpath": "",
+              "href": "",
+              "text": "",
+              "timestamp": 0
+            }""";
+
+    @BeforeAll
+    static void init() {
+        mockMessages(new ExtensionClientIntegration());
+    }
 
     private static final String AAA_URL = "https://aaa.com";
     private static final String BBB_URL = "https://bbb.com";
@@ -55,7 +98,7 @@ class ClientMapUnitTest {
     void setUp() {
         Session session = mock(Session.class);
         StandardParameterParser ssp = new StandardParameterParser();
-        given(session.getUrlParamParser(any(String.class))).willReturn(ssp);
+        lenient().when(session.getUrlParamParser(any(String.class))).thenReturn(ssp);
         root = new ClientNode(new ClientSideDetails("Root", ""), session);
         map = new ClientMap(root);
     }
@@ -363,5 +406,262 @@ class ClientMapUnitTest {
 
         // Then
         assertThat(node, is(nullValue()));
+    }
+
+    @Test
+    void shouldAddComponentCreatingNodeIfAbsent() {
+        // Given
+        ClientSideComponent component =
+                new ClientSideComponent(
+                        Map.of(),
+                        "A",
+                        null,
+                        BBB_URL,
+                        BBB_AAA_URL,
+                        null,
+                        ClientSideComponent.Type.LINK,
+                        null,
+                        -1);
+
+        // When
+        map.addComponent(BBB_URL, component);
+
+        // Then
+        ClientNode node = map.getNode(BBB_URL, false, false);
+        assertThat(node, is(notNullValue()));
+        assertThat(node.getUserObject().isVisited(), is(true));
+        assertThat(node.getUserObject().getComponents(), is(Set.of(component)));
+    }
+
+    @Test
+    void shouldAddComponentToExistingNode() {
+        // Given
+        ClientNode existing = map.getOrAddNode(BBB_URL, false, false);
+        ClientSideComponent component =
+                new ClientSideComponent(
+                        Map.of(),
+                        "A",
+                        null,
+                        BBB_URL,
+                        BBB_AAA_URL,
+                        null,
+                        ClientSideComponent.Type.LINK,
+                        null,
+                        -1);
+
+        // When
+        map.addComponent(BBB_URL, component);
+
+        // Then
+        assertThat(map.getNode(BBB_URL, false, false), is(existing));
+        assertThat(existing.getUserObject().getComponents(), is(Set.of(component)));
+    }
+
+    @Test
+    void shouldAddStorageComponentToStorageNode() {
+        // Given
+        ClientSideComponent component =
+                new ClientSideComponent(
+                        Map.of(),
+                        "",
+                        null,
+                        BBB_URL,
+                        null,
+                        null,
+                        ClientSideComponent.Type.LOCAL_STORAGE,
+                        null,
+                        -1);
+
+        // When
+        map.addComponent(BBB_URL, component);
+
+        // Then
+        ClientNode urlNode = map.getNode(BBB_URL, false, false);
+        assertThat(urlNode, is(notNullValue()));
+        assertThat(urlNode.getUserObject().getComponents(), is(Set.of(component)));
+        String storageUrl = urlNode.getSite() + component.getTypeForDisplay();
+        ClientNode storageNode = map.getNode(storageUrl, false, true);
+        assertThat(storageNode, is(notNullValue()));
+        assertThat(storageNode.getUserObject().getComponents(), is(Set.of(component)));
+    }
+
+    @Test
+    void shouldAddComponentToClientMapOnReportObject() {
+        // Given
+        String url = "https://www.example.com/page";
+        String json = REPORTED_OBJECT_JSON.formatted(url, null);
+
+        // When
+        map.handleReportObject(json);
+
+        // Then
+        assertThat(map.getNode(url, false, false), is(notNullValue()));
+    }
+
+    @Test
+    void shouldNotAddComponentForApiUrlOnReportObject() {
+        // Given
+        String apiUrl = "http://zap/JSON/core/view/version/";
+        String json = REPORTED_OBJECT_JSON.formatted(apiUrl, null);
+
+        // When
+        map.handleReportObject(json);
+
+        // Then
+        assertThat(map.getRoot().getChildCount(), is(0));
+    }
+
+    @Test
+    void shouldAddHrefNodeOnReportObject() {
+        // Given
+        String url = "https://www.example.com/page";
+        String href = "https://www.example.com/linked";
+        String json = REPORTED_OBJECT_JSON.formatted(url, "\"" + href + "\"");
+
+        // When
+        map.handleReportObject(json);
+
+        // Then
+        assertThat(map.getNode(href, false, false), is(notNullValue()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/relative/", "nothttp://www.example.com/"})
+    void shouldNotAddNodeForNonSupportedHrefOnReportObject(String href) {
+        // Given
+        String url = "https://www.example.com/page";
+        String json = REPORTED_OBJECT_JSON.formatted(url, "\"" + href + "\"");
+
+        // When
+        map.handleReportObject(json);
+
+        // Then
+        assertThat(root.getChildCount(), is(1));
+        assertThat(root.getChildAt(0).getChildCount(), is(1));
+    }
+
+    @Test
+    void shouldHandleReportObjectWithNoUrl() {
+        // Given
+        String json =
+                """
+                {
+                  "tagName": "INPUT",
+                  "id": "",
+                  "type": "input",
+                  "href": null,
+                  "nodeName": "INPUT",
+                  "timestamp": 0
+                }""";
+
+        // When
+        map.handleReportObject(json);
+
+        // Then
+        assertThat(map.getRoot().getChildCount(), is(0));
+    }
+
+    @Test
+    void shouldSetVisitedOnReportEvent() {
+        // Given
+        String url = "https://www.example.com/page";
+        String json = REPORTED_EVENT_JSON.formatted(url);
+
+        map.getOrAddNode(url, false, false);
+
+        // When
+        map.handleReportEvent(json);
+
+        // Then
+        assertThat(map.getNode(url, false, false).getUserObject().isVisited(), is(true));
+    }
+
+    @Test
+    void shouldNotModifyClientMapForApiUrlOnReportEvent() {
+        // Given
+        String apiUrl = "http://zap/JSON/core/view/version/";
+        String json = REPORTED_EVENT_JSON.formatted(apiUrl);
+
+        // When
+        map.handleReportEvent(json);
+
+        // Then
+        assertThat(map.getRoot().getChildCount(), is(0));
+    }
+
+    @Test
+    void shouldCallConsumerOnHandleReportObject() {
+        // Given
+        String url = "https://www.example.com/page";
+        String json = REPORTED_OBJECT_JSON.formatted(url, null);
+        Consumer<ReportedObject> consumer = mock();
+        map.setReportedObjectConsumer(consumer);
+
+        // When
+        map.handleReportObject(json);
+
+        // Then
+        verify(consumer).accept(any(ReportedElement.class));
+    }
+
+    @Test
+    void shouldNotCallConsumerForApiUrlOnHandleReportObject() {
+        // Given
+        String apiUrl = "http://zap/JSON/core/view/version/";
+        String json = REPORTED_OBJECT_JSON.formatted(apiUrl, null);
+        Consumer<ReportedObject> consumer = mock();
+        map.setReportedObjectConsumer(consumer);
+
+        // When
+        map.handleReportObject(json);
+
+        // Then
+        verify(consumer, never()).accept(any());
+    }
+
+    @Test
+    void shouldCallConsumerOnHandleReportEvent() {
+        // Given
+        String url = "https://www.example.com/page";
+        String json = REPORTED_EVENT_JSON.formatted(url);
+        map.getOrAddNode(url, false, false);
+        Consumer<ReportedObject> consumer = mock();
+        map.setReportedObjectConsumer(consumer);
+
+        // When
+        map.handleReportEvent(json);
+
+        // Then
+        verify(consumer).accept(any(ReportedEvent.class));
+    }
+
+    @Test
+    void shouldCallConsumerOnHandleReportEventWhenNodeAbsent() {
+        // Given
+        String url = "https://www.example.com/page";
+        String json = REPORTED_EVENT_JSON.formatted(url);
+        Consumer<ReportedObject> consumer = mock();
+        map.setReportedObjectConsumer(consumer);
+
+        // When
+        map.handleReportEvent(json);
+
+        // Then
+        verify(consumer).accept(any(ReportedEvent.class));
+    }
+
+    @Test
+    void shouldNotCallConsumerForApiUrlOnHandleReportEvent() {
+        // Given
+        String apiUrl = "http://zap/JSON/core/view/version/";
+        String json = REPORTED_EVENT_JSON.formatted(apiUrl);
+        Consumer<ReportedObject> consumer = mock();
+        map.setReportedObjectConsumer(consumer);
+
+        // When
+        map.handleReportEvent(json);
+
+        // Then
+        verify(consumer, never()).accept(any());
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -100,7 +100,10 @@ class ClientSpiderUnitTest extends TestUtils {
     private ExtensionClientIntegration extClient;
     private ClientOptions clientOptions;
     private ClientMap map;
+    private String seedUrl;
     private WebDriver wd;
+
+    private ClientSpider spider;
 
     @BeforeAll
     static void setUpAll() {
@@ -131,10 +134,27 @@ class ClientSpiderUnitTest extends TestUtils {
         clientOptions = new ClientOptions();
         clientOptions.load(new ZapXmlConfiguration());
         clientOptions.setThreadCount(1);
+
+        seedUrl = "https://www.example.com/";
+        spider =
+                new ClientSpider(
+                        extClient,
+                        map,
+                        "",
+                        seedUrl,
+                        clientOptions,
+                        1,
+                        null,
+                        null,
+                        false,
+                        mock(ValueProvider.class));
     }
 
     @AfterEach
     void tearDown() throws Exception {
+        if (!spider.isStopped()) {
+            spider.stopScan();
+        }
         ZAP.getEventBus().unregisterPublisher(map);
         Configurator.reconfigure(getClass().getResource("/log4j2-test.properties").toURI());
     }
@@ -142,8 +162,6 @@ class ClientSpiderUnitTest extends TestUtils {
     @Test
     void shouldRequestInScopeUrls() {
         // Given
-        ClientSpider spider =
-                new ClientSpider(extClient, "", "https://www.example.com/", clientOptions, 1);
         Options options = mock(Options.class);
         Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         when(wd.manage()).thenReturn(options);
@@ -179,8 +197,6 @@ class ClientSpiderUnitTest extends TestUtils {
     void shouldIgnoreRequestAfterStopped() throws Exception {
         // Given
         CountDownLatch cdl = new CountDownLatch(1);
-        String seedUrl = "https://www.example.com/";
-        ClientSpider spider = new ClientSpider(extClient, "", seedUrl, clientOptions, 1);
         Options options = mock(Options.class);
         Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         when(wd.manage()).thenReturn(options);
@@ -209,8 +225,6 @@ class ClientSpiderUnitTest extends TestUtils {
     @Test
     void shouldStartPauseResumeStopSpider() {
         // Given
-        ClientSpider spider =
-                new ClientSpider(extClient, "", "https://www.example.com", clientOptions, 1);
         SpiderStatus statusPostStart;
         SpiderStatus statusPostPause;
         SpiderStatus statusPostResume;
@@ -248,8 +262,6 @@ class ClientSpiderUnitTest extends TestUtils {
     void shouldIgnoreUrlsTooDeep() {
         // Given
         clientOptions.setMaxDepth(5);
-        ClientSpider spider =
-                new ClientSpider(extClient, "", "https://www.example.com/", clientOptions, 1);
         Options options = mock(Options.class);
         Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         when(wd.manage()).thenReturn(options);
@@ -295,8 +307,6 @@ class ClientSpiderUnitTest extends TestUtils {
     void shouldIgnoreUrlsTooWide() {
         // Given
         clientOptions.setMaxChildren(4);
-        ClientSpider spider =
-                new ClientSpider(extClient, "", "https://www.example.com/", clientOptions, 1);
         Options options = mock(Options.class);
         Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         when(wd.manage()).thenReturn(options);
@@ -337,25 +347,17 @@ class ClientSpiderUnitTest extends TestUtils {
     @Test
     void shouldVisitKnownUnvisitedUrls() {
         // Given
-        ClientSpider spider =
-                new ClientSpider(extClient, "", "https://www.example.com/", clientOptions, 1);
         Options options = mock(Options.class);
         Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         when(wd.manage()).thenReturn(options);
         when(options.timeouts()).thenReturn(timeouts);
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
 
-        ClientNode exampleTopNode = getClientNode("https://www.example.com", false);
-        ClientNode exampleSlashNode = getClientNode("https://www.example.com/", false);
-        ClientNode exampleTest1Node = getClientNode("https://www.example.com/test#1", false);
-        ClientNode exampleTest2Node = getClientNode("https://www.example.com/test#2", false);
-        ClientNode exampleVisitedNode = getClientNode("https://www.example.com/visited", true);
-        exampleTopNode.add(exampleSlashNode);
-        exampleTopNode.add(exampleTest1Node);
-        exampleTopNode.add(exampleTest2Node);
-        exampleTopNode.add(exampleVisitedNode);
-        when(extClient.getClientNode("https://www.example.com/", false, false))
-                .thenReturn(exampleSlashNode);
+        map.getOrAddNode("https://www.example.com", false, false);
+        map.getOrAddNode("https://www.example.com/", false, false);
+        map.getOrAddNode("https://www.example.com/test#1", false, false);
+        map.getOrAddNode("https://www.example.com/test#2", false, false);
+        map.getOrAddNode("https://www.example.com/visited", true, false);
 
         // When
         spider.run();
@@ -377,6 +379,8 @@ class ClientSpiderUnitTest extends TestUtils {
                         "https://www.example.com/",
                         "https://www.example.com",
                         "https://www.example.com/",
+                        "https://www.example.com/test",
+                        "https://www.example.com/test#",
                         "https://www.example.com/test#1",
                         "https://www.example.com/test#2"));
     }
@@ -385,8 +389,6 @@ class ClientSpiderUnitTest extends TestUtils {
     void shouldHandleComponentHrefWithoutHostname() {
         // Given
         List<String> logEvents = registerLogEvents(Level.ERROR);
-        ClientSpider spider =
-                new ClientSpider(extClient, "", "https://www.example.com/", clientOptions, 1);
         Options options = mock(Options.class);
         Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         when(wd.manage()).thenReturn(options);
@@ -436,17 +438,6 @@ class ClientSpiderUnitTest extends TestUtils {
         String logoutText = "logout";
         clientOptions.setLogoutAvoidance(logoutAvoidance);
         String url = "https://www.example.com/";
-        ClientSpider spider =
-                new ClientSpider(
-                        extClient,
-                        "",
-                        url,
-                        clientOptions,
-                        1,
-                        null,
-                        null,
-                        false,
-                        mock(ValueProvider.class));
         Options options = mock(Options.class);
         Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         when(wd.manage()).thenReturn(options);


### PR DESCRIPTION
Move the client map logic that was in the extension and the API to the client map itself to simplify the client map handling. Pass also the local port in the callback report handling to allow the map to later filter the source of the reported objects/events.