### PR TITLE
automation: address exception in active scan job

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fix exception during forced shutdown in the Active Scan job.
 
 ## [0.59.0] - 2026-04-02
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -269,8 +269,6 @@ public class ActiveScanJob extends AutomationJob {
             // Wait for the active scan to finish
             while (true) {
                 this.sleep(500);
-                scan = this.getExtAScan().getScan(scanId);
-                currentScan = scan;
                 if (scan.isStopped() || forceStop) {
                     break;
                 }
@@ -283,7 +281,7 @@ public class ActiveScanJob extends AutomationJob {
                 this.getExtAScan().stopScan(scanId);
                 progress.info(Constant.messages.getString("automation.info.jobstopped", getType()));
             }
-            progress.addJobResultData(createJobResultData(scanId));
+            progress.addJobResultData(createJobResultData(scan));
         } finally {
             currentScan = null;
         }
@@ -319,14 +317,14 @@ public class ActiveScanJob extends AutomationJob {
     public List<JobResultData> getJobResultData() {
         ActiveScan lastScan = this.getExtAScan().getLastScan();
         if (lastScan != null) {
-            return createJobResultData(lastScan.getId());
+            return createJobResultData(lastScan);
         }
         return new ArrayList<>();
     }
 
-    private List<JobResultData> createJobResultData(int scanId) {
+    private List<JobResultData> createJobResultData(ActiveScan scan) {
         List<JobResultData> list = new ArrayList<>();
-        list.add(new ActiveScanJobResultData(this.getName(), this.getExtAScan().getScan(scanId)));
+        list.add(new ActiveScanJobResultData(this.getName(), scan));
         return list;
     }
 

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -415,6 +415,8 @@ class ActiveScanJobUnitTest {
 
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(progress.hasErrors(), is(equalTo(false)));
+
+        verify(extAScan).getScan(1);
     }
 
     @Test


### PR DESCRIPTION
Prevent NPE from happening when shutting down ZAP due to high insight.