### PR TITLE
client: isolate spider's client map events

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Fixed
+- Prevent interferences between the spiders and manual actions.
 - Prevent loops when acting on elements due appended input data.
 
 ## [0.24.0] - 2026-05-07

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMap.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMap.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
@@ -53,6 +54,7 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
     private static final Logger LOGGER = LogManager.getLogger(ClientMap.class);
     private ClientNode root;
     private Consumer<ReportedObject> reportedObjectConsumer;
+    private final List<ClientMapListener> listeners = new CopyOnWriteArrayList<>();
 
     public ClientMap(ClientNode root) {
         super(root);
@@ -65,18 +67,36 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
         return root;
     }
 
+    public void addListener(ClientMapListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(ClientMapListener listener) {
+        listeners.remove(listener);
+    }
+
     public ClientNode getOrAddNode(String url, boolean visited, boolean storage) {
         LOGGER.debug("getOrAddNode {}", url);
-        return this.getNode(url, visited, storage, true, true);
+        return this.getNode(url, visited, storage, true, true, 0);
     }
 
     public ClientNode getNode(String url, boolean visited, boolean storage) {
         LOGGER.debug("getNode {}", url);
-        return this.getNode(url, visited, storage, false, false);
+        return this.getNode(url, visited, storage, false, false, 0);
     }
 
     private synchronized ClientNode getNode(
             String url, boolean visited, boolean storage, boolean add, boolean publishEvent) {
+        return getNode(url, visited, storage, add, publishEvent, 0);
+    }
+
+    private synchronized ClientNode getNode(
+            String url,
+            boolean visited,
+            boolean storage,
+            boolean add,
+            boolean publishEvent,
+            int source) {
         if (url == null) {
             throw new IllegalArgumentException("The url parameter should not be null");
         }
@@ -100,15 +120,18 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
                                     new ClientSideDetails(nodeName, url, visited, storage),
                                     storage);
                     if (!storage && publishEvent) {
+                        int depth = parent.getLevel() + 1;
+                        int siblings = parent.getChildCount() + 1;
                         Map<String, String> map = new HashMap<>();
                         map.put(URL_KEY, url);
                         // Note we haven't added the child to the parent yet
-                        map.put(DEPTH_KEY, Integer.toString(parent.getLevel() + 1));
-                        map.put(SIBLINGS_KEY, Integer.toString(parent.getChildCount() + 1));
+                        map.put(DEPTH_KEY, Integer.toString(depth));
+                        map.put(SIBLINGS_KEY, Integer.toString(siblings));
                         ZAP.getEventBus()
                                 .publishSyncEvent(
                                         this,
                                         new Event(this, MAP_NODE_ADDED_EVENT, new Target(), map));
+                        listeners.forEach(l -> l.nodeAdded(url, depth, siblings, source));
                     }
                 } else {
                     // Create intermediate node with a suitable URL
@@ -175,15 +198,24 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
     }
 
     public void addComponent(String url, ClientSideComponent component) {
-        ClientNode node = getOrAddNode(url, false, false);
-        addComponentToNode(node, component);
+        addComponent(url, component, 0);
+    }
+
+    private void addComponent(String url, ClientSideComponent component, int source) {
+        ClientNode node = getNode(url, false, false, true, true, source);
+        addComponentToNode(node, component, source);
         if (component.isStorageEvent()) {
             String storageUrl = node.getSite() + component.getTypeForDisplay();
-            addComponentToNode(getOrAddNode(storageUrl, false, true), component);
+            addComponentToNode(
+                    getNode(storageUrl, false, true, true, false, source), component, source);
         }
     }
 
     public boolean addComponentToNode(ClientNode node, ClientSideComponent component) {
+        return addComponentToNode(node, component, 0);
+    }
+
+    private boolean addComponentToNode(ClientNode node, ClientSideComponent component, int source) {
         ClientSideDetails details = node.getUserObject();
         boolean wasVisited = details.isVisited();
         boolean componentAdded = details.addComponent(component);
@@ -196,6 +228,7 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
             ZAP.getEventBus()
                     .publishSyncEvent(
                             this, new Event(this, MAP_COMPONENT_ADDED_EVENT, new Target(), map));
+            listeners.forEach(l -> l.componentAdded(map, source));
             notifyNodeChanged(node);
         }
         return componentAdded;
@@ -275,14 +308,14 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
         String url = rnode.getUrl();
         if (url != null) {
             if (!isApiUrl(url)) {
-                addComponent(url, new ClientSideComponent(json));
+                addComponent(url, new ClientSideComponent(json), source);
             }
         } else {
             LOGGER.debug("Not got url:(: {}", url);
         }
         String href = rnode.getHref();
         if (href != null && href.toLowerCase(Locale.ROOT).startsWith("http")) {
-            getOrAddNode(href, false, false);
+            getNode(href, false, false, true, true, source);
         }
     }
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMapListener.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMapListener.java
@@ -1,0 +1,46 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.internal;
+
+import java.util.Map;
+
+/** Listener notified when nodes or components are added to a {@link ClientMap}. */
+public interface ClientMapListener {
+
+    /**
+     * Called when a new node is added to the map.
+     *
+     * @param url the URL of the added node.
+     * @param depth the depth of the node in the map.
+     * @param siblings the sibling count of the node (including itself) after insertion.
+     * @param source an identifier for the source that triggered the addition, or {@code 0} if the
+     *     source is unknown.
+     */
+    void nodeAdded(String url, int depth, int siblings, int source);
+
+    /**
+     * Called when a component is added to a node in the map.
+     *
+     * @param parameters the component data parameters.
+     * @param source an identifier for the source that triggered the addition, or {@code 0} if the
+     *     source is unknown.
+     */
+    void componentAdded(Map<String, String> parameters, int source);
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -37,6 +38,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.swing.table.TableModel;
@@ -62,6 +64,7 @@ import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ClientOptions.ScopeCheck;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientMap;
+import org.zaproxy.addon.client.internal.ClientMapListener;
 import org.zaproxy.addon.client.internal.ClientNode;
 import org.zaproxy.addon.client.internal.ClientSideDetails;
 import org.zaproxy.addon.client.spider.actions.ClickElement;
@@ -74,9 +77,6 @@ import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.addon.network.server.HttpServerConfig;
 import org.zaproxy.addon.network.server.Server;
-import org.zaproxy.zap.ZAP;
-import org.zaproxy.zap.eventBus.Event;
-import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.GenericScanner2;
@@ -86,7 +86,7 @@ import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.ThreadUtils;
 
-public class ClientSpider implements EventConsumer, GenericScanner2 {
+public class ClientSpider implements GenericScanner2 {
 
     /*
      * Client Spider status - Work In Progress.
@@ -143,6 +143,8 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
 
     private List<WebDriverProcess> webDriverPool = new ArrayList<>();
     private Set<WebDriverProcess> webDriverActive = new HashSet<>();
+    private Set<Integer> proxyPorts = ConcurrentHashMap.newKeySet();
+    private ClientMapListener clientMapListener;
     private List<ClientSpiderTask> spiderTasks = new ArrayList<>();
     private List<ClientSpiderTask> pausedTasks = new ArrayList<>();
     private long startTime;
@@ -191,7 +193,8 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
         messagesTableModel = new MessagesTableModel();
         crawledUrls = Collections.synchronizedSet(new TreeSet<>());
 
-        ZAP.getEventBus().registerConsumer(this, ClientMap.class.getCanonicalName());
+        clientMapListener = new ClientMapListenerImpl();
+        clientMap.addListener(clientMapListener);
 
         extSelenium = getExtension(ExtensionSelenium.class);
         extensionNetwork = getExtension(ExtensionNetwork.class);
@@ -344,6 +347,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
                     throw new RuntimeException("Failed to create WebDriver process:", e);
                 }
             }
+            proxyPorts.add(wdp.getPort());
             this.webDriverActive.add(wdp);
         }
         return wdp;
@@ -405,54 +409,81 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
         }
     }
 
-    @Override
-    public void eventReceived(Event event) {
-        if (stopping.get() || stopped) {
-            return;
-        }
-        this.lastEventReceivedtime = System.currentTimeMillis();
-        if (maxTime > 0 && this.lastEventReceivedtime > maxTime) {
-            LOGGER.debug("Exceeded max time, stopping");
-            Stats.incCounter("stats.client.spider.event.max.time");
-            this.stopScan();
-            return;
+    private class ClientMapListenerImpl implements ClientMapListener {
+
+        private boolean shouldIgnore(
+                String url, int source, IntSupplier depthSupplier, IntSupplier childrenSupplier) {
+            if (stopping.get() || stopped || !proxyPorts.contains(source)) {
+                return true;
+            }
+
+            lastEventReceivedtime = System.currentTimeMillis();
+            if (maxTime > 0 && lastEventReceivedtime > maxTime) {
+                LOGGER.debug("Exceeded max time, stopping");
+                Stats.incCounter("stats.client.spider.event.max.time");
+                stopScan();
+                return true;
+            }
+
+            if (options.getMaxDepth() > 0) {
+                int depth = depthSupplier.getAsInt();
+                if (depth > options.getMaxDepth()) {
+                    LOGGER.debug(
+                            "Ignoring URL - too deep {} > {} : {}",
+                            depth,
+                            options.getMaxDepth(),
+                            url);
+                    Stats.incCounter("stats.client.spider.event.max.depth");
+                    return true;
+                }
+            }
+
+            if (options.getMaxChildren() > 0) {
+                int siblings = childrenSupplier.getAsInt();
+                if (siblings > options.getMaxChildren()) {
+                    LOGGER.debug(
+                            "Ignoring URL - too wide {} > {} : {}",
+                            siblings,
+                            options.getMaxChildren(),
+                            url);
+                    Stats.incCounter("stats.client.spider.event.max.children");
+                    return true;
+                }
+            }
+
+            if (!isUrlInScope(url)) {
+                Stats.incCounter("stats.client.spider.event.scope.out");
+                return true;
+            }
+
+            Stats.incCounter("stats.client.spider.event.scope.in");
+            addUriToAddedNodesModel(url);
+            return false;
         }
 
-        Map<String, String> parameters = event.getParameters();
-        String url = parameters.get(ClientMap.URL_KEY);
-        if (!isUrlInScope(url)) {
-            Stats.incCounter("stats.client.spider.event.scope.out");
-            return;
-        }
-
-        Stats.incCounter("stats.client.spider.event.scope.in");
-        addUriToAddedNodesModel(url);
-
-        if (options.getMaxDepth() > 0) {
-            int depth = Integer.parseInt(parameters.get(ClientMap.DEPTH_KEY));
-            if (depth > options.getMaxDepth()) {
-                LOGGER.debug(
-                        "Ignoring URL - too deep {} > {} : {}", depth, options.getMaxDepth(), url);
-                Stats.incCounter("stats.client.spider.event.max.depth");
+        @Override
+        public void nodeAdded(String url, int depth, int siblings, int source) {
+            if (shouldIgnore(url, source, () -> depth, () -> siblings)) {
                 return;
             }
-        }
-        if (options.getMaxChildren() > 0) {
-            int siblings = Integer.parseInt(parameters.get(ClientMap.SIBLINGS_KEY));
-            if (siblings > options.getMaxChildren()) {
-                LOGGER.debug(
-                        "Ignoring URL - too wide {} > {} : {}",
-                        siblings,
-                        options.getMaxChildren(),
-                        url);
-                Stats.incCounter("stats.client.spider.event.max.children");
-                return;
-            }
+
+            Stats.incCounter("stats.client.spider.event.url");
+            addOpenUrlTask(url, options.getPageLoadTimeInSecs());
         }
 
-        if (ClientMap.MAP_COMPONENT_ADDED_EVENT.equals(event.getEventType())) {
+        @Override
+        public void componentAdded(Map<String, String> parameters, int source) {
+            String url = parameters.get(ClientMap.URL_KEY);
+            if (shouldIgnore(
+                    url,
+                    source,
+                    () -> Integer.parseInt(parameters.get(ClientMap.DEPTH_KEY)),
+                    () -> Integer.parseInt(parameters.get(ClientMap.SIBLINGS_KEY)))) {
+                return;
+            }
+
             Stats.incCounter("stats.client.spider.event.component");
-            if (ClickElement.isSupported(this::isUrlInScope, parameters)
+            if (ClickElement.isSupported(ClientSpider.this::isUrlInScope, parameters)
                     && !(options.isLogoutAvoidance() && isLogoutElement(parameters))) {
                 Stats.incCounter("stats.client.spider.event.component.click");
                 addTask(
@@ -471,9 +502,6 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
                         Constant.messages.getString("client.spider.panel.table.action.submit"),
                         paramsToString(parameters));
             }
-        } else {
-            Stats.incCounter("stats.client.spider.event.url");
-            addOpenUrlTask(url, options.getPageLoadTimeInSecs());
         }
     }
 
@@ -606,7 +634,6 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
             this.paused = false;
         }
         finished();
-        ZAP.getEventBus().unregisterConsumer(this, ClientMap.class.getCanonicalName());
     }
 
     @Override
@@ -673,6 +700,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
             clear(webDriverActive);
         }
 
+        clientMap.removeListener(clientMapListener);
         finished = true;
 
         int contentLoaded = 0;
@@ -815,6 +843,8 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
         private WebDriver webDriver;
         private ExtensionClientIntegration extClient;
 
+        private int port;
+
         private WebDriverProcess(
                 ExtensionClientIntegration extensionClient,
                 ExtensionNetwork extensionNetwork,
@@ -830,7 +860,7 @@ public class ClientSpider implements EventConsumer, GenericScanner2 {
                                     .setHttpSender(new HttpSender(INITIATOR))
                                     .setServeZapApi(true)
                                     .build());
-            int port = proxy.start(Server.ANY_PORT);
+            port = proxy.start(Server.ANY_PORT);
 
             webDriver =
                     extensionSelenium.getWebDriver(

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
@@ -23,13 +23,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +44,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.zap.ZAP;
@@ -92,6 +97,8 @@ class ClientMapUnitTest extends TestUtils {
     private static final String BBB_DDD_URL = "https://bbb.com/ddd";
 
     private ClientNode root;
+    private ClientMapListener listener;
+
     ClientMap map;
 
     @BeforeEach
@@ -101,6 +108,8 @@ class ClientMapUnitTest extends TestUtils {
         lenient().when(session.getUrlParamParser(any(String.class))).thenReturn(ssp);
         root = new ClientNode(new ClientSideDetails("Root", ""), session);
         map = new ClientMap(root);
+        listener = mock(ClientMapListener.class);
+        map.addListener(listener);
     }
 
     @AfterEach
@@ -173,6 +182,57 @@ class ClientMapUnitTest extends TestUtils {
         assertThat(root.getChildAt(1).getChildAt(0).getUserObject().getName(), is("aaa"));
         assertThat(
                 root.getChildAt(1).getChildAt(0).getUserObject().getUrl(), is(BBB_AAA_URL + "/"));
+
+        InOrder inOrder = inOrder(listener);
+
+        inOrder.verify(listener).nodeAdded(CCC_URL + "/", 2, 1, 0);
+        inOrder.verify(listener).nodeAdded(BBB_DDD_URL + "/", 3, 1, 0);
+        inOrder.verify(listener).nodeAdded(DDD_URL + "/", 2, 1, 0);
+        inOrder.verify(listener).nodeAdded(BBB_CCC_URL + "/", 3, 1, 0);
+        inOrder.verify(listener).nodeAdded(AAA_URL + "/", 2, 1, 0);
+        inOrder.verify(listener).nodeAdded(BBB_BBB_URL + "/", 3, 1, 0);
+        inOrder.verify(listener).nodeAdded(BBB_AAA_URL + "/", 3, 1, 0);
+    }
+
+    @Test
+    void shouldNotifyAllListenersOnNodeAdded() {
+        // Given
+        ClientMapListener otherListener = mock(ClientMapListener.class);
+        map.addListener(otherListener);
+
+        // When
+        map.getOrAddNode(AAA_URL, false, false);
+
+        // Then
+        verify(listener).nodeAdded(AAA_URL, 1, 1, 0);
+        verify(otherListener).nodeAdded(AAA_URL, 1, 1, 0);
+    }
+
+    @Test
+    void shouldNotifyListenerOnceForSameNode() {
+        // Given
+        map.getOrAddNode(AAA_URL, false, false);
+        ClientMapListener otherListener = mock(ClientMapListener.class);
+        map.addListener(otherListener);
+
+        // When
+        map.getOrAddNode(AAA_URL, false, false);
+
+        // Then
+        verify(listener).nodeAdded(AAA_URL, 1, 1, 0);
+        verifyNoInteractions(otherListener);
+    }
+
+    @Test
+    void shouldNotNotifyRemovedListener() {
+        // Given
+        map.removeListener(listener);
+
+        // When
+        map.getOrAddNode(AAA_URL, false, false);
+
+        // Then
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -431,6 +491,8 @@ class ClientMapUnitTest extends TestUtils {
         assertThat(node, is(notNullValue()));
         assertThat(node.getUserObject().isVisited(), is(true));
         assertThat(node.getUserObject().getComponents(), is(Set.of(component)));
+        verify(listener).nodeAdded(BBB_URL, 1, 1, 0);
+        verify(listener).componentAdded(Map.of("siblings", "0", "depth", "1"), 0);
     }
 
     @Test
@@ -455,6 +517,8 @@ class ClientMapUnitTest extends TestUtils {
         // Then
         assertThat(map.getNode(BBB_URL, false, false), is(existing));
         assertThat(existing.getUserObject().getComponents(), is(Set.of(component)));
+        verify(listener).nodeAdded(BBB_URL, 1, 1, 0);
+        verify(listener).componentAdded(Map.of("siblings", "0", "depth", "1"), 0);
     }
 
     @Test
@@ -479,10 +543,12 @@ class ClientMapUnitTest extends TestUtils {
         ClientNode urlNode = map.getNode(BBB_URL, false, false);
         assertThat(urlNode, is(notNullValue()));
         assertThat(urlNode.getUserObject().getComponents(), is(Set.of(component)));
+        verify(listener).nodeAdded(BBB_URL, 1, 1, 0);
         String storageUrl = urlNode.getSite() + component.getTypeForDisplay();
         ClientNode storageNode = map.getNode(storageUrl, false, true);
         assertThat(storageNode, is(notNullValue()));
         assertThat(storageNode.getUserObject().getComponents(), is(Set.of(component)));
+        verify(listener, times(2)).componentAdded(Map.of("siblings", "0", "depth", "1"), 0);
     }
 
     @Test
@@ -496,6 +562,47 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         assertThat(map.getNode(url, false, false), is(notNullValue()));
+        verify(listener).nodeAdded(url, 2, 1, 0);
+        verify(listener)
+                .componentAdded(
+                        Map.of(
+                                "nodeName", "INPUT",
+                                "siblings", "0",
+                                "depth", "2",
+                                "id", "",
+                                "href", "null",
+                                "tagName", "INPUT",
+                                "type", "input",
+                                "url", url,
+                                "timestamp", "0"),
+                        0);
+    }
+
+    @Test
+    void shouldNotifyListenerWithCorrectSourceOnReportObject() {
+        // Given
+        String url = "https://www.example.com/page";
+        String json = REPORTED_OBJECT_JSON.formatted(url, null);
+
+        // When
+        map.handleReportObject(json, 42);
+
+        // Then
+        assertThat(map.getNode(url, false, false), is(notNullValue()));
+        verify(listener).nodeAdded(url, 2, 1, 42);
+        verify(listener)
+                .componentAdded(
+                        Map.of(
+                                "nodeName", "INPUT",
+                                "siblings", "0",
+                                "depth", "2",
+                                "id", "",
+                                "href", "null",
+                                "tagName", "INPUT",
+                                "type", "input",
+                                "url", url,
+                                "timestamp", "0"),
+                        42);
     }
 
     @Test
@@ -509,6 +616,7 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         assertThat(map.getRoot().getChildCount(), is(0));
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -523,6 +631,50 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         assertThat(map.getNode(href, false, false), is(notNullValue()));
+        verify(listener).nodeAdded(url, 2, 1, 0);
+        verify(listener).nodeAdded(href, 2, 2, 0);
+        verify(listener)
+                .componentAdded(
+                        Map.of(
+                                "nodeName", "INPUT",
+                                "siblings", "0",
+                                "depth", "2",
+                                "id", "",
+                                "href", href,
+                                "tagName", "INPUT",
+                                "type", "input",
+                                "url", url,
+                                "timestamp", "0"),
+                        0);
+    }
+
+    @Test
+    void shouldNotifyListenerWithCorrectSourceOnNodeAddedViaHref() {
+        // Given
+        String url = "https://www.example.com/page";
+        String href = "https://www.example.com/linked";
+        String json = REPORTED_OBJECT_JSON.formatted(url, "\"" + href + "\"");
+
+        // When
+        map.handleReportObject(json, 42);
+
+        // Then
+        assertThat(map.getNode(href, false, false), is(notNullValue()));
+        verify(listener).nodeAdded(url, 2, 1, 42);
+        verify(listener).nodeAdded(href, 2, 2, 42);
+        verify(listener)
+                .componentAdded(
+                        Map.of(
+                                "nodeName", "INPUT",
+                                "siblings", "0",
+                                "depth", "2",
+                                "id", "",
+                                "href", href,
+                                "tagName", "INPUT",
+                                "type", "input",
+                                "url", url,
+                                "timestamp", "0"),
+                        42);
     }
 
     @ParameterizedTest
@@ -538,6 +690,7 @@ class ClientMapUnitTest extends TestUtils {
         // Then
         assertThat(root.getChildCount(), is(1));
         assertThat(root.getChildAt(0).getChildCount(), is(1));
+        verify(listener).nodeAdded(url, 2, 1, 0);
     }
 
     @Test
@@ -559,6 +712,7 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         assertThat(map.getRoot().getChildCount(), is(0));
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -574,6 +728,7 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         assertThat(map.getNode(url, false, false).getUserObject().isVisited(), is(true));
+        verify(listener).nodeAdded(url, 2, 1, 0);
     }
 
     @Test
@@ -587,6 +742,7 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         assertThat(map.getRoot().getChildCount(), is(0));
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -602,6 +758,46 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         verify(consumer).accept(any(ReportedElement.class));
+        verify(listener).nodeAdded(url, 2, 1, 0);
+        verify(listener)
+                .componentAdded(
+                        Map.of(
+                                "nodeName", "INPUT",
+                                "siblings", "0",
+                                "depth", "2",
+                                "id", "",
+                                "href", "null",
+                                "tagName", "INPUT",
+                                "type", "input",
+                                "url", url,
+                                "timestamp", "0"),
+                        0);
+    }
+
+    @Test
+    void shouldNotifyListenerWithCorrectSourceOnComponentAdded() {
+        // Given
+        String url = "https://www.example.com/page";
+        String json = REPORTED_OBJECT_JSON.formatted(url, null);
+
+        // When
+        map.handleReportObject(json, 42);
+
+        // Then
+        verify(listener).nodeAdded(url, 2, 1, 42);
+        verify(listener)
+                .componentAdded(
+                        Map.of(
+                                "nodeName", "INPUT",
+                                "siblings", "0",
+                                "depth", "2",
+                                "id", "",
+                                "href", "null",
+                                "tagName", "INPUT",
+                                "type", "input",
+                                "url", url,
+                                "timestamp", "0"),
+                        42);
     }
 
     @Test
@@ -617,6 +813,7 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         verify(consumer, never()).accept(any());
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -633,6 +830,7 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         verify(consumer).accept(any(ReportedEvent.class));
+        verify(listener).nodeAdded(url, 2, 1, 0);
     }
 
     @Test
@@ -648,6 +846,7 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         verify(consumer).accept(any(ReportedEvent.class));
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -663,5 +862,42 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         verify(consumer, never()).accept(any());
+        verifyNoInteractions(listener);
+    }
+
+    @Test
+    void shouldNotThrowWhenChangingListenersDuringNotification() {
+        // Given
+        ClientMapListener changingListener =
+                new ClientMapListener() {
+                    @Override
+                    public void nodeAdded(String url, int depth, int siblings, int source) {
+                        map.removeListener(listener);
+                    }
+
+                    @Override
+                    public void componentAdded(Map<String, String> parameters, int source) {
+                        map.addListener(mock(ClientMapListener.class));
+                    }
+                };
+        ClientSideComponent component =
+                new ClientSideComponent(
+                        Map.of(),
+                        "A",
+                        null,
+                        AAA_URL,
+                        BBB_URL,
+                        null,
+                        ClientSideComponent.Type.LINK,
+                        null,
+                        -1);
+        map.addListener(changingListener);
+
+        // When / Then
+        assertDoesNotThrow(
+                () -> {
+                    map.getOrAddNode(AAA_URL, false, false);
+                    map.addComponent(AAA_URL, component);
+                });
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -20,14 +20,9 @@
 package org.zaproxy.addon.client.spider;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -72,7 +67,7 @@ import org.mockito.verification.VerificationMode;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriver.Options;
-import org.openqa.selenium.WebDriver.Timeouts;
+import org.openqa.selenium.WebElement;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
@@ -81,26 +76,28 @@ import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientMap;
+import org.zaproxy.addon.client.internal.ClientMapListener;
 import org.zaproxy.addon.client.internal.ClientNode;
-import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.ClientSideDetails;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.network.server.HttpServerConfig;
 import org.zaproxy.addon.network.server.Server;
-import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 class ClientSpiderUnitTest extends TestUtils {
 
-    private ExtensionSelenium extSel;
-    private ExtensionHistory history;
-    private ExtensionClientIntegration extClient;
+    private static final int PROXY_PORT = 8080;
+
+    private List<String> logEvents;
+
     private ClientOptions clientOptions;
+    private ClientMapListener mapListener;
     private ClientMap map;
     private String seedUrl;
+    private CountDownLatch proxyCdl;
     private WebDriver wd;
 
     private ClientSpider spider;
@@ -111,29 +108,54 @@ class ClientSpiderUnitTest extends TestUtils {
     }
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
+        logEvents = registerLogEvents(Level.ERROR);
+
         Model model = mock(Model.class);
         ExtensionLoader extensionLoader = mock(ExtensionLoader.class);
         Control.initSingletonForTesting(model, extensionLoader);
-        extClient = mock(ExtensionClientIntegration.class);
-        extSel = mock(ExtensionSelenium.class, withSettings().strictness(Strictness.LENIENT));
-        history = mock(ExtensionHistory.class);
+        ExtensionClientIntegration extClient = mock(ExtensionClientIntegration.class);
+        ExtensionSelenium extSel =
+                mock(ExtensionSelenium.class, withSettings().strictness(Strictness.LENIENT));
+        ExtensionHistory history = mock(ExtensionHistory.class);
         when(extensionLoader.getExtension(ExtensionHistory.class)).thenReturn(history);
         when(extensionLoader.getExtension(ExtensionSelenium.class)).thenReturn(extSel);
         ExtensionNetwork network =
                 mock(ExtensionNetwork.class, withSettings().strictness(Strictness.LENIENT));
         when(extensionLoader.getExtension(ExtensionNetwork.class)).thenReturn(network);
-        given(network.createHttpServer(any(HttpServerConfig.class))).willReturn(mock(Server.class));
-        wd = mock(WebDriver.class);
+        Server serverMock = mock(Server.class, withSettings().strictness(Strictness.LENIENT));
+        proxyCdl = new CountDownLatch(1);
+        given(serverMock.start(anyInt())).willReturn(PROXY_PORT);
+        given(network.createHttpServer(any(HttpServerConfig.class))).willReturn(serverMock);
+
+        wd = mock(withSettings().strictness(Strictness.LENIENT));
+        given(wd.findElement(any())).willReturn(mock(WebElement.class));
+        Options options = mock(withSettings().strictness(Strictness.LENIENT));
+        doAnswer(
+                        answer -> {
+                            proxyCdl.countDown();
+                            return null;
+                        })
+                .when(wd)
+                .get(any());
+        when(wd.manage()).thenReturn(options);
+        when(options.timeouts())
+                .thenReturn(
+                        mock(
+                                withSettings()
+                                        .defaultAnswer(CALLS_REAL_METHODS)
+                                        .strictness(Strictness.LENIENT)));
+
         when(extSel.getWebDriver(anyInt(), any(String.class), any(String.class), anyInt()))
                 .thenReturn(wd);
         given(extClient.getModel()).willReturn(model);
         Session session = mock(Session.class);
         given(model.getSession()).willReturn(session);
-        map = new ClientMap(new ClientNode(new ClientSideDetails("Root", ""), session));
+        map = mock();
         clientOptions = new ClientOptions();
         clientOptions.load(new ZapXmlConfiguration());
         clientOptions.setThreadCount(1);
+        clientOptions.setShutdownTimeInSecs(10);
 
         seedUrl = "https://www.example.com/";
         spider =
@@ -152,55 +174,63 @@ class ClientSpiderUnitTest extends TestUtils {
 
     @AfterEach
     void tearDown() throws Exception {
-        if (!spider.isStopped()) {
-            spider.stopScan();
-        }
-        ZAP.getEventBus().unregisterPublisher(map);
+        assertThat(logEvents, is(empty()));
+
         Configurator.reconfigure(getClass().getResource("/log4j2-test.properties").toURI());
+    }
+
+    @Test
+    void shouldAddListenerToClientMapOnCreation() {
+        verify(map).addListener(any(ClientMapListener.class));
+    }
+
+    @Test
+    void shouldRemoveListenerFromClientMapWhenFinished() {
+        // Given
+        clientMapListener();
+
+        // When
+        spider.run();
+        spider.stopScan();
+
+        // Then
+        verify(map).removeListener(clientMapListener());
+    }
+
+    private ClientMapListener clientMapListener() {
+        if (mapListener == null) {
+            ArgumentCaptor<ClientMapListener> captor = ArgumentCaptor.captor();
+            verify(map).addListener(captor.capture());
+            mapListener = captor.getValue();
+        }
+        return mapListener;
     }
 
     @Test
     void shouldRequestInScopeUrls() {
         // Given
-        Options options = mock(Options.class);
-        Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        when(wd.manage()).thenReturn(options);
-        when(options.timeouts()).thenReturn(timeouts);
-        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        spider.run();
+        waitForProxy();
 
         // When
-        spider.run();
-        map.getOrAddNode("https://www.example.com/test#1", false, false);
+        clientMapListener().nodeAdded("https://www.example.com/test", 0, 0, PROXY_PORT);
         // Note the ".org" - this should not be requested
-        map.getOrAddNode("https://www.example.org/test#2", false, false);
-        map.getOrAddNode("https://www.example.com/test#3", false, false);
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            // Ignore
-        }
-        spider.stopScan();
+        clientMapListener().nodeAdded("https://www.example.org/test", 0, 0, PROXY_PORT);
+        sleep();
 
         // Then
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         verify(wd, atLeastOnce()).get(argument.capture());
 
-        List<String> values = argument.getAllValues();
         assertThat(
-                values,
-                contains(
-                        "https://www.example.com/",
-                        "https://www.example.com/test#1",
-                        "https://www.example.com/test#3"));
+                argument.getAllValues(),
+                contains("https://www.example.com/", "https://www.example.com/test"));
     }
 
     @Test
     void shouldIgnoreRequestAfterStopped() throws Exception {
         // Given
         CountDownLatch cdl = new CountDownLatch(1);
-        Options options = mock(Options.class);
-        Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        when(wd.manage()).thenReturn(options);
-        when(options.timeouts()).thenReturn(timeouts);
         String urlAfterStop = "https://www.example.com/test#1";
         doAnswer(
                         invocation -> {
@@ -259,124 +289,139 @@ class ClientSpiderUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldIgnoreUrlsNotFromProxy() {
+        // Given
+        spider.run();
+        waitForProxy();
+
+        // When
+        clientMapListener().nodeAdded("https://www.example.com/notfromproxy", 0, 0, 1234);
+        sleep();
+
+        // Then
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        verify(wd, atLeastOnce()).get(argument.capture());
+
+        assertThat(argument.getAllValues(), contains(seedUrl));
+    }
+
+    @Test
     void shouldIgnoreUrlsTooDeep() {
         // Given
         clientOptions.setMaxDepth(5);
-        Options options = mock(Options.class);
-        Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        when(wd.manage()).thenReturn(options);
-        when(options.timeouts()).thenReturn(timeouts);
-        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        spider.run();
+        waitForProxy();
 
         // When
-        spider.run();
-        map.getOrAddNode("https://www.example.com/l1", false, false);
-        map.getOrAddNode("https://www.example.com/l1/l2", false, false);
-        map.getOrAddNode("https://www.example.com/l1/l2/l3", false, false);
-        map.getOrAddNode("https://www.example.com/l1/l2/l3/l4", false, false);
-        map.getOrAddNode("https://www.example.com/l1/l2/l3/l4/l5", false, false);
-        map.getOrAddNode("https://www.example.com/l1/l2/l3/l4/l5/l6", false, false);
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            // Ignore
-        }
-        spider.stopScan();
-        ClientNode l6Node = map.getNode("https://www.example.com/l1/l2/l3/l4/l5/l6", false, false);
+        clientMapListener().nodeAdded("https://www.example.com/l1", 2, 0, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l1/l2", 3, 0, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l1/l2/l3", 4, 0, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l1/l2/l3/l4", 5, 0, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l1/l2/l3/l4/l5", 6, 0, PROXY_PORT);
+        clientMapListener()
+                .nodeAdded("https://www.example.com/l1/l2/l3/l4/l5/l6", 7, 0, PROXY_PORT);
+        sleep();
 
         // Then
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         verify(wd, atLeastOnce()).get(argument.capture());
 
-        List<String> values = argument.getAllValues();
         assertThat(
-                values,
-                allOf(
-                        hasItems(
-                                "https://www.example.com/",
-                                "https://www.example.com/l1",
-                                "https://www.example.com/l1/l2",
-                                "https://www.example.com/l1/l2/l3",
-                                "https://www.example.com/l1/l2/l3/l4"),
-                        not(hasItem("https://www.example.com/l1/l2/l3/l4/l5")),
-                        not(hasItem("https://www.example.com/l1/l2/l3/l4/l5/l6"))));
-
-        assertThat(l6Node, is(notNullValue()));
+                argument.getAllValues(),
+                contains(
+                        seedUrl,
+                        "https://www.example.com/l1",
+                        "https://www.example.com/l1/l2",
+                        "https://www.example.com/l1/l2/l3",
+                        "https://www.example.com/l1/l2/l3/l4"));
     }
 
     @Test
     void shouldIgnoreUrlsTooWide() {
         // Given
         clientOptions.setMaxChildren(4);
-        Options options = mock(Options.class);
-        Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        when(wd.manage()).thenReturn(options);
-        when(options.timeouts()).thenReturn(timeouts);
-        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        spider.run();
+        waitForProxy();
 
         // When
-        spider.run();
-        map.getOrAddNode("https://www.example.com/l1", false, false);
-        map.getOrAddNode("https://www.example.com/l2", false, false);
-        map.getOrAddNode("https://www.example.com/l3", false, false);
-        map.getOrAddNode("https://www.example.com/l4", false, false);
-        map.getOrAddNode("https://www.example.com/l5", false, false);
-        map.getOrAddNode("https://www.example.com/l6", false, false);
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            // Ignore
-        }
-        spider.stopScan();
-        ClientNode l6Node = map.getNode("https://www.example.com/l6", false, false);
+        clientMapListener().nodeAdded("https://www.example.com/l1", 0, 1, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l2", 0, 2, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l3", 0, 3, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l4", 0, 4, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l5", 0, 5, PROXY_PORT);
+        clientMapListener().nodeAdded("https://www.example.com/l6", 0, 6, PROXY_PORT);
+        sleep();
 
         // Then
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         verify(wd, atLeastOnce()).get(argument.capture());
 
-        List<String> values = argument.getAllValues();
         assertThat(
-                values,
+                argument.getAllValues(),
                 contains(
-                        "https://www.example.com/",
+                        seedUrl,
                         "https://www.example.com/l1",
                         "https://www.example.com/l2",
                         "https://www.example.com/l3",
                         "https://www.example.com/l4"));
-        assertThat(l6Node, is(notNullValue()));
     }
 
     @Test
     void shouldVisitKnownUnvisitedUrls() {
         // Given
-        Options options = mock(Options.class);
-        Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        when(wd.manage()).thenReturn(options);
-        when(options.timeouts()).thenReturn(timeouts);
-        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        ClientNode seedNode = mockClientNode(seedUrl, false, false, false);
+        given(map.getNode(seedUrl, false, false)).willReturn(seedNode);
 
-        map.getOrAddNode("https://www.example.com", false, false);
-        map.getOrAddNode("https://www.example.com/", false, false);
-        map.getOrAddNode("https://www.example.com/test#1", false, false);
-        map.getOrAddNode("https://www.example.com/test#2", false, false);
-        map.getOrAddNode("https://www.example.com/visited", true, false);
+        ClientNode mainNode = mockClientNode("https://www.example.com", false, false, false);
+        given(seedNode.getParent()).willReturn(mainNode);
+        int childCount = -1;
+        mockChild(mainNode, ++childCount, seedNode);
+        mockChild(
+                mainNode,
+                ++childCount,
+                mockClientNode("https://www.example.com/test", false, false, false));
+        mockChild(
+                mainNode,
+                ++childCount,
+                mockClientNode("https://www.example.com/test#", false, false, false));
+        mockChild(
+                mainNode,
+                ++childCount,
+                mockClientNode("https://www.example.com/test#1", false, false, false));
+        mockChild(
+                mainNode,
+                ++childCount,
+                mockClientNode("https://www.example.com/test#2", false, false, false));
+        mockChild(
+                mainNode,
+                ++childCount,
+                mockClientNode("https://www.example.com/visited", false, true, false));
+        mockChild(
+                mainNode,
+                ++childCount,
+                mockClientNode("https://www.example.com/loaded", false, false, true));
+        mockChild(
+                mainNode,
+                ++childCount,
+                mockClientNode("https://www.example.com/storage", true, false, false));
+        mockChild(
+                mainNode,
+                ++childCount,
+                mockClientNode("https://www.example.org/outofscope", false, false, false));
+        given(mainNode.getChildCount()).willReturn(childCount + 1);
 
         // When
         spider.run();
-
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            // Ignore
-        }
-        spider.stopScan();
+        sleep();
 
         // Then
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
         verify(wd, atLeastOnce()).get(argument.capture());
 
-        List<String> values = argument.getAllValues();
         assertThat(
-                values,
+                argument.getAllValues(),
                 contains(
-                        "https://www.example.com/",
+                        seedUrl,
                         "https://www.example.com",
                         "https://www.example.com/",
                         "https://www.example.com/test",
@@ -386,44 +431,85 @@ class ClientSpiderUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldHandleComponentAdded() {
+        // Given
+        spider.run();
+        waitForProxy();
+
+        // When
+        clientMapListener()
+                .componentAdded(
+                        Map.of(
+                                ClientMap.URL_KEY,
+                                seedUrl,
+                                "tagName",
+                                "A",
+                                "text",
+                                "Click",
+                                "depth",
+                                "1"),
+                        PROXY_PORT);
+        sleep();
+
+        // Then
+        verify(wd).findElement(By.xpath("//A[contains(text(), 'Click')]"));
+    }
+
+    @Test
+    void shouldNotHandleComponentAddedIfNotFromProxy() {
+        // Given
+        spider.run();
+        waitForProxy();
+
+        // When
+        clientMapListener()
+                .componentAdded(
+                        Map.of(
+                                ClientMap.URL_KEY,
+                                seedUrl,
+                                "tagName",
+                                "A",
+                                "text",
+                                "Click",
+                                "depth",
+                                "1"),
+                        1234);
+        sleep();
+
+        // Then
+        verify(wd, never()).findElement(any());
+    }
+
+    @Test
     void shouldHandleComponentHrefWithoutHostname() {
         // Given
-        List<String> logEvents = registerLogEvents(Level.ERROR);
-        Options options = mock(Options.class);
-        Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        when(wd.manage()).thenReturn(options);
-        when(options.timeouts()).thenReturn(timeouts);
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
 
         spider.run();
+        waitForProxy();
         String url = "https://www.example.com/new";
-        ClientNode node = map.getOrAddNode(url, false, false);
+        clientMapListener().nodeAdded(url, 0, 1, PROXY_PORT);
+
         // When
-        map.addComponentToNode(
-                node,
-                new ClientSideComponent(
-                        Map.of(ClientMap.URL_KEY, url, "tagName", "area", "href", "#"),
-                        "area",
-                        null,
-                        url,
-                        "#",
-                        null,
-                        ClientSideComponent.Type.LINK,
-                        null,
-                        -1));
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            // Ignore
-        }
-        spider.stopScan();
+        clientMapListener()
+                .componentAdded(
+                        Map.of(
+                                ClientMap.URL_KEY,
+                                url,
+                                "tagName",
+                                "area",
+                                "href",
+                                "#",
+                                "depth",
+                                "1"),
+                        PROXY_PORT);
+        sleep();
 
         // Then
         verify(wd, atLeastOnce()).get(argument.capture());
 
         List<String> values = argument.getAllValues();
-        assertThat(values, contains("https://www.example.com/", "https://www.example.com/new"));
-        assertThat(logEvents, is(empty()));
+        assertThat(values, contains(seedUrl, "https://www.example.com/new"));
     }
 
     static Stream<Arguments> logoutAvoidanceArgs() {
@@ -438,39 +524,27 @@ class ClientSpiderUnitTest extends TestUtils {
         String logoutText = "logout";
         clientOptions.setLogoutAvoidance(logoutAvoidance);
         String url = "https://www.example.com/";
-        Options options = mock(Options.class);
-        Timeouts timeouts = mock(Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        when(wd.manage()).thenReturn(options);
-        when(options.timeouts()).thenReturn(timeouts);
+
+        spider.run();
+        waitForProxy();
 
         // When
-        spider.run();
-        ClientNode node = map.getOrAddNode(url, false, false);
-        map.addComponentToNode(
-                node,
-                new ClientSideComponent(
-                        Map.of(ClientMap.URL_KEY, url, "tagName", "A", "text", logoutText),
-                        "A",
-                        null,
-                        url,
-                        null,
-                        logoutText,
-                        ClientSideComponent.Type.LINK,
-                        null,
-                        -1));
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            // Ignore
-        }
-        spider.stopScan();
+        clientMapListener()
+                .componentAdded(
+                        Map.of(
+                                ClientMap.URL_KEY,
+                                url,
+                                "tagName",
+                                "A",
+                                "text",
+                                logoutText,
+                                "depth",
+                                "1"),
+                        PROXY_PORT);
+        sleep();
 
         // Then
         verify(wd, mode).findElement(By.xpath("//A[contains(text(), 'logout')]"));
-    }
-
-    private static ClientNode getClientNode(String url, boolean visited) {
-        return new ClientNode(new ClientSideDetails(url, url, visited, false), false);
     }
 
     class SpiderStatus {
@@ -494,6 +568,44 @@ class ClientSpiderUnitTest extends TestUtils {
 
         public boolean isStopped() {
             return stopped;
+        }
+    }
+
+    private static ClientNode mockClientNode(
+            String url, boolean storage, boolean visited, boolean contentLoaded) {
+        ClientNode node = mock(withSettings().strictness(Strictness.LENIENT));
+        given(node.isStorage()).willReturn(storage);
+
+        ClientSideDetails details = mock(withSettings().strictness(Strictness.LENIENT));
+        given(node.getUserObject()).willReturn(details);
+
+        given(details.getUrl()).willReturn(url);
+        given(details.isStorage()).willReturn(storage);
+        given(details.isVisited()).willReturn(visited);
+        given(details.isContentLoaded()).willReturn(contentLoaded);
+
+        return node;
+    }
+
+    private static void mockChild(ClientNode parent, int index, ClientNode child) {
+        given(parent.getChildAt(index)).willReturn(child);
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(750);
+        } catch (InterruptedException e) {
+            // Ignore
+        }
+    }
+
+    private void waitForProxy() {
+        try {
+            if (!proxyCdl.await(1, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Proxy not started in time.");
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Use the source to ignore any events that are not from the proxies started by the spider to prevent interferences from other spider(s) or events triggered manually.