### PR TITLE
client: rework test DB cleanup

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/db/TableJdo.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/db/TableJdo.java
@@ -72,6 +72,10 @@ public class TableJdo implements DatabaseListener {
 
     @Override
     public void closing(DatabaseServer db) {
+        closePmf();
+    }
+
+    static void closePmf() {
         if (pmf != null) {
             pmf.close();
             pmf = null;

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/internal/db/TableJdoUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/internal/db/TableJdoUnitTest.java
@@ -48,7 +48,7 @@ class TableJdoUnitTest {
 
     @AfterEach
     void cleanUp() throws Exception {
-        createTableJdo().closing(null);
+        TableJdo.closePmf();
     }
 
     @Test


### PR DESCRIPTION
Directly close the `PersistenceManagerFactory` to not trigger the DB migrations on cleanup.