### PR TITLE
reports: exclude invalid alerts from generated reports

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added a new section to Traditional JSON Report with Requests and Responses for script diagnostics.
 
+### Fixed
+- Invalid alerts, ones without a corresponding message, are now excluded from generated reports. Previously these could break templates that reference message fields (e.g. SARIF, modern, `*-plus`) (Issue 6880).
+
 ## [0.45.0] - 2026-05-06
 ### Fixed
 - The alert's systemic flag in JSON and XML reports now correctly reflects its state (Issue 9254).

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -204,6 +204,11 @@ public class ExtensionReports extends ExtensionAdaptor {
         if (alert == null) {
             return false;
         }
+        // Mirrors core ExtensionAlert#isInvalid: alerts without an HttpMessage or URI are
+        // not well-formed and break templates that reference message fields directly.
+        if (alert.getMessage() == null || alert.getUri().isEmpty()) {
+            return false;
+        }
         String uri = alert.getUri();
         // Filter by contexts
         List<org.zaproxy.zap.model.Context> contexts = reportData.getContexts();

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -327,12 +327,15 @@ class ExtensionReportsUnitTest extends TestUtils {
         reportData.setContexts(Arrays.asList(context));
 
         Alert alert1 = new Alert(1);
+        alert1.setMessage(new HttpMessage());
         alert1.setUri("https://www.example.com/");
 
         Alert alert2 = new Alert(2);
+        alert2.setMessage(new HttpMessage());
         alert2.setUri("https://www.example.com/test/");
 
         Alert alert3 = new Alert(3);
+        alert3.setMessage(new HttpMessage());
         alert3.setUri("https://www.example.com2/test/");
 
         // When
@@ -359,12 +362,15 @@ class ExtensionReportsUnitTest extends TestUtils {
         reportData.setContexts(Arrays.asList(context));
 
         Alert alert1 = new Alert(1);
+        alert1.setMessage(new HttpMessage());
         alert1.setUri("https://www.example.org/");
 
         Alert alert2 = new Alert(2);
+        alert2.setMessage(new HttpMessage());
         alert2.setUri("http://www.example.com/test/");
 
         Alert alert3 = new Alert(3);
+        alert3.setMessage(new HttpMessage());
         alert3.setUri("https://www.example.com2/");
 
         // When
@@ -391,12 +397,15 @@ class ExtensionReportsUnitTest extends TestUtils {
         reportData.setSites(Arrays.asList(site1, site2));
 
         Alert alert1 = new Alert(1);
+        alert1.setMessage(new HttpMessage());
         alert1.setUri("https://www.example.com/");
 
         Alert alert2 = new Alert(2);
+        alert2.setMessage(new HttpMessage());
         alert2.setUri("https://www.example.com/test/");
 
         Alert alert3 = new Alert(3);
+        alert3.setMessage(new HttpMessage());
         alert3.setUri("https://www.example.com2/test/");
 
         // When
@@ -423,12 +432,15 @@ class ExtensionReportsUnitTest extends TestUtils {
         reportData.setSites(Arrays.asList(site1, site2));
 
         Alert alert1 = new Alert(1);
+        alert1.setMessage(new HttpMessage());
         alert1.setUri("https://www.example.org/");
 
         Alert alert2 = new Alert(2);
+        alert2.setMessage(new HttpMessage());
         alert2.setUri("http://www.example.com/test/");
 
         Alert alert3 = new Alert(3);
+        alert3.setMessage(new HttpMessage());
         alert3.setUri("https://www.example.com3/");
 
         // When
@@ -459,12 +471,15 @@ class ExtensionReportsUnitTest extends TestUtils {
         reportData.setContexts(Arrays.asList(context));
 
         Alert alert1 = new Alert(1);
+        alert1.setMessage(new HttpMessage());
         alert1.setUri("https://www.example.com/");
 
         Alert alert2 = new Alert(2);
+        alert2.setMessage(new HttpMessage());
         alert2.setUri("https://www.example.com/test/");
 
         Alert alert3 = new Alert(3);
+        alert3.setMessage(new HttpMessage());
         alert3.setUri("https://www.example.com2/test/");
 
         // When
@@ -496,14 +511,17 @@ class ExtensionReportsUnitTest extends TestUtils {
         reportData.setContexts(Arrays.asList(context));
 
         Alert alert1 = new Alert(1);
+        alert1.setMessage(new HttpMessage());
         // In sites but not in contexts
         alert1.setUri("https://www.example.org/");
 
         Alert alert2 = new Alert(2);
+        alert2.setMessage(new HttpMessage());
         // In sites but excluded from contexts
         alert2.setUri("https://www.example.com/test/");
 
         Alert alert3 = new Alert(3);
+        alert3.setMessage(new HttpMessage());
         // In context but not in sites
         alert3.setUri("https://www.example.com2/test/");
 
@@ -519,6 +537,37 @@ class ExtensionReportsUnitTest extends TestUtils {
         assertThat(ExtensionReports.isIncluded(reportData, alertNode1), is(equalTo(false)));
         assertThat(ExtensionReports.isIncluded(reportData, alertNode2), is(equalTo(false)));
         assertThat(ExtensionReports.isIncluded(reportData, alertNode3), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldExcludeAlertsWithoutHttpMessage() {
+        // Given
+        ReportData reportData = new ReportData(true, true);
+
+        Alert alertWithoutMessage = new Alert(1);
+        alertWithoutMessage.setUri("https://www.example.com/");
+        // intentionally no setMessage(...) - mirrors core ExtensionAlert#isInvalid
+
+        Alert alertWithEmptyUri = new Alert(2);
+        alertWithEmptyUri.setMessage(new HttpMessage());
+        alertWithEmptyUri.setUri("");
+
+        Alert validAlert = new Alert(3);
+        validAlert.setMessage(new HttpMessage());
+        validAlert.setUri("https://www.example.com/");
+
+        // When
+        AlertNode alertNode1 = new AlertNode(-1, "Alert 1");
+        alertNode1.setUserObject(alertWithoutMessage);
+        AlertNode alertNode2 = new AlertNode(-2, "Alert 2");
+        alertNode2.setUserObject(alertWithEmptyUri);
+        AlertNode alertNode3 = new AlertNode(-3, "Alert 3");
+        alertNode3.setUserObject(validAlert);
+
+        // Then
+        assertThat(ExtensionReports.isIncluded(reportData, alertNode1), is(equalTo(false)));
+        assertThat(ExtensionReports.isIncluded(reportData, alertNode2), is(equalTo(false)));
+        assertThat(ExtensionReports.isIncluded(reportData, alertNode3), is(equalTo(true)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Description

Generating a SARIF report fails with

```
TemplateProcessingException Exception evaluating OGNL expression: "sarifSupport.results"
  (template: ".../reports/sarif-json/report.json" - line 4, col 34)
```

when the scan contains any alert whose `Alert.getMessage()` returns `null`. `SarifResult$SarifResultBuilder.build()` dereferences `httpMessage.getRequestHeader()` (and later `getResponseHeader()`) unconditionally; the resulting NPE is caught by Thymeleaf and reported against the outer `${sarifSupport.results}` expression, making the bug look like a template issue when the root cause is an invalid alert reaching the report.

The same latent crash exists in the `modern`, `traditional-html-plus`, `traditional-json-plus`, `traditional-xml-plus`, and `risk-confidence-html` templates — all reference `userObject.message.requestHeader` / etc. directly and would Thymeleaf-NPE on the same input.

## Fix

Reject malformed alerts at the existing `ExtensionReports.isIncluded` gate, mirroring core ZAP's `ExtensionAlert#isInvalid` contract:

```java
if (alert.getMessage() == null || alert.getUri().isEmpty()) {
    return false;
}
```

This sits alongside the existing `if (alert == null) return false` guard and matches its silent style. `getFilteredAlertTree` calls `isIncluded` per instance, so every report template benefits uniformly without per-template defensive code.

Fix zaproxy/zaproxy#6880.

## Behaviour change

- Templates that previously crashed on invalid alerts (`sarif-json`, `modern`, `*-plus`, `risk-confidence-html`) now render successfully with those alerts excluded.
- Templates that previously tolerated invalid alerts (`traditional-html`, `traditional-json`, `traditional-xml`, `traditional-md`) will now also exclude them. These alerts had no `HttpMessage` content to render anyway; the change brings them in line with core's `isInvalid` semantics.

## Reproduction (before this change)

1. Run a ZAP Automation Framework plan that imports an OpenAPI document and includes the `authhelper` add-on so the Session Management Response rule can fire.
2. Add a `report` job with `template: sarif-json`.
3. Observe the partial SARIF output (truncated at `"results": [`) and the `TemplateProcessingException` in stdout.

## Tests

- Existing `isIncluded` tests in `ExtensionReportsUnitTest` updated so their fixture alerts carry a non-null `HttpMessage` (previously they used bare `new Alert(N)` which doesn't reflect real alerts).
- New `shouldExcludeAlertsWithoutHttpMessage` covers both new exclusion conditions (null message, empty URI) plus a positive control.

## Notes

- The PR is purely defensive at the report boundary. The root cause — some path producing alerts with `null` message that bypasses core's `isInvalid` — is not addressed here. Happy to open a separate authhelper investigation if useful.
- `isIncluded` is `public static`. No callers exist outside `ExtensionReports` in this repo; downstream consumers passing barebones `Alert` instances will see the new behaviour.