### PR TITLE
Adjust Retire.js update workflow

### DIFF
--- a/.github/workflows/create_retirejs_update.yml
+++ b/.github/workflows/create_retirejs_update.yml
@@ -2,7 +2,7 @@ name: Create Retirejs Update PR
 
 on:
   schedule:
-    - cron:  '0 4 2 * *'
+    - cron:  '0 4 2,16 * *'
   workflow_dispatch:
 
 jobs:
@@ -38,6 +38,7 @@ jobs:
         ## If there are changes: comment, commit, PR
         if ! git diff-index --quiet HEAD --; then 
           ./gradlew :addOns:retire:updateChangelog --change="- Updated with upstream retire.js pattern changes."
+          ./gradlew :addOns:retire:prepareRelease
           git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-extensions.git
           git add .
           git commit -m "retire.js Update $SHORT_DATE" -m "Updates based on $SRC_BASE" --signoff


### PR DESCRIPTION
## Overview
- Run on the 2nd and 16th of the month. (['https://crontab.guru/#0_4_2,16_*_*'](https://crontab.guru/#0_4_2,16_*_*))
- Include the prepareRelease task.