### PR TITLE
scripts: show chain summary in script job

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update dependency.
 - Revised error handling for chained scripts, output is now more detailed/specific.
+- The Run Script action display for chains in the Automation panel has been updated to display the names of scripts in the chain instead of being blank.
 - Maintenance changes.
 - Formatted JavaScript files for consistency.
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
@@ -80,6 +80,11 @@ public class RunScriptAction extends ScriptAction {
 
     @Override
     public String getSummary() {
+        List<String> chain = parameters.getChain();
+        if (chain != null && !chain.isEmpty()) {
+            return Constant.messages.getString(
+                    "scripts.automation.dialog.summary.run", String.join(", ", chain));
+        }
         return Constant.messages.getString(
                 "scripts.automation.dialog.summary.run", parameters.getName());
     }

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptActionUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptActionUnitTest.java
@@ -142,6 +142,24 @@ class RunScriptActionUnitTest extends TestUtils {
         action = new RunScriptAction(parameters);
     }
 
+    @Test
+    void shouldSummarizeSingleRunWithScriptName() {
+        parameters.setName("my-script");
+
+        assertThat(
+                action.getSummary(),
+                is(equalTo(msg("scripts.automation.dialog.summary.run", "my-script"))));
+    }
+
+    @Test
+    void shouldSummarizeChainWithCommaSeparatedScriptNames() {
+        parameters.setChain(List.of("a", "b", "c"));
+
+        assertThat(
+                action.getSummary(),
+                is(equalTo(msg("scripts.automation.dialog.summary.run", "a, b, c"))));
+    }
+
     /** Zest standalone script wrapper for run-action tests. */
     private static ScriptWrapper createMockZestWrapper(String name) {
         ScriptWrapper wrapper = new ScriptWrapper();


### PR DESCRIPTION
## Overview
In the Automation panel chains now show as "Run Script: Chain (<length>)" instead of "Run Script: <blank>".

Ex:
<img width="452" height="87" alt="image" src="https://github.com/user-attachments/assets/847056eb-7834-4cb3-afda-f6a3913bf026" />

## Related Issues
- [af: Script chaining](https://github.com/zaproxy/zap-extensions/pull/7121)
