### PR TITLE
client: handle browser hook events in spider

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -336,18 +336,11 @@ public class ClientSpider implements GenericScanner2 {
                 wdp = this.webDriverPool.remove(0);
             } else {
                 try {
-                    wdp =
-                            new WebDriverProcess(
-                                    extClient,
-                                    extensionNetwork,
-                                    extSelenium,
-                                    new ProxyHandler(),
-                                    options);
+                    wdp = new WebDriverProcess(new ProxyHandler());
                 } catch (IOException e) {
                     throw new RuntimeException("Failed to create WebDriver process:", e);
                 }
             }
-            proxyPorts.add(wdp.getPort());
             this.webDriverActive.add(wdp);
         }
         return wdp;
@@ -834,25 +827,15 @@ public class ClientSpider implements GenericScanner2 {
     }
 
     @Getter
-    static class WebDriverProcess {
+    class WebDriverProcess {
 
         private static final String LOCAL_PROXY_IP = "127.0.0.1";
         private static final int INITIATOR = HttpSender.CLIENT_SPIDER_INITIATOR;
 
         private Server proxy;
         private WebDriver webDriver;
-        private ExtensionClientIntegration extClient;
 
-        private int port;
-
-        private WebDriverProcess(
-                ExtensionClientIntegration extensionClient,
-                ExtensionNetwork extensionNetwork,
-                ExtensionSelenium extensionSelenium,
-                ProxyHandler proxyHandler,
-                ClientOptions options)
-                throws IOException {
-            extClient = extensionClient;
+        private WebDriverProcess(ProxyHandler proxyHandler) throws IOException {
             proxy =
                     extensionNetwork.createHttpServer(
                             HttpServerConfig.builder()
@@ -860,10 +843,11 @@ public class ClientSpider implements GenericScanner2 {
                                     .setHttpSender(new HttpSender(INITIATOR))
                                     .setServeZapApi(true)
                                     .build());
-            port = proxy.start(Server.ANY_PORT);
+            int port = proxy.start(Server.ANY_PORT);
+            proxyPorts.add(port);
 
             webDriver =
-                    extensionSelenium.getWebDriver(
+                    extSelenium.getWebDriver(
                             INITIATOR, options.getBrowserId(), LOCAL_PROXY_IP, port);
             if (ScopeCheck.STRICT.equals(options.getScopeCheck())) {
                 proxyHandler.setAllowAll(false);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -99,6 +99,7 @@ class ClientSpiderUnitTest extends TestUtils {
     private String seedUrl;
     private CountDownLatch proxyCdl;
     private WebDriver wd;
+    private ExtensionSelenium extSel;
 
     private ClientSpider spider;
 
@@ -115,8 +116,7 @@ class ClientSpiderUnitTest extends TestUtils {
         ExtensionLoader extensionLoader = mock(ExtensionLoader.class);
         Control.initSingletonForTesting(model, extensionLoader);
         ExtensionClientIntegration extClient = mock(ExtensionClientIntegration.class);
-        ExtensionSelenium extSel =
-                mock(ExtensionSelenium.class, withSettings().strictness(Strictness.LENIENT));
+        extSel = mock(ExtensionSelenium.class, withSettings().strictness(Strictness.LENIENT));
         ExtensionHistory history = mock(ExtensionHistory.class);
         when(extensionLoader.getExtension(ExtensionHistory.class)).thenReturn(history);
         when(extensionLoader.getExtension(ExtensionSelenium.class)).thenReturn(extSel);
@@ -225,6 +225,32 @@ class ClientSpiderUnitTest extends TestUtils {
         assertThat(
                 argument.getAllValues(),
                 contains("https://www.example.com/", "https://www.example.com/test"));
+    }
+
+    @Test
+    void shouldRequestInScopeUrlFoundDuringBrowserStartup() throws Exception {
+        // Given
+        clientMapListener();
+        String urlFoundDuringStartup = "https://www.example.com/post-auth-page";
+        CountDownLatch getWebDriverCdl = new CountDownLatch(1);
+        when(extSel.getWebDriver(anyInt(), any(String.class), any(String.class), anyInt()))
+                .thenAnswer(
+                        invocation -> {
+                            mapListener.nodeAdded(urlFoundDuringStartup, 0, 0, PROXY_PORT);
+                            getWebDriverCdl.countDown();
+                            return wd;
+                        });
+
+        // When
+        spider.run();
+        getWebDriverCdl.await(2, TimeUnit.SECONDS);
+        sleep();
+
+        // Then
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        verify(wd, atLeastOnce()).get(argument.capture());
+
+        assertThat(argument.getAllValues(), contains(seedUrl, urlFoundDuringStartup));
     }
 
     @Test


### PR DESCRIPTION
Keep the proxy port as soon as possible to correctly handle events sent while browser hooks (e.g. auth) are being called.