### PR TITLE
Fix CI and reset release

### DIFF
--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -75,6 +75,9 @@ dependencies {
     zapAddOn("spider")
     zapAddOn("wappalyzer")
 
+    // Expose missing annotation GwtCompatible during compilation.
+    compileOnly("com.google.guava:guava:33.6.0-jre")
+
     implementation(libs.graphql.graphqlJava)
 
     testImplementation(project(":testutils"))

--- a/addOns/retire/gradle.properties
+++ b/addOns/retire/gradle.properties
@@ -1,2 +1,2 @@
 version=0.58.0
-release=true
+release=false


### PR DESCRIPTION
Add missing annotation to compile classpath of graphql which was now failing to compile (seems caused by newer Java 17 version).
Reset the release of retire as the release workflow is failing as well with same cause.