### PR TITLE
Add core test utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /buildSrc/.kotlin
 /addOns/**/build
 /testutils/build
-/sharedutils/build
+/testutilscore/build
 
 # IDEA
 # ----
@@ -26,7 +26,7 @@
 /out
 /addOns/**/out
 /testutils/out
-/sharedutils/out
+/testutilscore/out
 
 # Eclipse
 # -------
@@ -38,7 +38,7 @@
 /buildSrc/bin
 /addOns/**/bin
 /testutils/bin
-/sharedutils/bin
+/testutilscore/bin
 
 # NetBeans
 # --------

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -204,6 +204,8 @@ subprojects {
     val zapGav = "org.zaproxy:zap:2.17.0"
     dependencies {
         "zap"(zapGav)
+
+        "testImplementation"(project(":testutilscore"))
     }
 
     val apiGenClasspath = configurations.detachedConfiguration(dependencies.create(zapGav))

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -35,10 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -50,7 +47,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatcher;
@@ -92,14 +88,9 @@ class ActiveScanJobUnitTest {
     private ExtensionActiveScan extAScan;
     private static AbstractPlugin plugin;
 
-    @TempDir static Path tempDir;
-
     @BeforeAll
-    static void init() throws IOException {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
-
-        Constant.setZapHome(
-                Files.createDirectory(tempDir.resolve("home")).toAbsolutePath().toString());
 
         PluginFactoryTestHelper.init();
         plugin = new PluginTestHelper();

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanPolicyJobUnitTest.java
@@ -29,10 +29,7 @@ import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -42,7 +39,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.quality.Strictness;
@@ -71,14 +67,9 @@ class ActiveScanPolicyJobUnitTest {
     private ExtensionActiveScan extAScan;
     private static AbstractPlugin plugin;
 
-    @TempDir static Path tempDir;
-
     @BeforeAll
-    static void init() throws IOException {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
-
-        Constant.setZapHome(
-                Files.createDirectory(tempDir.resolve("home")).toAbsolutePath().toString());
 
         PluginFactoryTestHelper.init();
         plugin = new PluginTestHelper();

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PolicyDefinitionUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PolicyDefinitionUnitTest.java
@@ -27,16 +27,12 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
@@ -65,14 +61,9 @@ class PolicyDefinitionUnitTest {
     private static MockedStatic<CommandLine> mockedCmdLine;
     private static AbstractPlugin plugin;
 
-    @TempDir static Path tempDir;
-
     @BeforeAll
-    static void init() throws IOException {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
-
-        Constant.setZapHome(
-                Files.createDirectory(tempDir.resolve("home")).toAbsolutePath().toString());
 
         PluginFactoryTestHelper.init();
         plugin = new PluginTestHelper();

--- a/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/McpHttpMessageHandlerUnitTest.java
+++ b/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/McpHttpMessageHandlerUnitTest.java
@@ -33,12 +33,11 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
-import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit tests for {@link McpHttpMessageHandler}. */
-class McpHttpMessageHandlerUnitTest extends TestUtils {
+class McpHttpMessageHandlerUnitTest {
 
     private McpParam param;
     private McpToolRegistry toolRegistry;
@@ -49,7 +48,6 @@ class McpHttpMessageHandlerUnitTest extends TestUtils {
 
     @BeforeEach
     void setUp() throws Exception {
-        setUpZap();
         Constant.messages = new I18N(Locale.ROOT);
         param = new McpParam();
         param.load(new ZapXmlConfiguration());

--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -84,9 +84,5 @@ dependencies {
         setTransitive(false)
     }
 
-    testImplementation(libs.test.hamcrest)
-    testImplementation(libs.test.junit.jupiter)
-    testRuntimeOnly(libs.test.junit.platformLauncher)
-    testImplementation(libs.test.mockito.junit.jupiter)
     testImplementation(libs.log4j.core)
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/TestUtils.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/TestUtils.java
@@ -30,18 +30,11 @@ import static org.mockito.Mockito.withSettings;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.ResourceBundle;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
@@ -55,30 +48,9 @@ public abstract class TestUtils {
 
     @TempDir protected static Path tempDir;
 
-    private static String zapInstallDir;
-    private static String zapHomeDir;
-
     protected static ResourceBundle extensionResourceBundle;
 
-    @BeforeAll
-    public static void beforeClass() throws Exception {
-        Path installDir = Files.createDirectory(tempDir.resolve("install"));
-        Path xmlDir = Files.createDirectory(installDir.resolve("xml"));
-        Files.createFile(xmlDir.resolve("log4j2.properties"));
-
-        zapInstallDir = installDir.toAbsolutePath().toString();
-        createHomeDirectory();
-    }
-
-    private static void createHomeDirectory() throws Exception {
-        zapHomeDir = Files.createTempDirectory(tempDir, "home").toAbsolutePath().toString();
-    }
-
     protected void setUpZap() throws Exception {
-        Constant.setZapInstall(zapInstallDir);
-        createHomeDirectory();
-        Constant.setZapHome(zapHomeDir);
-
         Control control = mock(Control.class, withSettings().strictness(Strictness.LENIENT));
         when(control.getExtensionLoader()).thenReturn(mock(ExtensionLoader.class));
 
@@ -92,39 +64,6 @@ public abstract class TestUtils {
         try (ServerSocket server = new ServerSocket(0)) {
             return server.getLocalPort();
         }
-    }
-
-    @AfterEach
-    public void shutDown() throws Exception {
-        deleteDir(Paths.get(zapHomeDir));
-    }
-
-    private static void deleteDir(Path dir) throws IOException {
-        if (Files.notExists(dir)) {
-            return;
-        }
-
-        Files.walkFileTree(
-                dir,
-                new SimpleFileVisitor<Path>() {
-
-                    @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                            throws IOException {
-                        Files.delete(file);
-                        return FileVisitResult.CONTINUE;
-                    }
-
-                    @Override
-                    public FileVisitResult postVisitDirectory(Path dir, IOException e)
-                            throws IOException {
-                        if (e != null) {
-                            throw e;
-                        }
-                        Files.delete(dir);
-                        return FileVisitResult.CONTINUE;
-                    }
-                });
     }
 
     protected static void mockMessages(final Extension extension) {

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
@@ -298,8 +298,8 @@ public enum Browser {
         return false;
     }
 
-    static void setZapHomeDir(Path path) {
-        zapHomeDir = path;
+    static void clearZapHomeDir() {
+        zapHomeDir = null;
     }
 
     private static Path getZapHomeDir() {

--- a/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/HeadlessBrowsersUnitTest.java
+++ b/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/HeadlessBrowsersUnitTest.java
@@ -32,12 +32,10 @@ import fi.iki.elonen.NanoHTTPD;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -47,6 +45,7 @@ import org.mockito.quality.Strictness;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionLoader;
@@ -84,19 +83,16 @@ class HeadlessBrowsersUnitTest extends TestUtils {
 
     private WebDriver driver;
 
-    @BeforeAll
-    static void setupAll() {
+    @BeforeEach
+    void setUp() throws Exception {
         if (CHROME_WEB_DRIVER == null) {
             // Assume we are running locally
             String webdriversHome = System.getProperty("zap.test.webdrivers.home");
             if (webdriversHome != null && !webdriversHome.isEmpty()) {
-                Browser.setZapHomeDir(Paths.get(webdriversHome));
+                Constant.setZapHome(webdriversHome);
             }
         }
-    }
 
-    @BeforeEach
-    void setUp() throws Exception {
         extensionSelenium = new ExtensionSelenium();
         mockMessages(extensionSelenium);
         setUpZap();
@@ -184,7 +180,7 @@ class HeadlessBrowsersUnitTest extends TestUtils {
     @AfterEach
     void tearDown() throws Exception {
         stopServer();
-        Browser.setZapHomeDir(null);
+        Browser.clearZapHomeDir();
         extensionNetwork.stop();
         extensionSelenium.destroy();
         if (driver != null) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ rootProject.name = "zap-extensions"
 val addOnsProjectName = "addOns"
 include(addOnsProjectName)
 include("testutils")
+include("testutilscore")
 
 // Keep the add-ons in alphabetic order.
 val addOns =

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -35,12 +35,9 @@ import java.net.ServerSocket;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.text.MessageFormat;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -56,7 +53,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -99,9 +95,6 @@ public abstract class TestUtils {
      * <p>Can be used for other temporary files/dirs.
      */
     @TempDir protected static Path tempDir;
-
-    private static String zapInstallDir;
-    private static String zapHomeDir;
 
     private static CloseableHttpSenderImpl<?> httpSender;
 
@@ -155,20 +148,6 @@ public abstract class TestUtils {
         }
     }
 
-    @BeforeAll
-    public static void beforeClass() throws Exception {
-        Path installDir = Files.createTempDirectory(tempDir, "install");
-        Path xmlDir = Files.createDirectory(installDir.resolve("xml"));
-        Files.createFile(xmlDir.resolve("log4j2.properties"));
-
-        zapInstallDir = installDir.toAbsolutePath().toString();
-        createHomeDirectory();
-    }
-
-    private static void createHomeDirectory() throws Exception {
-        zapHomeDir = Files.createTempDirectory(tempDir, "home").toAbsolutePath().toString();
-    }
-
     /**
      * Sets up ZAP, by initialising the home/installation dirs and core classes (for example, {@link
      * Constant}, {@link Control}, {@link Model}).
@@ -177,10 +156,6 @@ public abstract class TestUtils {
      * @see #setUpMessages()
      */
     protected void setUpZap() throws Exception {
-        Constant.setZapInstall(zapInstallDir);
-        createHomeDirectory();
-        Constant.setZapHome(zapHomeDir);
-
         Control control = mock(Control.class, withSettings().strictness(Strictness.LENIENT));
         when(control.getExtensionLoader()).thenReturn(mock(ExtensionLoader.class));
 
@@ -246,44 +221,6 @@ public abstract class TestUtils {
      * @see #mockMessages(Extension...)
      */
     protected void setUpMessages() {}
-
-    /**
-     * Deletes the ZAP's home directory.
-     *
-     * @throws Exception if an error occurred while deleting the home directory.
-     */
-    @AfterEach
-    public void shutDown() throws Exception {
-        deleteDir(Paths.get(zapHomeDir));
-    }
-
-    private static void deleteDir(Path dir) throws IOException {
-        if (Files.notExists(dir)) {
-            return;
-        }
-
-        Files.walkFileTree(
-                dir,
-                new SimpleFileVisitor<Path>() {
-
-                    @Override
-                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                            throws IOException {
-                        Files.delete(file);
-                        return FileVisitResult.CONTINUE;
-                    }
-
-                    @Override
-                    public FileVisitResult postVisitDirectory(Path dir, IOException e)
-                            throws IOException {
-                        if (e != null) {
-                            throw e;
-                        }
-                        Files.delete(dir);
-                        return FileVisitResult.CONTINUE;
-                    }
-                });
-    }
 
     /**
      * Creates a (GET) HTTP message with the given path, for the {@link #nano test server}.

--- a/testutilscore/src/main/java/org/zaproxy/zap/testutils/ZapSetupExtension.java
+++ b/testutilscore/src/main/java/org/zaproxy/zap/testutils/ZapSetupExtension.java
@@ -1,0 +1,98 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.testutils;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.parosproxy.paros.Constant;
+
+/**
+ * An extension that automatically initialises the ZAP install and home directories before each test
+ * and cleans them up afterwards.
+ */
+public class ZapSetupExtension implements BeforeAllCallback, BeforeEachCallback {
+
+    private static final Namespace NAMESPACE = Namespace.create(ZapSetupExtension.class);
+
+    private static final String TEMP_DIR_KEY = "zapTempDir";
+    private static final String INSTALL_DIR_KEY = "zapInstallDir";
+    private static final String HOME_DIR_KEY = "zapHomeDir";
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        Path tempDir = Files.createTempDirectory("zap-test-");
+        Path installDir = Files.createTempDirectory(tempDir, "install");
+        Path xmlDir = Files.createDirectory(installDir.resolve("xml"));
+        Files.createFile(xmlDir.resolve("log4j2.properties"));
+
+        Store store = context.getStore(NAMESPACE);
+        store.put(INSTALL_DIR_KEY, installDir);
+        store.put(TEMP_DIR_KEY, (AutoCloseable) () -> deleteDir(tempDir));
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        Store classStore = context.getParent().orElseThrow().getStore(NAMESPACE);
+        Path installDir = classStore.get(INSTALL_DIR_KEY, Path.class);
+
+        Path homeDir = Files.createTempDirectory(installDir.getParent(), "home");
+        context.getStore(NAMESPACE).put(HOME_DIR_KEY, (AutoCloseable) () -> deleteDir(homeDir));
+
+        Constant.setZapInstall(installDir.toAbsolutePath().toString());
+        Constant.setZapHome(homeDir.toAbsolutePath().toString());
+    }
+
+    private static void deleteDir(Path dir) throws IOException {
+        if (dir == null || Files.notExists(dir)) {
+            return;
+        }
+
+        Files.walkFileTree(
+                dir,
+                new SimpleFileVisitor<Path>() {
+
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                            throws IOException {
+                        Files.delete(file);
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult postVisitDirectory(Path dir, IOException e)
+                            throws IOException {
+                        if (e != null) {
+                            throw e;
+                        }
+                        Files.delete(dir);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+    }
+}

--- a/testutilscore/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/testutilscore/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.zaproxy.zap.testutils.ZapSetupExtension

--- a/testutilscore/src/main/resources/junit-platform.properties
+++ b/testutilscore/src/main/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.extensions.autodetection.enabled = true
+junit.jupiter.extensions.autodetection.include = org.zaproxy.zap.testutils.ZapSetupExtension

--- a/testutilscore/testutilscore.gradle.kts
+++ b/testutilscore/testutilscore.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("org.zaproxy.common")
 }
 
-description = "Common test utilities for the add-ons."
+description = "Core test utilities for the add-ons."
 
 configurations {
     "compileClasspath" {
@@ -19,10 +19,8 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     compileOnly(libs.testutils.zap)
 
-    implementation(project(":testutilscore"))
-    implementation(project(":addOns:network"))
-    implementation(libs.testutils.httpclient5)
-
-    api(libs.testutils.nanohttpd.webserver)
-    api(libs.testutils.nanohttpd.websocket)
+    api(libs.test.hamcrest)
+    api(libs.test.junit.jupiter)
+    runtimeOnly(libs.test.junit.platformLauncher)
+    api(libs.test.mockito.junit.jupiter)
 }


### PR DESCRIPTION
Add test utils that all add-ons can use, `network` in particular which can't depend on `testutils` since the later setups the `HttpSender` implementation as provided by the `network` add-on.
Automatically setup the home and installation directories used by core to avoid conflicts between the tests when executed concurrently (home is of exclusive use).
Remove "manual" home dir setups in tests.