### PR TITLE
mcp: Support for SSE responses

### DIFF
--- a/addOns/mcp/CHANGELOG.md
+++ b/addOns/mcp/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - MCP Import.
 - Automation framework support.
+- Support for SSE responses.
 
 ### Changed
 - Maintenance changes.

--- a/addOns/mcp/mcp.gradle.kts
+++ b/addOns/mcp/mcp.gradle.kts
@@ -17,7 +17,7 @@ zapAddOn {
                     version.set(">=1.17.0")
                 }
                 register("network") {
-                    version.set(">=0.1.0")
+                    version.set(">=0.28.0")
                 }
                 register("pscan") {
                     version.set(">=0.6.0")

--- a/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/importer/EventStreams.java
+++ b/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/importer/EventStreams.java
@@ -1,0 +1,143 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.mcp.importer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.util.Optional;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * Helpers for accessing the body of an event-stream ({@code Content-Type: text/event-stream})
+ * response after {@code HttpSender.sendAndReceive}.
+ *
+ * <p>The default sender deliberately leaves SSE response bodies empty on the {@link HttpMessage} so
+ * the proxy can stream events live. When an add-on initiates the request itself and needs to
+ * consume a finite SSE response (e.g. an MCP Streamable HTTP reply that wraps the JSON-RPC payload
+ * in a single SSE frame), it can use {@link #getInputStream(HttpMessage)} to read events
+ * incrementally or {@link #consumeBody(HttpMessage)} to drain the whole body into the message and
+ * release the underlying socket.
+ */
+final class EventStreams {
+
+    private EventStreams() {}
+
+    /**
+     * Returns the event-stream response body as an {@link InputStream}, if one is attached to the
+     * given message. Will be present only after a successful {@code sendAndReceive} on a request
+     * whose response is {@code text/event-stream}. The caller owns the stream and the underlying
+     * socket; both must be closed when reading is finished.
+     */
+    @SuppressWarnings("deprecation")
+    static Optional<InputStream> getInputStream(HttpMessage msg) throws IOException {
+        Object userObject = msg.getUserObject();
+        if (userObject instanceof org.zaproxy.zap.ZapGetMethod) {
+            return Optional.ofNullable(
+                    ((org.zaproxy.zap.ZapGetMethod) userObject).getResponseBodyAsStream());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the underlying {@link Socket} for an event-stream response, if one is attached to the
+     * given message. The caller is responsible for closing it.
+     */
+    @SuppressWarnings("deprecation")
+    static Optional<Socket> getSocket(HttpMessage msg) {
+        Object userObject = msg.getUserObject();
+        if (userObject instanceof org.zaproxy.zap.ZapGetMethod) {
+            return Optional.ofNullable(
+                    ((org.zaproxy.zap.ZapGetMethod) userObject).getUpgradedConnection());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Drains the event-stream response body into {@link HttpMessage#setResponseBody(byte[])},
+     * updates {@code Content-Length} to match, and closes the underlying socket. Does nothing if
+     * the message is not an event-stream response.
+     *
+     * <p>If the response carries a {@code Content-Length} header, exactly that many bytes are read
+     * from the stream so the call does not block waiting for an EOF that never arrives on a
+     * keep-alive connection. Otherwise the stream is drained until EOF.
+     *
+     * @return {@code true} if a body was consumed, {@code false} otherwise.
+     */
+    static boolean consumeBody(HttpMessage msg) throws IOException {
+        Optional<InputStream> stream = getInputStream(msg);
+        if (stream.isEmpty()) {
+            return false;
+        }
+        int contentLength = parseContentLength(msg);
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        try (InputStream is = stream.get()) {
+            byte[] chunk = new byte[8 * 1024];
+            if (contentLength >= 0) {
+                int remaining = contentLength;
+                while (remaining > 0) {
+                    int n = is.read(chunk, 0, Math.min(chunk.length, remaining));
+                    if (n < 0) {
+                        break;
+                    }
+                    buf.write(chunk, 0, n);
+                    remaining -= n;
+                }
+            } else {
+                int n;
+                while ((n = is.read(chunk)) >= 0) {
+                    buf.write(chunk, 0, n);
+                }
+            }
+        } finally {
+            closeQuietly(getSocket(msg).orElse(null));
+        }
+        byte[] body = buf.toByteArray();
+        msg.setResponseBody(body);
+        msg.getResponseHeader().setContentLength(body.length);
+        return true;
+    }
+
+    private static int parseContentLength(HttpMessage msg) {
+        String value = msg.getResponseHeader().getHeader(HttpHeader.CONTENT_LENGTH);
+        if (value == null) {
+            return -1;
+        }
+        try {
+            int length = Integer.parseInt(value.trim());
+            return length >= 0 ? length : -1;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private static void closeQuietly(Socket socket) {
+        if (socket == null) {
+            return;
+        }
+        try {
+            socket.close();
+        } catch (IOException ignore) {
+            // Best effort; nothing to do.
+        }
+    }
+}

--- a/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/importer/McpImporter.java
+++ b/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/importer/McpImporter.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.httpclient.URI;
@@ -54,6 +55,14 @@ public class McpImporter {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String PROTOCOL_VERSION = "2024-11-05";
     private static final String CONTENT_TYPE = "application/json; charset=UTF-8";
+    private static final String ACCEPT = "application/json, text/event-stream";
+    private static final String SESSION_HEADER = "Mcp-Session-Id";
+    // Bounds how many pages of any paginated list (tools/list, resources/list, prompts/list,
+    // resources/templates/list) the importer will follow before giving up — guards against
+    // misbehaving servers that never clear nextCursor.
+    private static final int MAX_LIST_PAGES = 50;
+    private static final java.util.regex.Pattern URI_TEMPLATE_VAR =
+            java.util.regex.Pattern.compile("\\{([^}/]+)\\}");
 
     /** Configuration for a single import run. */
     public record ImportConfig(String serverUrl, String securityKey) {}
@@ -61,14 +70,30 @@ public class McpImporter {
     /** Results of a completed import run. */
     public record ImportResults(int requestCount, List<String> errors) {}
 
+    /**
+     * Network abstraction used to send each MCP request. The default implementation calls ZAP's
+     * {@link HttpSender#sendAndReceive(HttpMessage)} and, for {@code text/event-stream} responses,
+     * drains the SSE body via {@link EventStreams#consumeBody(HttpMessage)} — required for the MCP
+     * Streamable HTTP transport, which embeds JSON-RPC responses inside short-lived SSE frames.
+     */
+    @FunctionalInterface
+    public interface NetworkClient {
+        void send(HttpMessage msg) throws IOException;
+    }
+
     private final ExtensionHistory extHistory;
-    private final HttpSender httpSender;
+    private final NetworkClient networkClient;
     private final ValueProvider valueProvider;
 
     public McpImporter() {
         this.extHistory =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
-        this.httpSender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
+        HttpSender sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
+        this.networkClient =
+                msg -> {
+                    sender.sendAndReceive(msg);
+                    EventStreams.consumeBody(msg);
+                };
         this.valueProvider =
                 Control.getSingleton()
                         .getExtensionLoader()
@@ -77,12 +102,12 @@ public class McpImporter {
     }
 
     /**
-     * Constructor for testing — accepts a pre-built {@link HttpSender} and optional {@link
+     * Constructor for testing — accepts a custom {@link NetworkClient} and optional {@link
      * ValueProvider} to avoid ZAP infrastructure.
      */
-    McpImporter(HttpSender httpSender, ValueProvider valueProvider) {
+    McpImporter(NetworkClient networkClient, ValueProvider valueProvider) {
         this.extHistory = null;
-        this.httpSender = httpSender;
+        this.networkClient = networkClient;
         this.valueProvider = valueProvider;
     }
 
@@ -125,14 +150,10 @@ public class McpImporter {
         clientInfo.put("name", "ZAP MCP Importer");
         clientInfo.put("version", "1.0.0");
 
+        String securityKey = config.securityKey();
         HttpMessage initMsg =
                 sendAndRecord(
-                        serverUri,
-                        "initialize",
-                        initParams,
-                        config.securityKey(),
-                        idCounter,
-                        errors);
+                        serverUri, "initialize", initParams, securityKey, null, idCounter, errors);
         if (initMsg == null) {
             return new ImportResults(0, errors);
         }
@@ -154,42 +175,82 @@ public class McpImporter {
             return new ImportResults(requestCount, errors);
         }
 
+        String sessionId = initMsg.getResponseHeader().getHeader(SESSION_HEADER);
+        JsonNode capabilities = readJsonRpcPayload(initMsg).path("result").path("capabilities");
+
         // 1b. notifications/initialized — completes the initialization phase
-        if (sendNotification(serverUri, "notifications/initialized", config.securityKey())) {
+        if (sendNotification(serverUri, "notifications/initialized", securityKey, sessionId)) {
             requestCount++;
         }
 
-        // 2. tools/list
+        // 1c. ping — every conformant MCP server supports this; gives a cheap liveness signal.
+        if (sendAndRecord(serverUri, "ping", null, securityKey, sessionId, idCounter, errors)
+                != null) {
+            requestCount++;
+        }
+
+        // 1d. logging/setLevel — only call when the server advertises the logging capability.
+        if (capabilities.has("logging")) {
+            ObjectNode logParams = MAPPER.createObjectNode();
+            logParams.put("level", "info");
+            if (sendAndRecord(
+                            serverUri,
+                            "logging/setLevel",
+                            logParams,
+                            securityKey,
+                            sessionId,
+                            idCounter,
+                            errors)
+                    != null) {
+                requestCount++;
+            }
+        }
+
+        // 2. tools/list (paginated)
         List<ToolDef> tools = new ArrayList<>();
-        HttpMessage toolsListMsg =
-                sendAndRecord(
-                        serverUri, "tools/list", null, config.securityKey(), idCounter, errors);
-        if (toolsListMsg != null) {
-            requestCount++;
-            tools = extractToolDefs(toolsListMsg);
+        List<HttpMessage> toolsPages =
+                listAllPages(serverUri, "tools/list", securityKey, sessionId, idCounter, errors);
+        requestCount += toolsPages.size();
+        for (HttpMessage page : toolsPages) {
+            tools.addAll(extractToolDefs(page));
         }
 
-        // 3. resources/list
+        // 3. resources/list (paginated)
         List<String> resourceUris = new ArrayList<>();
-        HttpMessage resourcesListMsg =
-                sendAndRecord(
-                        serverUri, "resources/list", null, config.securityKey(), idCounter, errors);
-        if (resourcesListMsg != null) {
-            requestCount++;
-            resourceUris = extractStringArray(resourcesListMsg, "result", "resources", "uri");
+        List<HttpMessage> resourcePages =
+                listAllPages(
+                        serverUri, "resources/list", securityKey, sessionId, idCounter, errors);
+        requestCount += resourcePages.size();
+        for (HttpMessage page : resourcePages) {
+            resourceUris.addAll(extractStringArray(page, "result", "resources", "uri"));
         }
 
-        // 4. prompts/list
+        // 4. resources/templates/list (paginated) — many servers expose parametric URIs here.
+        List<String> templateUris = new ArrayList<>();
+        List<HttpMessage> templatePages =
+                listAllPages(
+                        serverUri,
+                        "resources/templates/list",
+                        securityKey,
+                        sessionId,
+                        idCounter,
+                        errors);
+        requestCount += templatePages.size();
+        for (HttpMessage page : templatePages) {
+            templateUris.addAll(
+                    extractStringArray(page, "result", "resourceTemplates", "uriTemplate"));
+        }
+
+        // 5. prompts/list (paginated)
         List<PromptDef> prompts = new ArrayList<>();
-        HttpMessage promptsListMsg =
-                sendAndRecord(
-                        serverUri, "prompts/list", null, config.securityKey(), idCounter, errors);
-        if (promptsListMsg != null) {
-            requestCount++;
-            prompts = extractPromptDefs(promptsListMsg);
+        List<HttpMessage> promptPages =
+                listAllPages(serverUri, "prompts/list", securityKey, sessionId, idCounter, errors);
+        requestCount += promptPages.size();
+        for (HttpMessage page : promptPages) {
+            prompts.addAll(extractPromptDefs(page));
         }
 
-        // 5. resources/read for each discovered resource
+        // 6. resources/read for each discovered resource
         for (String uri : resourceUris) {
             ObjectNode params = MAPPER.createObjectNode();
             params.put("uri", uri);
@@ -198,7 +259,8 @@ public class McpImporter {
                             serverUri,
                             "resources/read",
                             params,
-                            config.securityKey(),
+                            securityKey,
+                            sessionId,
                             idCounter,
                             errors);
             if (msg != null) {
@@ -206,7 +268,26 @@ public class McpImporter {
             }
         }
 
-        // 6. tools/call for each tool with schema-derived placeholder arguments
+        // 7. resources/read for each resource template, with {var} placeholders resolved.
+        for (String template : templateUris) {
+            String resolved = resolveUriTemplate(template, serverUri);
+            ObjectNode params = MAPPER.createObjectNode();
+            params.put("uri", resolved);
+            HttpMessage msg =
+                    sendAndRecord(
+                            serverUri,
+                            "resources/read",
+                            params,
+                            securityKey,
+                            sessionId,
+                            idCounter,
+                            errors);
+            if (msg != null) {
+                requestCount++;
+            }
+        }
+
+        // 8. tools/call for each tool with schema-derived placeholder arguments
         for (ToolDef tool : tools) {
             ObjectNode params = MAPPER.createObjectNode();
             params.put("name", tool.name());
@@ -216,7 +297,8 @@ public class McpImporter {
                             serverUri,
                             "tools/call",
                             params,
-                            config.securityKey(),
+                            securityKey,
+                            sessionId,
                             idCounter,
                             errors);
             if (msg != null) {
@@ -224,7 +306,7 @@ public class McpImporter {
             }
         }
 
-        // 7. prompts/get for each prompt with schema-derived placeholder arguments
+        // 9. prompts/get for each prompt with schema-derived placeholder arguments
         for (PromptDef prompt : prompts) {
             ObjectNode params = MAPPER.createObjectNode();
             params.put("name", prompt.name());
@@ -234,7 +316,8 @@ public class McpImporter {
                             serverUri,
                             "prompts/get",
                             params,
-                            config.securityKey(),
+                            securityKey,
+                            sessionId,
                             idCounter,
                             errors);
             if (msg != null) {
@@ -246,19 +329,75 @@ public class McpImporter {
     }
 
     /**
+     * Calls a paginated MCP list method, following {@code nextCursor} up to {@link #MAX_LIST_PAGES}
+     * pages, and returns the response message from each page. Aborts the loop on the first failed
+     * page so the caller can still process what came before.
+     */
+    private List<HttpMessage> listAllPages(
+            URI serverUri,
+            String method,
+            String securityKey,
+            String sessionId,
+            AtomicInteger idCounter,
+            List<String> errors) {
+        List<HttpMessage> pages = new ArrayList<>();
+        String cursor = null;
+        for (int i = 0; i < MAX_LIST_PAGES; i++) {
+            ObjectNode params = null;
+            if (cursor != null) {
+                params = MAPPER.createObjectNode();
+                params.put("cursor", cursor);
+            }
+            HttpMessage page =
+                    sendAndRecord(
+                            serverUri, method, params, securityKey, sessionId, idCounter, errors);
+            if (page == null) {
+                break;
+            }
+            pages.add(page);
+            JsonNode next = readJsonRpcPayload(page).path("result").path("nextCursor");
+            if (next.isMissingNode() || next.isNull() || next.asText().isEmpty()) {
+                break;
+            }
+            cursor = next.asText();
+        }
+        return pages;
+    }
+
+    /**
+     * Replaces RFC 6570 {@code {var}} placeholders in a resource template URI with values from the
+     * {@link ValueProvider}. Falls back to the variable name if no provider is configured.
+     */
+    private String resolveUriTemplate(String template, URI serverUri) {
+        java.util.regex.Matcher matcher = URI_TEMPLATE_VAR.matcher(template);
+        StringBuilder out = new StringBuilder();
+        while (matcher.find()) {
+            String var = matcher.group(1);
+            String value = resolveStringValue(serverUri, var, "string");
+            if (value == null || value.isEmpty()) {
+                value = var;
+            }
+            matcher.appendReplacement(out, java.util.regex.Matcher.quoteReplacement(value));
+        }
+        matcher.appendTail(out);
+        return out.toString();
+    }
+
+    /**
      * Sends a JSON-RPC notification (no {@code id} field) and records it in history. Notifications
      * do not carry a response body, so the recorded message captures the server's acknowledgement
      * (typically HTTP 202) without attempting to parse a JSON-RPC result.
      *
      * @return {@code true} if the notification was sent successfully, {@code false} otherwise
      */
-    private boolean sendNotification(URI serverUri, String method, String securityKey) {
-        HttpMessage msg = buildNotification(serverUri, method, securityKey);
+    private boolean sendNotification(
+            URI serverUri, String method, String securityKey, String sessionId) {
+        HttpMessage msg = buildNotification(serverUri, method, securityKey, sessionId);
         if (msg == null) {
             return false;
         }
         try {
-            httpSender.sendAndReceive(msg);
+            networkClient.send(msg);
         } catch (IOException e) {
             LOGGER.warn("MCP notification failed for method {}: {}", method, e.getMessage());
             return false;
@@ -267,18 +406,15 @@ public class McpImporter {
         return true;
     }
 
-    private HttpMessage buildNotification(URI serverUri, String method, String securityKey) {
+    private HttpMessage buildNotification(
+            URI serverUri, String method, String securityKey, String sessionId) {
         try {
             ObjectNode body = MAPPER.createObjectNode();
             body.put("jsonrpc", "2.0");
             body.put("method", method);
 
             HttpMessage msg = new HttpMessage(serverUri);
-            msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
-            msg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, CONTENT_TYPE);
-            if (securityKey != null && !securityKey.isBlank()) {
-                msg.getRequestHeader().setHeader("Authorization", securityKey);
-            }
+            applyCommonRequestHeaders(msg, securityKey, sessionId);
 
             String bodyStr = MAPPER.writeValueAsString(body);
             msg.setRequestBody(bodyStr);
@@ -296,14 +432,16 @@ public class McpImporter {
             String method,
             ObjectNode paramsNode,
             String securityKey,
+            String sessionId,
             AtomicInteger idCounter,
             List<String> errors) {
-        HttpMessage msg = buildRequest(serverUri, method, paramsNode, securityKey, idCounter);
+        HttpMessage msg =
+                buildRequest(serverUri, method, paramsNode, securityKey, sessionId, idCounter);
         if (msg == null) {
             return null;
         }
         try {
-            httpSender.sendAndReceive(msg);
+            networkClient.send(msg);
         } catch (IOException e) {
             errors.add(
                     Constant.messages.getString(
@@ -320,6 +458,7 @@ public class McpImporter {
             String method,
             ObjectNode paramsNode,
             String securityKey,
+            String sessionId,
             AtomicInteger idCounter) {
         try {
             ObjectNode body = MAPPER.createObjectNode();
@@ -331,11 +470,7 @@ public class McpImporter {
             }
 
             HttpMessage msg = new HttpMessage(serverUri);
-            msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
-            msg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, CONTENT_TYPE);
-            if (securityKey != null && !securityKey.isBlank()) {
-                msg.getRequestHeader().setHeader("Authorization", securityKey);
-            }
+            applyCommonRequestHeaders(msg, securityKey, sessionId);
 
             String bodyStr = MAPPER.writeValueAsString(body);
             msg.setRequestBody(bodyStr);
@@ -344,6 +479,19 @@ public class McpImporter {
         } catch (Exception e) {
             LOGGER.warn("Failed to build MCP request for method {}: {}", method, e.getMessage());
             return null;
+        }
+    }
+
+    private static void applyCommonRequestHeaders(
+            HttpMessage msg, String securityKey, String sessionId) {
+        msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
+        msg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, CONTENT_TYPE);
+        msg.getRequestHeader().setHeader("Accept", ACCEPT);
+        if (securityKey != null && !securityKey.isBlank()) {
+            msg.getRequestHeader().setHeader("Authorization", securityKey);
+        }
+        if (sessionId != null && !sessionId.isBlank()) {
+            msg.getRequestHeader().setHeader(SESSION_HEADER, sessionId);
         }
     }
 
@@ -364,34 +512,53 @@ public class McpImporter {
         }
     }
 
-    private boolean isValidMcpInitializeResult(HttpMessage msg) {
+    /**
+     * Parses the JSON-RPC payload from a response. The Streamable HTTP transport allows the server
+     * to reply either with a single JSON object or with an SSE stream carrying a single JSON-RPC
+     * message (possibly split across multiple {@code data:} lines, joined with {@code \n} per the
+     * SSE spec). Returns a {@link com.fasterxml.jackson.databind.node.MissingNode} if the body
+     * cannot be parsed.
+     */
+    private JsonNode readJsonRpcPayload(HttpMessage msg) {
+        String body = msg.getResponseBody().toString();
+        String contentType = msg.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
         try {
-            JsonNode response = MAPPER.readTree(msg.getResponseBody().toString());
-            JsonNode result = response.get("result");
-            return result != null && result.has("protocolVersion");
+            if (contentType != null
+                    && contentType.toLowerCase(Locale.ROOT).contains("text/event-stream")) {
+                StringBuilder data = new StringBuilder();
+                for (String line : body.split("\\R")) {
+                    if (line.startsWith("data:")) {
+                        if (data.length() > 0) {
+                            data.append('\n');
+                        }
+                        data.append(line.substring(5).stripLeading());
+                    }
+                }
+                if (data.length() == 0) {
+                    return MAPPER.missingNode();
+                }
+                return MAPPER.readTree(data.toString());
+            }
+            return MAPPER.readTree(body);
         } catch (Exception e) {
-            return false;
+            LOGGER.warn("Failed to parse MCP response body: {}", e.getMessage());
+            return MAPPER.missingNode();
         }
+    }
+
+    private boolean isValidMcpInitializeResult(HttpMessage msg) {
+        JsonNode result = readJsonRpcPayload(msg).get("result");
+        return result != null && result.has("protocolVersion");
     }
 
     private boolean hasJsonRpcError(HttpMessage msg) {
-        try {
-            JsonNode response = MAPPER.readTree(msg.getResponseBody().toString());
-            return response.has("error");
-        } catch (Exception e) {
-            return false;
-        }
+        return readJsonRpcPayload(msg).has("error");
     }
 
     private String getJsonRpcErrorMessage(HttpMessage msg) {
-        try {
-            JsonNode response = MAPPER.readTree(msg.getResponseBody().toString());
-            JsonNode error = response.get("error");
-            if (error != null && error.has("message")) {
-                return error.get("message").asText();
-            }
-        } catch (Exception e) {
-            // ignore
+        JsonNode error = readJsonRpcPayload(msg).get("error");
+        if (error != null && error.has("message")) {
+            return error.get("message").asText();
         }
         return "Unknown error";
     }
@@ -405,19 +572,14 @@ public class McpImporter {
     /** Parses the {@code tools/list} response into {@link ToolDef} objects. */
     private List<ToolDef> extractToolDefs(HttpMessage msg) {
         List<ToolDef> tools = new ArrayList<>();
-        try {
-            JsonNode toolsNode =
-                    MAPPER.readTree(msg.getResponseBody().toString()).path("result").path("tools");
-            if (toolsNode.isArray()) {
-                for (JsonNode tool : toolsNode) {
-                    String name = tool.path("name").asText(null);
-                    if (name != null) {
-                        tools.add(new ToolDef(name, tool.path("inputSchema")));
-                    }
+        JsonNode toolsNode = readJsonRpcPayload(msg).path("result").path("tools");
+        if (toolsNode.isArray()) {
+            for (JsonNode tool : toolsNode) {
+                String name = tool.path("name").asText(null);
+                if (name != null) {
+                    tools.add(new ToolDef(name, tool.path("inputSchema")));
                 }
             }
-        } catch (Exception e) {
-            LOGGER.warn("Failed to parse tools/list response: {}", e.getMessage());
         }
         return tools;
     }
@@ -425,31 +587,24 @@ public class McpImporter {
     /** Parses the {@code prompts/list} response into {@link PromptDef} objects. */
     private List<PromptDef> extractPromptDefs(HttpMessage msg) {
         List<PromptDef> prompts = new ArrayList<>();
-        try {
-            JsonNode promptsNode =
-                    MAPPER.readTree(msg.getResponseBody().toString())
-                            .path("result")
-                            .path("prompts");
-            if (promptsNode.isArray()) {
-                for (JsonNode prompt : promptsNode) {
-                    String name = prompt.path("name").asText(null);
-                    if (name != null) {
-                        List<String> argNames = new ArrayList<>();
-                        JsonNode args = prompt.path("arguments");
-                        if (args.isArray()) {
-                            for (JsonNode arg : args) {
-                                String argName = arg.path("name").asText(null);
-                                if (argName != null) {
-                                    argNames.add(argName);
-                                }
+        JsonNode promptsNode = readJsonRpcPayload(msg).path("result").path("prompts");
+        if (promptsNode.isArray()) {
+            for (JsonNode prompt : promptsNode) {
+                String name = prompt.path("name").asText(null);
+                if (name != null) {
+                    List<String> argNames = new ArrayList<>();
+                    JsonNode args = prompt.path("arguments");
+                    if (args.isArray()) {
+                        for (JsonNode arg : args) {
+                            String argName = arg.path("name").asText(null);
+                            if (argName != null) {
+                                argNames.add(argName);
                             }
                         }
-                        prompts.add(new PromptDef(name, argNames));
                     }
+                    prompts.add(new PromptDef(name, argNames));
                 }
             }
-        } catch (Exception e) {
-            LOGGER.warn("Failed to parse prompts/list response: {}", e.getMessage());
         }
         return prompts;
     }
@@ -529,24 +684,20 @@ public class McpImporter {
      */
     private List<String> extractStringArray(HttpMessage msg, String... path) {
         List<String> result = new ArrayList<>();
-        try {
-            JsonNode node = MAPPER.readTree(msg.getResponseBody().toString());
-            for (int i = 0; i < path.length - 1; i++) {
-                if (node == null || !node.has(path[i])) {
-                    return result;
-                }
-                node = node.get(path[i]);
+        JsonNode node = readJsonRpcPayload(msg);
+        for (int i = 0; i < path.length - 1; i++) {
+            if (node == null || !node.has(path[i])) {
+                return result;
             }
-            String fieldName = path[path.length - 1];
-            if (node != null && node.isArray()) {
-                for (JsonNode item : node) {
-                    if (item.has(fieldName)) {
-                        result.add(item.get(fieldName).asText());
-                    }
+            node = node.get(path[i]);
+        }
+        String fieldName = path[path.length - 1];
+        if (node != null && node.isArray()) {
+            for (JsonNode item : node) {
+                if (item.has(fieldName)) {
+                    result.add(item.get(fieldName).asText());
                 }
             }
-        } catch (Exception e) {
-            LOGGER.warn("Failed to parse MCP response: {}", e.getMessage());
         }
         return result;
     }

--- a/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/importer/EventStreamsUnitTest.java
+++ b/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/importer/EventStreamsUnitTest.java
@@ -1,0 +1,207 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.mcp.importer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Unit tests for {@link EventStreams}. */
+@SuppressWarnings("deprecation")
+class EventStreamsUnitTest {
+
+    private static final String SSE_BODY =
+            "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n";
+
+    @Test
+    void shouldReturnEmptyInputStreamWhenUserObjectIsNotZapGetMethod() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setUserObject("not a ZapGetMethod");
+        // When
+        Optional<InputStream> stream = EventStreams.getInputStream(msg);
+        // Then
+        assertThat(stream.isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldReturnEmptySocketWhenUserObjectIsNotZapGetMethod() {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        // When / Then
+        assertThat(EventStreams.getSocket(msg).isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldReturnInputStreamFromZapGetMethod() throws Exception {
+        // Given
+        InputStream attached = new ByteArrayInputStream(new byte[0]);
+        org.zaproxy.zap.ZapGetMethod method = mock(org.zaproxy.zap.ZapGetMethod.class);
+        given(method.getResponseBodyAsStream()).willReturn(attached);
+        HttpMessage msg = new HttpMessage();
+        msg.setUserObject(method);
+        // When
+        Optional<InputStream> stream = EventStreams.getInputStream(msg);
+        // Then
+        assertThat(stream.isPresent(), is(true));
+        assertThat(stream.get(), is(sameInstance(attached)));
+    }
+
+    @Test
+    void shouldReturnSocketFromZapGetMethod() {
+        // Given
+        Socket socket = mock(Socket.class);
+        org.zaproxy.zap.ZapGetMethod method = mock(org.zaproxy.zap.ZapGetMethod.class);
+        given(method.getUpgradedConnection()).willReturn(socket);
+        HttpMessage msg = new HttpMessage();
+        msg.setUserObject(method);
+        // When / Then
+        assertThat(EventStreams.getSocket(msg).orElse(null), is(sameInstance(socket)));
+    }
+
+    @Test
+    void shouldReturnFalseFromConsumeBodyWhenNoStreamAttached() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        // When / Then
+        assertThat(EventStreams.consumeBody(msg), is(false));
+    }
+
+    @Test
+    void shouldDrainStreamIntoBodyAndCloseSocketOnConsumeBody() throws Exception {
+        // Given
+        InputStream stream = new ByteArrayInputStream(SSE_BODY.getBytes(StandardCharsets.UTF_8));
+        Socket socket = mock(Socket.class);
+        org.zaproxy.zap.ZapGetMethod method = mock(org.zaproxy.zap.ZapGetMethod.class);
+        given(method.getResponseBodyAsStream()).willReturn(stream);
+        given(method.getUpgradedConnection()).willReturn(socket);
+        HttpMessage msg = new HttpMessage();
+        msg.setUserObject(method);
+        // When
+        boolean consumed = EventStreams.consumeBody(msg);
+        // Then
+        assertThat(consumed, is(true));
+        assertThat(msg.getResponseBody().toString(), is(equalTo(SSE_BODY)));
+        assertThat(
+                msg.getResponseHeader().getContentLength(),
+                is(equalTo(SSE_BODY.getBytes(StandardCharsets.UTF_8).length)));
+        verify(socket).close();
+    }
+
+    @Test
+    void shouldReadOnlyContentLengthBytesWhenHeaderIsPresent() throws Exception {
+        // Given - stream has trailing bytes that must NOT be read or the call would block on a
+        // keep-alive connection.
+        byte[] bodyBytes = SSE_BODY.getBytes(StandardCharsets.UTF_8);
+        InputStream stream =
+                new ByteArrayInputStream(
+                        (SSE_BODY + "extra-bytes-that-should-not-be-read")
+                                .getBytes(StandardCharsets.UTF_8));
+        Socket socket = mock(Socket.class);
+        org.zaproxy.zap.ZapGetMethod method = mock(org.zaproxy.zap.ZapGetMethod.class);
+        given(method.getResponseBodyAsStream()).willReturn(stream);
+        given(method.getUpgradedConnection()).willReturn(socket);
+        HttpMessage msg = new HttpMessage();
+        msg.setUserObject(method);
+        msg.getResponseHeader().setContentLength(bodyBytes.length);
+        // When
+        boolean consumed = EventStreams.consumeBody(msg);
+        // Then
+        assertThat(consumed, is(true));
+        assertThat(msg.getResponseBody().toString(), is(equalTo(SSE_BODY)));
+        assertThat(msg.getResponseHeader().getContentLength(), is(equalTo(bodyBytes.length)));
+        verify(socket).close();
+    }
+
+    @Test
+    void shouldStopAtEofWhenContentLengthExceedsAvailableBytes() throws Exception {
+        // Given - declared Content-Length is larger than the stream actually delivers.
+        byte[] bodyBytes = SSE_BODY.getBytes(StandardCharsets.UTF_8);
+        InputStream stream = new ByteArrayInputStream(bodyBytes);
+        Socket socket = mock(Socket.class);
+        org.zaproxy.zap.ZapGetMethod method = mock(org.zaproxy.zap.ZapGetMethod.class);
+        given(method.getResponseBodyAsStream()).willReturn(stream);
+        given(method.getUpgradedConnection()).willReturn(socket);
+        HttpMessage msg = new HttpMessage();
+        msg.setUserObject(method);
+        msg.getResponseHeader().setContentLength(bodyBytes.length + 100);
+        // When
+        boolean consumed = EventStreams.consumeBody(msg);
+        // Then
+        assertThat(consumed, is(true));
+        assertThat(msg.getResponseBody().toString(), is(equalTo(SSE_BODY)));
+        assertThat(msg.getResponseHeader().getContentLength(), is(equalTo(bodyBytes.length)));
+        verify(socket).close();
+    }
+
+    @Test
+    void shouldStillCloseSocketWhenStreamReadFails() throws Exception {
+        // Given
+        InputStream failing =
+                new InputStream() {
+                    @Override
+                    public int read() throws java.io.IOException {
+                        throw new java.io.IOException("boom");
+                    }
+                };
+        Socket socket = mock(Socket.class);
+        org.zaproxy.zap.ZapGetMethod method = mock(org.zaproxy.zap.ZapGetMethod.class);
+        given(method.getResponseBodyAsStream()).willReturn(failing);
+        given(method.getUpgradedConnection()).willReturn(socket);
+        HttpMessage msg = new HttpMessage();
+        msg.setUserObject(method);
+        // When
+        try {
+            EventStreams.consumeBody(msg);
+        } catch (java.io.IOException expected) {
+            // Then
+        }
+        verify(socket).close();
+    }
+
+    @Test
+    void shouldNotTouchSocketWhenConsumeBodyIsANoOp() throws Exception {
+        // Given - ZapGetMethod attached with a socket but no stream, so consumeBody bails early.
+        Socket socket = mock(Socket.class);
+        org.zaproxy.zap.ZapGetMethod method = mock(org.zaproxy.zap.ZapGetMethod.class);
+        given(method.getResponseBodyAsStream()).willReturn(null);
+        given(method.getUpgradedConnection()).willReturn(socket);
+        HttpMessage msg = new HttpMessage();
+        msg.setUserObject(method);
+        // When
+        boolean consumed = EventStreams.consumeBody(msg);
+        // Then
+        assertThat(consumed, is(false));
+        verify(socket, never()).close();
+    }
+}

--- a/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/importer/McpImporterUnitTest.java
+++ b/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/importer/McpImporterUnitTest.java
@@ -50,10 +50,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.addon.mcp.importer.McpImporter.ImportConfig;
 import org.zaproxy.addon.mcp.importer.McpImporter.ImportResults;
+import org.zaproxy.addon.mcp.importer.McpImporter.NetworkClient;
 import org.zaproxy.zap.utils.I18N;
 
 /** Unit tests for {@link McpImporter}. */
@@ -67,13 +67,13 @@ class McpImporterUnitTest {
         Constant.messages = new I18N(Locale.ROOT);
     }
 
-    /** Per-method response bodies dispatched by the mock sender. */
+    /** Per-method response bodies dispatched by the mock client. */
     private Map<String, String> responses;
 
-    /** All messages passed to {@code sendAndReceive} during a test, in call order. */
+    /** All messages passed to {@code send} during a test, in call order. */
     private List<HttpMessage> capturedRequests;
 
-    private HttpSender sender;
+    private NetworkClient client;
     private McpImporter importer;
 
     @BeforeEach
@@ -84,18 +84,22 @@ class McpImporterUnitTest {
                 "initialize",
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{}}}");
         responses.put("notifications/initialized", "");
-        responses.put("tools/list", "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}");
+        responses.put("ping", "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{}}");
+        responses.put("tools/list", "{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"tools\":[]}}");
         responses.put(
-                "resources/list", "{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"resources\":[]}}");
-        responses.put("prompts/list", "{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"prompts\":[]}}");
+                "resources/list", "{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"resources\":[]}}");
+        responses.put(
+                "resources/templates/list",
+                "{\"jsonrpc\":\"2.0\",\"id\":5,\"result\":{\"resourceTemplates\":[]}}");
+        responses.put("prompts/list", "{\"jsonrpc\":\"2.0\",\"id\":6,\"result\":{\"prompts\":[]}}");
 
-        sender = mock(HttpSender.class, withSettings().strictness(Strictness.LENIENT));
-        importer = new McpImporter(sender, null);
-        configureDefaultSender();
+        client = mock(NetworkClient.class, withSettings().strictness(Strictness.LENIENT));
+        importer = new McpImporter(client, null);
+        configureDefaultClient();
     }
 
-    /** Stubs {@code sendAndReceive} to capture messages and return per-method responses. */
-    private void configureDefaultSender() throws IOException {
+    /** Stubs {@code send} to capture messages and return per-method responses. */
+    private void configureDefaultClient() throws IOException {
         willAnswer(
                         inv -> {
                             HttpMessage msg = inv.getArgument(0);
@@ -111,8 +115,8 @@ class McpImporterUnitTest {
                             msg.setResponseBody(responseBody);
                             return null;
                         })
-                .given(sender)
-                .sendAndReceive(any(HttpMessage.class));
+                .given(client)
+                .send(any(HttpMessage.class));
     }
 
     // ---- invalid URL ----
@@ -128,7 +132,7 @@ class McpImporterUnitTest {
         assertThat(results.requestCount(), is(0));
         assertThat(results.errors(), hasSize(1));
         assertThat(results.errors().get(0), is("!mcp.importserver.error.nohttp!"));
-        verify(sender, never()).sendAndReceive(any(HttpMessage.class));
+        verify(client, never()).send(any(HttpMessage.class));
     }
 
     // ---- initialize failure — aborts immediately ----
@@ -136,9 +140,7 @@ class McpImporterUnitTest {
     @Test
     void shouldStopOnInitializeIoFailure() throws IOException {
         // Given
-        willThrow(new IOException("connection refused"))
-                .given(sender)
-                .sendAndReceive(any(HttpMessage.class));
+        willThrow(new IOException("connection refused")).given(client).send(any(HttpMessage.class));
 
         // When
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
@@ -159,8 +161,8 @@ class McpImporterUnitTest {
                             msg.setResponseBody("");
                             return null;
                         })
-                .given(sender)
-                .sendAndReceive(any(HttpMessage.class));
+                .given(client)
+                .send(any(HttpMessage.class));
 
         // When
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
@@ -226,20 +228,20 @@ class McpImporterUnitTest {
     // ---- happy path ----
 
     @Test
-    void shouldCountFiveRequestsForMinimalSuccessfulImport() throws IOException {
+    void shouldCountBaselineRequestsForMinimalSuccessfulImport() throws IOException {
         // Given
 
         // When
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
 
-        // Then - initialize + notifications/initialized + tools/list + resources/list +
-        // prompts/list
+        // Then - initialize + notifications/initialized + ping + tools/list + resources/list
+        // + resources/templates/list + prompts/list = 7
         assertThat(results.errors(), is(empty()));
-        assertThat(results.requestCount(), is(5));
+        assertThat(results.requestCount(), is(7));
     }
 
     @Test
-    void shouldIncludeAllFiveMethodsInMinimalImport() throws IOException {
+    void shouldIncludeAllBaselineMethodsInMinimalImport() throws IOException {
         // Given
 
         // When
@@ -248,8 +250,10 @@ class McpImporterUnitTest {
         // Then
         assertThat(findRequestByMethod("initialize"), is(notNullValue()));
         assertThat(findRequestByMethod("notifications/initialized"), is(notNullValue()));
+        assertThat(findRequestByMethod("ping"), is(notNullValue()));
         assertThat(findRequestByMethod("tools/list"), is(notNullValue()));
         assertThat(findRequestByMethod("resources/list"), is(notNullValue()));
+        assertThat(findRequestByMethod("resources/templates/list"), is(notNullValue()));
         assertThat(findRequestByMethod("prompts/list"), is(notNullValue()));
     }
 
@@ -294,6 +298,111 @@ class McpImporterUnitTest {
         JsonNode body = parseBody(findRequestByMethod("notifications/initialized"));
         assertThat(body.has("id"), is(false));
         assertThat(body.path("jsonrpc").asText(), equalTo("2.0"));
+    }
+
+    @Test
+    void shouldSetAcceptHeaderForJsonAndEventStreamOnAllRequests() throws IOException {
+        // Given / When
+        importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        assertThat(capturedRequests, not(empty()));
+        for (HttpMessage msg : capturedRequests) {
+            String accept = msg.getRequestHeader().getHeader("Accept");
+            assertThat(accept, containsString("application/json"));
+            assertThat(accept, containsString("text/event-stream"));
+        }
+    }
+
+    @Test
+    void shouldEchoMcpSessionIdFromInitializeOnSubsequentRequests() throws IOException {
+        // Given
+        String sessionId = "session-abc-123";
+        willAnswer(
+                        inv -> {
+                            HttpMessage msg = inv.getArgument(0);
+                            capturedRequests.add(msg);
+                            String method =
+                                    MAPPER.readTree(msg.getRequestBody().toString())
+                                            .path("method")
+                                            .asText();
+                            String responseBody =
+                                    responses.getOrDefault(
+                                            method, "{\"jsonrpc\":\"2.0\",\"result\":{}}");
+                            String headers =
+                                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n";
+                            if ("initialize".equals(method)) {
+                                headers += "Mcp-Session-Id: " + sessionId + "\r\n";
+                            }
+                            msg.setResponseHeader(headers + "\r\n");
+                            msg.setResponseBody(responseBody);
+                            return null;
+                        })
+                .given(client)
+                .send(any(HttpMessage.class));
+
+        // When
+        importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        HttpMessage initRequest = findRequestByMethod("initialize");
+        assertThat(initRequest.getRequestHeader().getHeader("Mcp-Session-Id"), is(nullValue()));
+        List<String> followups =
+                List.of(
+                        "notifications/initialized",
+                        "ping",
+                        "tools/list",
+                        "resources/list",
+                        "resources/templates/list",
+                        "prompts/list");
+        for (String method : followups) {
+            HttpMessage msg = findRequestByMethod(method);
+            assertThat(
+                    "expected session header on " + method,
+                    msg.getRequestHeader().getHeader("Mcp-Session-Id"),
+                    equalTo(sessionId));
+        }
+    }
+
+    @Test
+    void shouldNotSendMcpSessionIdWhenInitializeOmitsIt() throws IOException {
+        // Given / When
+        importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        for (HttpMessage msg : capturedRequests) {
+            assertThat(msg.getRequestHeader().getHeader("Mcp-Session-Id"), is(nullValue()));
+        }
+    }
+
+    @Test
+    void shouldParseSseFramedInitializeResponse() throws IOException {
+        // Given
+        willAnswer(
+                        inv -> {
+                            HttpMessage msg = inv.getArgument(0);
+                            capturedRequests.add(msg);
+                            String method =
+                                    MAPPER.readTree(msg.getRequestBody().toString())
+                                            .path("method")
+                                            .asText();
+                            String json =
+                                    responses.getOrDefault(
+                                            method, "{\"jsonrpc\":\"2.0\",\"result\":{}}");
+                            msg.setResponseHeader(
+                                    "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n");
+                            msg.setResponseBody("event: message\ndata: " + json + "\n\n");
+                            return null;
+                        })
+                .given(client)
+                .send(any(HttpMessage.class));
+
+        // When
+        ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        assertThat(results.errors(), is(empty()));
+        assertThat(results.requestCount(), is(7));
     }
 
     // ---- security key ----
@@ -353,7 +462,7 @@ class McpImporterUnitTest {
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
 
         // Then
-        assertThat(results.requestCount(), is(6)); // 5 base + 1 tools/call
+        assertThat(results.requestCount(), is(8)); // 7 base + 1 tools/call
         HttpMessage toolsCallMsg = findRequestByMethod("tools/call");
         assertThat(toolsCallMsg, is(notNullValue()));
         assertThat(
@@ -375,7 +484,7 @@ class McpImporterUnitTest {
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
 
         // Then
-        assertThat(results.requestCount(), is(7)); // 5 base + 2 tools/call
+        assertThat(results.requestCount(), is(9)); // 7 base + 2 tools/call
         assertThat(findAllRequestsByMethod("tools/call"), hasSize(2));
     }
 
@@ -410,7 +519,7 @@ class McpImporterUnitTest {
         willAnswer(inv -> "generated-" + inv.getArgument(2))
                 .given(valueProvider)
                 .getValue(any(), any(), any(), any(), any(), any(), any());
-        importer = new McpImporter(sender, valueProvider);
+        importer = new McpImporter(client, valueProvider);
         responses.put(
                 "tools/list",
                 toolsListResponse(
@@ -471,7 +580,7 @@ class McpImporterUnitTest {
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
 
         // Then
-        assertThat(results.requestCount(), is(6)); // 5 base + 1 resources/read
+        assertThat(results.requestCount(), is(8)); // 7 base + 1 resources/read
         HttpMessage readMsg = findRequestByMethod("resources/read");
         assertThat(readMsg, is(notNullValue()));
         assertThat(parseBody(readMsg).path("params").path("uri").asText(), equalTo("zap://alerts"));
@@ -491,7 +600,7 @@ class McpImporterUnitTest {
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
 
         // Then
-        assertThat(results.requestCount(), is(7)); // 5 base + 2 resources/read
+        assertThat(results.requestCount(), is(9)); // 7 base + 2 resources/read
         assertThat(findAllRequestsByMethod("resources/read"), hasSize(2));
     }
 
@@ -506,7 +615,7 @@ class McpImporterUnitTest {
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
 
         // Then
-        assertThat(results.requestCount(), is(6)); // 5 base + 1 prompts/get
+        assertThat(results.requestCount(), is(8)); // 7 base + 1 prompts/get
         HttpMessage getMsg = findRequestByMethod("prompts/get");
         assertThat(getMsg, is(notNullValue()));
         assertThat(
@@ -526,6 +635,104 @@ class McpImporterUnitTest {
                 parseBody(findRequestByMethod("prompts/get")).path("params").path("arguments");
         assertThat(args.path("target").asText(), equalTo("target"));
         assertThat(args.path("config").asText(), equalTo("config"));
+    }
+
+    // ---- pagination ----
+
+    @Test
+    void shouldFollowNextCursorOnPaginatedToolsList() throws IOException {
+        // Given
+        Map<String, String> pageQueue = new java.util.LinkedHashMap<>();
+        pageQueue.put(
+                "<noCursor>",
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"t1\",\"inputSchema\":{}}],\"nextCursor\":\"page2\"}}");
+        pageQueue.put(
+                "page2",
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"t2\",\"inputSchema\":{}}]}}");
+        willAnswer(
+                        inv -> {
+                            HttpMessage msg = inv.getArgument(0);
+                            capturedRequests.add(msg);
+                            JsonNode json = MAPPER.readTree(msg.getRequestBody().toString());
+                            String method = json.path("method").asText();
+                            String responseBody;
+                            if ("tools/list".equals(method)) {
+                                String cursor =
+                                        json.path("params").path("cursor").asText("<noCursor>");
+                                responseBody =
+                                        pageQueue.getOrDefault(
+                                                cursor,
+                                                "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}");
+                            } else {
+                                responseBody =
+                                        responses.getOrDefault(
+                                                method, "{\"jsonrpc\":\"2.0\",\"result\":{}}");
+                            }
+                            msg.setResponseHeader(
+                                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n");
+                            msg.setResponseBody(responseBody);
+                            return null;
+                        })
+                .given(client)
+                .send(any(HttpMessage.class));
+
+        // When
+        importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        List<HttpMessage> toolsListRequests = findAllRequestsByMethod("tools/list");
+        assertThat(toolsListRequests, hasSize(2));
+        assertThat(
+                parseBody(toolsListRequests.get(1)).path("params").path("cursor").asText(),
+                equalTo("page2"));
+        assertThat(findAllRequestsByMethod("tools/call"), hasSize(2));
+    }
+
+    // ---- ping / logging / resources/templates/list ----
+
+    @Test
+    void shouldNotSendLoggingSetLevelWhenCapabilityNotAdvertised() throws IOException {
+        // Given / When
+        importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        assertThat(findRequestByMethod("logging/setLevel"), is(nullValue()));
+    }
+
+    @Test
+    void shouldSendLoggingSetLevelWhenCapabilityAdvertised() throws IOException {
+        // Given
+        responses.put(
+                "initialize",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{\"logging\":{}}}}");
+
+        // When
+        importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        HttpMessage logMsg = findRequestByMethod("logging/setLevel");
+        assertThat(logMsg, is(notNullValue()));
+        assertThat(parseBody(logMsg).path("params").path("level").asText(), equalTo("info"));
+    }
+
+    @Test
+    void shouldResolveResourceTemplateVariablesAndReadEach() throws IOException {
+        // Given
+        responses.put(
+                "resources/templates/list",
+                "{\"jsonrpc\":\"2.0\",\"id\":5,\"result\":{\"resourceTemplates\":["
+                        + "{\"uriTemplate\":\"demo://resource/dynamic/{resourceId}\",\"name\":\"Dynamic\"}"
+                        + "]}}");
+
+        // When
+        importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        HttpMessage readMsg = findRequestByMethod("resources/read");
+        assertThat(readMsg, is(notNullValue()));
+        assertThat(
+                parseBody(readMsg).path("params").path("uri").asText(),
+                equalTo("demo://resource/dynamic/resourceId"));
     }
 
     // ---- non-fatal failures in list calls ----
@@ -550,8 +757,8 @@ class McpImporterUnitTest {
                             msg.setResponseBody(responseBody);
                             return null;
                         })
-                .given(sender)
-                .sendAndReceive(any(HttpMessage.class));
+                .given(client)
+                .send(any(HttpMessage.class));
 
         // When
         ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));


### PR DESCRIPTION
To test run https://github.com/modelcontextprotocol/servers/tree/main/src/everything and try to import it.
The easiest option is to use `npx @modelcontextprotocol/server-everything streamableHttp`

Without this PR the import fails. With the PR the ZAP successfully imports all of the endpoints.