### PR TITLE
authhelper: handle Microsoft "Permissions requested" consent screen

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Support for handling the Microsoft login "Permissions requested" user consent screen.
 
 ### Fixed
 - Handling of Ionic input elements, which can appear to not be displayed until they are clicked on.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/MsLoginAuthenticator.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/MsLoginAuthenticator.java
@@ -64,6 +64,23 @@ public final class MsLoginAuthenticator implements Authenticator {
     private static final By PROOF_TOTP_VERIFY_FIELD = By.id("idSubmit_SAOTCC_Continue");
     private static final By PROOF_DONE_FIELD = By.id("id__5");
 
+    private static final String PERMISSIONS_REQUESTED_TEXT = "Permissions requested";
+    private static final String ACCEPT_TEXT = "Accept";
+
+    private static final By PERMISSIONS_REQUESTED_HEADING =
+            By.xpath(
+                    "//*[@role='heading' and normalize-space(.)='"
+                            + PERMISSIONS_REQUESTED_TEXT
+                            + "']");
+
+    // Consent Accept button reuses the idSIButton9 name (not id) on the consent page.
+    private static final By CONSENT_PRIMARY_BUTTON =
+            By.cssSelector(
+                    "input#idSIButton9,"
+                            + "input[name='idSIButton9'],"
+                            + "button#idSIButton9,"
+                            + "button[name='idSIButton9']");
+
     private enum State {
         START,
 
@@ -79,6 +96,8 @@ public final class MsLoginAuthenticator implements Authenticator {
         PROOF_REDIRECT,
         PROOF_TOTP,
         PROOF,
+
+        PERMISSIONS_REQUESTED,
     }
 
     @Override
@@ -160,6 +179,11 @@ public final class MsLoginAuthenticator implements Authenticator {
                         userField = true;
                         pwdField = true;
                         states.add(State.PROOF_TOTP);
+                    } else if (findPermissionsAcceptButton(wd) != null) {
+                        // SSO already signed in; landed directly on consent screen.
+                        userField = true;
+                        pwdField = true;
+                        states.add(State.PERMISSIONS_REQUESTED);
                     } else {
                         diags.recordStep(
                                 wd,
@@ -321,12 +345,25 @@ public final class MsLoginAuthenticator implements Authenticator {
                         states.add(State.STAY_SIGNED_IN);
                         break;
                     } catch (TimeoutException e) {
+                        // KMSI not present; try consent before giving up.
+                    }
+
+                    if (isMsLoginFlowFinished(wd, authHandle, targetHandle)) {
+                        successful = true;
+                        break;
+                    }
+
+                    try {
+                        waitForElement(wd, new PermissionsRequestedAcceptButton());
+                        states.add(State.PERMISSIONS_REQUESTED);
+                        break;
+                    } catch (TimeoutException e) {
                         diags.recordStep(
                                 wd,
                                 Constant.messages.getString(
                                         "authhelper.auth.method.diags.steps.ms.stepunknown"));
                         LOGGER.debug(
-                                "Still in login URL but no keep me signed in field found, assuming unsuccessful login.");
+                                "Still in login URL but no known MS login step found, assuming unsuccessful login.");
                     }
 
                     break;
@@ -411,6 +448,19 @@ public final class MsLoginAuthenticator implements Authenticator {
                                 "Still in proof but no skip/done button found, assuming unsuccessful login.");
                         break;
                     }
+
+                case PERMISSIONS_REQUESTED:
+                    WebElement acceptElement =
+                            waitForElement(wd, new PermissionsRequestedAcceptButton());
+                    diags.recordStep(
+                            wd,
+                            Constant.messages.getString(
+                                    "authhelper.auth.method.diags.steps.ms.clickpermissionsaccept"),
+                            acceptElement);
+                    acceptElement.click();
+                    // Accept is itself the submit; just loop back to POST_PASSWORD.
+                    states.add(State.POST_PASSWORD);
+                    break;
             }
         } while (!states.isEmpty());
 
@@ -530,5 +580,58 @@ public final class MsLoginAuthenticator implements Authenticator {
         public String toString() {
             return String.format("element '%s' containing text '%s' is not present", locator, text);
         }
+    }
+
+    private static class PermissionsRequestedAcceptButton implements ExpectedCondition<WebElement> {
+
+        @Override
+        public WebElement apply(WebDriver driver) {
+            return findPermissionsAcceptButton(driver);
+        }
+
+        @Override
+        public String toString() {
+            return "Microsoft permissions requested page with enabled Accept button is not present";
+        }
+    }
+
+    private static WebElement findPermissionsAcceptButton(WebDriver wd) {
+        if (!hasDisplayedElement(wd, PERMISSIONS_REQUESTED_HEADING)) {
+            return null;
+        }
+        return wd.findElements(CONSENT_PRIMARY_BUTTON).stream()
+                .filter(MsLoginAuthenticator::isDisplayedAndEnabled)
+                .filter(MsLoginAuthenticator::isAcceptButton)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean hasDisplayedElement(WebDriver wd, By by) {
+        return wd.findElements(by).stream().anyMatch(MsLoginAuthenticator::isDisplayed);
+    }
+
+    private static boolean isDisplayed(WebElement element) {
+        try {
+            return element.isDisplayed();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    private static boolean isDisplayedAndEnabled(WebElement element) {
+        try {
+            return element.isDisplayed() && element.isEnabled();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    private static boolean isAcceptButton(WebElement element) {
+        String value = element.getAttribute("value");
+        if (ACCEPT_TEXT.equalsIgnoreCase(value)) {
+            return true;
+        }
+        String text = element.getText();
+        return ACCEPT_TEXT.equalsIgnoreCase(text);
     }
 }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/MsLoginAuthenticator.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/auth/MsLoginAuthenticator.java
@@ -65,7 +65,6 @@ public final class MsLoginAuthenticator implements Authenticator {
     private static final By PROOF_DONE_FIELD = By.id("id__5");
 
     private static final String PERMISSIONS_REQUESTED_TEXT = "Permissions requested";
-    private static final String ACCEPT_TEXT = "Accept";
 
     private static final By PERMISSIONS_REQUESTED_HEADING =
             By.xpath(
@@ -73,13 +72,7 @@ public final class MsLoginAuthenticator implements Authenticator {
                             + PERMISSIONS_REQUESTED_TEXT
                             + "']");
 
-    // Consent Accept button reuses the idSIButton9 name (not id) on the consent page.
-    private static final By CONSENT_PRIMARY_BUTTON =
-            By.cssSelector(
-                    "input#idSIButton9,"
-                            + "input[name='idSIButton9'],"
-                            + "button#idSIButton9,"
-                            + "button[name='idSIButton9']");
+    private static final By CONSENT_PRIMARY_BUTTON = By.cssSelector("input[name='idSIButton9']");
 
     private enum State {
         START,
@@ -179,8 +172,7 @@ public final class MsLoginAuthenticator implements Authenticator {
                         userField = true;
                         pwdField = true;
                         states.add(State.PROOF_TOTP);
-                    } else if (findPermissionsAcceptButton(wd) != null) {
-                        // SSO already signed in; landed directly on consent screen.
+                    } else if (findElement(wd, PERMISSIONS_REQUESTED_HEADING) != null) {
                         userField = true;
                         pwdField = true;
                         states.add(State.PERMISSIONS_REQUESTED);
@@ -345,7 +337,7 @@ public final class MsLoginAuthenticator implements Authenticator {
                         states.add(State.STAY_SIGNED_IN);
                         break;
                     } catch (TimeoutException e) {
-                        // KMSI not present; try consent before giving up.
+                        // Try next state.
                     }
 
                     if (isMsLoginFlowFinished(wd, authHandle, targetHandle)) {
@@ -354,7 +346,7 @@ public final class MsLoginAuthenticator implements Authenticator {
                     }
 
                     try {
-                        waitForElement(wd, new PermissionsRequestedAcceptButton());
+                        waitForElement(wd, PERMISSIONS_REQUESTED_HEADING);
                         states.add(State.PERMISSIONS_REQUESTED);
                         break;
                     } catch (TimeoutException e) {
@@ -450,15 +442,13 @@ public final class MsLoginAuthenticator implements Authenticator {
                     }
 
                 case PERMISSIONS_REQUESTED:
-                    WebElement acceptElement =
-                            waitForElement(wd, new PermissionsRequestedAcceptButton());
+                    WebElement acceptElement = wd.findElement(CONSENT_PRIMARY_BUTTON);
                     diags.recordStep(
                             wd,
                             Constant.messages.getString(
                                     "authhelper.auth.method.diags.steps.ms.clickpermissionsaccept"),
                             acceptElement);
                     acceptElement.click();
-                    // Accept is itself the submit; just loop back to POST_PASSWORD.
                     states.add(State.POST_PASSWORD);
                     break;
             }
@@ -580,58 +570,5 @@ public final class MsLoginAuthenticator implements Authenticator {
         public String toString() {
             return String.format("element '%s' containing text '%s' is not present", locator, text);
         }
-    }
-
-    private static class PermissionsRequestedAcceptButton implements ExpectedCondition<WebElement> {
-
-        @Override
-        public WebElement apply(WebDriver driver) {
-            return findPermissionsAcceptButton(driver);
-        }
-
-        @Override
-        public String toString() {
-            return "Microsoft permissions requested page with enabled Accept button is not present";
-        }
-    }
-
-    private static WebElement findPermissionsAcceptButton(WebDriver wd) {
-        if (!hasDisplayedElement(wd, PERMISSIONS_REQUESTED_HEADING)) {
-            return null;
-        }
-        return wd.findElements(CONSENT_PRIMARY_BUTTON).stream()
-                .filter(MsLoginAuthenticator::isDisplayedAndEnabled)
-                .filter(MsLoginAuthenticator::isAcceptButton)
-                .findFirst()
-                .orElse(null);
-    }
-
-    private static boolean hasDisplayedElement(WebDriver wd, By by) {
-        return wd.findElements(by).stream().anyMatch(MsLoginAuthenticator::isDisplayed);
-    }
-
-    private static boolean isDisplayed(WebElement element) {
-        try {
-            return element.isDisplayed();
-        } catch (RuntimeException e) {
-            return false;
-        }
-    }
-
-    private static boolean isDisplayedAndEnabled(WebElement element) {
-        try {
-            return element.isDisplayed() && element.isEnabled();
-        } catch (RuntimeException e) {
-            return false;
-        }
-    }
-
-    private static boolean isAcceptButton(WebElement element) {
-        String value = element.getAttribute("value");
-        if (ACCEPT_TEXT.equalsIgnoreCase(value)) {
-            return true;
-        }
-        String text = element.getText();
-        return ACCEPT_TEXT.equalsIgnoreCase(text);
     }
 }

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -71,6 +71,7 @@ authhelper.auth.method.diags.steps.ms.clickaccount = [MS] Click Account
 authhelper.auth.method.diags.steps.ms.clickaccountother = [MS] Click Account Other
 authhelper.auth.method.diags.steps.ms.clickbutton = [MS] Click Button
 authhelper.auth.method.diags.steps.ms.clickkmsi = [MS] Click KMSI
+authhelper.auth.method.diags.steps.ms.clickpermissionsaccept = [MS] Click Permissions Accept
 authhelper.auth.method.diags.steps.ms.clickproofdone = [MS] Click Proof Done
 authhelper.auth.method.diags.steps.ms.clickproofredirect = [MS] Click Proof Redirect
 authhelper.auth.method.diags.steps.ms.clickprooftotperror = [MS] TOTP Error


### PR DESCRIPTION
## Overview
`MsLoginAuthenticator` doesn't recognize the Microsoft "Permissions requested" user-consent screen, so flows that hit it (first-time consent for an app) fall through to "step unknown" and fail.

## Testing
Validated locally end-to-end against a real Microsoft Entra login that hits the "Permissions requested" consent screen, the authenticator now advances through it and completes auth successfully. Verified the happy path (no consent screen) is unaffected.

## Changes
- New `PERMISSIONS_REQUESTED` state. Detection runs only inside the existing KMSI timeout branch, so the happy path is unchanged.
- Heading-text gated (`Permissions requested`) before clicking the `idSIButton9` Accept button, won't hijack the same button id used on other MS pages.
- CHANGELOG + one new `Messages.properties` key.