### PR TITLE
ascanrulesAlpha: use consistent example data

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [57] - 2026-05-06
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -24,6 +24,7 @@ import java.net.UnknownHostException;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -67,7 +68,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin
     // LDAP errors for Injection testing
     // Use an inverse map to avoid multimap use
     // ----------------------------------------
-    private static final Map<Pattern, String> LDAP_ERRORS = new HashMap<>();
+    private static final Map<Pattern, String> LDAP_ERRORS = new LinkedHashMap<>();
     private static final Map<String, String> ALERT_TAGS;
 
     static {

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRuleUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.ascanrulesAlpha;
 
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
@@ -185,7 +186,7 @@ class LdapInjectionScanRuleUnitTest extends ActiveScannerTest<LdapInjectionScanR
         Alert errorBasedAlert = alerts.get(0);
         assertThat(errorBasedAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(errorBasedAlert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
-        assertThat(errorBasedAlert.getOtherInfo(), is(not(emptyString())));
+        assertThat(errorBasedAlert.getOtherInfo(), containsString("0x00005011L"));
 
         Alert booleanBasedAlert = alerts.get(1);
         assertThat(booleanBasedAlert.getRisk(), is(equalTo(Alert.RISK_HIGH)));


### PR DESCRIPTION
Keep the LDAP errors in a predictable order for the example data to be always the same.