### PR TITLE
client: Add more spider programmatic control

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- More programmatic control of the spider.
 
 ## [0.25.0] - 2026-05-22
 ### Changed

--- a/addOns/client/client.gradle.kts
+++ b/addOns/client/client.gradle.kts
@@ -51,7 +51,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("selenium") {
-                    version.set(">=15.14.0")
+                    version.set(">=15.49.0")
                 }
                 register("network") {
                     version.set(">=0.8.0")

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientCallBackImplementor.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientCallBackImplementor.java
@@ -27,9 +27,33 @@ import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
  */
 public interface ClientCallBackImplementor {
 
+    /**
+     * Context for a client callback request.
+     *
+     * @param initiator the {@link org.parosproxy.paros.network.HttpSender} initiator that launched
+     *     the browser, or {@code -1} if unknown
+     * @since 0.26.0
+     */
+    record ClientCallBackContext(int initiator) {}
+
     String getImplementorName();
 
     String handleCallBack(HttpMessage msg);
+
+    /**
+     * Handles a callback request from a browser connection.
+     *
+     * <p>The default implementation ignores {@link ClientCallBackContext} and delegates to {@link
+     * #handleCallBack(HttpMessage)} for backward compatibility. Implementors that need the context
+     * data must override this method.
+     *
+     * @param msg the callback request
+     * @param context the callback context
+     * @since 0.26.0
+     */
+    default String handleCallBack(HttpMessage msg, ClientCallBackContext context) {
+        return handleCallBack(msg);
+    }
 
     /**
      * This method will be removed soon.

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
@@ -72,6 +72,8 @@ public class ClientIntegrationAPI extends ApiImplementor {
     private Map<WebDriver, ClientCallBackUtils> wdMap =
             Collections.synchronizedMap(new HashMap<>());
 
+    private Map<Integer, Integer> portInitiators = Collections.synchronizedMap(new HashMap<>());
+
     public ClientIntegrationAPI(ExtensionClientIntegration extension, ClientMap clientMap) {
         this.extension = extension;
         this.clientMap = clientMap;
@@ -159,7 +161,11 @@ public class ClientIntegrationAPI extends ApiImplementor {
             ClientCallBackImplementor impl = this.clientCallBacks.get(paths[3]);
             if (impl != null) {
                 try {
-                    return impl.handleCallBack(msg);
+                    int initiator =
+                            portInitiators.getOrDefault(
+                                    msg.getRequestHeader().getLocalAddress().getPort(), -1);
+                    return impl.handleCallBack(
+                            msg, new ClientCallBackImplementor.ClientCallBackContext(initiator));
                 } catch (Exception e) {
                     LOGGER.error(
                             "Error in client callback implementation {}: {}",
@@ -253,8 +259,17 @@ public class ClientIntegrationAPI extends ApiImplementor {
         this.clientCallBacks.remove(callback.getImplementorName());
     }
 
+    void registerPortInitiator(int port, int initiator) {
+        portInitiators.put(port, initiator);
+    }
+
+    void unregisterPortInitiator(int port) {
+        portInitiators.remove(port);
+    }
+
     protected void browserLaunched(ClientCallBackUtils ccbu) {
         wdMap.put(ccbu.getWebDriver(), ccbu);
+        registerPortInitiator(ccbu.getProxyPort(), ccbu.getRequester());
         this.clientCallBacks.forEach(
                 (n, callback) -> {
                     try {
@@ -282,5 +297,6 @@ public class ClientIntegrationAPI extends ApiImplementor {
 
     void clear() {
         this.wdMap.clear();
+        this.portInitiators.clear();
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -946,6 +946,29 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
         this.api.browserClosing(wd);
     }
 
+    /**
+     * Associates a browser proxy port with an {@link org.parosproxy.paros.network.HttpSender}
+     * initiator for client callback handling.
+     *
+     * <p>Should be called as soon as the proxy port is known, before the browser is launched, so
+     * that callbacks received during browser initialisation are associated correctly.
+     *
+     * @param port the browser proxy port
+     * @param initiator the HttpSender initiator
+     */
+    public void registerPortInitiator(int port, int initiator) {
+        this.api.registerPortInitiator(port, initiator);
+    }
+
+    /**
+     * Removes the initiator associated with the given browser proxy port.
+     *
+     * @param port the browser proxy port
+     */
+    public void unregisterPortInitiator(int port) {
+        this.api.unregisterPortInitiator(port);
+    }
+
     private class ClientPassiveScanRuleProvider implements PassiveScanRuleProvider {
 
         @Override

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -77,6 +77,8 @@ import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.addon.network.server.HttpServerConfig;
 import org.zaproxy.addon.network.server.Server;
+import org.zaproxy.zap.extension.selenium.DriverConfiguration;
+import org.zaproxy.zap.extension.selenium.DriverConfiguration.DriverConfigurationBuilder;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.GenericScanner2;
@@ -865,27 +867,62 @@ public class ClientSpider implements GenericScanner2 {
     class WebDriverProcess {
 
         private static final String LOCAL_PROXY_IP = "127.0.0.1";
-        private static final int INITIATOR = HttpSender.CLIENT_SPIDER_INITIATOR;
 
         private Server proxy;
         private WebDriver webDriver;
+        private final int proxyPort;
 
         private WebDriverProcess(ProxyHandler proxyHandler) throws IOException {
+            int initiator = scanOptions.getInitiator();
+            HttpSender httpSender = scanOptions.getHttpSender();
+            if (httpSender == null) {
+                httpSender = new HttpSender(initiator);
+            }
             proxy =
                     extensionNetwork.createHttpServer(
                             HttpServerConfig.builder()
                                     .setHttpMessageHandler(proxyHandler)
-                                    .setHttpSender(new HttpSender(INITIATOR))
+                                    .setHttpSender(httpSender)
                                     .setServeZapApi(true)
                                     .build());
-            int port = proxy.start(Server.ANY_PORT);
-            proxyPorts.add(port);
+            proxyPort = proxy.start(Server.ANY_PORT);
+            proxyPorts.add(proxyPort);
+            extClient.registerPortInitiator(proxyPort, initiator);
 
-            webDriver =
-                    extSelenium.getWebDriver(
-                            INITIATOR, options.getBrowserId(), LOCAL_PROXY_IP, port);
-            if (ScopeCheck.STRICT.equals(options.getScopeCheck())) {
-                proxyHandler.setAllowAll(false);
+            DriverConfigurationBuilder driverConfBuilder =
+                    DriverConfiguration.builder()
+                            .requester(initiator)
+                            .proxyAddress(LOCAL_PROXY_IP)
+                            .proxyPort(proxyPort)
+                            .enableExtensions(true);
+            if (!scanOptions.getIncludeExtensions().isEmpty()) {
+                driverConfBuilder.includeExtensions(scanOptions.getIncludeExtensions());
+            }
+            if (!scanOptions.getExcludeExtensions().isEmpty()) {
+                driverConfBuilder.excludeExtensions(scanOptions.getExcludeExtensions());
+            }
+
+            try {
+                webDriver =
+                        extSelenium.getWebDriver(options.getBrowserId(), driverConfBuilder.build());
+                if (ScopeCheck.STRICT.equals(options.getScopeCheck())) {
+                    proxyHandler.setAllowAll(false);
+                }
+            } catch (Exception e) {
+                closeProxy();
+                throw e;
+            }
+        }
+
+        private void closeProxy() {
+            if (proxy != null) {
+                extClient.unregisterPortInitiator(proxyPort);
+                try {
+                    proxy.close();
+                } catch (IOException e) {
+                    LOGGER.debug("An error occurred while stopping the proxy.", e);
+                }
+                proxy = null;
             }
         }
 
@@ -899,13 +936,7 @@ public class ClientSpider implements GenericScanner2 {
                 }
             }
 
-            if (proxy != null) {
-                try {
-                    proxy.close();
-                } catch (IOException e) {
-                    LOGGER.debug("An error occurred while stopping the proxy.", e);
-                }
-            }
+            closeProxy();
         }
     }
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ScanOptions.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ScanOptions.java
@@ -19,9 +19,12 @@
  */
 package org.zaproxy.addon.client.spider;
 
+import java.util.Collections;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.users.User;
 
@@ -40,11 +43,37 @@ public class ScanOptions {
      */
     @Builder.Default private final boolean externalControl = false;
 
+    @Builder.Default private final int initiator = HttpSender.CLIENT_SPIDER_INITIATOR;
+
+    /**
+     * The {@code HttpSender} to use for browser proxy traffic. If not set a new {@code HttpSender}
+     * is created using {@link #initiator}.
+     *
+     * @since 0.26.0
+     */
+    private final HttpSender httpSender;
+
     @Builder.Default private final int hrefType = HistoryReference.TYPE_CLIENT_SPIDER;
 
     @Builder.Default private final int tmpHrefType = HistoryReference.TYPE_CLIENT_SPIDER_TEMPORARY;
 
     @Builder.Default private final String threadPrefix = "ZAP-ClientSpiderThreadPool-";
+
+    /**
+     * Browser extension names to include when launching browsers, even if disabled in the Selenium
+     * options.
+     *
+     * @since 0.26.0
+     */
+    @Builder.Default private final List<String> includeExtensions = Collections.emptyList();
+
+    /**
+     * Browser extension names to exclude when launching browsers, even if enabled in the Selenium
+     * options.
+     *
+     * @since 0.26.0
+     */
+    @Builder.Default private final List<String> excludeExtensions = Collections.emptyList();
 
     /** A builder of options. */
     public static class Builder {

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientIntegrationAPIUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientIntegrationAPIUnitTest.java
@@ -39,6 +39,7 @@ import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.zap.extension.selenium.SeleniumScriptUtils;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -106,12 +107,15 @@ class ClientIntegrationAPIUnitTest extends TestUtils {
         // Given
         CallBackImp callback = new CallBackImp("test");
         api.registerClientCallBack(callback);
+        InetSocketAddress addr = new InetSocketAddress(9999);
 
         // When
-        String resp1 = api.handleCallBack(getMsg("GET", api.getCallbackUrl() + "/test"));
-        String resp2 = api.handleCallBack(getMsg("POST", api.getCallbackUrl() + "/test/1/2/3"));
+        String resp1 = api.handleCallBack(getMsg("GET", api.getCallbackUrl() + "/test", addr));
+        String resp2 =
+                api.handleCallBack(getMsg("POST", api.getCallbackUrl() + "/test/1/2/3", addr));
         String resp3 =
-                api.handleCallBack(getMsg("OPTIONS", api.getCallbackUrl() + "/test?querystring"));
+                api.handleCallBack(
+                        getMsg("OPTIONS", api.getCallbackUrl() + "/test?querystring", addr));
 
         // Then
         assertThat(callback.calls, is(3));
@@ -281,6 +285,56 @@ class ClientIntegrationAPIUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldPassInitiatorToClientCallBackWhenPortRegistered() throws Exception {
+        // Given
+        int proxyPort = 5678;
+        InitiatorCallBackImp callback = new InitiatorCallBackImp("test");
+        api.registerClientCallBack(callback);
+        api.registerPortInitiator(proxyPort, HttpSender.CLIENT_SPIDER_INITIATOR);
+        HttpMessage msg =
+                getMsg("GET", api.getCallbackUrl() + "/test", new InetSocketAddress(proxyPort));
+
+        // When
+        api.handleCallBack(msg);
+
+        // Then
+        assertThat(callback.initiator, is(HttpSender.CLIENT_SPIDER_INITIATOR));
+    }
+
+    @Test
+    void shouldPassUnknownInitiatorWhenPortUnknown() throws Exception {
+        // Given
+        InitiatorCallBackImp callback = new InitiatorCallBackImp("test");
+        api.registerClientCallBack(callback);
+        HttpMessage msg =
+                getMsg("GET", api.getCallbackUrl() + "/test", new InetSocketAddress(9999));
+
+        // When
+        api.handleCallBack(msg);
+
+        // Then
+        assertThat(callback.initiator, is(-1));
+    }
+
+    @Test
+    void shouldRemoveInitiatorMappingOnUnregisterPortInitiator() throws Exception {
+        // Given
+        int proxyPort = 5678;
+        api.registerPortInitiator(proxyPort, HttpSender.CLIENT_SPIDER_INITIATOR);
+        InitiatorCallBackImp callback = new InitiatorCallBackImp("test");
+        api.registerClientCallBack(callback);
+
+        // When
+        api.unregisterPortInitiator(proxyPort);
+        HttpMessage msg =
+                getMsg("GET", api.getCallbackUrl() + "/test", new InetSocketAddress(proxyPort));
+        api.handleCallBack(msg);
+
+        // Then
+        assertThat(callback.initiator, is(-1));
+    }
+
+    @Test
     void shouldDelegateReportObjectViaCallback() throws Exception {
         // Given
         String reportedObject = "ReportedObject";
@@ -317,15 +371,28 @@ class ClientIntegrationAPIUnitTest extends TestUtils {
     }
 
     private static ClientCallBackUtils createClientCallBackUtils() {
+        return createClientCallBackUtils(8080, 0);
+    }
+
+    private static ClientCallBackUtils createClientCallBackUtils(int proxyPort, int requester) {
         WebDriver wd = mock(WebDriver.class);
-        SeleniumScriptUtils ssu = new SeleniumScriptUtils(wd, 0, "firefox", "localhost", 8080);
+        SeleniumScriptUtils ssu =
+                new SeleniumScriptUtils(wd, requester, "firefox", "localhost", proxyPort);
         return new ClientCallBackUtils(ssu, UUID.randomUUID());
     }
 
     private static HttpMessage getMsg(String method, String url) throws Exception {
+        return getMsg(method, url, null);
+    }
+
+    private static HttpMessage getMsg(String method, String url, InetSocketAddress localAddress)
+            throws Exception {
         HttpMessage msg = new HttpMessage();
         URI uri = new URI(url, true);
         msg.setRequestHeader(new HttpRequestHeader(method, uri, HttpHeader.HTTP11));
+        if (localAddress != null) {
+            msg.getRequestHeader().setLocalAddress(localAddress);
+        }
         return msg;
     }
 
@@ -364,6 +431,33 @@ class ClientIntegrationAPIUnitTest extends TestUtils {
         @Override
         public void browserClosing(ClientCallBackUtils ccbu) {
             this.closingCcbu = ccbu;
+        }
+    }
+
+    static class InitiatorCallBackImp implements ClientCallBackImplementor {
+
+        private final String name;
+        int initiator = -1;
+
+        InitiatorCallBackImp(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getImplementorName() {
+            return name;
+        }
+
+        @Override
+        public String handleCallBack(HttpMessage msg) {
+            return "";
+        }
+
+        @Override
+        public String handleCallBack(
+                HttpMessage msg, ClientCallBackImplementor.ClientCallBackContext context) {
+            this.initiator = context.initiator();
+            return "";
         }
     }
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -83,6 +83,7 @@ import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.network.server.HttpServerConfig;
 import org.zaproxy.addon.network.server.Server;
+import org.zaproxy.zap.extension.selenium.DriverConfiguration;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -146,8 +147,7 @@ class ClientSpiderUnitTest extends TestUtils {
                                         .defaultAnswer(CALLS_REAL_METHODS)
                                         .strictness(Strictness.LENIENT)));
 
-        when(extSel.getWebDriver(anyInt(), any(String.class), any(String.class), anyInt()))
-                .thenReturn(wd);
+        when(extSel.getWebDriver(any(String.class), any(DriverConfiguration.class))).thenReturn(wd);
         given(extClient.getModel()).willReturn(model);
         Session session = mock(Session.class);
         given(model.getSession()).willReturn(session);
@@ -233,7 +233,7 @@ class ClientSpiderUnitTest extends TestUtils {
         clientMapListener();
         String urlFoundDuringStartup = "https://www.example.com/post-auth-page";
         CountDownLatch getWebDriverCdl = new CountDownLatch(1);
-        when(extSel.getWebDriver(anyInt(), any(String.class), any(String.class), anyInt()))
+        when(extSel.getWebDriver(any(String.class), any(DriverConfiguration.class)))
                 .thenAnswer(
                         invocation -> {
                             mapListener.nodeAdded(urlFoundDuringStartup, 0, 0, PROXY_PORT);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ScanOptionsUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ScanOptionsUnitTest.java
@@ -20,12 +20,16 @@
 package org.zaproxy.addon.client.spider;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.users.User;
 
@@ -33,28 +37,34 @@ import org.zaproxy.zap.users.User;
 class ScanOptionsUnitTest {
 
     @Test
-    void shouldHaveDefaultHrefType() {
-        assertThat(
-                ScanOptions.builder().build().getHrefType(),
-                is(HistoryReference.TYPE_CLIENT_SPIDER));
+    void shouldHaveDefaults() {
+        ScanOptions options = ScanOptions.builder().build();
+        assertThat(options.getHrefType(), is(HistoryReference.TYPE_CLIENT_SPIDER));
+        assertThat(options.getTmpHrefType(), is(HistoryReference.TYPE_CLIENT_SPIDER_TEMPORARY));
+        assertThat(options.getThreadPrefix(), is("ZAP-ClientSpiderThreadPool-"));
+        assertThat(options.isExternalControl(), is(false));
+        assertThat(options.getIncludeExtensions(), is(empty()));
+        assertThat(options.getExcludeExtensions(), is(empty()));
+        assertThat(options.getHttpSender(), is(nullValue()));
     }
 
     @Test
-    void shouldHaveDefaultTmpHrefType() {
+    void shouldAllowHttpSenderToBeSet() {
+        HttpSender httpSender = new HttpSender(HttpSender.CLIENT_SPIDER_INITIATOR);
         assertThat(
-                ScanOptions.builder().build().getTmpHrefType(),
-                is(HistoryReference.TYPE_CLIENT_SPIDER_TEMPORARY));
+                ScanOptions.builder().setHttpSender(httpSender).build().getHttpSender(),
+                is(httpSender));
     }
 
     @Test
-    void shouldHaveDefaultThreadPrefix() {
-        assertThat(
-                ScanOptions.builder().build().getThreadPrefix(), is("ZAP-ClientSpiderThreadPool-"));
-    }
-
-    @Test
-    void shouldHaveExternalControlDisabledByDefault() {
-        assertThat(ScanOptions.builder().build().isExternalControl(), is(false));
+    void shouldAllowExtensionListsToBeSet() {
+        ScanOptions options =
+                ScanOptions.builder()
+                        .setIncludeExtensions(List.of("zap-browser-extension"))
+                        .setExcludeExtensions(List.of("other-extension"))
+                        .build();
+        assertThat(options.getIncludeExtensions(), is(List.of("zap-browser-extension")));
+        assertThat(options.getExcludeExtensions(), is(List.of("other-extension")));
     }
 
     @Test
@@ -90,6 +100,9 @@ class ScanOptionsUnitTest {
                         .setHrefType(99)
                         .setTmpHrefType(100)
                         .setThreadPrefix("custom-prefix-")
+                        .setIncludeExtensions(List.of("included-ext"))
+                        .setExcludeExtensions(List.of("excluded-ext"))
+                        .setHttpSender(new HttpSender(99))
                         .build();
 
         // When
@@ -103,5 +116,8 @@ class ScanOptionsUnitTest {
         assertThat(copy.getHrefType(), is(99));
         assertThat(copy.getTmpHrefType(), is(100));
         assertThat(copy.getThreadPrefix(), is("custom-prefix-"));
+        assertThat(copy.getIncludeExtensions(), is(List.of("included-ext")));
+        assertThat(copy.getExcludeExtensions(), is(List.of("excluded-ext")));
+        assertThat(copy.getHttpSender(), is(original.getHttpSender()));
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/SpiderScanControllerUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/SpiderScanControllerUnitTest.java
@@ -55,6 +55,7 @@ import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.network.server.HttpServerConfig;
 import org.zaproxy.addon.network.server.Server;
+import org.zaproxy.zap.extension.selenium.DriverConfiguration;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ScanListenner2;
@@ -104,7 +105,7 @@ class SpiderScanControllerUnitTest extends TestUtils {
                                 withSettings()
                                         .defaultAnswer(CALLS_REAL_METHODS)
                                         .strictness(Strictness.LENIENT)));
-        when(extSelenium.getWebDriver(anyInt(), any(String.class), any(String.class), anyInt()))
+        when(extSelenium.getWebDriver(any(String.class), any(DriverConfiguration.class)))
                 .thenReturn(wd);
 
         extension = mock(ExtensionClientIntegration.class);

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Programmatic options to force extensions to be included or excluded.
 
 ## [15.48.0] - 2026-05-21
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/DriverConfiguration.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/DriverConfiguration.java
@@ -56,4 +56,6 @@ public class DriverConfiguration {
     @Builder.Default private final String driverPath = "";
     @Builder.Default private final List<String> arguments = Collections.emptyList();
     @Builder.Default private final Map<String, String> preferences = Collections.emptyMap();
+    @Builder.Default private final List<String> includeExtensions = Collections.emptyList();
+    @Builder.Default private final List<String> excludeExtensions = Collections.emptyList();
 }

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -39,6 +39,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -883,12 +884,9 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         if (provider == null) {
             throw new IllegalArgumentException("Unknown browser: " + browserId);
         }
-        Consumer<MutableCapabilities> consumer =
-                driverConf.getConsumer() != null ? driverConf.getConsumer() : c -> {};
         int requester = driverConf.getRequester();
         String proxyAddress = driverConf.getProxyAddress();
         int proxyPort = driverConf.getProxyPort();
-        boolean enableExtensions = driverConf.isEnableExtensions();
         WebDriver wd;
         DriverConfiguration config;
         String statsKey;
@@ -896,31 +894,12 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         if (provider instanceof BuiltInSingleWebDriverProvider builtinBrowserProv) {
             Browser browser = builtinBrowserProv.getBrowser();
             statsKey = "stats.selenium.launch." + requester + "." + browser.getId();
-            config =
-                    buildConfigFromBrowser(
-                            browser,
-                            requester,
-                            proxyAddress,
-                            proxyPort,
-                            consumer,
-                            enableExtensions,
-                            driverConf.getArguments(),
-                            driverConf.getPreferences());
+            config = buildConfigFromBrowser(browser, driverConf);
         } else if (provider instanceof CustomBrowserWebDriverProvider customBrowserProv) {
             CustomBrowserImpl customBrowser = customBrowserProv.getCustomBrowser();
             boolean headless = browserId.endsWith("-headless");
             statsKey = "stats.selenium.launch." + requester + ".custom." + customBrowser.getName();
-            config =
-                    buildConfigFromCustomBrowser(
-                            customBrowser,
-                            requester,
-                            proxyAddress,
-                            proxyPort,
-                            headless,
-                            consumer,
-                            enableExtensions,
-                            driverConf.getArguments(),
-                            driverConf.getPreferences());
+            config = buildConfigFromCustomBrowser(customBrowser, headless, driverConf);
         } else {
             throw new IllegalArgumentException(
                     "Unknown ProvidedBrowser: " + provided.getClass().getCanonicalName());
@@ -1164,9 +1143,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
 
                 if (isEdge) {
                     return configureDriver(
-                            Browser.EDGE,
-                            new EdgeDriver((EdgeOptions) chromiumOptions),
-                            conf.isEnableExtensions());
+                            Browser.EDGE, new EdgeDriver((EdgeOptions) chromiumOptions), conf);
                 }
                 ChromeDriver chromeDriver;
                 if (StringUtils.isNotEmpty(conf.getDriverPath())) {
@@ -1178,7 +1155,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                 } else {
                     chromeDriver = new ChromeDriver((ChromeOptions) chromiumOptions);
                 }
-                return configureDriver(Browser.CHROME, chromeDriver, conf.isEnableExtensions());
+                return configureDriver(Browser.CHROME, chromeDriver, conf);
 
             case FIREFOX:
                 FirefoxOptions firefoxOptions = new FirefoxOptions();
@@ -1215,7 +1192,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                 } else {
                     firefoxDriver = new FirefoxDriver(firefoxOptions);
                 }
-                return configureDriver(Browser.FIREFOX, firefoxDriver, conf.isEnableExtensions());
+                return configureDriver(Browser.FIREFOX, firefoxDriver, conf);
 
             case HTML_UNIT:
                 DesiredCapabilities htmlunitCapabilities = new DesiredCapabilities();
@@ -1251,14 +1228,12 @@ public class ExtensionSelenium extends ExtensionAdaptor {
     }
 
     protected static DriverConfiguration buildConfigFromBrowser(
-            Browser browser,
-            int requester,
-            String proxyAddress,
-            int proxyPort,
-            Consumer<MutableCapabilities> consumer,
-            boolean enableExtensions,
-            List<String> extraArguments,
-            Map<String, String> extraPreferences) {
+            Browser browser, DriverConfiguration driverConf) {
+        Consumer<MutableCapabilities> consumer =
+                driverConf.getConsumer() != null ? driverConf.getConsumer() : c -> {};
+        List<String> extraArguments = driverConf.getArguments();
+        Map<String, String> extraPreferences = driverConf.getPreferences();
+
         boolean headless;
         Browser baseBrowser;
         switch (browser) {
@@ -1310,30 +1285,29 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         }
 
         return DriverConfiguration.builder()
-                .requester(requester)
+                .requester(driverConf.getRequester())
                 .type(browserToType(browser))
-                .proxyAddress(proxyAddress)
-                .proxyPort(proxyPort)
+                .proxyAddress(driverConf.getProxyAddress())
+                .proxyPort(driverConf.getProxyPort())
                 .headless(headless)
                 .binaryPath(binaryPath)
                 .driverPath("")
                 .arguments(arguments)
                 .preferences(preferences)
                 .consumer(consumer)
-                .enableExtensions(enableExtensions)
+                .enableExtensions(driverConf.isEnableExtensions())
+                .includeExtensions(driverConf.getIncludeExtensions())
+                .excludeExtensions(driverConf.getExcludeExtensions())
                 .build();
     }
 
     protected static DriverConfiguration buildConfigFromCustomBrowser(
-            CustomBrowserImpl customBrowser,
-            int requester,
-            String proxyAddress,
-            int proxyPort,
-            boolean headless,
-            Consumer<MutableCapabilities> consumer,
-            boolean enableExtensions,
-            List<String> extraArguments,
-            Map<String, String> extraPreferences) {
+            CustomBrowserImpl customBrowser, boolean headless, DriverConfiguration driverConf) {
+        Consumer<MutableCapabilities> consumer =
+                driverConf.getConsumer() != null ? driverConf.getConsumer() : c -> {};
+        List<String> extraArguments = driverConf.getArguments();
+        Map<String, String> extraPreferences = driverConf.getPreferences();
+
         List<String> arguments = new ArrayList<>(getCustomBrowserArguments(customBrowser));
         if (extraArguments != null && !extraArguments.isEmpty()) {
             arguments.addAll(extraArguments);
@@ -1382,17 +1356,19 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         }
 
         return DriverConfiguration.builder()
-                .requester(requester)
+                .requester(driverConf.getRequester())
                 .type(type)
-                .proxyAddress(proxyAddress)
-                .proxyPort(proxyPort)
+                .proxyAddress(driverConf.getProxyAddress())
+                .proxyPort(driverConf.getProxyPort())
                 .headless(headless)
                 .binaryPath(binaryPath)
                 .driverPath(driverPath != null ? driverPath : "")
                 .arguments(arguments)
                 .preferences(preferences)
                 .consumer(consumer)
-                .enableExtensions(enableExtensions)
+                .enableExtensions(driverConf.isEnableExtensions())
+                .includeExtensions(driverConf.getIncludeExtensions())
+                .excludeExtensions(driverConf.getExcludeExtensions())
                 .build();
     }
 
@@ -1606,26 +1582,63 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         return path != null ? path : "";
     }
 
-    private static RemoteWebDriver configureDriver(
-            Browser browser, RemoteWebDriver driver, boolean enableExtensions) {
-        driver.script().addConsoleMessageHandler(e -> WEBDRIVER_LOGGER.debug(e.getText()));
-        if (enableExtensions) {
-            WebExtension webExt = new WebExtension(driver);
-            boolean isChromium =
-                    browser == Browser.CHROME
-                            || browser == Browser.CHROME_HEADLESS
-                            || browser == Browser.EDGE
-                            || browser == Browser.EDGE_HEADLESS;
-            getSeleniumOptions()
-                    .getEnabledBrowserExtensions(isChromium ? Browser.CHROME : browser)
-                    .stream()
-                    .map(BrowserExtension::getPath)
-                    .map(Path::toAbsolutePath)
-                    .map(Path::toString)
-                    .map(isChromium ? ExtensionPath::new : ExtensionArchivePath::new)
-                    .map(InstallExtensionParameters::new)
-                    .forEach(webExt::install);
+    private static boolean isChromiumBased(Browser browser) {
+        return switch (browser) {
+            case CHROME, CHROME_HEADLESS, EDGE, EDGE_HEADLESS -> true;
+            default -> false;
+        };
+    }
+
+    static boolean matchesExtensionName(Path path, List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return false;
         }
+        return names.stream()
+                .anyMatch(name -> Strings.CI.equals(name, path.getFileName().toString()));
+    }
+
+    static boolean shouldInstallBrowserExtension(
+            BrowserExtension extension,
+            List<String> includeExtensions,
+            List<String> excludeExtensions,
+            boolean enableExtensions) {
+        Path path = extension.getPath();
+        if (matchesExtensionName(path, excludeExtensions)) {
+            return false;
+        }
+        if (matchesExtensionName(path, includeExtensions)) {
+            return true;
+        }
+        return enableExtensions && extension.isEnabled();
+    }
+
+    private static RemoteWebDriver configureDriver(
+            Browser browser, RemoteWebDriver driver, DriverConfiguration conf) {
+        driver.script().addConsoleMessageHandler(e -> WEBDRIVER_LOGGER.debug(e.getText()));
+
+        if (!conf.isEnableExtensions() && conf.getIncludeExtensions().isEmpty()) {
+            return driver;
+        }
+
+        boolean chromiumBased = isChromiumBased(browser);
+        Browser extensionsBrowser = chromiumBased ? Browser.CHROME : browser;
+        WebExtension webExt = new WebExtension(driver);
+
+        getSeleniumOptions().getBrowserExtensions().stream()
+                .filter(ext -> ext.getBrowser() == extensionsBrowser)
+                .filter(
+                        ext ->
+                                shouldInstallBrowserExtension(
+                                        ext,
+                                        conf.getIncludeExtensions(),
+                                        conf.getExcludeExtensions(),
+                                        conf.isEnableExtensions()))
+                .map(BrowserExtension::getPath)
+                .map(Path::toAbsolutePath)
+                .map(Path::toString)
+                .map(chromiumBased ? ExtensionPath::new : ExtensionArchivePath::new)
+                .map(InstallExtensionParameters::new)
+                .forEach(webExt::install);
 
         return driver;
     }

--- a/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/ExtensionSeleniumUnitTest.java
+++ b/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/ExtensionSeleniumUnitTest.java
@@ -35,6 +35,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +62,25 @@ class ExtensionSeleniumUnitTest extends TestUtils {
     private static final int REQUESTER = 100;
     private static final String PROXY_ADDRESS = "127.0.0.1";
     private static final int PROXY_PORT = 8080;
+
+    private static DriverConfiguration testDriverConf(
+            String proxyAddress,
+            int proxyPort,
+            List<String> arguments,
+            Map<String, String> preferences) {
+        DriverConfiguration.DriverConfigurationBuilder builder =
+                DriverConfiguration.builder().requester(REQUESTER).proxyPort(proxyPort);
+        if (proxyAddress != null) {
+            builder.proxyAddress(proxyAddress);
+        }
+        if (arguments != null) {
+            builder.arguments(arguments);
+        }
+        if (preferences != null) {
+            builder.preferences(preferences);
+        }
+        return builder.build();
+    }
 
     private Model model;
     private SeleniumOptions seleniumOptions;
@@ -93,13 +114,7 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromBrowser(
                             Browser.CHROME_HEADLESS,
-                            REQUESTER,
-                            PROXY_ADDRESS,
-                            PROXY_PORT,
-                            c -> {},
-                            false,
-                            null,
-                            null);
+                            testDriverConf(PROXY_ADDRESS, PROXY_PORT, null, null));
 
             assertThat(config.getRequester(), is(REQUESTER));
             assertThat(config.getProxyAddress(), is(PROXY_ADDRESS));
@@ -119,13 +134,7 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromBrowser(
                             Browser.CHROME_HEADLESS,
-                            REQUESTER,
-                            null,
-                            PROXY_PORT,
-                            c -> {},
-                            false,
-                            extraArgs,
-                            null);
+                            testDriverConf(null, PROXY_PORT, extraArgs, null));
 
             assertThat(
                     config.getArguments(),
@@ -143,13 +152,7 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromBrowser(
                             Browser.CHROME_HEADLESS,
-                            REQUESTER,
-                            PROXY_ADDRESS,
-                            PROXY_PORT,
-                            c -> {},
-                            false,
-                            null,
-                            extraPrefs);
+                            testDriverConf(PROXY_ADDRESS, PROXY_PORT, null, extraPrefs));
 
             assertThat(config.getPreferences(), hasEntry("options.pref", "from-options"));
             assertThat(config.getPreferences(), hasEntry("extra.pref", "extra-value"));
@@ -169,14 +172,7 @@ class ExtensionSeleniumUnitTest extends TestUtils {
 
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromBrowser(
-                            Browser.CHROME_HEADLESS,
-                            REQUESTER,
-                            null,
-                            PROXY_PORT,
-                            c -> {},
-                            false,
-                            null,
-                            null);
+                            Browser.CHROME_HEADLESS, testDriverConf(null, PROXY_PORT, null, null));
 
             assertThat(config.getArguments(), contains("--enabled-arg"));
             assertThat(config.getPreferences(), hasEntry("enabled.pref", "v1"));
@@ -190,13 +186,7 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromBrowser(
                             Browser.FIREFOX_HEADLESS,
-                            REQUESTER,
-                            PROXY_ADDRESS,
-                            PROXY_PORT,
-                            c -> {},
-                            false,
-                            null,
-                            null);
+                            testDriverConf(PROXY_ADDRESS, PROXY_PORT, null, null));
 
             assertThat(config.getType(), is(DriverConfiguration.DriverType.FIREFOX));
             assertThat(config.isHeadless(), is(true));
@@ -208,13 +198,7 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromBrowser(
                             Browser.CHROME_HEADLESS,
-                            REQUESTER,
-                            PROXY_ADDRESS,
-                            PROXY_PORT,
-                            c -> {},
-                            false,
-                            null,
-                            null);
+                            testDriverConf(PROXY_ADDRESS, PROXY_PORT, null, null));
 
             assertThat(config.getArguments(), is(equalTo(Collections.emptyList())));
             assertThat(config.getPreferences(), is(equalTo(Collections.emptyMap())));
@@ -225,13 +209,11 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromBrowser(
                             Browser.CHROME_HEADLESS,
-                            REQUESTER,
-                            PROXY_ADDRESS,
-                            PROXY_PORT,
-                            c -> {},
-                            false,
-                            Collections.emptyList(),
-                            Collections.emptyMap());
+                            testDriverConf(
+                                    PROXY_ADDRESS,
+                                    PROXY_PORT,
+                                    Collections.emptyList(),
+                                    Collections.emptyMap()));
 
             assertThat(config.getArguments(), is(equalTo(Collections.emptyList())));
             assertThat(config.getPreferences(), is(equalTo(Collections.emptyMap())));
@@ -259,14 +241,8 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromCustomBrowser(
                             customBrowser,
-                            REQUESTER,
-                            PROXY_ADDRESS,
-                            PROXY_PORT,
                             true,
-                            c -> {},
-                            false,
-                            null,
-                            null);
+                            testDriverConf(PROXY_ADDRESS, PROXY_PORT, null, null));
 
             assertThat(config.getRequester(), is(REQUESTER));
             assertThat(config.getProxyAddress(), is(PROXY_ADDRESS));
@@ -295,14 +271,8 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromCustomBrowser(
                             customBrowser,
-                            REQUESTER,
-                            null,
-                            PROXY_PORT,
                             false,
-                            c -> {},
-                            false,
-                            extraArgs,
-                            extraPrefs);
+                            testDriverConf(null, PROXY_PORT, extraArgs, extraPrefs));
 
             assertThat(config.getArguments(), containsInAnyOrder("--from-browser", "--extra-arg"));
             assertThat(config.getPreferences(), hasEntry("browser.pref", "browserVal"));
@@ -322,15 +292,7 @@ class ExtensionSeleniumUnitTest extends TestUtils {
 
             DriverConfiguration config =
                     ExtensionSelenium.buildConfigFromCustomBrowser(
-                            customBrowser,
-                            REQUESTER,
-                            null,
-                            PROXY_PORT,
-                            true,
-                            c -> {},
-                            false,
-                            null,
-                            null);
+                            customBrowser, true, testDriverConf(null, PROXY_PORT, null, null));
 
             assertThat(config.getArguments(), contains("--headless"));
             assertThat(config.getPreferences(), is(equalTo(Collections.emptyMap())));
@@ -563,6 +525,102 @@ class ExtensionSeleniumUnitTest extends TestUtils {
             } finally {
                 driver2.quit();
             }
+        }
+    }
+
+    @Nested
+    class BrowserExtensionFiltering {
+
+        private static BrowserExtension extension(String name, boolean enabled) {
+            Path path = Paths.get("extensions", name);
+            BrowserExtension ext = new BrowserExtension(path, enabled, Browser.CHROME);
+            return ext;
+        }
+
+        @Test
+        void shouldMatchExtensionByDirectoryName() {
+            Path path = Paths.get("extensions", "zap-browser-extension");
+            assertThat(
+                    ExtensionSelenium.matchesExtensionName(path, List.of("zap-browser-extension")),
+                    is(true));
+            assertThat(
+                    ExtensionSelenium.matchesExtensionName(path, List.of("other-extension")),
+                    is(false));
+        }
+
+        @Test
+        void shouldMatchExtensionNameCaseInsensitively() {
+            Path path = Paths.get("extensions", "My-Extension");
+            assertThat(
+                    ExtensionSelenium.matchesExtensionName(path, List.of("my-extension")),
+                    is(true));
+        }
+
+        @Test
+        void shouldIncludeDisabledExtensionWhenExplicitlyIncluded() {
+            BrowserExtension ext = extension("forced-ext", false);
+            assertThat(
+                    ExtensionSelenium.shouldInstallBrowserExtension(
+                            ext, List.of("forced-ext"), Collections.emptyList(), true),
+                    is(true));
+        }
+
+        @Test
+        void shouldExcludeEnabledExtensionWhenExplicitlyExcluded() {
+            BrowserExtension ext = extension("blocked-ext", true);
+            assertThat(
+                    ExtensionSelenium.shouldInstallBrowserExtension(
+                            ext, Collections.emptyList(), List.of("blocked-ext"), true),
+                    is(false));
+        }
+
+        @Test
+        void shouldUseEnabledStateWhenNotIncludedOrExcluded() {
+            assertThat(
+                    ExtensionSelenium.shouldInstallBrowserExtension(
+                            extension("enabled-ext", true),
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            true),
+                    is(true));
+            assertThat(
+                    ExtensionSelenium.shouldInstallBrowserExtension(
+                            extension("disabled-ext", false),
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            true),
+                    is(false));
+        }
+
+        @Test
+        void shouldNotInstallEnabledExtensionWhenExtensionsDisabledAndNotIncluded() {
+            assertThat(
+                    ExtensionSelenium.shouldInstallBrowserExtension(
+                            extension("enabled-ext", true),
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            false),
+                    is(false));
+        }
+
+        @Test
+        void shouldInstallIncludedExtensionWhenExtensionsDisabled() {
+            assertThat(
+                    ExtensionSelenium.shouldInstallBrowserExtension(
+                            extension("forced-ext", false),
+                            List.of("forced-ext"),
+                            Collections.emptyList(),
+                            false),
+                    is(true));
+        }
+
+        @Test
+        void excludeShouldTakePrecedenceOverInclude() {
+            BrowserExtension ext = extension("conflict-ext", true);
+            assertThat(
+                    ExtensionSelenium.shouldInstallBrowserExtension(
+                            ext, List.of("conflict-ext"), List.of("conflict-ext"), true),
+                    is(false));
         }
     }
 


### PR DESCRIPTION
Add options to set the initiator, include and exclude specific browser extensions.
Needed for PTK ascan rule, but may be useful for other add-ons in the future as well.
