### PR TITLE
sequence: send requests using ZAP

### DIFF
--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Send requests using ZAP instead of default Zest HTTP client implementation.
 
 ## [9] - 2025-12-15
 ### Changed

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/StdActiveScanRunner.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/StdActiveScanRunner.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
@@ -77,6 +78,8 @@ public class StdActiveScanRunner extends ZestZapRunner {
     private final ExtensionHistory extHistory;
     private final ExtensionSequence extSeq;
 
+    private final HttpSender httpSender;
+
     @Getter private List<SequenceStepData> steps = new ArrayList<>();
 
     public StdActiveScanRunner(
@@ -104,6 +107,17 @@ public class StdActiveScanRunner extends ZestZapRunner {
         fakeDirectory = new SiteNode(null, HistoryReference.TYPE_SEQUENCE_TEMPORARY, name);
         fakeRoot.add(fakeDirectory);
         step = 0;
+
+        httpSender = new HttpSender(HttpSender.ACTIVE_SCANNER_INITIATOR);
+        httpSender.setUser(user);
+    }
+
+    @Override
+    public ZestResponse send(ZestRequest request) throws IOException {
+        HttpMessage msg = ZestZapUtils.toHttpMessage(request, null);
+        msg.setRequestingUser(httpSender.getUser(msg));
+        httpSender.sendAndReceive(msg, request.isFollowRedirects());
+        return ZestZapUtils.toZestResponse(msg);
     }
 
     @Override


### PR DESCRIPTION
Change the Zest runner to send the requests using ZAP not through the default Zest HTTP client implementation (which might not support all that ZAP supports and bypasses ZAP configurations).

---
From: https://github.com/zaproxy/zest/issues/370