### PR TITLE
zest: fix exception in GUI

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Restore JSON deserialization behaviour.
   - Handle text (and similar) input elements which only become visible when interacted with.
 
+### Fixed
+- Fix exception when adding/editing Zest non-standalone type scripts through the GUI.
 
 ## [48.13.0] - 2026-03-31
 ### Added

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
@@ -375,7 +375,8 @@ public class ZestScriptsDialog extends StandardFieldsDialog {
         scriptWrapper.setDebug(this.getBoolValue(FIELD_DEBUG));
 
         int stmtDelay = this.getIntValue(FIELD_STMT_DELAY);
-        if (scriptWrapper.getZestScript().getStatementDelay() != stmtDelay) {
+        if (ZestScript.Type.StandAlone.equals(this.type)
+                && scriptWrapper.getZestScript().getStatementDelay() != stmtDelay) {
             scriptWrapper
                     .getZestScript()
                     .setOptions(Map.of(ZestScript.STATEMENT_DELAY_MS, Integer.toString(stmtDelay)));


### PR DESCRIPTION
Check if the script type is the expected before attempting to set the statement delay value, otherwise it would set an invalid value leading to exception.

---
e.g.:
```
2912631 [AWT-EventQueue-0] ERROR org.zaproxy.zap.ZAP.UncaughtExceptionLogger - Exception in thread "AWT-EventQueue-0"
java.lang.IllegalArgumentException: Invalid statementDelay value: -1
	at org.zaproxy.zest.core.v1.ZestScript.setOptions(ZestScript.java:457)
	at org.zaproxy.zap.extension.zest.dialogs.ZestScriptsDialog.save(ZestScriptsDialog.java:381)
	at org.zaproxy.zap.view.StandardFieldsDialog.savePressed(StandardFieldsDialog.java:428)
	at org.zaproxy.zap.view.StandardFieldsDialog$3.actionPerformed(StandardFieldsDialog.java:411)
```