### PR TITLE
automation: Pack columns on plan load

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Adjust columns in plan display after loading a plan.
+
 ### Removed
 - The Params automation support was moved into the Params add-on (Issue 9210).
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
@@ -666,6 +666,7 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
     public void setCurrentPlan(AutomationPlan plan) {
         currentPlan = plan;
         getTreeModel().setPlan(currentPlan);
+        packPlanTableColumns();
         getRunPlanButton()
                 .setEnabled(
                         currentPlan != null
@@ -746,6 +747,14 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
         getRemoveJobButton().setEnabled(false);
         getAddTestButton().setEnabled(false);
         getRemoveTestButton().setEnabled(false);
+    }
+
+    private void packPlanTableColumns() {
+        if (currentPlan == null) {
+            return;
+        }
+        // Allow the tree table to reflect the new plan before resizing columns.
+        EventQueue.invokeLater(tree::packAll);
     }
 
     private PlanTreeTableModel getTreeModel() {


### PR DESCRIPTION
## Overview

Just a small quality of life adjustment. Before this the table column were just adjusted in equal widths. With this after a plan is loaded the columns are packed so that they're more appropriately sized. Which can make the "Info" column more readable/usable.

### AI Disclosure

Cursor was used in the preparation of this change.