### PR TITLE
network: support client certs

### DIFF
--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -39,13 +39,3 @@ dependencies {
     testImplementation(libs.test.webdrivermanager)
     testImplementation(project(":testutils"))
 }
-
-tasks.withType<Test>().configureEach {
-    systemProperties.putAll(
-        mapOf(
-            "wdm.chromeDriverVersion" to "108.0.5359.71",
-            "wdm.geckoDriverVersion" to "0.32.0",
-            "wdm.forceCache" to "true",
-        ),
-    )
-}

--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Option to support client certificates programmatically.
 
 ## [0.28.0] - 2026-05-21
 ### Changed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -57,6 +57,7 @@ import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javax.net.ssl.X509TrustManager;
 import javax.swing.GroupLayout;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -106,6 +107,7 @@ import org.zaproxy.addon.network.internal.client.ZapAuthenticator;
 import org.zaproxy.addon.network.internal.client.ZapProxySelector;
 import org.zaproxy.addon.network.internal.client.apachev5.HttpSenderApache;
 import org.zaproxy.addon.network.internal.handlers.PassThroughHandler;
+import org.zaproxy.addon.network.internal.handlers.TlsConfig;
 import org.zaproxy.addon.network.internal.ratelimit.RateLimitExtensionHelper;
 import org.zaproxy.addon.network.internal.ratelimit.RateLimitOptions;
 import org.zaproxy.addon.network.internal.server.AliasChecker;
@@ -577,11 +579,18 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
             mainServerHandler = () -> new MainServerHandler(blockingServerExecutor, handlers);
         }
 
+        TlsConfig tlsConfig = null;
+        X509TrustManager trustManager = config.getTrustManager();
+        if (trustManager != null) {
+            tlsConfig = TlsConfig.withClientAuth(trustManager);
+        }
+
         return new HttpServer(
                 getMainEventLoopGroup(),
                 getMainEventExecutorGroup(),
                 serverCertificateService,
-                mainServerHandler);
+                mainServerHandler,
+                tlsConfig);
     }
 
     @Override

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsConfig.java
@@ -19,9 +19,11 @@
  */
 package org.zaproxy.addon.network.internal.handlers;
 
+import io.netty.handler.ssl.ClientAuth;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import javax.net.ssl.X509TrustManager;
 import org.zaproxy.addon.network.internal.TlsUtils;
 
 /** The configuration for {@link TlsProtocolHandler}. */
@@ -41,6 +43,8 @@ public class TlsConfig {
     private List<String> tlsProtocols;
     private boolean alpnEnabled;
     private List<String> applicationProtocols;
+    private ClientAuth clientAuthMode;
+    private X509TrustManager trustManager;
 
     /**
      * Constructs a {@code TlsConfig} with all the SSL/TLS protocol versions supported, with ALPN
@@ -69,6 +73,23 @@ public class TlsConfig {
         this.alpnEnabled = alpnEnabled;
         this.applicationProtocols =
                 TlsUtils.filterUnsupportedApplicationProtocols(applicationProtocols);
+        this.clientAuthMode = ClientAuth.NONE;
+    }
+
+    /**
+     * Creates a {@code TlsConfig} that requires a client certificate validated against the given
+     * trust manager, using all default TLS protocol versions and ALPN.
+     *
+     * @param trustManager the trust manager to validate client certificates.
+     * @return a new {@code TlsConfig} with client authentication required.
+     * @throws NullPointerException if the given {@code trustManager} is {@code null}.
+     */
+    public static TlsConfig withClientAuth(X509TrustManager trustManager) {
+        Objects.requireNonNull(trustManager);
+        TlsConfig config = new TlsConfig();
+        config.clientAuthMode = ClientAuth.REQUIRE;
+        config.trustManager = trustManager;
+        return config;
     }
 
     /**
@@ -98,9 +119,33 @@ public class TlsConfig {
         return applicationProtocols;
     }
 
+    /**
+     * Gets the client authentication mode.
+     *
+     * @return the client auth mode, never {@code null}.
+     */
+    public ClientAuth getClientAuthMode() {
+        return clientAuthMode;
+    }
+
+    /**
+     * Gets the trust manager used to validate client certificates, or {@code null} to use the JVM
+     * default.
+     *
+     * @return the trust manager, or {@code null}.
+     */
+    public X509TrustManager getTrustManager() {
+        return trustManager;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(tlsProtocols, alpnEnabled, applicationProtocols);
+        return Objects.hash(
+                tlsProtocols,
+                alpnEnabled,
+                applicationProtocols,
+                clientAuthMode.ordinal(),
+                trustManager);
     }
 
     @Override
@@ -114,6 +159,8 @@ public class TlsConfig {
         TlsConfig other = (TlsConfig) object;
         return Objects.equals(tlsProtocols, other.tlsProtocols)
                 && alpnEnabled == other.alpnEnabled
-                && Objects.equals(applicationProtocols, other.applicationProtocols);
+                && Objects.equals(applicationProtocols, other.applicationProtocols)
+                && clientAuthMode == other.clientAuthMode
+                && Objects.equals(trustManager, other.trustManager);
     }
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandler.java
@@ -29,6 +29,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
+import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
@@ -109,15 +110,21 @@ public class TlsProtocolHandler extends ByteToMessageDecoder {
         Channel ch = ctx.channel();
         TlsConfig config = ch.attr(ChannelAttributes.TLS_CONFIG).get();
 
-        SslContext sslCtx =
+        SslContextBuilder sslCtxBuilder =
                 SslContextBuilder.forServer(
                                 new SniX509KeyManager(
                                         ch.attr(ChannelAttributes.CERTIFICATE_SERVICE).get(),
                                         ch.attr(ChannelAttributes.LOCAL_ADDRESS).get().getAddress(),
                                         authority))
                         .protocols(config.getTlsProtocols())
-                        .applicationProtocolConfig(createApplicationProtocolConfig(config))
-                        .build();
+                        .applicationProtocolConfig(createApplicationProtocolConfig(config));
+
+        ClientAuth clientAuthMode = config.getClientAuthMode();
+        if (clientAuthMode != null && clientAuthMode != ClientAuth.NONE) {
+            sslCtxBuilder.clientAuth(clientAuthMode).trustManager(config.getTrustManager());
+        }
+
+        SslContext sslCtx = sslCtxBuilder.build();
         ctx.pipeline().addAfter(ctx.name(), TLS_HANDLER_NAME, sslCtx.newHandler(ctx.alloc()));
         if (config.isAlpnEnabled()) {
             ctx.pipeline().addAfter(TLS_HANDLER_NAME, "tls.alpn", new AlpnHandlerImpl());

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/HttpServer.java
@@ -83,6 +83,7 @@ public class HttpServer extends BaseServer {
     private final ServerCertificateService certificateService;
     private Supplier<MainServerHandler> handler;
     private DefaultServerConfig serverConfig;
+    private TlsConfig tlsConfig;
 
     /**
      * Constructs a {@code HttpServer} with the given properties and no handler.
@@ -125,6 +126,26 @@ public class HttpServer extends BaseServer {
     }
 
     /**
+     * Constructs a {@code HttpServer} with the given properties and TLS configuration.
+     *
+     * @param group the event loop group.
+     * @param mainHandlerExecutor the event executor for the main handler.
+     * @param certificateService the certificate service.
+     * @param handler the main handler.
+     * @param tlsConfig the TLS configuration to use, or {@code null} to use the default.
+     */
+    public HttpServer(
+            NioEventLoopGroup group,
+            EventExecutorGroup mainHandlerExecutor,
+            ServerCertificateService certificateService,
+            Supplier<MainServerHandler> handler,
+            TlsConfig tlsConfig) {
+        this(group, mainHandlerExecutor, certificateService, handler);
+
+        this.tlsConfig = tlsConfig;
+    }
+
+    /**
      * Sets the main server handler.
      *
      * @param handler the main server handler.
@@ -137,7 +158,8 @@ public class HttpServer extends BaseServer {
     protected void initChannel(SocketChannel ch) {
         ch.attr(ChannelAttributes.CERTIFICATE_SERVICE).set(certificateService);
         ch.attr(ChannelAttributes.SERVER_CONFIG).set(serverConfig);
-        ch.attr(ChannelAttributes.TLS_CONFIG).set(DEFAULT_TLS_CONFIG);
+        ch.attr(ChannelAttributes.TLS_CONFIG)
+                .set(tlsConfig != null ? tlsConfig : DEFAULT_TLS_CONFIG);
         ch.attr(ChannelAttributes.PIPELINE_CONFIGURATOR).set(HttpServer::protocolConfiguration);
 
         ch.pipeline()

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/server/HttpServerConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/server/HttpServerConfig.java
@@ -20,6 +20,7 @@
 package org.zaproxy.addon.network.server;
 
 import java.util.Objects;
+import javax.net.ssl.X509TrustManager;
 import org.parosproxy.paros.network.HttpSender;
 
 /**
@@ -33,12 +34,17 @@ public class HttpServerConfig {
     private final HttpMessageHandler httpMessageHandler;
     private final HttpSender httpSender;
     private final boolean serveZapApi;
+    private final X509TrustManager trustManager;
 
     private HttpServerConfig(
-            HttpMessageHandler httpMessageHandler, HttpSender httpSender, boolean serveZapApi) {
+            HttpMessageHandler httpMessageHandler,
+            HttpSender httpSender,
+            boolean serveZapApi,
+            X509TrustManager trustManager) {
         this.httpMessageHandler = httpMessageHandler;
         this.httpSender = httpSender;
         this.serveZapApi = serveZapApi;
+        this.trustManager = trustManager;
     }
 
     public HttpMessageHandler getHttpMessageHandler() {
@@ -51,6 +57,17 @@ public class HttpServerConfig {
 
     public boolean isServeZapApi() {
         return serveZapApi;
+    }
+
+    /**
+     * Gets the trust manager to use to validate client certificates, or {@code null} if client
+     * certificate authentication is not required.
+     *
+     * @return the trust manager, or {@code null}.
+     * @since 0.29.0
+     */
+    public X509TrustManager getTrustManager() {
+        return trustManager;
     }
 
     /**
@@ -74,6 +91,8 @@ public class HttpServerConfig {
         private HttpSender httpSender;
 
         private boolean serveZapApi;
+
+        private X509TrustManager trustManager;
 
         /**
          * Sets the HTTP message handler.
@@ -110,6 +129,20 @@ public class HttpServerConfig {
         }
 
         /**
+         * Sets the trust manager used to validate client certificates, making client certificate
+         * authentication required. Pass {@code null} to disable client certificate authentication.
+         *
+         * @param trustManager the trust manager, or {@code null} to disable client certificate
+         *     authentication.
+         * @return the builder for chaining.
+         * @since 0.29.0
+         */
+        public Builder setTrustManager(X509TrustManager trustManager) {
+            this.trustManager = trustManager;
+            return this;
+        }
+
+        /**
          * Builds the {@link HttpServerConfig} with properties set.
          *
          * @return the configuration.
@@ -120,7 +153,7 @@ public class HttpServerConfig {
                 throw new IllegalStateException("The httpMessageHandler was not set.");
             }
 
-            return new HttpServerConfig(httpMessageHandler, httpSender, serveZapApi);
+            return new HttpServerConfig(httpMessageHandler, httpSender, serveZapApi, trustManager);
         }
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsConfigUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsConfigUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -32,10 +33,12 @@ import static org.zaproxy.addon.network.internal.TlsUtils.TLS_V1_2;
 import static org.zaproxy.addon.network.internal.TlsUtils.getSupportedApplicationProtocols;
 import static org.zaproxy.addon.network.internal.TlsUtils.getSupportedTlsProtocols;
 
+import io.netty.handler.ssl.ClientAuth;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,6 +46,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 /** Unit test for {@link TlsConfig}. */
 class TlsConfigUnitTest {
@@ -66,6 +70,8 @@ class TlsConfigUnitTest {
         assertThat(
                 tlsConfig.getApplicationProtocols(),
                 is(equalTo(getSupportedApplicationProtocols())));
+        assertThat(tlsConfig.getClientAuthMode(), is(equalTo(ClientAuth.NONE)));
+        assertThat(tlsConfig.getTrustManager(), is(nullValue()));
     }
 
     @Test
@@ -172,7 +178,7 @@ class TlsConfigUnitTest {
         // When
         int hashCode = tlsConfig.hashCode();
         // Then
-        assertThat(hashCode, is(equalTo(2014107303)));
+        assertThat(hashCode, is(equalTo(-1473132313)));
     }
 
     @Test
@@ -277,5 +283,33 @@ class TlsConfigUnitTest {
         boolean equals = tlsConfig.equals(otherTlsConfig);
         // Then
         assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldThrowWhenCreatingWithClientAuthWithNullTrustManager() {
+        // Given / When / Then
+        assertThrows(NullPointerException.class, () -> TlsConfig.withClientAuth(null));
+    }
+
+    @Test
+    void shouldCreateWithTrustManager() {
+        // Given
+        X509TrustManager trustManager = Mockito.mock(X509TrustManager.class);
+        // When
+        TlsConfig tlsConfig = TlsConfig.withClientAuth(trustManager);
+        // Then
+        assertThat(tlsConfig.getClientAuthMode(), is(equalTo(ClientAuth.REQUIRE)));
+        assertThat(tlsConfig.getTrustManager(), is(equalTo(trustManager)));
+    }
+
+    @Test
+    void shouldNotBeEqualWhenClientAuthModeDiffers() {
+        // Given
+        TlsConfig defaultConfig = new TlsConfig();
+        TlsConfig clientAuthConfig = TlsConfig.withClientAuth(Mockito.mock(X509TrustManager.class));
+        // When
+        boolean equals = defaultConfig.equals(clientAuthConfig);
+        // Then
+        assertThat(equals, is(equalTo(false)));
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
@@ -58,6 +58,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.Attribute;
 import io.netty.util.NettyRuntime;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -67,6 +68,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -76,6 +78,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -614,6 +617,75 @@ class TlsProtocolHandlerUnitTest {
         clientTls.connect(port, "");
         // Then
         verify(pipelineConfigurator).configure(any(), eq(TlsUtils.APPLICATION_PROTOCOL_HTTP_2));
+    }
+
+    @Test
+    void shouldRejectConnectionWhenClientAuthRequiredButNoCertPresented() throws Exception {
+        // Given
+        server.stop();
+        serverChannelReady = new CountDownLatch(1);
+        tlsConfig = TlsConfig.withClientAuth(acceptAllTrustManager());
+        createDefaultServer();
+        int port = server.start(Server.ANY_PORT);
+        createClientTls(port);
+        // When / Then
+        assertThrows(Exception.class, () -> clientTls.connect(port, "test"));
+        assertThat(messagesReceived, is(empty()));
+    }
+
+    @Test
+    void shouldAllowConnectionWhenClientAuthRequiredAndCertPresented() throws Exception {
+        // Given
+        server.stop();
+        serverChannelReady = new CountDownLatch(1);
+        tlsConfig = TlsConfig.withClientAuth(acceptAllTrustManager());
+        createDefaultServer();
+        int port = server.start(Server.ANY_PORT);
+        SelfSignedCertificate clientCert = new SelfSignedCertificate();
+        createClientTlsWithCert(port, clientCert);
+        String message = "Sending with client cert.";
+        // When
+        clientTls.connect(port, message);
+        // Then
+        assertThat(messagesReceived, contains(message));
+    }
+
+    private void createClientTlsWithCert(int port, SelfSignedCertificate clientCert) {
+        clientTls =
+                new TextTestClient(
+                        SERVER_ADDRESS,
+                        ch -> {
+                            SslContext sslCtx;
+                            try {
+                                sslCtx =
+                                        SslContextBuilder.forClient()
+                                                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                                .keyManager(clientCert.key(), clientCert.cert())
+                                                .protocols(TlsUtils.getSupportedTlsProtocols())
+                                                .build();
+                            } catch (SSLException e) {
+                                throw new RuntimeException(e);
+                            }
+                            SslHandler sslHandler =
+                                    sslCtx.newHandler(ch.alloc(), SERVER_ADDRESS, port);
+                            sslHandler.setHandshakeTimeout(5, TimeUnit.SECONDS);
+                            ch.pipeline().addFirst(sslHandler);
+                        });
+    }
+
+    private static X509TrustManager acceptAllTrustManager() {
+        return new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
     }
 
     private void waitForServerChannel() throws InterruptedException {

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/server/HttpServerConfigUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/server/HttpServerConfigUnitTest.java
@@ -23,10 +23,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
+import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -114,5 +116,41 @@ class HttpServerConfigUnitTest {
         boolean retrievedServeZapApi = config.isServeZapApi();
         // Then
         assertThat(retrievedServeZapApi, is(equalTo(serve)));
+    }
+
+    @Test
+    void shouldDefaultToNullTrustManager() {
+        // Given
+        config = builderWithRequiredProperties().build();
+        // When
+        X509TrustManager trustManager = config.getTrustManager();
+        // Then
+        assertThat(trustManager, is(nullValue()));
+    }
+
+    @Test
+    void shouldRetrieveTrustManagerSet() {
+        // Given
+        X509TrustManager trustManager = mock(X509TrustManager.class);
+        config = builderWithRequiredProperties().setTrustManager(trustManager).build();
+        // When
+        X509TrustManager retrievedTrustManager = config.getTrustManager();
+        // Then
+        assertThat(retrievedTrustManager, is(equalTo(trustManager)));
+    }
+
+    @Test
+    void shouldClearTrustManagerWhenSetToNull() {
+        // Given
+        X509TrustManager trustManager = mock(X509TrustManager.class);
+        config =
+                builderWithRequiredProperties()
+                        .setTrustManager(trustManager)
+                        .setTrustManager(null)
+                        .build();
+        // When
+        X509TrustManager retrievedTrustManager = config.getTrustManager();
+        // Then
+        assertThat(retrievedTrustManager, is(nullValue()));
     }
 }

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -26,3 +26,13 @@ dependencies {
     api(libs.testutils.nanohttpd.webserver)
     api(libs.testutils.nanohttpd.websocket)
 }
+
+tasks.withType<Test>().configureEach {
+    systemProperties.putAll(
+        mapOf(
+            "wdm.chromeDriverVersion" to "108.0.5359.71",
+            "wdm.geckoDriverVersion" to "0.36.0",
+            "wdm.forceCache" to "true",
+        ),
+    )
+}


### PR DESCRIPTION
Allows us to create a TLS server which uses client certs.
This is needed by the dev add-on to create a test auth app.