### PR TITLE
webdriverlinux: remove geckodriver Linux x32

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Removed
+- The Linux 32-bit `geckodriver` binary is no longer provided, discontinued by upstream.
 
 ## [199] - 2026-06-02
 ### Changed

--- a/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
+++ b/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
@@ -6,7 +6,6 @@ description = "Linux WebDrivers for Firefox and Chrome."
 extra["webdrivers"] =
     listOf(
         WebDriverData(WebDriverData.OS.LINUX, WebDriverData.Browser.CHROME, WebDriverData.Arch.X64),
-        WebDriverData(WebDriverData.OS.LINUX, WebDriverData.Browser.FIREFOX, WebDriverData.Arch.X32, false),
         WebDriverData(WebDriverData.OS.LINUX, WebDriverData.Browser.FIREFOX, WebDriverData.Arch.X64, false),
         WebDriverData(WebDriverData.OS.LINUX, WebDriverData.Browser.FIREFOX, WebDriverData.Arch.ARM64, false),
     )


### PR DESCRIPTION
Stop downloading the binary as it is discontinued by upstream.