### PR TITLE
soap: fix SOAP request generation for complex WSDL schemas

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
 - Update dependency.
+
+### Fixed
+- Fix SOAP requests generated from some WSDLs being incomplete. Requests now correctly include all fields defined in the schema, and requests are no longer broken by certain characters in element or attribute names and values.
 
 ## [30] - 2026-04-14
 ### Changed

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -19,12 +19,17 @@
  */
 package org.zaproxy.zap.extension.soap;
 
+import com.predic8.schema.Attribute;
+import com.predic8.schema.Choice;
+import com.predic8.schema.ComplexContent;
 import com.predic8.schema.ComplexType;
 import com.predic8.schema.Element;
-import com.predic8.schema.Schema;
+import com.predic8.schema.Extension;
+import com.predic8.schema.Sequence;
 import com.predic8.schema.SimpleType;
 import com.predic8.schema.restriction.BaseRestriction;
 import com.predic8.schema.restriction.facet.EnumerationFacet;
+import com.predic8.soamodel.ModelAccessException;
 import com.predic8.soamodel.WrongGrammarException;
 import com.predic8.wsdl.AbstractBinding;
 import com.predic8.wsdl.Binding;
@@ -390,78 +395,154 @@ public class WSDLCustomParser {
         return null;
     }
 
-    private HashMap<String, String> fillParameters(Element element, String parent) {
+    private Map<String, String> fillParameters(Element element, String parent) {
+        if (element.getRef() != null) {
+            return fillFromRef(element, parent);
+        }
+        String xpath = parent != null ? parent + "/" + element.getName() : element.getName();
         HashMap<String, String> formParams = new HashMap<>();
         try {
-            /* Tries to parse it as a complex type first. */
-            String xpath;
-            if (parent != null) xpath = parent + "/" + element.getName();
-            else xpath = element.getName();
-            ComplexType ct = (ComplexType) element.getEmbeddedType();
-            /* Handles when ComplexType is not embedded but referenced by 'type'. */
-            if (ct == null) {
-                Schema currentSchema = element.getSchema();
-                ct = (ComplexType) currentSchema.getType(element.getType());
-                if (ct == null)
-                    throw new ClassCastException(
-                            "Complex Type is null after cast."); // Hashmap is empty here.
+            ComplexType ct = resolveComplexType(element);
+            if (ct != null) {
+                return fillFromComplexType(ct, xpath);
             }
-            for (Element e : ct.getSequence().getElements()) {
-                /* Recursive parsing for nested complex types. */
-                formParams.putAll(fillParameters(e, xpath));
-            }
-        } catch (ClassCastException cce) {
-            /* Handles simple types. */
-            SimpleType simpleType;
-            try {
-                simpleType = (SimpleType) element.getEmbeddedType();
-                if (simpleType == null) {
-                    Schema currentSchema = element.getSchema();
-                    simpleType = (SimpleType) currentSchema.getType(element.getType());
-                    if (simpleType == null) {
-                        /* It is not simple type, so it is treated as a plain element. */
-                        String xpath;
-                        if (parent != null) xpath = parent + "/" + element.getName();
-                        else xpath = element.getName();
-                        if (element.getType() != null)
-                            return addParameter(
-                                    xpath,
-                                    element.getType().getQualifiedName(),
-                                    element.getName(),
-                                    null);
-                        else return formParams;
-                    }
-                }
-            } catch (ClassCastException cce2) {
-                /* It is not simple type, so it is treated as a plain element. */
-                String xpath;
-                if (parent != null) xpath = parent + "/" + element.getName();
-                else xpath = element.getName();
-                return addParameter(
-                        xpath, element.getType().getQualifiedName(), element.getName(), null);
-            }
-            /* Handles enumeration restriction. */
-            BaseRestriction br = simpleType.getRestriction();
-            if (br != null) {
-                List<EnumerationFacet> enums = br.getEnumerationFacets();
-                if (enums != null && enums.size() > 0) {
-                    String defaultValue = enums.get(0).getValue();
-                    formParams.putAll(
-                            addParameter(
-                                    parent + "/" + element.getName(),
-                                    "string",
-                                    element.getName(),
-                                    defaultValue));
-                }
-            }
-            return formParams;
-        } catch (Exception e) {
+            return fillFromSimpleOrPlainElement(element, xpath);
+        } catch (RuntimeException e) {
             LOGGER.warn(
                     "There was an error when trying to parse element {} from WSDL file.",
                     element.getName(),
                     e);
         }
         return formParams;
+    }
+
+    private Map<String, String> fillFromRef(Element element, String parent) {
+        try {
+            Element resolved = element.getSchema().getElement(element.getRef());
+            if (resolved == null) {
+                LOGGER.warn("Could not resolve ref element {} from WSDL file.", element.getRef());
+                return new HashMap<>();
+            }
+            return fillParameters(resolved, parent);
+        } catch (ModelAccessException e) {
+            LOGGER.warn("Could not resolve ref element {} from WSDL file.", element.getRef(), e);
+            return new HashMap<>();
+        }
+    }
+
+    private ComplexType resolveComplexType(Element element) {
+        Object embedded = element.getEmbeddedType();
+        if (embedded instanceof ComplexType) {
+            return (ComplexType) embedded;
+        }
+        if (element.getType() == null) {
+            return null;
+        }
+        Object resolved = element.getSchema().getType(element.getType());
+        return resolved instanceof ComplexType ? (ComplexType) resolved : null;
+    }
+
+    private Map<String, String> fillFromComplexType(ComplexType ct, String xpath) {
+        HashMap<String, String> formParams = new HashMap<>();
+        if (ct.getSequence() != null) {
+            formParams.putAll(fillFromSequence(ct.getSequence(), xpath));
+        }
+        Object model = ct.getModel();
+        if (model instanceof ComplexContent && ((ComplexContent) model).hasExtension()) {
+            Extension ext = (Extension) ((ComplexContent) model).getDerivation();
+            if (ext.getBase() != null) {
+                try {
+                    Object baseType = ct.getSchema().getType(ext.getBase());
+                    if (baseType instanceof ComplexType) {
+                        formParams.putAll(fillFromComplexType((ComplexType) baseType, xpath));
+                    }
+                } catch (ModelAccessException e) {
+                    LOGGER.warn("Could not resolve base type {} from WSDL file.", ext.getBase(), e);
+                }
+            }
+            if (ext.getModel() instanceof Sequence) {
+                formParams.putAll(fillFromSequence((Sequence) ext.getModel(), xpath));
+            }
+        }
+        List<Attribute> attrs = ct.getAllAttributes();
+        if (attrs != null) {
+            for (Attribute attr : attrs) {
+                String attrName = attr.getName();
+                if (attrName == null) {
+                    continue;
+                }
+                String attrType = attr.getType() != null ? attr.getType().getLocalPart() : "string";
+                String attrValue = resolveAttributeValue(attr);
+                formParams.putAll(
+                        addParameter(xpath + "/@" + attrName, attrType, attrName, attrValue));
+            }
+        }
+        return formParams;
+    }
+
+    private Map<String, String> fillFromSequence(Sequence seq, String xpath) {
+        HashMap<String, String> formParams = new HashMap<>();
+        for (Element e : seq.getElements()) {
+            formParams.putAll(fillParameters(e, xpath));
+        }
+        for (Object particle : seq.getParticles()) {
+            if (particle instanceof Choice) {
+                List<Element> options = ((Choice) particle).getElements();
+                if (!options.isEmpty()) {
+                    formParams.putAll(fillParameters(options.get(0), xpath));
+                }
+            }
+        }
+        return formParams;
+    }
+
+    private Map<String, String> fillFromSimpleOrPlainElement(Element element, String xpath) {
+        Object embedded = element.getEmbeddedType();
+        SimpleType simpleType = null;
+        if (embedded instanceof SimpleType) {
+            simpleType = (SimpleType) embedded;
+        } else if (element.getType() != null) {
+            Object resolved = element.getSchema().getType(element.getType());
+            if (resolved instanceof SimpleType) {
+                simpleType = (SimpleType) resolved;
+            }
+        }
+        if (simpleType != null) {
+            BaseRestriction br = simpleType.getRestriction();
+            if (br != null) {
+                List<EnumerationFacet> enums = br.getEnumerationFacets();
+                if (enums != null && !enums.isEmpty()) {
+                    return addParameter(
+                            xpath, "string", element.getName(), enums.get(0).getValue());
+                }
+                String baseType = br.getBuildInTypeName();
+                if (baseType != null && !baseType.isEmpty()) {
+                    return addParameter(xpath, baseType, element.getName(), null);
+                }
+            }
+        }
+        if (element.getType() != null) {
+            return addParameter(
+                    xpath, element.getType().getQualifiedName(), element.getName(), null);
+        }
+        return addParameter(xpath, "string", element.getName(), null);
+    }
+
+    private static String resolveAttributeValue(Attribute attr) {
+        if (attr.getFixedValue() != null) {
+            return attr.getFixedValue();
+        }
+        SimpleType st = attr.getSimpleType();
+        if (st != null) {
+            BaseRestriction br = st.getRestriction();
+            if (br != null) {
+                List<EnumerationFacet> enums = br.getEnumerationFacets();
+                if (enums != null && !enums.isEmpty()) {
+                    return enums.get(0).getValue();
+                }
+            }
+        }
+        return null;
     }
 
     protected HashMap<String, String> addParameter(
@@ -497,20 +578,29 @@ public class WSDLCustomParser {
     }
 
     private String getDefaultValue(String paramType) {
-        switch (paramType) {
-            case "string":
-                return "paramValue";
-            case "int":
-            case "double":
-            case "long":
-                return "0";
-            case "date":
-                return dateFormat("yyyy-MM-dd");
-            case "dateTime":
-                return dateFormat("yyyy-MM-dd'T'hh:mm:ssZ");
-            default:
-                return "";
-        }
+        return switch (paramType) {
+            case "int",
+                    "integer",
+                    "decimal",
+                    "float",
+                    "double",
+                    "long",
+                    "short",
+                    "byte",
+                    "unsignedLong",
+                    "unsignedInt",
+                    "unsignedShort",
+                    "unsignedByte",
+                    "nonNegativeInteger",
+                    "nonPositiveInteger" ->
+                    "0";
+            case "positiveInteger" -> "1";
+            case "negativeInteger" -> "-1";
+            case "boolean" -> "true";
+            case "date" -> dateFormat("yyyy-MM-dd");
+            case "dateTime" -> dateFormat("yyyy-MM-dd'T'hh:mm:ssZ");
+            default -> "paramValue";
+        };
     }
 
     private String dateFormat(String format) {
@@ -549,13 +639,6 @@ public class WSDLCustomParser {
             /* HTTP Request. */
             String endpointLocation = port.getAddress().getLocation();
             HttpMessage httpRequest = new HttpMessage(new URI(endpointLocation, true));
-            /* Body. */
-            HttpRequestBody httpReqBody = httpRequest.getRequestBody();
-            /* [MARK] Not sure if all servers would handle this encoding type. */
-            httpReqBody.append(
-                    "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n"
-                            + writerSOAPReq.getBuffer().toString());
-            httpRequest.setRequestBody(httpReqBody);
             /* Header. */
             HttpRequestHeader httpReqHeader = httpRequest.getRequestHeader();
             httpReqHeader.setMethod("POST");
@@ -569,8 +652,11 @@ public class WSDLCustomParser {
                 if (!action.trim().equals("")) contentType += ";action=" + action;
                 httpReqHeader.setHeader(HttpHeader.CONTENT_TYPE, contentType);
             }
-            httpReqHeader.setContentLength(httpReqBody.length());
             httpRequest.setRequestHeader(httpReqHeader);
+            httpRequest.setRequestBody(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n"
+                            + writerSOAPReq.getBuffer().toString());
+            httpRequest.getRequestHeader().setContentLength(httpRequest.getRequestBody().length());
             return httpRequest;
         } catch (Exception e) {
             LOGGER.error(

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -21,7 +21,10 @@ package org.zaproxy.zap.extension.soap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -57,6 +60,9 @@ import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.testutils.TestUtils;
 
 class WSDLCustomParserTestCase extends TestUtils {
+
+    private static final String MOCK_FILL_VALUE = "mock-fill-value";
+    private static final String FILL_PARAMETERS_WSDL = "fill-parameters.wsdl";
 
     private ValueProvider valueProvider;
     private Supplier<Date> dateSupplier;
@@ -145,11 +151,28 @@ class WSDLCustomParserTestCase extends TestUtils {
             value = {
                 "string, paramValue",
                 "int, 0",
+                "integer, 0",
+                "decimal, 0",
+                "float, 0",
                 "double, 0",
                 "long, 0",
+                "short, 0",
+                "byte, 0",
+                "unsignedLong, 0",
+                "unsignedInt, 0",
+                "unsignedShort, 0",
+                "unsignedByte, 0",
+                "positiveInteger, 1",
+                "negativeInteger, -1",
+                "nonNegativeInteger, 0",
+                "nonPositiveInteger, 0",
+                "boolean, true",
+                "token, paramValue",
+                "normalizedString, paramValue",
+                "anyURI, paramValue",
                 "date, 2023-11-21",
                 "dateTime, 2023-11-21T05:16:40+0000",
-                "something, ''"
+                "something, paramValue"
             })
     void shouldGenerateAppropriateDefaultValueForValueProvider(
             String paramType, String expectedDefaultValue) {
@@ -164,5 +187,135 @@ class WSDLCustomParserTestCase extends TestUtils {
                 .getValue(
                         any(), any(), any(), defaultValueArgCaptor.capture(), any(), any(), any());
         assertThat(defaultValueArgCaptor.getValue(), is(equalTo(expectedDefaultValue)));
+    }
+
+    @Test
+    void shouldPopulateFieldsViaRefElement() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasKey("xpath:/Request/refOuter/refBlock/leafField"));
+    }
+
+    @Test
+    void shouldPickFirstChoiceOption() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasKey("xpath:/Request/branchBox/optA"));
+        assertThat(params, not(hasKey("xpath:/Request/branchBox/optB")));
+    }
+
+    @Test
+    void shouldUseFixedValueForAttribute() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/attrBox/@fixedKey", "FIXED-VAL"));
+        assertThat(params.get("xpath:/Request/attrBox/@fixedKey"), is(not(MOCK_FILL_VALUE)));
+    }
+
+    @Test
+    void shouldUseEnumerationValueForElement() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/enumField", "EL-1"));
+        assertThat(params.get("xpath:/Request/enumField"), is(not(MOCK_FILL_VALUE)));
+    }
+
+    @Test
+    void shouldPopulateAttributeFields() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasKey("xpath:/Request/attrBox/@keyA"));
+        assertThat(params, hasKey("xpath:/Request/attrBox/@keyB"));
+    }
+
+    @Test
+    void shouldUseEnumerationValueForAttribute() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/enumBox/@enumKey", "EV-1"));
+        assertThat(params.get("xpath:/Request/enumBox/@enumKey"), is(not(MOCK_FILL_VALUE)));
+    }
+
+    @Test
+    void shouldUseUnicodeEnumerationValue() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/unicodeBox/@codeKey", "val-ää"));
+    }
+
+    @Test
+    void shouldEmitParamForBoundedSimpleType() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasKey("xpath:/Request/boundedInt"));
+    }
+
+    @Test
+    void shouldEmitParamForTokenTypedElement() throws Exception {
+        // Given – 'tokenField' has type xs:token; must not be dropped and VP must receive a
+        // non-empty default so it can generate a value
+        // When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/tokenField", MOCK_FILL_VALUE));
+    }
+
+    @Test
+    void shouldPopulateExtendedTypeFields() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasKey("xpath:/Request/block/inherited"));
+        assertThat(params, hasKey("xpath:/Request/block/added"));
+    }
+
+    @Test
+    void shouldSkipAttrOnlyTypeAndProcessSibling() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasKey("xpath:/Request/groupOuter/group/leafField"));
+        assertThat(params, hasKey("xpath:/Request/groupOuter/group/metaBlock/@idKey"));
+        assertThat(params, hasKey("xpath:/Request/groupOuter/group/metaBlock/@nameKey"));
+    }
+
+    @Test
+    void shouldAcceptUnicodeAttributeNames() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasKey("xpath:/Request/attrWrapper/@plainKey"));
+        assertThat(params, hasKey("xpath:/Request/attrWrapper/@äKey"));
+    }
+
+    private Map<String, String> parseWsdlParams() throws Exception {
+        return parseWsdlParams(FILL_PARAMETERS_WSDL);
+    }
+
+    private Map<String, String> parseWsdlParams(String resourceName) throws Exception {
+        WSDLCustomParser p = createParserForWsdl(resourceName);
+        return p.getLastConfig().getParams();
+    }
+
+    private WSDLCustomParser createParserForWsdl(String resourceName) throws Exception {
+        Supplier<Date> dateSupplier = mock(withSettings().strictness(Strictness.LENIENT));
+        ValueProvider vp = mock(ValueProvider.class);
+        when(vp.getValue(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(MOCK_FILL_VALUE);
+        WSDLCustomParser p = new WSDLCustomParser(() -> vp, null, dateSupplier);
+        String content =
+                new String(
+                        Files.readAllBytes(getResourcePath("resources/" + resourceName)),
+                        StandardCharsets.UTF_8);
+        p.extContentWSDLImport(content, false);
+        return p;
     }
 }

--- a/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/fill-parameters.wsdl
+++ b/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/fill-parameters.wsdl
@@ -1,0 +1,204 @@
+<?xml version='1.0' encoding='utf-8'?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://example.org/main"
+                  targetNamespace="http://example.org/main"
+                  name="FillParamsService">
+  <wsdl:types>
+
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               targetNamespace="http://example.org/main"
+               elementFormDefault="qualified">
+
+      <xs:complexType name="TypeA">
+        <xs:sequence>
+          <xs:element name="inherited" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+      </xs:complexType>
+
+      <xs:complexType name="TypeB">
+        <xs:complexContent>
+          <xs:extension base="tns:TypeA">
+            <xs:sequence>
+              <xs:element name="added" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+
+      <xs:element name="Request">
+        <xs:complexType>
+          <xs:sequence>
+
+            <xs:element name="refOuter" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element xmlns:data="http://example.org/data"
+                              ref="data:refBlock"
+                              minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="branchBox" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:choice minOccurs="1" maxOccurs="1">
+                    <xs:element name="optA" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="optB" type="xs:int"    minOccurs="0" maxOccurs="1"/>
+                  </xs:choice>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="attrBox" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute name="keyA" type="xs:string"/>
+                <xs:attribute name="keyB" type="xs:string"/>
+                <xs:attribute name="fixedKey" type="xs:string" fixed="FIXED-VAL"/>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="enumField" minOccurs="0" maxOccurs="1">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="EL-1"/>
+                  <xs:enumeration value="EL-2"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+
+            <xs:element name="enumBox" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute name="enumKey" use="required">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="EV-1"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="unicodeBox" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute name="codeKey" use="required">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="val-ää"/>
+                      <xs:enumeration value="val-bb"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="boundedInt" minOccurs="0" maxOccurs="1">
+              <xs:simpleType>
+                <xs:restriction base="xs:int">
+                  <xs:minInclusive value="0"/>
+                  <xs:maxInclusive value="100"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+
+            <!-- xs:token is a string-derived built-in; must produce a param with a non-empty hint -->
+            <xs:element name="tokenField" type="xs:token" minOccurs="0" maxOccurs="1"/>
+
+            <xs:element name="block" type="tns:TypeB" minOccurs="0" maxOccurs="1"/>
+
+            <xs:element name="groupOuter" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element xmlns:data="http://example.org/data"
+                              ref="data:group"
+                              minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="attrWrapper" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute name="plainKey" type="xs:string"/>
+                <xs:attribute name="äKey"     type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:element name="RequestResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ack" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+    </xs:schema>
+
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               targetNamespace="http://example.org/data"
+               elementFormDefault="qualified">
+
+      <xs:element name="refBlock">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="leafField" type="xs:string" minOccurs="0" maxOccurs="1"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:element name="group">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="data:metaBlock" minOccurs="0" maxOccurs="1"
+                        xmlns:data="http://example.org/data"/>
+            <xs:element name="leafField" type="xs:string" minOccurs="0" maxOccurs="1"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:element name="metaBlock">
+        <xs:complexType>
+          <xs:attribute name="idKey"   type="xs:string"/>
+          <xs:attribute name="nameKey" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+
+    </xs:schema>
+
+  </wsdl:types>
+
+  <wsdl:message name="RequestMsg">
+    <wsdl:part name="parameters" element="tns:Request"/>
+  </wsdl:message>
+  <wsdl:message name="RequestResponseMsg">
+    <wsdl:part name="parameters" element="tns:RequestResponse"/>
+  </wsdl:message>
+
+  <wsdl:portType name="FillParamsPortType">
+    <wsdl:operation name="Invoke">
+      <wsdl:input  message="tns:RequestMsg"/>
+      <wsdl:output message="tns:RequestResponseMsg"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="FillParamsBinding" type="tns:FillParamsPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Invoke">
+      <soap:operation soapAction="Invoke"/>
+      <wsdl:input><soap:body use="literal"/></wsdl:input>
+      <wsdl:output><soap:body use="literal"/></wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="FillParamsService">
+    <wsdl:port name="FillParamsPort" binding="tns:FillParamsBinding">
+      <soap:address location="http://localhost:8080/fill-params"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>


### PR DESCRIPTION
## Overview

When a WSDL schema uses element references, type inheritance, choice groups, or attribute declarations, ZAP was silently dropping fields when generating SOAP requests. Affected requests were missing entire sections of the expected body or failing to send due to encoding errors.

The fix refactors WSDLCustomParser.fillParameters into focused helpers that handle each schema construct: ref= resolution across namespaces, xs:complexContent/xs:extension base-type traversal, xs:choice first-option selection, xs:attribute declarations, and enumeration facets as attribute values. Bounded integer types (positiveInteger, negativeInteger, etc.) now get schema-valid default values. Body encoding in createSoapRequest is corrected — setRequestBody(String) is used so the Content-Type charset drives body encoding, preventing non-ASCII characters in element or attribute names from corrupting the XML.