### PR TITLE
accessControl: fix node name discrepancy failing rule check

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Formatted JavaScript files for consistency.
 
+### Fixed
+- Discrepancy between Sites tree node name & Access Control recomputed node name made check silently fail and fallback to parent rule.
+
 ## [12] - 2026-04-14
 ### Changed
 - Maintenance changes.

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/widgets/ContextSiteTree.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/widgets/ContextSiteTree.java
@@ -45,7 +45,7 @@ public class ContextSiteTree extends SiteTree {
         for (SiteNode node : contextNodes) {
             HistoryReference ref = node.getHistoryReference();
             if (ref != null) {
-                this.addPath(context, ref.getURI(), ref.getMethod());
+                this.addPath(context, ref.getURI(), node.getNodeName());
             }
         }
     }

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/widgets/SiteTree.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/widgets/SiteTree.java
@@ -19,13 +19,10 @@
  */
 package org.zaproxy.zap.extension.accessControl.widgets;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
 import javax.swing.tree.TreeNode;
 import org.apache.commons.httpclient.URI;
-import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.model.Context;
@@ -49,24 +46,7 @@ public class SiteTree {
         return root;
     }
 
-    public SiteTreeNode addPath(Context context, URI uri, String method) {
-        Collection<String> urlParams = new ArrayList<>();
-        try {
-            context.getUrlParamParser()
-                    .parseParameters(uri.getQuery())
-                    .forEach(param -> urlParams.add(param.getName()));
-        } catch (URIException e) {
-        }
-        return addPath(context, uri, method, urlParams, null, null);
-    }
-
-    public SiteTreeNode addPath(
-            Context context,
-            URI uri,
-            String method,
-            Collection<String> urlParameters,
-            Collection<String> formParameters,
-            String contentType) {
+    public SiteTreeNode addPath(Context context, URI uri, String leafNodeName) {
         SiteTreeNode parent = this.root;
         SiteTreeNode leaf = null;
         String pathSegment = "";
@@ -86,14 +66,7 @@ public class SiteTree {
                 pathSegment = path.get(i);
                 if (pathSegment != null && !pathSegment.equals("")) {
                     if (i == path.size() - 1) {
-                        String leafName =
-                                UriUtils.getLeafNodeRepresentation(
-                                        pathSegment,
-                                        method,
-                                        urlParameters,
-                                        formParameters,
-                                        contentType);
-                        leaf = findOrAddPathSegmentNode(parent, leafName, uri);
+                        leaf = findOrAddPathSegmentNode(parent, leafNodeName, uri);
                     } else {
                         pathSegmentUri =
                                 new URI(hostUri, paramParser.getAncestorPath(uri, i + 1), false);

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/widgets/UriUtils.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/widgets/UriUtils.java
@@ -19,10 +19,8 @@
  */
 package org.zaproxy.zap.extension.accessControl.widgets;
 
-import java.util.Collection;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.parosproxy.paros.network.HttpRequestHeader;
 
 /** An utility class with various methods related to URIs and URLs used throughout ZAP. */
 public final class UriUtils {
@@ -56,98 +54,6 @@ public final class UriUtils {
         }
 
         return host.toString();
-    }
-
-    /**
-     * Gets the query parameters representation for being displayed in a node throughout ZAP. Method
-     * should be used to keep consistency whenever displaying a node with parameters.
-     *
-     * <p>If the parameter name is longer than 40 characters, it gets truncated.
-     *
-     * <p>Example output: "<i>(param1,param2)</i>"
-     *
-     * @see #getLeafNodeRepresentation(String, String, Collection, Collection, String)
-     * @param params the collection of parameters. Can be null or empty, in which case this method
-     *     will return an empty String
-     * @return the query params node representation
-     */
-    public static String getQueryParamsNodeRepresentation(Collection<String> params) {
-        if (params == null || params.isEmpty()) {
-            return "";
-        }
-
-        StringBuilder sb = new StringBuilder();
-        for (String name : params) {
-            if (name == null) {
-                continue;
-            }
-            if (name.length() > 40) {
-                // Truncate
-                name = name.substring(0, 40);
-            }
-            sb.append(name).append(',');
-        }
-
-        String result = "";
-        if (sb.length() > 0) {
-            result = sb.deleteCharAt(sb.length() - 1).insert(0, '(').append(')').toString();
-        }
-
-        return result;
-    }
-
-    /**
-     * Gets the node representation of a leaf node (a web resource page) for being displayed
-     * throughout ZAP. The representation contains the HTTP method, node name and, if present, any
-     * url or form parameters. Method should be used to keep consistency whenever displaying a
-     * node's hostname.
-     *
-     * <p>Example outputs:
-     *
-     * <ul>
-     *   <li><i>example.jsp</i>
-     *   <li><i>POST:login.php(pass,username)</i>
-     *   <li><i>GET:index.html</i>
-     *   <li><i>POST:upload.jsp(page)(filename)</i>
-     *   <li><i>PUT:example.php(multipart/form-data)</i>
-     * </ul>
-     *
-     * @param nodeName the resource name
-     * @param method the HTTP method used to fetch the resource
-     * @param urlParameters the collection of parsed url parameters, if any, or {@code null}
-     *     otherwise
-     * @param formParameters the collection of parsed request body parameters, if any, or {@code
-     *     null} otherwise. Will be used only if the method is PUT or POST
-     * @param contentType the content type, if any. Will be used to check for multipart form data
-     * @return a string representing the site node
-     */
-    public static String getLeafNodeRepresentation(
-            String nodeName,
-            String method,
-            Collection<String> urlParameters,
-            Collection<String> formParameters,
-            String contentType) {
-
-        StringBuilder leafName = new StringBuilder();
-        if (method != null) {
-            leafName.append(method).append(':');
-        }
-        leafName.append(nodeName);
-
-        if (urlParameters != null) {
-            leafName.append(getQueryParamsNodeRepresentation(urlParameters));
-        }
-
-        if (method != null
-                && (method.equalsIgnoreCase(HttpRequestHeader.POST)
-                        || method.equalsIgnoreCase(HttpRequestHeader.PUT))) {
-            if (contentType != null && contentType.startsWith("multipart/form-data")) {
-                leafName.append("(multipart/form-data)");
-            } else if (formParameters != null) {
-                leafName.append(getQueryParamsNodeRepresentation(formParameters));
-            }
-        }
-        return leafName.toString();
     }
 
     private UriUtils() {


### PR DESCRIPTION
## Overview

Use Zap `node.getNodeName()` instead of recomputing it differently. This created Discrepancies in parsing. (see below)

If node names were not  identical, access control silently falled back to the parent rule.

deleted now unused methods in UriUtils

#### bug example

request
```
curl -k 'https:/zaproxy.org//test/XML' --proxy http://127.0.0.1:8080 -H "Content-Type: text/xml"  \
  -X POST \
  --data-raw $'<note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>test</body></note>'
```

will generate on Zap the node with name `POST:XML()(<note:<to>,<from>,<heading>,<body>>)`

While accessControl plugin would only have inferred the name `POST:XML`

Briefly describe the purpose, goals, and changes or improvements made in this pull request.

## Related Issues
didn't check yet