### PR TITLE
ascanrules: Hidden File Finder test typo fix

### DIFF
--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HiddenFilesScanRuleUnitTest.java
@@ -450,7 +450,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
     }
 
     @Test
-    void shouldtRaiseAlertForMatchWith404As200() throws HttpMalformedHeaderException {
+    void shouldRaiseAlertForMatchWith404As200() throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
 


### PR DESCRIPTION
## Overview
Remove spurious "t" in unit test method name.

## Related Issues
- zaproxy/zaproxy#8588
