### PR TITLE
mcp: Content type and event fixes

### DIFF
--- a/addOns/mcp/CHANGELOG.md
+++ b/addOns/mcp/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Content type to not include charset (some servers complain).
 
+### Fixed
+- Handling of multiple SSE events on import.
 
 ## [0.1.0] - 2026-05-21
 ### Added

--- a/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/importer/McpImporter.java
+++ b/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/importer/McpImporter.java
@@ -55,7 +55,7 @@ public class McpImporter {
     private static final Logger LOGGER = LogManager.getLogger(McpImporter.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String PROTOCOL_VERSION = "2024-11-05";
-    private static final String CONTENT_TYPE = "application/json; charset=UTF-8";
+    private static final String CONTENT_TYPE = "application/json";
     private static final String ACCEPT = "application/json, text/event-stream";
     private static final String SESSION_HEADER = "Mcp-Session-Id";
     // Bounds how many pages of any paginated list (tools/list, resources/list, prompts/list,
@@ -529,10 +529,13 @@ public class McpImporter {
 
     /**
      * Parses the JSON-RPC payload from a response. The Streamable HTTP transport allows the server
-     * to reply either with a single JSON object or with an SSE stream carrying a single JSON-RPC
-     * message (possibly split across multiple {@code data:} lines, joined with {@code \n} per the
-     * SSE spec). Returns a {@link com.fasterxml.jackson.databind.node.MissingNode} if the body
-     * cannot be parsed.
+     * to reply either with a single JSON object or with an SSE stream. An SSE stream may carry
+     * multiple events (e.g. a server notification followed by the actual response). Each event is
+     * delimited by a blank line; within an event, multiple {@code data:} lines are joined with
+     * {@code \n} per the SSE spec. Notifications (objects with a {@code method} field but no {@code
+     * id}) are skipped; the first JSON-RPC response object (has an {@code id} field) is returned.
+     * Returns a {@link com.fasterxml.jackson.databind.node.MissingNode} if the body cannot be
+     * parsed or contains no response.
      */
     private JsonNode readJsonRpcPayload(HttpMessage msg) {
         String body = msg.getResponseBody().toString();
@@ -540,25 +543,57 @@ public class McpImporter {
         try {
             if (contentType != null
                     && contentType.toLowerCase(Locale.ROOT).contains("text/event-stream")) {
-                StringBuilder data = new StringBuilder();
-                for (String line : body.split("\\R")) {
-                    if (line.startsWith("data:")) {
-                        if (data.length() > 0) {
-                            data.append('\n');
+                // Split into individual SSE events (blank-line delimited) and return the first
+                // JSON-RPC response, skipping any server-sent notifications.
+                StringBuilder eventData = new StringBuilder();
+                for (String line : body.split("\\R", -1)) {
+                    if (line.isEmpty()) {
+                        if (eventData.length() > 0) {
+                            JsonNode node = parseSseEventData(eventData.toString());
+                            if (node != null) {
+                                return node;
+                            }
+                            eventData.setLength(0);
                         }
-                        data.append(line.substring(5).stripLeading());
+                    } else if (line.startsWith("data:")) {
+                        if (eventData.length() > 0) {
+                            eventData.append('\n');
+                        }
+                        eventData.append(line.substring(5).stripLeading());
                     }
                 }
-                if (data.length() == 0) {
-                    return MAPPER.missingNode();
+                // Handle trailing event with no final blank line.
+                if (eventData.length() > 0) {
+                    JsonNode node = parseSseEventData(eventData.toString());
+                    if (node != null) {
+                        return node;
+                    }
                 }
-                return MAPPER.readTree(data.toString());
+                return MAPPER.missingNode();
             }
             return MAPPER.readTree(body);
         } catch (Exception e) {
             LOGGER.warn("Failed to parse MCP response body: {}", e.getMessage());
             return MAPPER.missingNode();
         }
+    }
+
+    /**
+     * Parses one SSE event's accumulated data string. Returns the parsed node if it is a JSON-RPC
+     * response (has an {@code id} field), or {@code null} to indicate the caller should skip it
+     * (e.g. it is a notification).
+     */
+    private JsonNode parseSseEventData(String data) {
+        try {
+            JsonNode node = MAPPER.readTree(data);
+            // JSON-RPC responses have an "id"; notifications have "method" but no "id".
+            if (node.has("id")) {
+                return node;
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse SSE event data: {}", e.getMessage());
+        }
+        return null;
     }
 
     private boolean isValidMcpInitializeResult(HttpMessage msg) {

--- a/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/importer/McpImporterUnitTest.java
+++ b/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/importer/McpImporterUnitTest.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
@@ -301,6 +303,19 @@ class McpImporterUnitTest {
     }
 
     @Test
+    void shouldSetContentTypeApplicationJsonOnAllRequests() throws IOException {
+        // Given / When
+        importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then
+        assertThat(capturedRequests, not(empty()));
+        for (HttpMessage msg : capturedRequests) {
+            assertThat(
+                    msg.getRequestHeader().getHeader("Content-Type"), equalTo("application/json"));
+        }
+    }
+
+    @Test
     void shouldSetAcceptHeaderForJsonAndEventStreamOnAllRequests() throws IOException {
         // Given / When
         importer.importServer(new ImportConfig(SERVER_URL, null));
@@ -391,7 +406,7 @@ class McpImporterUnitTest {
                                             method, "{\"jsonrpc\":\"2.0\",\"result\":{}}");
                             msg.setResponseHeader(
                                     "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n");
-                            msg.setResponseBody("event: message\ndata: " + json + "\n\n");
+                            msg.setResponseBody(sseEvent(json));
                             return null;
                         })
                 .given(client)
@@ -403,6 +418,74 @@ class McpImporterUnitTest {
         // Then
         assertThat(results.errors(), is(empty()));
         assertThat(results.requestCount(), is(7));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3})
+    void shouldSkipServerNotificationsBeforeResponseInSseStream(int notificationCount)
+            throws IOException {
+        // Given — server sends N notifications before the response (e.g. auth banners)
+        String notification =
+                """
+                {"jsonrpc":"2.0","method":"notifications/message",\
+                "params":{"level":"info","data":"Authentication successful"}}""";
+        willAnswer(
+                        inv -> {
+                            HttpMessage msg = inv.getArgument(0);
+                            capturedRequests.add(msg);
+                            String method =
+                                    MAPPER.readTree(msg.getRequestBody().toString())
+                                            .path("method")
+                                            .asText();
+                            String responseJson =
+                                    responses.getOrDefault(
+                                            method, "{\"jsonrpc\":\"2.0\",\"result\":{}}");
+                            msg.setResponseHeader(
+                                    "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n");
+                            StringBuilder body = new StringBuilder();
+                            for (int i = 0; i < notificationCount; i++) {
+                                body.append(sseEvent(notification));
+                            }
+                            body.append(sseEvent(responseJson));
+                            msg.setResponseBody(body.toString());
+                            return null;
+                        })
+                .given(client)
+                .send(any(HttpMessage.class));
+
+        // When
+        ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then — all notifications are skipped; the real response drives the handshake
+        assertThat(results.errors(), is(empty()));
+        assertThat(results.requestCount(), is(7));
+    }
+
+    @Test
+    void shouldFailHandshakeWhenSseStreamContainsOnlyNotifications() throws IOException {
+        // Given — server never sends a response, only notifications
+        willAnswer(
+                        inv -> {
+                            HttpMessage msg = inv.getArgument(0);
+                            capturedRequests.add(msg);
+                            msg.setResponseHeader(
+                                    "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n");
+                            msg.setResponseBody(
+                                    sseEvent(
+                                            """
+                                            {"jsonrpc":"2.0","method":"notifications/message",\
+                                            "params":{}}"""));
+                            return null;
+                        })
+                .given(client)
+                .send(any(HttpMessage.class));
+
+        // When
+        ImportResults results = importer.importServer(new ImportConfig(SERVER_URL, null));
+
+        // Then — no response found, handshake fails
+        assertThat(results.errors(), hasSize(1));
+        assertThat(results.errors().get(0), containsString("handshakefailed"));
     }
 
     // ---- security key ----
@@ -796,6 +879,15 @@ class McpImporterUnitTest {
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse request body", e);
         }
+    }
+
+    private static String sseEvent(String data) {
+        return """
+                event: message
+                data: %s
+
+                """
+                .formatted(data);
     }
 
     private static String toolsListResponse(String toolName, String inputSchema) {


### PR DESCRIPTION
ZAP failed to import an MCP vs a private MCP server.
It turns out the server was very strict re the content type header - I think its being too heavy handed, but the charset doesnt make much difference to us anyway.
Also it was returning multiple events before the data we needed, which we didnt cope with.
With these fixes it imports the definition correctly.