### PR TITLE
ascanrules: add multipart/form-data XXE detection support

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [82] - 2026-05-06
 ### Changed
+- XML External Entity Attack scan rule extended to detect XXE attacks when XML is part of a multipart request (Issue 1190).
 - The following scan rules now include example alert functionality for documentation generation purposes (Issue 6119):
     - SQL Injection - Hypersonic SQL (Time Based)
     - SQL Injection - MsSQL (Time Based)

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- XML External Entity Attack scan rule extended to detect XXE attacks when XML is part of a multipart request (Issue 1190).
 
 ## [82] - 2026-05-06
 ### Changed
-- XML External Entity Attack scan rule extended to detect XXE attacks when XML is part of a multipart request (Issue 1190).
 - The following scan rules now include example alert functionality for documentation generation purposes (Issue 6119):
     - SQL Injection - Hypersonic SQL (Time Based)
     - SQL Injection - MsSQL (Time Based)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/XxeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/XxeScanRule.java
@@ -23,20 +23,20 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.core.scanner.NameValuePair;
-import org.parosproxy.paros.core.scanner.VariantMultipartFormParameters;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.PolicyTag;
@@ -50,7 +50,7 @@ import org.zaproxy.addon.oast.ExtensionOast;
  *
  * @author yhawke (2104)
  */
-public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRuleInfo {
+public class XxeScanRule extends AbstractAppParamPlugin implements CommonActiveScanRuleInfo {
 
     private static final String MESSAGE_PREFIX = "ascanrules.xxe.";
     private static final int PLUGIN_ID = 90023;
@@ -132,7 +132,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
 
     // Logger instance
     private static final Logger LOGGER = LogManager.getLogger(XxeScanRule.class);
-    private VariantMultipartFormParameters multipartVariant;
+    private Set<String> xmlFileNames = Set.of();
     private boolean alertRaised = false;
 
     @Override
@@ -185,62 +185,86 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
         return Alert.RISK_HIGH;
     }
 
+    /**
+     * Scan rule to check for XXE vulnerabilities. It checks both for local and remote using the ZAP
+     * API and also a new model based on parameter substitution.
+     *
+     * <p>For direct XML requests, the whole body is attacked. For multipart/form-data requests, the
+     * variant framework is used so that the user's input vector selection is respected.
+     */
     @Override
     public void scan() {
-        multipartVariant = null;
         alertRaised = false;
 
         HttpMessage msg = getBaseMsg();
         String contentType = msg.getRequestHeader().getHeader(HttpFieldsNames.CONTENT_TYPE);
 
         if ((contentType != null) && (contentType.contains("xml"))) {
+            // Direct XML body — attack the whole body
             scanForXxe(null);
-        } else if ((contentType != null) && (contentType.contains("multipart"))) {
-            multipartVariant = new VariantMultipartFormParameters();
-            multipartVariant.setMessage(getNewMsg());
-            List<String> xmlFileNames =
-                    multipartVariant.getParamList().stream()
-                            .filter(
-                                    p ->
-                                            (p.getType()
-                                                            == NameValuePair
-                                                                    .TYPE_MULTIPART_DATA_FILE_CONTENTTYPE
-                                                    && p.getValue().toLowerCase().contains("xml")))
-                            .map(NameValuePair::getName)
-                            .collect(Collectors.toList());
-
-            for (NameValuePair originalPair : multipartVariant.getParamList()) {
-                if (xmlFileNames.contains(originalPair.getName())
-                        && (originalPair.getType()
-                                == NameValuePair.TYPE_MULTIPART_DATA_FILE_PARAM)) {
-                    scanForXxe(originalPair);
-                }
-                if (alertRaised) {
-                    break;
-                }
-            }
+        } else {
+            // Let the framework iterate variants/parameters
+            super.scan();
         }
     }
 
+    @Override
+    protected void scan(List<NameValuePair> nameValuePairs) {
+        xmlFileNames = new HashSet<>();
+        for (NameValuePair p : nameValuePairs) {
+            if (p.getType() == NameValuePair.TYPE_MULTIPART_DATA_FILE_CONTENTTYPE
+                    && p.getValue() != null
+                    && p.getValue().toLowerCase().contains("xml")) {
+                xmlFileNames.add(p.getName());
+            }
+        }
+        super.scan(nameValuePairs);
+    }
+
+    @Override
+    public void scan(HttpMessage msg, NameValuePair originalParam) {
+        if (alertRaised || isStop()) {
+            return;
+        }
+        if (originalParam.getType() == NameValuePair.TYPE_MULTIPART_DATA_FILE_PARAM
+                && xmlFileNames.contains(originalParam.getName())) {
+            scanForXxe(originalParam);
+        }
+    }
+
+    @Override
+    public void scan(HttpMessage msg, String param, String value) {
+        // Not used — XXE is handled at body level in scan()
+        // or via NameValuePair for multipart parameters.
+    }
+
     private void scanForXxe(NameValuePair originalPair) {
+        // Check #1 : XXE Remote File Inclusion Attack
         remoteFileInclusionAttack(originalPair);
 
+        // Check #2 : Out-of-band XXE Attack
         outOfBandFileInclusionAttack(originalPair);
 
+        // Check if we've to do only basic analysis (only remote should be done)...
         if (this.getAttackStrength() == AttackStrength.LOW) {
             return;
         }
 
+        // Check #3 : XXE Local File Reflection Attack
         localFileReflectionAttack(getNewMsg(), originalPair);
 
+        // Check if we've to do only medium sized analysis
+        // (only remote and reflected will be done)
         if (this.getAttackStrength() == AttackStrength.MEDIUM) {
             return;
         }
 
+        // Exit if the scan has been stopped
         if (isStop()) {
             return;
         }
 
+        // Check #4 : XXE Local File Inclusion Attack
         localFileInclusionAttack(getNewMsg(), originalPair);
     }
 
@@ -268,8 +292,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
                 String payload = MessageFormat.format(ATTACK_MESSAGE, callbackPayload);
                 alert.setAttack(payload);
                 if (originalPair != null) {
-                    multipartVariant.setParameter(
-                            msg, originalPair, originalPair.getName(), payload);
+                    setParameter(msg, originalPair.getName(), payload);
                 } else {
                     msg.setRequestBody(payload);
                 }
@@ -296,8 +319,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
                 String payload = MessageFormat.format(ATTACK_MESSAGE, "http://" + oastPayload);
                 alert.setAttack(payload);
                 if (originalPair != null) {
-                    multipartVariant.setParameter(
-                            msg, originalPair, originalPair.getName(), payload);
+                    setParameter(msg, originalPair.getName(), payload);
                 } else {
                     msg.setRequestBody(payload);
                 }
@@ -306,8 +328,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
                 msg = getNewMsg();
                 payload = MessageFormat.format(ATTACK_MESSAGE, "https://" + oastPayload);
                 if (originalPair != null) {
-                    multipartVariant.setParameter(
-                            msg, originalPair, originalPair.getName(), payload);
+                    setParameter(msg, originalPair.getName(), payload);
                 } else {
                     msg.setRequestBody(payload);
                 }
@@ -318,6 +339,18 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
         }
     }
 
+    /**
+     * Local File Reflection Attack initially substitutes every attribute in the original XML
+     * request with a fake entity which includes a sensitive local file. The attack is repeated for
+     * every file listed in the LOCAL_FILE_TARGETS. The response returned is pattern matched against
+     * LOCAL_FILE_PATTERNS. An alert is raised when a match is found. If no alert is raised, then
+     * the process is repeated by replacing one attribute at a time, for a fixed number of
+     * attributes depending on the strength of the rule.
+     *
+     * @param msg new HttpMessage with the same request as the base. This is used to build the
+     *     attack payload.
+     * @param originalPair the multipart parameter to attack, or null for direct XML body
+     */
     private void localFileReflectionAttack(HttpMessage msg, NameValuePair originalPair) {
         String originalXml;
         if (originalPair != null) {
@@ -350,6 +383,21 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
         }
     }
 
+    /**
+     * Local File Inclusion Attack is described in
+     * https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing. The
+     * attack builds a payload for every file listed in LOCAL_FILE_TARGETS with the ATTACK_HEADER
+     * and the ATTACK_BODY. The response returned is pattern matched against LOCAL_FILE_PATTERNS. An
+     * alert is raised when a match is found.
+     *
+     * <p>This situation is very uncommon because it works only in case of a bare XML parser which
+     * execute the content and then returns the content almost untouched (maybe because it applies
+     * an XSLT or query it using XPath and give back the result)
+     *
+     * @param msg new HttpMessage with the same request as the base. This is used to build the
+     *     attack payload.
+     * @param originalPair the multipart parameter to attack, or null for direct XML body
+     */
     private void localFileInclusionAttack(HttpMessage msg, NameValuePair originalPair) {
         String payload = null;
         try {
@@ -358,8 +406,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
                 String localFile = LOCAL_FILE_TARGETS[idx];
                 payload = MessageFormat.format(ATTACK_MESSAGE, localFile);
                 if (originalPair != null) {
-                    multipartVariant.setParameter(
-                            msg, originalPair, originalPair.getName(), payload);
+                    setParameter(msg, originalPair.getName(), payload);
                 } else {
                     msg.setRequestBody(payload);
                 }
@@ -408,7 +455,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
             String localFile = LOCAL_FILE_TARGETS[idx];
             String payload = MessageFormat.format(requestBody, localFile);
             if (originalPair != null) {
-                multipartVariant.setParameter(msg, originalPair, originalPair.getName(), payload);
+                setParameter(msg, originalPair.getName(), payload);
             } else {
                 msg.setRequestBody(payload);
             }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/XxeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/XxeScanRule.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -34,6 +35,8 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.NameValuePair;
+import org.parosproxy.paros.core.scanner.VariantMultipartFormParameters;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.PolicyTag;
@@ -129,6 +132,8 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
 
     // Logger instance
     private static final Logger LOGGER = LogManager.getLogger(XxeScanRule.class);
+    private VariantMultipartFormParameters multipartVariant;
+    private boolean alertRaised = false;
 
     @Override
     public int getId() {
@@ -180,47 +185,63 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
         return Alert.RISK_HIGH;
     }
 
-    /**
-     * Scan rule to check for XXE vulnerabilities. It checks both for local and remote using the ZAP
-     * API and also a new model based on parameter substitution
-     */
     @Override
     public void scan() {
-        // Prepare the message
+        multipartVariant = null;
+        alertRaised = false;
+
         HttpMessage msg = getBaseMsg();
         String contentType = msg.getRequestHeader().getHeader(HttpFieldsNames.CONTENT_TYPE);
 
-        // first check if it's an XML otherwise it's useless...
         if ((contentType != null) && (contentType.contains("xml"))) {
+            scanForXxe(null);
+        } else if ((contentType != null) && (contentType.contains("multipart"))) {
+            multipartVariant = new VariantMultipartFormParameters();
+            multipartVariant.setMessage(getNewMsg());
+            List<String> xmlFileNames =
+                    multipartVariant.getParamList().stream()
+                            .filter(
+                                    p ->
+                                            (p.getType()
+                                                            == NameValuePair
+                                                                    .TYPE_MULTIPART_DATA_FILE_CONTENTTYPE
+                                                    && p.getValue().toLowerCase().contains("xml")))
+                            .map(NameValuePair::getName)
+                            .collect(Collectors.toList());
 
-            // Check #1 : XXE Remote File Inclusion Attack
-            remoteFileInclusionAttack();
-
-            // Check #2 : Out-of-band XXE Attack
-            outOfBandFileInclusionAttack();
-
-            // Check if we've to do only basic analysis (only remote should be done)...
-            if (this.getAttackStrength() == AttackStrength.LOW) {
-                return;
+            for (NameValuePair originalPair : multipartVariant.getParamList()) {
+                if (xmlFileNames.contains(originalPair.getName())
+                        && (originalPair.getType()
+                                == NameValuePair.TYPE_MULTIPART_DATA_FILE_PARAM)) {
+                    scanForXxe(originalPair);
+                }
+                if (alertRaised) {
+                    break;
+                }
             }
-
-            // Check #3 : XXE Local File Reflection Attack
-            localFileReflectionAttack(getNewMsg());
-
-            // Check if we've to do only medium sized analysis
-            // (only remote and reflected will be done)
-            if (this.getAttackStrength() == AttackStrength.MEDIUM) {
-                return;
-            }
-
-            // Exit if the scan has been stopped
-            if (isStop()) {
-                return;
-            }
-
-            // Check #4 : XXE Local File Inclusion Attack
-            localFileInclusionAttack(getNewMsg());
         }
+    }
+
+    private void scanForXxe(NameValuePair originalPair) {
+        remoteFileInclusionAttack(originalPair);
+
+        outOfBandFileInclusionAttack(originalPair);
+
+        if (this.getAttackStrength() == AttackStrength.LOW) {
+            return;
+        }
+
+        localFileReflectionAttack(getNewMsg(), originalPair);
+
+        if (this.getAttackStrength() == AttackStrength.MEDIUM) {
+            return;
+        }
+
+        if (isStop()) {
+            return;
+        }
+
+        localFileInclusionAttack(getNewMsg(), originalPair);
     }
 
     /**
@@ -229,7 +250,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
      * external bouncing site, in this case we use the ZAP API as a server for the vulnerability
      * check using a challenge/response model based on a random string
      */
-    private void remoteFileInclusionAttack() {
+    private void remoteFileInclusionAttack(NameValuePair originalPair) {
         try {
             ExtensionOast extOast =
                     Control.getSingleton().getExtensionLoader().getExtension(ExtensionOast.class);
@@ -246,7 +267,12 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
                                 alert, XxeScanRule.class.getSimpleName());
                 String payload = MessageFormat.format(ATTACK_MESSAGE, callbackPayload);
                 alert.setAttack(payload);
-                msg.setRequestBody(payload);
+                if (originalPair != null) {
+                    multipartVariant.setParameter(
+                            msg, originalPair, originalPair.getName(), payload);
+                } else {
+                    msg.setRequestBody(payload);
+                }
                 sendAndReceive(msg);
             }
         } catch (Exception e) {
@@ -254,7 +280,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
         }
     }
 
-    private void outOfBandFileInclusionAttack() {
+    private void outOfBandFileInclusionAttack(NameValuePair originalPair) {
         try {
             ExtensionOast extOast =
                     Control.getSingleton().getExtensionLoader().getExtension(ExtensionOast.class);
@@ -269,12 +295,22 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
                 String oastPayload = extOast.registerAlertAndGetPayload(alert);
                 String payload = MessageFormat.format(ATTACK_MESSAGE, "http://" + oastPayload);
                 alert.setAttack(payload);
-                msg.setRequestBody(payload);
+                if (originalPair != null) {
+                    multipartVariant.setParameter(
+                            msg, originalPair, originalPair.getName(), payload);
+                } else {
+                    msg.setRequestBody(payload);
+                }
                 sendAndReceive(msg);
                 // Try again with https
                 msg = getNewMsg();
                 payload = MessageFormat.format(ATTACK_MESSAGE, "https://" + oastPayload);
-                msg.setRequestBody(payload);
+                if (originalPair != null) {
+                    multipartVariant.setParameter(
+                            msg, originalPair, originalPair.getName(), payload);
+                } else {
+                    msg.setRequestBody(payload);
+                }
                 sendAndReceive(msg);
             }
         } catch (Exception e) {
@@ -282,29 +318,19 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
         }
     }
 
-    /**
-     * Local File Reflection Attack initially substitutes every attribute in the original XML
-     * request with a fake entity which includes a sensitive local file. The attack is repeated for
-     * every file listed in the LOCAL_FILE_TARGETS. The response returned is pattern matched against
-     * LOCAL_FILE_PATTERNS. An alert is raised when a match is found. If no alert is raised, then
-     * the process is repeated by replacing one attribute at a time, for a fixed number of
-     * attributes depending on the strength of the rule.
-     *
-     * @param msg new HttpMessage with the same request as the base. This is used to build the
-     *     attack payload.
-     */
-    private void localFileReflectionAttack(HttpMessage msg) {
-        // First replace the values in all the Elements by the Attack Entity
-        String originalRequestBody = msg.getRequestBody().toString();
-        String requestBody = createLfrPayload(originalRequestBody);
-        if (localFileReflectionTest(msg, requestBody)) {
+    private void localFileReflectionAttack(HttpMessage msg, NameValuePair originalPair) {
+        String originalXml;
+        if (originalPair != null) {
+            originalXml = originalPair.getValue();
+        } else {
+            originalXml = msg.getRequestBody().toString();
+        }
+        String requestBody = createLfrPayload(originalXml);
+        if (localFileReflectionTest(requestBody, originalPair)) {
             return;
         }
-        // Now if no issue is found yet, then we replace the values one at a time. Do this for a
-        // fixed number of Elements, depending on the strength at which the rule is used.
 
-        // Remove original xml header
-        Matcher headerMatcher = xmlHeaderPattern.matcher(originalRequestBody);
+        Matcher headerMatcher = xmlHeaderPattern.matcher(originalXml);
         String headerlessRequestBody = headerMatcher.replaceAll("");
         int maxValuesChanged = 0;
 
@@ -318,46 +344,37 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
         Matcher tagMatcher = tagPattern.matcher(headerlessRequestBody);
         for (int tagIdx = 1; (tagIdx <= maxValuesChanged) && tagMatcher.find(); tagIdx++) {
             requestBody = createTagSpecificLfrPayload(headerlessRequestBody, tagMatcher);
-            if (localFileReflectionTest(msg, requestBody)) {
+            if (localFileReflectionTest(requestBody, originalPair)) {
                 return;
             }
         }
     }
 
-    /**
-     * Local File Inclusion Attack is described in
-     * https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing. The
-     * attack builds a payload for every file listed in LOCAL_FILE_TARGETS with the ATTACK_HEADER
-     * and the ATTACK_BODY. The response returned is pattern matched against LOCAL_FILE_PATTERNS. An
-     * alert is raised when a match is found.
-     *
-     * <p>This situation is very uncommon because it works only in case of a bare XML parser which
-     * execute the content and then returns the content almost untouched (maybe because it applies
-     * an XSLT or query it using XPath and give back the result)
-     *
-     * @param msg new HttpMessage with the same request as the base. This is used to build the
-     *     attack payload.
-     */
-    private void localFileInclusionAttack(HttpMessage msg) {
+    private void localFileInclusionAttack(HttpMessage msg, NameValuePair originalPair) {
         String payload = null;
         try {
             for (int idx = 0; idx < LOCAL_FILE_TARGETS.length; idx++) {
+                msg = getNewMsg();
                 String localFile = LOCAL_FILE_TARGETS[idx];
                 payload = MessageFormat.format(ATTACK_MESSAGE, localFile);
-                msg.setRequestBody(payload);
+                if (originalPair != null) {
+                    multipartVariant.setParameter(
+                            msg, originalPair, originalPair.getName(), payload);
+                } else {
+                    msg.setRequestBody(payload);
+                }
                 sendAndReceive(msg);
                 String response = msg.getResponseBody().toString();
                 Matcher matcher = LOCAL_FILE_PATTERNS[idx].matcher(response);
                 if (matcher.find()) {
                     createAlert(payload, matcher.group()).setMessage(msg).raise();
+                    alertRaised = true;
                 }
                 if (isStop()) {
                     return;
                 }
             }
         } catch (IOException ex) {
-            // Do not try to internationalise this.. we need an error message in any event..
-            // if it's in English, it's still better than not having it at all.
             LOGGER.warn(
                     "XXE Injection vulnerability check failed for payload [{}] due to an I/O error",
                     payload,
@@ -385,11 +402,16 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
         return sb.toString();
     }
 
-    private boolean localFileReflectionTest(HttpMessage msg, String requestBody) {
+    private boolean localFileReflectionTest(String requestBody, NameValuePair originalPair) {
         for (int idx = 0; idx < LOCAL_FILE_TARGETS.length; idx++) {
+            HttpMessage msg = getNewMsg();
             String localFile = LOCAL_FILE_TARGETS[idx];
             String payload = MessageFormat.format(requestBody, localFile);
-            msg.setRequestBody(payload);
+            if (originalPair != null) {
+                multipartVariant.setParameter(msg, originalPair, originalPair.getName(), payload);
+            } else {
+                msg.setRequestBody(payload);
+            }
             try {
                 sendAndReceive(msg);
             } catch (IOException ex) {
@@ -403,6 +425,7 @@ public class XxeScanRule extends AbstractAppPlugin implements CommonActiveScanRu
             Matcher matcher = LOCAL_FILE_PATTERNS[idx].matcher(response);
             if (matcher.find()) {
                 createAlert(payload, matcher.group()).setMessage(msg).raise();
+                alertRaised = true;
                 return true;
             }
             if (isStop()) {

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -529,8 +529,11 @@ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/90017/">90017</a>.
 <H2 id="id-90023">XXE</H2>
 This component attempts to identify applications which are subject to XML eXternal Entity (XXE) attacks.
 Applications which parse XML input may be subject to XXE when weakly or poorly configured parsers 
-handle XML input containing reference to an external entity such as a local file, HTTP requests to 
+handle XML input containing reference to an external entity such as a local file, HTTP requests to
 internal or tertiary systems, etc. The number of tags which are tested individually depends on the strength of the rule.<br>
+<br>
+As well as requests with an XML body, the rule also tests XML files uploaded as part of a multipart/form-data
+request (the input vectors selected in the scan policy are respected).<br>
 <br>
 This scan rule will only run if the OAST add-on is installed and available.
 It is also recommended that you test that the Callbacks service in the OAST add-on is correctly configured for your target site.

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/XxeScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/XxeScanRuleUnitTest.java
@@ -270,6 +270,86 @@ class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
         assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
     }
 
+    @ParameterizedTest
+    @EnumSource(
+            value = NanoHTTPD.Response.Status.class,
+            names = {"OK", "BAD_REQUEST"})
+    void shouldAlertWhenLocalFileReflectedInMultipartXmlPart(NanoHTTPD.Response.Status status)
+            throws HttpMalformedHeaderException {
+        // Given
+        String test = "/test";
+        String responseBody = "<foo>root:*:0:0:System Administrator:/var/root:/bin/sh</foo>";
+        this.nano.addHandler(createNanoHandler(test, status, responseBody));
+        HttpMessage msg = getMultipartXmlPostMessage(test);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        String localFileInclusionAttackPayload =
+                MessageFormat.format(XxeScanRule.ATTACK_HEADER, "file:///etc/passwd")
+                        + "<comment><text>&zapxxe;</text></comment>";
+        List<Alert> alertList =
+                alertsRaised.stream()
+                        .filter(alert -> alert.getAttack().equals(localFileInclusionAttackPayload))
+                        .collect(Collectors.toList());
+        assertThat(alertList.size(), equalTo(1));
+        Alert alert = alertList.get(0);
+        assertThat(alert.getEvidence(), equalTo("root:*:0:0"));
+        assertThat(alert.getRisk(), equalTo(Alert.RISK_HIGH));
+        assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = NanoHTTPD.Response.Status.class,
+            names = {"OK", "BAD_REQUEST"})
+    void shouldAlertWhenLocalFileIncludedInMultipartXmlPart(NanoHTTPD.Response.Status status)
+            throws HttpMalformedHeaderException {
+        // Given
+        String test = "/test";
+        String responseBody = "[drivers]\n" + "wave=mmdrv.dll";
+        this.nano.addHandler(createNanoHandler(test, status, responseBody));
+        HttpMessage msg = getMultipartXmlPostMessage(test);
+        rule.init(msg, parent);
+        // When
+        // Local File Inclusion Attacks is triggered only when AttackStrength is > Medium
+        rule.setAttackStrength(Plugin.AttackStrength.HIGH);
+        rule.scan();
+        // Then
+        String localFileInclusionAttackPayload =
+                MessageFormat.format(XxeScanRule.ATTACK_HEADER, "file:///c:/Windows/system.ini")
+                        + XxeScanRule.ATTACK_BODY;
+        List<Alert> alertList =
+                alertsRaised.stream()
+                        .filter(alert -> alert.getAttack().equals(localFileInclusionAttackPayload))
+                        .collect(Collectors.toList());
+        assertThat(alertList.size(), equalTo(1));
+        Alert alert = alertList.get(0);
+        assertThat(alert.getEvidence(), equalTo("[drivers]"));
+        assertThat(alert.getRisk(), equalTo(Alert.RISK_HIGH));
+        assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
+    void shouldNotScanMultipartFilePartWhenContentTypeIsNotXml()
+            throws HttpMalformedHeaderException {
+        // Given
+        String test = "/test";
+        String responseBody = "<foo>root:*:0:0:System Administrator:/var/root:/bin/sh</foo>";
+        this.nano.addHandler(createNanoHandler(test, NanoHTTPD.Response.Status.OK, responseBody));
+        HttpMessage msg =
+                getMultipartPostMessage(
+                        test,
+                        "text/plain",
+                        "<?xml version=\"1.0\"?><comment><text>test</text></comment>");
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(countMessagesSent, equalTo(0));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
     @Test
     void shouldAlertOnlyIfCertainTagValuesArePresent()
             throws HttpMalformedHeaderException, IOException {
@@ -425,6 +505,41 @@ class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
         msg.setRequestBody("<?xml version=\"1.0\"?><comment><text>test</text></comment>");
         msg.getRequestHeader().setMethod("POST");
         msg.getRequestHeader().setHeader("Content-Type", "application/xml");
+        return msg;
+    }
+
+    private HttpMessage getMultipartXmlPostMessage(String path)
+            throws HttpMalformedHeaderException {
+        return getMultipartPostMessage(
+                path,
+                "application/xml",
+                "<?xml version=\"1.0\"?><comment><text>test</text></comment>");
+    }
+
+    private HttpMessage getMultipartPostMessage(
+            String path, String fileContentType, String fileContent)
+            throws HttpMalformedHeaderException {
+        HttpMessage msg = this.getHttpMessage(path);
+        String bodyBoundary = "--------------------------d74496d66958873e";
+        String headerBoundary = "------------------------d74496d66958873e";
+        StringBuilder body = new StringBuilder();
+        body.append(bodyBoundary).append("\r\n");
+        body.append("Content-Disposition: form-data; name=\"person\"").append("\r\n");
+        body.append("\r\n");
+        body.append("anonymous").append("\r\n");
+        body.append(bodyBoundary).append("\r\n");
+        body.append("Content-Disposition: form-data; name=\"somefile\"; filename=\"test.xml\"")
+                .append("\r\n");
+        body.append("Content-Type: ").append(fileContentType).append("\r\n");
+        body.append("\r\n");
+        body.append(fileContent).append("\r\n");
+        body.append(bodyBoundary).append("--").append("\r\n");
+        msg.getRequestHeader().setMethod("POST");
+        msg.getRequestHeader()
+                .setHeader(
+                        HttpFieldsNames.CONTENT_TYPE,
+                        "multipart/form-data; boundary=" + headerBoundary);
+        msg.setRequestBody(body.toString());
         return msg;
     }
 


### PR DESCRIPTION
Port logic from PR #2864 to detect XXE vulnerabilities when XML content is uploaded as part of a multipart/form-data request. Uses VariantMultipartFormParameters to parse and inject payloads into multipart bodies while preserving other form parts.

Includes import reorder and state reset fix for scanner reuse.

## Overview
The original PR #2864 was apparently in a working state, but abandoned (and no longer relevant since aimed at ascan-beta, while XXE was moved to ascan). This PR steals the idea, adapting the code for the latest ascan code.
I tested it against juice-shop, and it worked:
step 1: upload a random XML file in the "complaints" form
step 2: attack the file-upload() POST endpoint, and make sure that XXE policy is enabled

## Related Issues
https://github.com/zaproxy/zaproxy/issues/8817
https://github.com/zaproxy/zaproxy/issues/1190