### PR TITLE
selenium: do not collect console log by default

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Only collect browser's `console.log` when DEBUG level is set for `org.zaproxy.webdriver`, to avoid unnecessary work for common browser usage.
 
 ## [15.49.0] - 2026-05-27
 ### Added

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -1614,7 +1614,9 @@ public class ExtensionSelenium extends ExtensionAdaptor {
 
     private static RemoteWebDriver configureDriver(
             Browser browser, RemoteWebDriver driver, DriverConfiguration conf) {
-        driver.script().addConsoleMessageHandler(e -> WEBDRIVER_LOGGER.debug(e.getText()));
+        if (WEBDRIVER_LOGGER.isDebugEnabled()) {
+            driver.script().addConsoleMessageHandler(e -> WEBDRIVER_LOGGER.debug(e.getText()));
+        }
 
         if (!conf.isEnableExtensions() && conf.getIncludeExtensions().isEmpty()) {
             return driver;


### PR DESCRIPTION
Only collect browser's `console.log` when DEBUG level is set for `org.zaproxy.webdriver`, to avoid unnecessary work for common browser usage.