### PR TITLE
client: adjust test assertion

### DIFF
--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
@@ -21,7 +21,7 @@ package org.zaproxy.addon.client.spider.actions;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
@@ -191,7 +191,7 @@ class FollowGraphUnitTest extends TestUtils {
         boolean result = action.run(wd);
 
         // Then
-        assertThat(System.currentTimeMillis() - start, is(greaterThan(950L)));
+        assertThat(System.currentTimeMillis() - start, is(greaterThanOrEqualTo(950L)));
         assertCommonState(wd, result);
     }
 


### PR DESCRIPTION
Allow the time to be the same, for the cases where it does not take anymore than the wait specified.

---
e.g. https://github.com/zaproxy/zap-extensions/actions/runs/27212084503/job/80343594149#step:6:2398
```
FollowGraphUnitTest > shouldFollowMultiHopPathWaitingAfterFirstHop() FAILED
    java.lang.AssertionError: 
    Expected: is a value greater than <950L>
         but: <950L> was equal to <950L>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.zaproxy.addon.client.spider.actions.FollowGraphUnitTest.shouldFollowMultiHopPathWaitingAfterFirstHop(FollowGraphUnitTest.java:194)
```