### PR TITLE
soap: Additional unit tests

### DIFF
--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.lenient;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -63,6 +64,7 @@ class WSDLCustomParserTestCase extends TestUtils {
 
     private static final String MOCK_FILL_VALUE = "mock-fill-value";
     private static final String FILL_PARAMETERS_WSDL = "fill-parameters.wsdl";
+    private static final String DEGRADED_PARAMETERS_WSDL = "degraded-parameters.wsdl";
 
     private ValueProvider valueProvider;
     private Supplier<Date> dateSupplier;
@@ -70,14 +72,16 @@ class WSDLCustomParserTestCase extends TestUtils {
     private WSDLCustomParser parser;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     void setUp() throws Exception {
         /* Gets test wsdl file and retrieves its content as String. */
         Path wsdlPath = getResourcePath("resources/test.wsdl");
         wsdlContent = new String(Files.readAllBytes(wsdlPath), StandardCharsets.UTF_8);
 
         valueProvider = mock(ValueProvider.class);
-        dateSupplier = mock(Supplier.class, withSettings().strictness(Strictness.LENIENT));
+        lenient()
+                .when(valueProvider.getValue(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(MOCK_FILL_VALUE);
+        dateSupplier = mockLenientDateSupplier();
         parser = new WSDLCustomParser(() -> valueProvider, null, dateSupplier);
     }
 
@@ -194,7 +198,7 @@ class WSDLCustomParserTestCase extends TestUtils {
         // Given / When
         Map<String, String> params = parseWsdlParams();
         // Then
-        assertThat(params, hasKey("xpath:/Request/refOuter/refBlock/leafField"));
+        assertThat(params, hasEntry("xpath:/Request/refOuter/refBlock/leafField", MOCK_FILL_VALUE));
     }
 
     @Test
@@ -202,7 +206,7 @@ class WSDLCustomParserTestCase extends TestUtils {
         // Given / When
         Map<String, String> params = parseWsdlParams();
         // Then
-        assertThat(params, hasKey("xpath:/Request/branchBox/optA"));
+        assertThat(params, hasEntry("xpath:/Request/branchBox/optA", MOCK_FILL_VALUE));
         assertThat(params, not(hasKey("xpath:/Request/branchBox/optB")));
     }
 
@@ -212,7 +216,6 @@ class WSDLCustomParserTestCase extends TestUtils {
         Map<String, String> params = parseWsdlParams();
         // Then
         assertThat(params, hasEntry("xpath:/Request/attrBox/@fixedKey", "FIXED-VAL"));
-        assertThat(params.get("xpath:/Request/attrBox/@fixedKey"), is(not(MOCK_FILL_VALUE)));
     }
 
     @Test
@@ -221,7 +224,6 @@ class WSDLCustomParserTestCase extends TestUtils {
         Map<String, String> params = parseWsdlParams();
         // Then
         assertThat(params, hasEntry("xpath:/Request/enumField", "EL-1"));
-        assertThat(params.get("xpath:/Request/enumField"), is(not(MOCK_FILL_VALUE)));
     }
 
     @Test
@@ -229,8 +231,8 @@ class WSDLCustomParserTestCase extends TestUtils {
         // Given / When
         Map<String, String> params = parseWsdlParams();
         // Then
-        assertThat(params, hasKey("xpath:/Request/attrBox/@keyA"));
-        assertThat(params, hasKey("xpath:/Request/attrBox/@keyB"));
+        assertThat(params, hasEntry("xpath:/Request/attrBox/@keyA", MOCK_FILL_VALUE));
+        assertThat(params, hasEntry("xpath:/Request/attrBox/@keyB", MOCK_FILL_VALUE));
     }
 
     @Test
@@ -239,7 +241,6 @@ class WSDLCustomParserTestCase extends TestUtils {
         Map<String, String> params = parseWsdlParams();
         // Then
         assertThat(params, hasEntry("xpath:/Request/enumBox/@enumKey", "EV-1"));
-        assertThat(params.get("xpath:/Request/enumBox/@enumKey"), is(not(MOCK_FILL_VALUE)));
     }
 
     @Test
@@ -255,17 +256,58 @@ class WSDLCustomParserTestCase extends TestUtils {
         // Given / When
         Map<String, String> params = parseWsdlParams();
         // Then
-        assertThat(params, hasKey("xpath:/Request/boundedInt"));
+        assertThat(params, hasEntry("xpath:/Request/boundedInt", MOCK_FILL_VALUE));
+        verify(valueProvider)
+                .getValue(any(), any(), eq("boundedInt"), eq("0"), any(), any(), any());
+    }
+
+    @Test
+    void shouldPassIntegerDefaultsToValueProviderViaWsdlImport() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/positiveIntField", MOCK_FILL_VALUE));
+        assertThat(params, hasEntry("xpath:/Request/negativeIntField", MOCK_FILL_VALUE));
+        assertThat(params, hasEntry("xpath:/Request/nonNegativeIntField", MOCK_FILL_VALUE));
+        assertThat(params, hasEntry("xpath:/Request/nonPositiveIntField", MOCK_FILL_VALUE));
+        verify(valueProvider)
+                .getValue(any(), any(), eq("positiveIntField"), eq("1"), any(), any(), any());
+        verify(valueProvider)
+                .getValue(any(), any(), eq("negativeIntField"), eq("-1"), any(), any(), any());
+        verify(valueProvider)
+                .getValue(any(), any(), eq("nonNegativeIntField"), eq("0"), any(), any(), any());
+        verify(valueProvider)
+                .getValue(any(), any(), eq("nonPositiveIntField"), eq("0"), any(), any(), any());
+    }
+
+    @Test
+    void shouldFallbackToStringForPlainElementWithNoType() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/plainField", MOCK_FILL_VALUE));
+        verify(valueProvider)
+                .getValue(any(), any(), eq("plainField"), eq("paramValue"), any(), any(), any());
     }
 
     @Test
     void shouldEmitParamForTokenTypedElement() throws Exception {
-        // Given – 'tokenField' has type xs:token; must not be dropped and VP must receive a
-        // non-empty default so it can generate a value
-        // When
+        // Given / When
         Map<String, String> params = parseWsdlParams();
         // Then
         assertThat(params, hasEntry("xpath:/Request/tokenField", MOCK_FILL_VALUE));
+        verify(valueProvider)
+                .getValue(any(), any(), eq("tokenField"), eq("paramValue"), any(), any(), any());
+    }
+
+    @Test
+    void shouldPopulateFieldsFromNamedComplexTypeReference() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/namedBox/inner", MOCK_FILL_VALUE));
     }
 
     @Test
@@ -273,8 +315,8 @@ class WSDLCustomParserTestCase extends TestUtils {
         // Given / When
         Map<String, String> params = parseWsdlParams();
         // Then
-        assertThat(params, hasKey("xpath:/Request/block/inherited"));
-        assertThat(params, hasKey("xpath:/Request/block/added"));
+        assertThat(params, hasEntry("xpath:/Request/block/inherited", MOCK_FILL_VALUE));
+        assertThat(params, hasEntry("xpath:/Request/block/added", MOCK_FILL_VALUE));
     }
 
     @Test
@@ -282,9 +324,13 @@ class WSDLCustomParserTestCase extends TestUtils {
         // Given / When
         Map<String, String> params = parseWsdlParams();
         // Then
-        assertThat(params, hasKey("xpath:/Request/groupOuter/group/leafField"));
-        assertThat(params, hasKey("xpath:/Request/groupOuter/group/metaBlock/@idKey"));
-        assertThat(params, hasKey("xpath:/Request/groupOuter/group/metaBlock/@nameKey"));
+        assertThat(params, hasEntry("xpath:/Request/groupOuter/group/leafField", MOCK_FILL_VALUE));
+        assertThat(
+                params,
+                hasEntry("xpath:/Request/groupOuter/group/metaBlock/@idKey", MOCK_FILL_VALUE));
+        assertThat(
+                params,
+                hasEntry("xpath:/Request/groupOuter/group/metaBlock/@nameKey", MOCK_FILL_VALUE));
     }
 
     @Test
@@ -292,8 +338,62 @@ class WSDLCustomParserTestCase extends TestUtils {
         // Given / When
         Map<String, String> params = parseWsdlParams();
         // Then
-        assertThat(params, hasKey("xpath:/Request/attrWrapper/@plainKey"));
-        assertThat(params, hasKey("xpath:/Request/attrWrapper/@äKey"));
+        assertThat(params, hasEntry("xpath:/Request/attrWrapper/@plainKey", MOCK_FILL_VALUE));
+        assertThat(params, hasEntry("xpath:/Request/attrWrapper/@äKey", MOCK_FILL_VALUE));
+    }
+
+    @Test
+    void shouldContinueWhenRefElementCannotBeResolved() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams(DEGRADED_PARAMETERS_WSDL);
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/controlField", MOCK_FILL_VALUE));
+        assertThat(params, hasEntry("xpath:/Request/badRefOuter/siblingField", MOCK_FILL_VALUE));
+        assertThat(params, not(hasKey("xpath:/Request/badRefOuter/missingBlock")));
+    }
+
+    @Test
+    void shouldContinueWhenExtensionBaseTypeCannotBeResolved() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams(DEGRADED_PARAMETERS_WSDL);
+        // Then – import continues; predic8 omits the extension sequence when the base
+        // type is unresolvable, so neither inherited nor localField params are emitted
+        assertThat(params, hasEntry("xpath:/Request/controlField", MOCK_FILL_VALUE));
+        assertThat(params, not(hasKey("xpath:/Request/brokenBlock/localField")));
+        assertThat(params, not(hasKey("xpath:/Request/brokenBlock/inherited")));
+    }
+
+    @Test
+    void shouldContinueWhenExtensionBaseIsNotComplexType() throws Exception {
+        // Given / When
+        Map<String, String> params = parseWsdlParams(DEGRADED_PARAMETERS_WSDL);
+        // Then
+        assertThat(
+                params, hasEntry("xpath:/Request/simpleBaseBlock/derivedField", MOCK_FILL_VALUE));
+        assertThat(params, not(hasKey("xpath:/Request/simpleBaseBlock/value")));
+    }
+
+    @Test
+    void shouldContinueWhenElementTypeLookupFails() throws Exception {
+        // Given / When – type="tns:MissingNamedType" makes resolveComplexType throw
+        // ModelAccessException; fillParameters catches per-element and returns an empty map
+        // for badTypeField only, while siblings continue to be processed
+        Map<String, String> params = parseWsdlParams(DEGRADED_PARAMETERS_WSDL);
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/controlField", MOCK_FILL_VALUE));
+        assertThat(
+                params, hasEntry("xpath:/Request/badTypeOuter/typeSiblingField", MOCK_FILL_VALUE));
+        assertThat(params, not(hasKey("xpath:/Request/badTypeOuter/badTypeField")));
+    }
+
+    @Test
+    void shouldSkipAttributeDeclaredByRefWithNullName() throws Exception {
+        // Given / When – valid XSD uses <xs:attribute ref="tns:globalRefKey"/>; predic8 leaves
+        // Attribute.getName() null until resolved, and fillFromComplexType skips it
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/attrRefWrapper/@inlineKey", MOCK_FILL_VALUE));
+        assertThat(params, not(hasKey("xpath:/Request/attrRefWrapper/@globalRefKey")));
     }
 
     private Map<String, String> parseWsdlParams() throws Exception {
@@ -301,21 +401,20 @@ class WSDLCustomParserTestCase extends TestUtils {
     }
 
     private Map<String, String> parseWsdlParams(String resourceName) throws Exception {
-        WSDLCustomParser p = createParserForWsdl(resourceName);
-        return p.getLastConfig().getParams();
+        importWsdl(resourceName);
+        return parser.getLastConfig().getParams();
     }
 
-    private WSDLCustomParser createParserForWsdl(String resourceName) throws Exception {
-        Supplier<Date> dateSupplier = mock(withSettings().strictness(Strictness.LENIENT));
-        ValueProvider vp = mock(ValueProvider.class);
-        when(vp.getValue(any(), any(), any(), any(), any(), any(), any()))
-                .thenReturn(MOCK_FILL_VALUE);
-        WSDLCustomParser p = new WSDLCustomParser(() -> vp, null, dateSupplier);
+    private void importWsdl(String resourceName) throws Exception {
         String content =
                 new String(
                         Files.readAllBytes(getResourcePath("resources/" + resourceName)),
                         StandardCharsets.UTF_8);
-        p.extContentWSDLImport(content, false);
-        return p;
+        parser.extContentWSDLImport(content, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Supplier<Date> mockLenientDateSupplier() {
+        return mock(Supplier.class, withSettings().strictness(Strictness.LENIENT));
     }
 }

--- a/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/degraded-parameters.wsdl
+++ b/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/degraded-parameters.wsdl
@@ -1,0 +1,122 @@
+<?xml version='1.0' encoding='utf-8'?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://example.org/main"
+                  targetNamespace="http://example.org/main"
+                  name="DegradedParamsService">
+  <wsdl:types>
+
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               targetNamespace="http://example.org/main"
+               elementFormDefault="qualified">
+
+      <xs:element name="Request">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="controlField" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+            <xs:element name="badRefOuter" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element xmlns:data="http://example.org/data"
+                              ref="data:missingBlock"
+                              minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="siblingField" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="brokenBlock" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:complexContent>
+                  <xs:extension base="other:MissingBase"
+                                xmlns:other="http://example.org/other">
+                    <xs:sequence>
+                      <xs:element name="localField" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                  </xs:extension>
+                </xs:complexContent>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="simpleBaseBlock" type="tns:SimpleBaseExtension" minOccurs="0" maxOccurs="1"/>
+
+            <xs:element name="badTypeOuter" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="badTypeField" type="tns:MissingNamedType" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="typeSiblingField" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:simpleType name="SimpleBase">
+        <xs:restriction base="xs:string"/>
+      </xs:simpleType>
+
+      <!--
+        Intentionally-invalid XSD construct for degradation-path tests:
+        This complexType uses complexContent extension where the base resolves to a simpleType,
+        to ensure the importer/code under test behaves gracefully with malformed schemas.
+      -->
+      <xs:complexType name="SimpleBaseExtension">
+        <xs:complexContent>
+          <xs:extension base="tns:SimpleBase">
+            <xs:sequence>
+              <xs:element name="derivedField" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+
+      <xs:element name="RequestResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ack" type="xs:string" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+    </xs:schema>
+
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               targetNamespace="http://example.org/data"
+               elementFormDefault="qualified">
+    </xs:schema>
+
+  </wsdl:types>
+
+  <wsdl:message name="RequestMsg">
+    <wsdl:part name="parameters" element="tns:Request"/>
+  </wsdl:message>
+  <wsdl:message name="RequestResponseMsg">
+    <wsdl:part name="parameters" element="tns:RequestResponse"/>
+  </wsdl:message>
+
+  <wsdl:portType name="DegradedParamsPortType">
+    <wsdl:operation name="Invoke">
+      <wsdl:input  message="tns:RequestMsg"/>
+      <wsdl:output message="tns:RequestResponseMsg"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="DegradedParamsBinding" type="tns:DegradedParamsPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Invoke">
+      <soap:operation soapAction="Invoke"/>
+      <wsdl:input><soap:body use="literal"/></wsdl:input>
+      <wsdl:output><soap:body use="literal"/></wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="DegradedParamsService">
+    <wsdl:port name="DegradedParamsPort" binding="tns:DegradedParamsBinding">
+      <soap:address location="http://localhost:8080/degraded-params"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>

--- a/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/fill-parameters.wsdl
+++ b/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/fill-parameters.wsdl
@@ -27,6 +27,14 @@
         </xs:complexContent>
       </xs:complexType>
 
+      <xs:complexType name="NamedBox">
+        <xs:sequence>
+          <xs:element name="inner" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+      </xs:complexType>
+
+      <xs:attribute name="globalRefKey" type="xs:string"/>
+
       <xs:element name="Request">
         <xs:complexType>
           <xs:sequence>
@@ -103,8 +111,45 @@
               </xs:simpleType>
             </xs:element>
 
+            <xs:element name="positiveIntField" minOccurs="0" maxOccurs="1">
+              <xs:simpleType>
+                <xs:restriction base="xs:positiveInteger">
+                  <xs:maxInclusive value="100"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+
+            <xs:element name="negativeIntField" minOccurs="0" maxOccurs="1">
+              <xs:simpleType>
+                <xs:restriction base="xs:negativeInteger">
+                  <xs:minInclusive value="-100"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+
+            <xs:element name="nonNegativeIntField" minOccurs="0" maxOccurs="1">
+              <xs:simpleType>
+                <xs:restriction base="xs:nonNegativeInteger">
+                  <xs:maxInclusive value="100"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+
+            <xs:element name="nonPositiveIntField" minOccurs="0" maxOccurs="1">
+              <xs:simpleType>
+                <xs:restriction base="xs:nonPositiveInteger">
+                  <xs:minInclusive value="-100"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+
             <!-- xs:token is a string-derived built-in; must produce a param with a non-empty hint -->
             <xs:element name="tokenField" type="xs:token" minOccurs="0" maxOccurs="1"/>
+
+            <!-- No type attribute: parser falls back to xs:string / paramValue default -->
+            <xs:element name="plainField" minOccurs="0" maxOccurs="1"/>
+
+            <xs:element name="namedBox" type="tns:NamedBox" minOccurs="0" maxOccurs="1"/>
 
             <xs:element name="block" type="tns:TypeB" minOccurs="0" maxOccurs="1"/>
 
@@ -122,6 +167,13 @@
               <xs:complexType>
                 <xs:attribute name="plainKey" type="xs:string"/>
                 <xs:attribute name="äKey"     type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="attrRefWrapper" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute ref="tns:globalRefKey"/>
+                <xs:attribute name="inlineKey" type="xs:string"/>
               </xs:complexType>
             </xs:element>
 


### PR DESCRIPTION
## Overview
The team pointed out in the previous PR that there were likely un-tested functional changes. This PR attempts to address that, with regard to the following items:

1. getBuildInTypeName() default — boundedInt should resolve to "0" via base type int; test only checks key exists, not value.
2. Plain element with no type — fallback to "string" / "paramValue"; not exercised.
3. Complex type via type= reference (not embedded) — covered indirectly via block/TypeB; no isolated case.
4. Integer defaults through WSDL import — positiveInteger, negativeInteger, etc. only tested via direct addParameter, not end-to-end import.
5. Unresolvable ref= or base type — ModelAccessException, null resolved element; degradation paths untested.
6. Null attribute name skip — untested.
7. fillParameters catch → empty map on RuntimeException — untested.

## Related Issues

- Follow-up to: zaproxy/zap-extensions#7426
