### PR TITLE
client: add more API endpoints

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Client Spider Options panel.
 - Support for ZAP modes in the Client Spider.
+- More option API endpoints.
 
 ### Changed
 - Change the Client Spider to crawl through page components (e.g. links) to reduce full page reloads, improving support for SPAs.

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientIntegrationAPI.java
@@ -88,6 +88,8 @@ public class ClientIntegrationAPI extends ApiImplementor {
         this.addApiAction(
                 new ApiAction(ACTION_EXPORT_CLIENT_MAP, new String[] {PARAM_EXPORT_PATH}));
 
+        addApiOptions(extension.getClientParam());
+
         callbackUrl =
                 API.getInstance().getCallBackUrl(this, HttpHeader.SCHEME_HTTPS + API.API_DOMAIN);
         LOGGER.debug("Client API callback URL: {}", callbackUrl);
@@ -129,7 +131,9 @@ public class ClientIntegrationAPI extends ApiImplementor {
                                 "Failed to export client map: " + exportPath);
                     }
                 }
-                default -> throw new ApiException(ApiException.Type.BAD_ACTION);
+                default -> {
+                    throw new ApiException(ApiException.Type.BAD_ACTION);
+                }
             }
         } catch (ApiException e) {
             throw e;

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ClientOptions.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ClientOptions.java
@@ -21,14 +21,9 @@ package org.zaproxy.addon.client;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.Constant;
-import org.zaproxy.addon.commonlib.Constants;
 import org.zaproxy.zap.common.VersionedAbstractParam;
-import org.zaproxy.zap.extension.api.ZapApiIgnore;
-import org.zaproxy.zap.extension.selenium.Browser;
 
 public class ClientOptions extends VersionedAbstractParam {
 
@@ -38,101 +33,16 @@ public class ClientOptions extends VersionedAbstractParam {
 
     static final String CLIENT_BASE_KEY = "client";
 
-    public static final String DEFAULT_BROWSER_ID = Browser.FIREFOX_HEADLESS.getId();
-    public static final int DEFAULT_MAX_DEPTH = 5;
-    public static final int DEFAULT_INITIAL_LOAD_TIME = 5;
-    public static final int DEFAULT_PAGE_LOAD_TIME = 1;
-    public static final int DEFAULT_SHUTDOWN_TIME = 5;
-    public static final int DEFAULT_ACTION_WAIT_TIME = 0;
-    public static final boolean DEFAULT_LOGOUT_AVOIDANCE = true;
-
     private static final String CONFIG_VERSION_KEY = CLIENT_BASE_KEY + VERSION_ATTRIBUTE;
     private static final String PSCAN_ENABLED_KEY = CLIENT_BASE_KEY + ".pscanEnabled";
     private static final String PSCAN_DISABLED_RULES_KEY = CLIENT_BASE_KEY + ".pscanRulesDisabled";
-    private static final String BROWSER_ID_KEY = CLIENT_BASE_KEY + ".browserId";
-    private static final String SHOW_ADV_OPTIONS_KEY = CLIENT_BASE_KEY + ".showAdvOptions";
-    private static final String THREAD_COUNT_KEY = CLIENT_BASE_KEY + ".threads";
-    private static final String INITIAL_LOAD_TIME_KEY = CLIENT_BASE_KEY + ".initialLoadTime";
-    private static final String PAGE_LOAD_TIME_KEY = CLIENT_BASE_KEY + ".pageLoadTime";
-    private static final String SHUTDOWN_TIME_KEY = CLIENT_BASE_KEY + ".shutdownTime";
-    private static final String MAX_DEPTH_KEY = CLIENT_BASE_KEY + ".maxDepth";
-    private static final String MAX_DURATION_KEY = CLIENT_BASE_KEY + ".maxDuration";
-    private static final String MAX_CHILDREN_KEY = CLIENT_BASE_KEY + ".maxChildren";
-    private static final String MAX_SCANS_IN_UI_KEY = CLIENT_BASE_KEY + ".maxScansInUI";
-    private static final String SCOPE_CHECK_KEY = CLIENT_BASE_KEY + ".scopeCheck";
-    private static final String LOGOUT_AVOIDANCE_KEY = CLIENT_BASE_KEY + ".logoutAvoidance";
-    private static final String ACTION_WAIT_TIME_KEY = CLIENT_BASE_KEY + ".actionWaitTime";
 
-    public enum ScopeCheck {
-        FLEXIBLE,
-        STRICT;
-
-        private final String label;
-
-        ScopeCheck() {
-            label =
-                    Constant.messages.getString(
-                            "client.options.label.scope." + name().toLowerCase(Locale.ROOT));
-        }
-
-        @Override
-        public String toString() {
-            return label;
-        }
-
-        public static ScopeCheck getDefault() {
-            return FLEXIBLE;
-        }
-
-        public static ScopeCheck parse(String value) {
-            if (value == null || value.isBlank()) {
-                return getDefault();
-            }
-
-            try {
-                return valueOf(value.toUpperCase(Locale.ROOT));
-            } catch (Exception e) {
-                return getDefault();
-            }
-        }
-    }
-
-    private String browserId;
-    private int threadCount;
-    private int initialLoadTimeInSecs = DEFAULT_INITIAL_LOAD_TIME;
-    private int pageLoadTimeInSecs = DEFAULT_PAGE_LOAD_TIME;
-    private int shutdownTimeInSecs = DEFAULT_SHUTDOWN_TIME;
     private boolean pscanEnabled;
     private List<Integer> pscanRulesDisabled;
-    private boolean showAdvancedDialog;
-    private int maxChildren;
-    private int maxDepth = DEFAULT_MAX_DEPTH;
-    private int maxDuration;
-    private int maxScansInUi = 5;
-    private ScopeCheck scopeCheck = ScopeCheck.getDefault();
-    private boolean logoutAvoidance;
-    private int actionWaitTimeInSecs = DEFAULT_ACTION_WAIT_TIME;
-
-    @Override
-    public ClientOptions clone() {
-        return (ClientOptions) super.clone();
-    }
 
     @Override
     protected void parseImpl() {
         this.pscanEnabled = getBoolean(PSCAN_ENABLED_KEY, true);
-        this.browserId = getString(BROWSER_ID_KEY, DEFAULT_BROWSER_ID);
-        this.threadCount = Math.max(1, getInt(THREAD_COUNT_KEY, Constants.getDefaultThreadCount()));
-        this.initialLoadTimeInSecs = getInt(INITIAL_LOAD_TIME_KEY, DEFAULT_INITIAL_LOAD_TIME);
-        this.pageLoadTimeInSecs = getInt(PAGE_LOAD_TIME_KEY, DEFAULT_PAGE_LOAD_TIME);
-        this.shutdownTimeInSecs = getInt(SHUTDOWN_TIME_KEY, DEFAULT_SHUTDOWN_TIME);
-        this.maxChildren = getInt(MAX_CHILDREN_KEY, 0);
-        this.maxDepth = getInt(MAX_DEPTH_KEY, DEFAULT_MAX_DEPTH);
-        this.maxDuration = getInt(MAX_DURATION_KEY, 0);
-        this.maxScansInUi = getInt(MAX_SCANS_IN_UI_KEY, 5);
-        this.scopeCheck = getEnum(SCOPE_CHECK_KEY, ScopeCheck.getDefault());
-        logoutAvoidance = getBoolean(LOGOUT_AVOIDANCE_KEY, DEFAULT_LOGOUT_AVOIDANCE);
-        this.actionWaitTimeInSecs = getInt(ACTION_WAIT_TIME_KEY, DEFAULT_ACTION_WAIT_TIME);
 
         try {
             pscanRulesDisabled =
@@ -144,15 +54,6 @@ public class ClientOptions extends VersionedAbstractParam {
             LOGGER.warn(e.getMessage(), e);
             pscanRulesDisabled = new ArrayList<>();
         }
-        browserId = getString(BROWSER_ID_KEY, DEFAULT_BROWSER_ID);
-        try {
-            Browser.getBrowserWithId(browserId);
-        } catch (IllegalArgumentException e) {
-            LOGGER.warn(
-                    "Unknown browser [{}] using default [{}].", browserId, DEFAULT_BROWSER_ID, e);
-            browserId = DEFAULT_BROWSER_ID;
-        }
-        this.showAdvancedDialog = getBoolean(SHOW_ADV_OPTIONS_KEY, false);
     }
 
     @Override
@@ -186,131 +87,5 @@ public class ClientOptions extends VersionedAbstractParam {
     public void setPscanRulesDisabled(List<Integer> pscanDisabled) {
         this.pscanRulesDisabled = pscanDisabled;
         getConfig().setProperty(PSCAN_DISABLED_RULES_KEY, pscanDisabled);
-    }
-
-    public String getBrowserId() {
-        return browserId;
-    }
-
-    public void setBrowserId(String browserId) {
-        this.browserId = browserId;
-        getConfig().setProperty(BROWSER_ID_KEY, browserId);
-    }
-
-    @ZapApiIgnore
-    public boolean isShowAdvancedDialog() {
-        return this.showAdvancedDialog;
-    }
-
-    @ZapApiIgnore
-    public void setShowAdvancedDialog(boolean show) {
-        this.showAdvancedDialog = show;
-        getConfig().setProperty(SHOW_ADV_OPTIONS_KEY, Boolean.valueOf(showAdvancedDialog));
-    }
-
-    public int getThreadCount() {
-        return threadCount;
-    }
-
-    public void setThreadCount(int threadCount) {
-        if (threadCount <= 0) {
-            threadCount = Constant.getDefaultThreadCount();
-        }
-        this.threadCount = threadCount;
-        getConfig().setProperty(THREAD_COUNT_KEY, threadCount);
-    }
-
-    public int getInitialLoadTimeInSecs() {
-        return initialLoadTimeInSecs;
-    }
-
-    public void setInitialLoadTimeInSecs(int initialLoadTimeInSecs) {
-        this.initialLoadTimeInSecs = initialLoadTimeInSecs;
-        getConfig().setProperty(INITIAL_LOAD_TIME_KEY, initialLoadTimeInSecs);
-    }
-
-    public int getPageLoadTimeInSecs() {
-        return pageLoadTimeInSecs;
-    }
-
-    public void setPageLoadTimeInSecs(int pageLoadTimeInSecs) {
-        this.pageLoadTimeInSecs = pageLoadTimeInSecs;
-        getConfig().setProperty(PAGE_LOAD_TIME_KEY, pageLoadTimeInSecs);
-    }
-
-    public int getShutdownTimeInSecs() {
-        return shutdownTimeInSecs;
-    }
-
-    public void setShutdownTimeInSecs(int shutdownTimeInSecs) {
-        this.shutdownTimeInSecs = shutdownTimeInSecs;
-        getConfig().setProperty(SHUTDOWN_TIME_KEY, shutdownTimeInSecs);
-    }
-
-    public int getMaxChildren() {
-        return maxChildren;
-    }
-
-    public void setMaxChildren(int maxChildren) {
-        this.maxChildren = maxChildren;
-        getConfig().setProperty(MAX_CHILDREN_KEY, maxChildren);
-    }
-
-    public int getMaxDepth() {
-        return maxDepth;
-    }
-
-    public void setMaxDepth(int maxDepth) {
-        this.maxDepth = maxDepth;
-        getConfig().setProperty(MAX_DEPTH_KEY, maxDepth);
-    }
-
-    public int getMaxDuration() {
-        return maxDuration;
-    }
-
-    public void setMaxDuration(int maxDuration) {
-        this.maxDuration = maxDuration;
-        getConfig().setProperty(MAX_DURATION_KEY, maxDuration);
-    }
-
-    public int getMaxScansInUi() {
-        return this.maxScansInUi;
-    }
-
-    public void setMaxScansInUi(int maxScansInUi) {
-        this.maxScansInUi = maxScansInUi;
-        getConfig().setProperty(MAX_SCANS_IN_UI_KEY, maxScansInUi);
-    }
-
-    public ScopeCheck getScopeCheck() {
-        return scopeCheck;
-    }
-
-    public void setScopeCheck(String scopeCheck) {
-        setScopeCheck(ScopeCheck.parse(scopeCheck));
-    }
-
-    public void setScopeCheck(ScopeCheck scopeCheck) {
-        this.scopeCheck = scopeCheck == null ? ScopeCheck.getDefault() : scopeCheck;
-        getConfig().setProperty(SCOPE_CHECK_KEY, this.scopeCheck.name());
-    }
-
-    public boolean isLogoutAvoidance() {
-        return logoutAvoidance;
-    }
-
-    public void setLogoutAvoidance(boolean logoutAvoidance) {
-        this.logoutAvoidance = logoutAvoidance;
-        getConfig().setProperty(LOGOUT_AVOIDANCE_KEY, logoutAvoidance);
-    }
-
-    public int getActionWaitTimeInSecs() {
-        return actionWaitTimeInSecs;
-    }
-
-    public void setActionWaitTimeInSecs(int actionWaitTimeInSecs) {
-        this.actionWaitTimeInSecs = actionWaitTimeInSecs;
-        getConfig().setProperty(ACTION_WAIT_TIME_KEY, actionWaitTimeInSecs);
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/ExtensionClientIntegration.java
@@ -80,8 +80,9 @@ import org.zaproxy.addon.client.spider.AuthenticationHandler;
 import org.zaproxy.addon.client.spider.ClientSpider;
 import org.zaproxy.addon.client.spider.ClientSpiderApi;
 import org.zaproxy.addon.client.spider.ClientSpiderDialog;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions;
+import org.zaproxy.addon.client.spider.ClientSpiderOptionsDialog;
 import org.zaproxy.addon.client.spider.ClientSpiderPanel;
-import org.zaproxy.addon.client.spider.OptionsClientSpider;
 import org.zaproxy.addon.client.spider.PopupMenuSpider;
 import org.zaproxy.addon.client.spider.ScanOptions;
 import org.zaproxy.addon.client.spider.SpiderScanController;
@@ -155,6 +156,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
     private ClientPassiveScanController passiveScanController;
     private ClientPassiveScanHelper pscanHelper;
     private ClientOptions clientParam;
+    private ClientSpiderOptions clientSpiderParam;
     private ClientIntegrationAPI api;
     private EventConsumer eventConsumer;
     private Event lastAjaxSpiderStartEvent;
@@ -214,6 +216,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
 
         extensionHook.addSessionListener(new SessionChangedListenerImpl());
         extensionHook.addOptionsParamSet(getClientParam());
+        extensionHook.addOptionsParamSet(getClientSpiderParam());
         extensionHook.addApiImplementor(this.api);
         extensionHook.addApiImplementor(new ClientSpiderApi(this));
 
@@ -321,7 +324,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
                     .getHookView()
                     .addOptionPanel(
                             List.of(Constant.messages.getString("client.options.name")),
-                            new OptionsClientSpider());
+                            new ClientSpiderOptionsDialog());
 
             getView()
                     .getMainFrame()
@@ -443,6 +446,13 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
             clientParam = new ClientOptions();
         }
         return clientParam;
+    }
+
+    public ClientSpiderOptions getClientSpiderParam() {
+        if (clientSpiderParam == null) {
+            clientSpiderParam = new ClientSpiderOptions();
+        }
+        return clientSpiderParam;
     }
 
     protected void checkFirefoxProfilesFile(Path iniPath, Path profilePath) throws IOException {
@@ -587,7 +597,8 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
     private ClientSpiderPanel getClientSpiderPanel() {
         if (clientSpiderPanel == null) {
             clientSpiderPanel =
-                    new ClientSpiderPanel(this, this.spiderScanController, this.getClientParam());
+                    new ClientSpiderPanel(
+                            this, this.spiderScanController, this.getClientSpiderParam());
         }
         return clientSpiderPanel;
     }
@@ -750,7 +761,11 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
     }
 
     public int startScan(
-            String url, ClientOptions options, Context context, User user, boolean subtreeOnly)
+            String url,
+            ClientSpiderOptions options,
+            Context context,
+            User user,
+            boolean subtreeOnly)
             throws URIException, NullPointerException {
         return startScan(
                 url,
@@ -762,7 +777,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
                         .build());
     }
 
-    public int startScan(String url, ClientOptions options, ScanOptions scanOptions)
+    public int startScan(String url, ClientSpiderOptions options, ScanOptions scanOptions)
             throws URIException, NullPointerException {
         return startScan(abbreviateDisplayName(url), null, url, options, scanOptions);
     }
@@ -783,7 +798,7 @@ public class ExtensionClientIntegration extends ExtensionAdaptor {
             String displayName,
             Target target,
             String startUrl,
-            ClientOptions clientOptions,
+            ClientSpiderOptions clientOptions,
             ScanOptions scanOptions) {
         int id =
                 this.spiderScanController.startScan(

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/automation/ClientSpiderJob.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/automation/ClientSpiderJob.java
@@ -37,10 +37,10 @@ import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.addon.automation.ContextWrapper;
 import org.zaproxy.addon.automation.jobs.JobData;
 import org.zaproxy.addon.automation.jobs.JobUtils;
-import org.zaproxy.addon.client.ClientOptions;
-import org.zaproxy.addon.client.ClientOptions.ScopeCheck;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.spider.ClientSpider;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions.ScopeCheck;
 import org.zaproxy.addon.commonlib.Constants;
 import org.zaproxy.zap.users.User;
 
@@ -159,8 +159,8 @@ public class ClientSpiderJob extends AutomationJob {
         forceStop = true;
     }
 
-    protected ClientOptions paramsToOptions() {
-        ClientOptions options = new ClientOptions();
+    protected ClientSpiderOptions paramsToOptions() {
+        ClientSpiderOptions options = new ClientSpiderOptions();
         options.load(new XMLConfiguration());
 
         if (!StringUtils.isBlank(this.parameters.getBrowserId())) {
@@ -294,15 +294,15 @@ public class ClientSpiderJob extends AutomationJob {
         private String url = "";
         private Integer maxDuration;
         private Integer maxChildren;
-        private Integer maxCrawlDepth = ClientOptions.DEFAULT_MAX_DEPTH;
+        private Integer maxCrawlDepth = ClientSpiderOptions.DEFAULT_MAX_DEPTH;
         private Integer numberOfBrowsers = Constants.getDefaultThreadCount() / 2;
         private String browserId;
-        private Integer initialLoadTime = ClientOptions.DEFAULT_INITIAL_LOAD_TIME;
-        private Integer pageLoadTime = ClientOptions.DEFAULT_PAGE_LOAD_TIME;
-        private Integer shutdownTime = ClientOptions.DEFAULT_SHUTDOWN_TIME;
+        private Integer initialLoadTime = ClientSpiderOptions.DEFAULT_INITIAL_LOAD_TIME;
+        private Integer pageLoadTime = ClientSpiderOptions.DEFAULT_PAGE_LOAD_TIME;
+        private Integer shutdownTime = ClientSpiderOptions.DEFAULT_SHUTDOWN_TIME;
         private String scopeCheck = ScopeCheck.getDefault().toString();
-        private Boolean logoutAvoidance = ClientOptions.DEFAULT_LOGOUT_AVOIDANCE;
-        private Integer actionWaitTime = ClientOptions.DEFAULT_ACTION_WAIT_TIME;
+        private Boolean logoutAvoidance = ClientSpiderOptions.DEFAULT_LOGOUT_AVOIDANCE;
+        private Integer actionWaitTime = ClientSpiderOptions.DEFAULT_ACTION_WAIT_TIME;
 
         public Parameters() {}
     }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/automation/ClientSpiderJobDialog.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/automation/ClientSpiderJobDialog.java
@@ -25,9 +25,9 @@ import java.util.List;
 import javax.swing.JTextField;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.automation.ClientSpiderJob.Parameters;
 import org.zaproxy.addon.client.internal.ScopeCheckComponent;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions;
 import org.zaproxy.addon.commonlib.Constants;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.selenium.ProvidedBrowserUI;
@@ -132,7 +132,7 @@ public class ClientSpiderJobDialog extends StandardFieldsDialog {
                 Integer.MAX_VALUE,
                 getInt(
                         this.job.getParameters().getMaxCrawlDepth(),
-                        ClientOptions.DEFAULT_MAX_DEPTH));
+                        ClientSpiderOptions.DEFAULT_MAX_DEPTH));
 
         this.addNumberField(
                 1,
@@ -147,7 +147,7 @@ public class ClientSpiderJobDialog extends StandardFieldsDialog {
                 Integer.MAX_VALUE,
                 getInt(
                         this.job.getParameters().getInitialLoadTime(),
-                        ClientOptions.DEFAULT_INITIAL_LOAD_TIME));
+                        ClientSpiderOptions.DEFAULT_INITIAL_LOAD_TIME));
         this.addNumberField(
                 1,
                 PAGE_LOADTIME_PARAM,
@@ -155,7 +155,7 @@ public class ClientSpiderJobDialog extends StandardFieldsDialog {
                 Integer.MAX_VALUE,
                 getInt(
                         this.job.getParameters().getPageLoadTime(),
-                        ClientOptions.DEFAULT_PAGE_LOAD_TIME));
+                        ClientSpiderOptions.DEFAULT_PAGE_LOAD_TIME));
         this.addNumberField(
                 1,
                 ACTION_WAIT_TIME_PARAM,
@@ -163,7 +163,7 @@ public class ClientSpiderJobDialog extends StandardFieldsDialog {
                 Integer.MAX_VALUE,
                 getInt(
                         this.job.getParameters().getActionWaitTime(),
-                        ClientOptions.DEFAULT_ACTION_WAIT_TIME));
+                        ClientSpiderOptions.DEFAULT_ACTION_WAIT_TIME));
         this.addNumberField(
                 1,
                 SHUTDOWN_TIME_PARAM,
@@ -171,7 +171,7 @@ public class ClientSpiderJobDialog extends StandardFieldsDialog {
                 Integer.MAX_VALUE,
                 getInt(
                         this.job.getParameters().getShutdownTime(),
-                        ClientOptions.DEFAULT_SHUTDOWN_TIME));
+                        ClientSpiderOptions.DEFAULT_SHUTDOWN_TIME));
         this.addNumberField(
                 1,
                 MAX_DURATION_PARAM,
@@ -183,7 +183,7 @@ public class ClientSpiderJobDialog extends StandardFieldsDialog {
                 LOGOUT_AVOIDANCE_PARAM,
                 getBoolean(
                         job.getParameters().getLogoutAvoidance(),
-                        ClientOptions.DEFAULT_LOGOUT_AVOIDANCE));
+                        ClientSpiderOptions.DEFAULT_LOGOUT_AVOIDANCE));
 
         this.addPadding(1);
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ScopeCheckComponent.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ScopeCheckComponent.java
@@ -23,7 +23,7 @@ import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import org.jdesktop.swingx.JXRadioGroup;
 import org.parosproxy.paros.Constant;
-import org.zaproxy.addon.client.ClientOptions.ScopeCheck;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions.ScopeCheck;
 
 public class ScopeCheckComponent {
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -62,13 +62,12 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.network.HttpStatusCode;
-import org.zaproxy.addon.client.ClientOptions;
-import org.zaproxy.addon.client.ClientOptions.ScopeCheck;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.client.internal.ClientMapListener;
 import org.zaproxy.addon.client.internal.ClientNode;
 import org.zaproxy.addon.client.internal.ClientSideDetails;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions.ScopeCheck;
 import org.zaproxy.addon.client.spider.actions.ClickElement;
 import org.zaproxy.addon.client.spider.actions.FollowGraph;
 import org.zaproxy.addon.client.spider.actions.SubmitForm;
@@ -117,7 +116,7 @@ public class ClientSpider implements GenericScanner2 {
     private ExecutorService threadPool;
 
     private final ValueProvider valueProvider;
-    private ClientOptions options;
+    private ClientSpiderOptions options;
     private final Duration pageLoadTime;
     private int scanId;
     private String displayName;
@@ -163,7 +162,7 @@ public class ClientSpider implements GenericScanner2 {
             ClientMap clientMap,
             String displayName,
             String targetUrl,
-            ClientOptions options,
+            ClientSpiderOptions options,
             int id,
             Context context,
             User user,
@@ -189,7 +188,7 @@ public class ClientSpider implements GenericScanner2 {
             ClientMap clientMap,
             String displayName,
             String targetUrl,
-            ClientOptions options,
+            ClientSpiderOptions options,
             ScanOptions scanOptions,
             ValueProvider valueProvider,
             int id) {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderApi.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderApi.java
@@ -28,9 +28,8 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
-import org.zaproxy.addon.client.ClientOptions;
-import org.zaproxy.addon.client.ClientOptions.ScopeCheck;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions.ScopeCheck;
 import org.zaproxy.zap.extension.api.ApiAction;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiException.Type;
@@ -98,6 +97,9 @@ public class ClientSpiderApi extends ApiImplementor {
         addApiAction(new ApiAction(ACTION_STOP_SCAN, List.of(PARAM_SCAN_ID)));
 
         addApiView(new ApiView(VIEW_STATUS, List.of(PARAM_SCAN_ID)));
+
+        addApiOptions(
+                extension != null ? extension.getClientSpiderParam() : new ClientSpiderOptions());
     }
 
     @Override
@@ -152,7 +154,7 @@ public class ClientSpiderApi extends ApiImplementor {
 
         validateMode(url, context, validateUrl);
 
-        ClientOptions options = extension.getClientParam().clone();
+        ClientSpiderOptions options = extension.getClientSpiderParam().clone();
         options.setBrowserId(getBrowser(params));
 
         if (params.containsKey(PARAM_MAX_CRAWL_DEPTH)) {
@@ -273,7 +275,6 @@ public class ClientSpiderApi extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-
         switch (name) {
             case VIEW_STATUS:
                 ClientSpider scan = getClientSpider(params);

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderDialog.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderDialog.java
@@ -39,7 +39,6 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ScopeCheckComponent;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
@@ -87,7 +86,7 @@ public class ClientSpiderDialog extends StandardFieldsDialog {
 
     private SiteNode targetNode;
     private String targetUrl;
-    private ClientOptions params = null;
+    private ClientSpiderOptions params = null;
     private ZapTextField urlStartField;
     private boolean subtreeOnlyPreviousCheckedState;
     private ScopeCheckComponent scopeCheckComponent;
@@ -98,7 +97,7 @@ public class ClientSpiderDialog extends StandardFieldsDialog {
     public ClientSpiderDialog(ExtensionClientIntegration ext, Frame owner) {
         super(owner, "client.scandialog.title", DisplayUtils.getScaledDimension(700, 350), LABELS);
         this.extension = ext;
-        params = this.extension.getClientParam();
+        params = this.extension.getClientSpiderParam();
         this.extUserMgmt =
                 Control.getSingleton()
                         .getExtensionLoader()
@@ -310,7 +309,7 @@ public class ClientSpiderDialog extends StandardFieldsDialog {
                 },
                 adv);
         // Always save in the 'global' options
-        extension.getClientParam().setShowAdvancedDialog(adv);
+        extension.getClientSpiderParam().setShowAdvancedDialog(adv);
     }
 
     /** Resets the spider dialogue to its default state. */
@@ -349,7 +348,7 @@ public class ClientSpiderDialog extends StandardFieldsDialog {
     /** Use the save method to launch a scan */
     @Override
     public void save() {
-        ClientOptions clientParams = this.extension.getClientParam();
+        ClientSpiderOptions clientParams = this.extension.getClientSpiderParam();
 
         String selectedBrowser = getSelectedBrowser();
         if (selectedBrowser != null) {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderOptions.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderOptions.java
@@ -1,0 +1,303 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import java.util.Locale;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.commonlib.Constants;
+import org.zaproxy.zap.common.VersionedAbstractParam;
+import org.zaproxy.zap.extension.api.ZapApiIgnore;
+import org.zaproxy.zap.extension.selenium.Browser;
+
+public class ClientSpiderOptions extends VersionedAbstractParam {
+
+    private static final Logger LOGGER = LogManager.getLogger(ClientSpiderOptions.class);
+
+    protected static final int CURRENT_CONFIG_VERSION = 1;
+
+    static final String CLIENT_SPIDER_BASE_KEY = "client.spider";
+
+    private static final String OLD_CLIENT_BASE_KEY = "client";
+
+    public static final String DEFAULT_BROWSER_ID = Browser.FIREFOX_HEADLESS.getId();
+    public static final int DEFAULT_MAX_DEPTH = 5;
+    public static final int DEFAULT_INITIAL_LOAD_TIME = 5;
+    public static final int DEFAULT_PAGE_LOAD_TIME = 1;
+    public static final int DEFAULT_SHUTDOWN_TIME = 5;
+    public static final int DEFAULT_ACTION_WAIT_TIME = 0;
+    public static final boolean DEFAULT_LOGOUT_AVOIDANCE = true;
+
+    private static final String CONFIG_VERSION_KEY = CLIENT_SPIDER_BASE_KEY + VERSION_ATTRIBUTE;
+    private static final String BROWSER_ID_KEY = CLIENT_SPIDER_BASE_KEY + ".browserId";
+    private static final String SHOW_ADV_OPTIONS_KEY = CLIENT_SPIDER_BASE_KEY + ".showAdvOptions";
+    private static final String THREAD_COUNT_KEY = CLIENT_SPIDER_BASE_KEY + ".threads";
+    private static final String INITIAL_LOAD_TIME_KEY = CLIENT_SPIDER_BASE_KEY + ".initialLoadTime";
+    private static final String PAGE_LOAD_TIME_KEY = CLIENT_SPIDER_BASE_KEY + ".pageLoadTime";
+    private static final String SHUTDOWN_TIME_KEY = CLIENT_SPIDER_BASE_KEY + ".shutdownTime";
+    private static final String MAX_DEPTH_KEY = CLIENT_SPIDER_BASE_KEY + ".maxDepth";
+    private static final String MAX_DURATION_KEY = CLIENT_SPIDER_BASE_KEY + ".maxDuration";
+    private static final String MAX_CHILDREN_KEY = CLIENT_SPIDER_BASE_KEY + ".maxChildren";
+    private static final String MAX_SCANS_IN_UI_KEY = CLIENT_SPIDER_BASE_KEY + ".maxScansInUI";
+    private static final String SCOPE_CHECK_KEY = CLIENT_SPIDER_BASE_KEY + ".scopeCheck";
+    private static final String LOGOUT_AVOIDANCE_KEY = CLIENT_SPIDER_BASE_KEY + ".logoutAvoidance";
+    private static final String ACTION_WAIT_TIME_KEY = CLIENT_SPIDER_BASE_KEY + ".actionWaitTime";
+
+    public enum ScopeCheck {
+        FLEXIBLE,
+        STRICT;
+
+        private final String label;
+
+        ScopeCheck() {
+            label =
+                    Constant.messages.getString(
+                            "client.options.label.scope." + name().toLowerCase(Locale.ROOT));
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+
+        public static ScopeCheck getDefault() {
+            return FLEXIBLE;
+        }
+
+        public static ScopeCheck parse(String value) {
+            if (value == null || value.isBlank()) {
+                return getDefault();
+            }
+
+            try {
+                return valueOf(value.toUpperCase(Locale.ROOT));
+            } catch (Exception e) {
+                return getDefault();
+            }
+        }
+    }
+
+    private String browserId;
+    private int threadCount;
+    private int initialLoadTimeInSecs = DEFAULT_INITIAL_LOAD_TIME;
+    private int pageLoadTimeInSecs = DEFAULT_PAGE_LOAD_TIME;
+    private int shutdownTimeInSecs = DEFAULT_SHUTDOWN_TIME;
+    private boolean showAdvancedDialog;
+    private int maxChildren;
+    private int maxDepth = DEFAULT_MAX_DEPTH;
+    private int maxDuration;
+    private int maxScansInUi = 5;
+    private ScopeCheck scopeCheck = ScopeCheck.getDefault();
+    private boolean logoutAvoidance;
+    private int actionWaitTimeInSecs = DEFAULT_ACTION_WAIT_TIME;
+
+    @Override
+    public ClientSpiderOptions clone() {
+        return (ClientSpiderOptions) super.clone();
+    }
+
+    @Override
+    protected void parseImpl() {
+        this.browserId = getString(BROWSER_ID_KEY, DEFAULT_BROWSER_ID);
+        try {
+            Browser.getBrowserWithId(browserId);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn(
+                    "Unknown browser [{}] using default [{}].", browserId, DEFAULT_BROWSER_ID, e);
+            browserId = DEFAULT_BROWSER_ID;
+        }
+        this.threadCount = Math.max(1, getInt(THREAD_COUNT_KEY, Constants.getDefaultThreadCount()));
+        this.initialLoadTimeInSecs = getInt(INITIAL_LOAD_TIME_KEY, DEFAULT_INITIAL_LOAD_TIME);
+        this.pageLoadTimeInSecs = getInt(PAGE_LOAD_TIME_KEY, DEFAULT_PAGE_LOAD_TIME);
+        this.shutdownTimeInSecs = getInt(SHUTDOWN_TIME_KEY, DEFAULT_SHUTDOWN_TIME);
+        this.maxChildren = getInt(MAX_CHILDREN_KEY, 0);
+        this.maxDepth = getInt(MAX_DEPTH_KEY, DEFAULT_MAX_DEPTH);
+        this.maxDuration = getInt(MAX_DURATION_KEY, 0);
+        this.maxScansInUi = getInt(MAX_SCANS_IN_UI_KEY, 5);
+        this.scopeCheck = getEnum(SCOPE_CHECK_KEY, ScopeCheck.getDefault());
+        this.logoutAvoidance = getBoolean(LOGOUT_AVOIDANCE_KEY, DEFAULT_LOGOUT_AVOIDANCE);
+        this.actionWaitTimeInSecs = getInt(ACTION_WAIT_TIME_KEY, DEFAULT_ACTION_WAIT_TIME);
+        this.showAdvancedDialog = getBoolean(SHOW_ADV_OPTIONS_KEY, false);
+    }
+
+    @Override
+    protected int getCurrentVersion() {
+        return CURRENT_CONFIG_VERSION;
+    }
+
+    @Override
+    protected void updateConfigsImpl(int fileVersion) {
+        if (getConfig().containsKey(OLD_CLIENT_BASE_KEY + ".browserId")) {
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".browserId", BROWSER_ID_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".threads", THREAD_COUNT_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".initialLoadTime", INITIAL_LOAD_TIME_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".pageLoadTime", PAGE_LOAD_TIME_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".shutdownTime", SHUTDOWN_TIME_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".maxDepth", MAX_DEPTH_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".maxDuration", MAX_DURATION_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".maxChildren", MAX_CHILDREN_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".maxScansInUI", MAX_SCANS_IN_UI_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".scopeCheck", SCOPE_CHECK_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".logoutAvoidance", LOGOUT_AVOIDANCE_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".actionWaitTime", ACTION_WAIT_TIME_KEY);
+            migrateConfigIfSet(OLD_CLIENT_BASE_KEY + ".showAdvOptions", SHOW_ADV_OPTIONS_KEY);
+        }
+    }
+
+    private void migrateConfigIfSet(String oldKey, String newKey) {
+        Object value = getConfig().getProperty(oldKey);
+        if (value != null) {
+            getConfig().setProperty(newKey, value);
+            getConfig().clearProperty(oldKey);
+        }
+    }
+
+    @Override
+    protected String getConfigVersionKey() {
+        return CONFIG_VERSION_KEY;
+    }
+
+    public String getBrowserId() {
+        return browserId;
+    }
+
+    public void setBrowserId(String browserId) {
+        this.browserId = browserId;
+        getConfig().setProperty(BROWSER_ID_KEY, browserId);
+    }
+
+    @ZapApiIgnore
+    public boolean isShowAdvancedDialog() {
+        return this.showAdvancedDialog;
+    }
+
+    @ZapApiIgnore
+    public void setShowAdvancedDialog(boolean show) {
+        this.showAdvancedDialog = show;
+        getConfig().setProperty(SHOW_ADV_OPTIONS_KEY, Boolean.valueOf(showAdvancedDialog));
+    }
+
+    public int getThreadCount() {
+        return threadCount;
+    }
+
+    public void setThreadCount(int threadCount) {
+        if (threadCount <= 0) {
+            threadCount = Constant.getDefaultThreadCount();
+        }
+        this.threadCount = threadCount;
+        getConfig().setProperty(THREAD_COUNT_KEY, threadCount);
+    }
+
+    public int getInitialLoadTimeInSecs() {
+        return initialLoadTimeInSecs;
+    }
+
+    public void setInitialLoadTimeInSecs(int initialLoadTimeInSecs) {
+        this.initialLoadTimeInSecs = initialLoadTimeInSecs;
+        getConfig().setProperty(INITIAL_LOAD_TIME_KEY, initialLoadTimeInSecs);
+    }
+
+    public int getPageLoadTimeInSecs() {
+        return pageLoadTimeInSecs;
+    }
+
+    public void setPageLoadTimeInSecs(int pageLoadTimeInSecs) {
+        this.pageLoadTimeInSecs = pageLoadTimeInSecs;
+        getConfig().setProperty(PAGE_LOAD_TIME_KEY, pageLoadTimeInSecs);
+    }
+
+    public int getShutdownTimeInSecs() {
+        return shutdownTimeInSecs;
+    }
+
+    public void setShutdownTimeInSecs(int shutdownTimeInSecs) {
+        this.shutdownTimeInSecs = shutdownTimeInSecs;
+        getConfig().setProperty(SHUTDOWN_TIME_KEY, shutdownTimeInSecs);
+    }
+
+    public int getMaxChildren() {
+        return maxChildren;
+    }
+
+    public void setMaxChildren(int maxChildren) {
+        this.maxChildren = maxChildren;
+        getConfig().setProperty(MAX_CHILDREN_KEY, maxChildren);
+    }
+
+    public int getMaxDepth() {
+        return maxDepth;
+    }
+
+    public void setMaxDepth(int maxDepth) {
+        this.maxDepth = maxDepth;
+        getConfig().setProperty(MAX_DEPTH_KEY, maxDepth);
+    }
+
+    public int getMaxDuration() {
+        return maxDuration;
+    }
+
+    public void setMaxDuration(int maxDuration) {
+        this.maxDuration = maxDuration;
+        getConfig().setProperty(MAX_DURATION_KEY, maxDuration);
+    }
+
+    public int getMaxScansInUi() {
+        return this.maxScansInUi;
+    }
+
+    public void setMaxScansInUi(int maxScansInUi) {
+        this.maxScansInUi = maxScansInUi;
+        getConfig().setProperty(MAX_SCANS_IN_UI_KEY, maxScansInUi);
+    }
+
+    public ScopeCheck getScopeCheck() {
+        return scopeCheck;
+    }
+
+    public void setScopeCheck(String scopeCheck) {
+        setScopeCheck(ScopeCheck.parse(scopeCheck));
+    }
+
+    public void setScopeCheck(ScopeCheck scopeCheck) {
+        this.scopeCheck = scopeCheck == null ? ScopeCheck.getDefault() : scopeCheck;
+        getConfig().setProperty(SCOPE_CHECK_KEY, this.scopeCheck.name());
+    }
+
+    public boolean isLogoutAvoidance() {
+        return logoutAvoidance;
+    }
+
+    public void setLogoutAvoidance(boolean logoutAvoidance) {
+        this.logoutAvoidance = logoutAvoidance;
+        getConfig().setProperty(LOGOUT_AVOIDANCE_KEY, logoutAvoidance);
+    }
+
+    public int getActionWaitTimeInSecs() {
+        return actionWaitTimeInSecs;
+    }
+
+    public void setActionWaitTimeInSecs(int actionWaitTimeInSecs) {
+        this.actionWaitTimeInSecs = actionWaitTimeInSecs;
+        getConfig().setProperty(ACTION_WAIT_TIME_KEY, actionWaitTimeInSecs);
+    }
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderOptionsDialog.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderOptionsDialog.java
@@ -28,7 +28,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
-import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.internal.ScopeCheckComponent;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.selenium.ProvidedBrowserUI;
@@ -37,7 +36,7 @@ import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.view.LayoutHelper;
 
 @SuppressWarnings("serial")
-public class OptionsClientSpider extends AbstractParamPanel {
+public class ClientSpiderOptionsDialog extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;
 
@@ -53,7 +52,7 @@ public class OptionsClientSpider extends AbstractParamPanel {
     private final JCheckBox logoutAvoidanceCheckbox;
     private final ScopeCheckComponent scopeCheckComponent;
 
-    public OptionsClientSpider() {
+    public ClientSpiderOptionsDialog() {
         setName(Constant.messages.getString("client.spider.options.panel.name"));
 
         ExtensionSelenium extSelenium =
@@ -61,16 +60,20 @@ public class OptionsClientSpider extends AbstractParamPanel {
         browserCombo = new JComboBox<>(extSelenium.createProvidedBrowsersComboBoxModel());
         numBrowsersSpinner = new ZapNumberSpinner(1, 1, 64);
         maxDepthSpinner =
-                new ZapNumberSpinner(0, ClientOptions.DEFAULT_MAX_DEPTH, Integer.MAX_VALUE);
+                new ZapNumberSpinner(0, ClientSpiderOptions.DEFAULT_MAX_DEPTH, Integer.MAX_VALUE);
         maxChildrenSpinner = new ZapNumberSpinner(0, 0, Integer.MAX_VALUE);
         initialLoadTimeSpinner =
-                new ZapNumberSpinner(0, ClientOptions.DEFAULT_INITIAL_LOAD_TIME, Integer.MAX_VALUE);
+                new ZapNumberSpinner(
+                        0, ClientSpiderOptions.DEFAULT_INITIAL_LOAD_TIME, Integer.MAX_VALUE);
         pageLoadTimeSpinner =
-                new ZapNumberSpinner(0, ClientOptions.DEFAULT_PAGE_LOAD_TIME, Integer.MAX_VALUE);
+                new ZapNumberSpinner(
+                        0, ClientSpiderOptions.DEFAULT_PAGE_LOAD_TIME, Integer.MAX_VALUE);
         actionWaitTimeSpinner =
-                new ZapNumberSpinner(0, ClientOptions.DEFAULT_ACTION_WAIT_TIME, Integer.MAX_VALUE);
+                new ZapNumberSpinner(
+                        0, ClientSpiderOptions.DEFAULT_ACTION_WAIT_TIME, Integer.MAX_VALUE);
         shutdownTimeSpinner =
-                new ZapNumberSpinner(0, ClientOptions.DEFAULT_SHUTDOWN_TIME, Integer.MAX_VALUE);
+                new ZapNumberSpinner(
+                        0, ClientSpiderOptions.DEFAULT_SHUTDOWN_TIME, Integer.MAX_VALUE);
         maxDurationSpinner = new ZapNumberSpinner(0, 0, Integer.MAX_VALUE);
         logoutAvoidanceCheckbox =
                 new JCheckBox(Constant.messages.getString("client.options.label.logoutAvoidance"));
@@ -156,7 +159,7 @@ public class OptionsClientSpider extends AbstractParamPanel {
     @Override
     public void initParam(Object obj) {
         OptionsParam optionsParam = (OptionsParam) obj;
-        ClientOptions clientOptions = optionsParam.getParamSet(ClientOptions.class);
+        ClientSpiderOptions clientOptions = optionsParam.getParamSet(ClientSpiderOptions.class);
 
         ((ProvidedBrowsersComboBoxModel) browserCombo.getModel())
                 .setSelectedBrowser(clientOptions.getBrowserId());
@@ -176,7 +179,7 @@ public class OptionsClientSpider extends AbstractParamPanel {
     @Override
     public void saveParam(Object obj) throws Exception {
         OptionsParam optionsParam = (OptionsParam) obj;
-        ClientOptions clientOptions = optionsParam.getParamSet(ClientOptions.class);
+        ClientSpiderOptions clientOptions = optionsParam.getParamSet(ClientSpiderOptions.class);
 
         ProvidedBrowserUI selectedBrowser = (ProvidedBrowserUI) browserCombo.getSelectedItem();
         if (selectedBrowser != null) {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderPanel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderPanel.java
@@ -35,7 +35,6 @@ import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.zap.model.ScanController;
 import org.zaproxy.zap.model.ScanListenner2;
@@ -77,12 +76,12 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
     private JScrollPane tasksTableScrollPane;
 
     private ExtensionClientIntegration extension;
-    private ClientOptions clientOptions;
+    private ClientSpiderOptions clientOptions;
 
     public ClientSpiderPanel(
             ExtensionClientIntegration extension,
             SpiderScanController controller,
-            ClientOptions clientOptions) {
+            ClientSpiderOptions clientOptions) {
         super("client.spider", ExtensionClientIntegration.getIcon(), controller);
         this.extension = extension;
         this.clientOptions = clientOptions;

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/SpiderScanController.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/SpiderScanController.java
@@ -29,7 +29,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.commonlib.ValueProvider;
@@ -102,7 +101,7 @@ public class SpiderScanController implements ScanController<ClientSpider> {
 
     @Override
     public int startScan(String name, Target target, User user, Object[] contextSpecificObjects) {
-        ClientOptions clientOptions = null;
+        ClientSpiderOptions clientOptions = null;
         String startUrl = null;
 
         ScanOptions.Builder scanOptionsBuilder = ScanOptions.builder();
@@ -117,9 +116,9 @@ public class SpiderScanController implements ScanController<ClientSpider> {
                     continue;
                 }
 
-                if (obj instanceof ClientOptions) {
+                if (obj instanceof ClientSpiderOptions) {
                     LOGGER.debug("Setting custom spider params");
-                    clientOptions = (ClientOptions) obj;
+                    clientOptions = (ClientSpiderOptions) obj;
                 } else if (obj instanceof URI uri) {
                     startUrl = uri.toString();
                 } else if (obj instanceof Context ctx) {
@@ -141,14 +140,14 @@ public class SpiderScanController implements ScanController<ClientSpider> {
             String name,
             Target target,
             String startUrl,
-            ClientOptions clientOptions,
+            ClientSpiderOptions clientOptions,
             ScanOptions scanOptions) {
         clientSpidersLock.lock();
         try {
             int id = this.scanIdCounter++;
 
             if (clientOptions == null) {
-                clientOptions = extension.getClientParam();
+                clientOptions = extension.getClientSpiderParam();
             }
 
             ClientSpider scan =

--- a/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
+++ b/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
@@ -2,6 +2,11 @@ client.activeActionPrefix = Client Spidering: {0}
 
 client.api.action.exportClientMap = Exports the Client Map to a file.
 client.api.action.exportClientMap.param.pathYaml = The file system path to the file.
+client.api.action.setOptionPscanEnabled = Sets whether or not the client passive scanner is enabled.
+client.api.action.setOptionPscanEnabled.param.Boolean = true to enable the passive scanner, false otherwise.
+
+client.api.view.optionPscanEnabled = Gets whether or not the client passive scanner is enabled.
+client.api.view.optionPscanRulesDisabled = Gets the IDs of the disabled client passive scan rules.
 
 client.attack.spider = Client Spider...
 client.automation.default = Default
@@ -28,7 +33,6 @@ client.automation.dialog.summary = Default
 
 client.automation.dialog.tab.params = Scope
 client.automation.name = Client Spider Automation
-
 client.clientSpider.api.action.scan = Starts a client spider scan.
 client.clientSpider.api.action.scan.param.actionWaitTime = Action Wait Time (seconds).
 client.clientSpider.api.action.scan.param.browser = The ID of the browser. See Selenium documentation for valid IDs.
@@ -41,9 +45,46 @@ client.clientSpider.api.action.scan.param.scopeCheck = Scope Check (FLEXIBLE or 
 client.clientSpider.api.action.scan.param.subtreeOnly = true to spider only under the subtree, false otherwise.
 client.clientSpider.api.action.scan.param.url = The URL from where to start the spider.
 client.clientSpider.api.action.scan.param.userName = The name of the user.
+
+client.clientSpider.api.action.setOptionActionWaitTimeInSecs = Sets the action wait time option.
+client.clientSpider.api.action.setOptionActionWaitTimeInSecs.param.Integer = The action wait time in seconds.
+client.clientSpider.api.action.setOptionBrowserId = Sets the browser ID option.
+client.clientSpider.api.action.setOptionBrowserId.param.String = The browser ID.
+client.clientSpider.api.action.setOptionInitialLoadTimeInSecs = Sets the initial page load time option.
+client.clientSpider.api.action.setOptionInitialLoadTimeInSecs.param.Integer = The initial page load time in seconds.
+client.clientSpider.api.action.setOptionLogoutAvoidance = Sets whether or not the spider should avoid clicking logout elements.
+client.clientSpider.api.action.setOptionLogoutAvoidance.param.Boolean = true to avoid clicking logout elements, false otherwise.
+client.clientSpider.api.action.setOptionMaxChildren = Sets the maximum children option.
+client.clientSpider.api.action.setOptionMaxChildren.param.Integer = The maximum number of children to crawl (0 is unlimited).
+client.clientSpider.api.action.setOptionMaxDepth = Sets the maximum crawl depth option.
+client.clientSpider.api.action.setOptionMaxDepth.param.Integer = The maximum crawl depth (0 is unlimited).
+client.clientSpider.api.action.setOptionMaxDuration = Sets the maximum duration option.
+client.clientSpider.api.action.setOptionMaxDuration.param.Integer = The maximum duration in minutes (0 is unlimited).
+client.clientSpider.api.action.setOptionMaxScansInUi = Sets the maximum scans in the UI option.
+client.clientSpider.api.action.setOptionMaxScansInUi.param.Integer = The maximum number of scans to show in the UI.
+client.clientSpider.api.action.setOptionPageLoadTimeInSecs = Sets the page load time option.
+client.clientSpider.api.action.setOptionPageLoadTimeInSecs.param.Integer = The page load time in seconds.
+client.clientSpider.api.action.setOptionScopeCheck = Sets the scope check option.
+client.clientSpider.api.action.setOptionScopeCheck.param.String = The scope check (FLEXIBLE or STRICT).
+client.clientSpider.api.action.setOptionShutdownTimeInSecs = Sets the shutdown time option.
+client.clientSpider.api.action.setOptionShutdownTimeInSecs.param.Integer = The shutdown time in seconds.
+client.clientSpider.api.action.setOptionThreadCount = Sets the number of browser windows to open option.
+client.clientSpider.api.action.setOptionThreadCount.param.Integer = The number of browser windows to open.
 client.clientSpider.api.action.stop = Stops a client spider scan.
 client.clientSpider.api.action.stop.param.scanId = The ID of the client spider scan.
 client.clientSpider.api.desc = Allows to manage the Client Spider.
+client.clientSpider.api.view.optionActionWaitTimeInSecs = Gets the action wait time option.
+client.clientSpider.api.view.optionBrowserId = Gets the browser ID option.
+client.clientSpider.api.view.optionInitialLoadTimeInSecs = Gets the initial page load time option.
+client.clientSpider.api.view.optionLogoutAvoidance = Gets whether or not the spider avoids clicking logout elements.
+client.clientSpider.api.view.optionMaxChildren = Gets the maximum children option.
+client.clientSpider.api.view.optionMaxDepth = Gets the maximum crawl depth option.
+client.clientSpider.api.view.optionMaxDuration = Gets the maximum duration option.
+client.clientSpider.api.view.optionMaxScansInUi = Gets the maximum scans in the UI option.
+client.clientSpider.api.view.optionPageLoadTimeInSecs = Gets the page load time option.
+client.clientSpider.api.view.optionScopeCheck = Gets the scope check option.
+client.clientSpider.api.view.optionShutdownTimeInSecs = Gets the shutdown time option.
+client.clientSpider.api.view.optionThreadCount = Gets the number of browser windows to open option.
 client.clientSpider.api.view.status = Gets the status of a client spider scan.
 client.clientSpider.api.view.status.param.scanId = The ID of the client spider scan.
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientIntegrationAPIUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientIntegrationAPIUnitTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -55,6 +56,7 @@ class ClientIntegrationAPIUnitTest extends TestUtils {
     void setUp() {
         extension = mock(ExtensionClientIntegration.class);
         clientMap = mock(ClientMap.class);
+        given(extension.getClientParam()).willReturn(new ClientOptions());
         api = new ClientIntegrationAPI(extension, clientMap);
     }
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientParamUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientParamUnitTest.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.zaproxy.addon.commonlib.Constants;
 import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -50,8 +49,6 @@ class ClientParamUnitTest extends TestUtils {
         // Then
         assertThat(clientParam.isPscanEnabled(), is(true));
         assertThat(clientParam.getPscanRulesDisabled().size(), is(0));
-        assertThat(clientParam.isLogoutAvoidance(), is(true));
-        assertThat(clientParam.getActionWaitTimeInSecs(), is(0));
     }
 
     @Test
@@ -59,7 +56,6 @@ class ClientParamUnitTest extends TestUtils {
         // Given
         config.addProperty("client.pscanEnabled", false);
         config.addProperty("client.pscanRulesDisabled", Arrays.asList("1", "3"));
-        config.addProperty("client.logoutAvoidance", false);
         // When
         clientParam.load(config);
         // Then
@@ -67,16 +63,6 @@ class ClientParamUnitTest extends TestUtils {
         assertThat(clientParam.getPscanRulesDisabled().size(), is(2));
         assertThat(clientParam.getPscanRulesDisabled().get(0), is(1));
         assertThat(clientParam.getPscanRulesDisabled().get(1), is(3));
-
-        assertThat(clientParam.getBrowserId(), is("firefox-headless"));
-        assertThat(clientParam.getInitialLoadTimeInSecs(), is(5));
-        assertThat(clientParam.getMaxChildren(), is(0));
-        assertThat(clientParam.getMaxDepth(), is(5));
-        assertThat(clientParam.getMaxDuration(), is(0));
-        assertThat(clientParam.getPageLoadTimeInSecs(), is(1));
-        assertThat(clientParam.getShutdownTimeInSecs(), is(5));
-        assertThat(clientParam.getThreadCount(), is(Constants.getDefaultThreadCount()));
-        assertThat(clientParam.isLogoutAvoidance(), is(false));
     }
 
     @Test
@@ -84,13 +70,11 @@ class ClientParamUnitTest extends TestUtils {
         // Given
         config.addProperty("client.pscanEnabled", "test");
         config.addProperty("client.pscanRulesDisabled", "test");
-        config.addProperty("client.logoutAvoidance", "test");
         // When
         clientParam.load(config);
         // Then
         assertThat(clientParam.isPscanEnabled(), is(true));
         assertThat(clientParam.getPscanRulesDisabled().size(), is(0));
-        assertThat(clientParam.isLogoutAvoidance(), is(true));
     }
 
     @Test
@@ -99,40 +83,9 @@ class ClientParamUnitTest extends TestUtils {
         clientParam.load(config);
         // When
         clientParam.setPscanEnabled(false);
-        clientParam.setBrowserId("test-browser");
-        clientParam.setInitialLoadTimeInSecs(4);
-        clientParam.setMaxChildren(100);
-        clientParam.setMaxDepth(10);
-        clientParam.setMaxDuration(100);
-        clientParam.setPageLoadTimeInSecs(3);
-        clientParam.setShutdownTimeInSecs(10);
-        clientParam.setThreadCount(32);
-        clientParam.setLogoutAvoidance(false);
-        clientParam.setActionWaitTimeInSecs(2);
         // Then
         assertThat(config.getProperty("client.pscanEnabled"), is(false));
-        assertThat(config.getProperty("client.browserId"), is("test-browser"));
-        assertThat(config.getProperty("client.initialLoadTime"), is(4));
-        assertThat(config.getProperty("client.maxChildren"), is(100));
-        assertThat(config.getProperty("client.maxDepth"), is(10));
-        assertThat(config.getProperty("client.maxDuration"), is(100));
-        assertThat(config.getProperty("client.pageLoadTime"), is(3));
-        assertThat(config.getProperty("client.shutdownTime"), is(10));
-        assertThat(config.getProperty("client.threads"), is(32));
-        assertThat(config.getProperty("client.logoutAvoidance"), is(false));
-        assertThat(config.getProperty("client.actionWaitTime"), is(2));
-
         assertThat(clientParam.getPscanRulesDisabled().size(), is(0));
-        assertThat(clientParam.getBrowserId(), is("test-browser"));
-        assertThat(clientParam.getInitialLoadTimeInSecs(), is(4));
-        assertThat(clientParam.getMaxChildren(), is(100));
-        assertThat(clientParam.getMaxDepth(), is(10));
-        assertThat(clientParam.getMaxDuration(), is(100));
-        assertThat(clientParam.getPageLoadTimeInSecs(), is(3));
-        assertThat(clientParam.getShutdownTimeInSecs(), is(10));
-        assertThat(clientParam.getThreadCount(), is(32));
-        assertThat(clientParam.isLogoutAvoidance(), is(false));
-        assertThat(clientParam.getActionWaitTimeInSecs(), is(2));
     }
 
     @Test

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ClientSpiderOptionsUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ClientSpiderOptionsUnitTest.java
@@ -1,0 +1,146 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions;
+import org.zaproxy.addon.commonlib.Constants;
+import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ClientSpiderOptions}. */
+class ClientSpiderOptionsUnitTest extends TestUtils {
+
+    private ClientSpiderOptions options;
+    private ZapXmlConfiguration config;
+
+    @BeforeEach
+    void setUp() {
+        mockMessages(new ExtensionClientIntegration());
+        options = new ClientSpiderOptions();
+        config = new ZapXmlConfiguration();
+    }
+
+    @Test
+    void shouldUseTheRightDefaults() {
+        // Given / When
+        options.load(config);
+        // Then
+        assertThat(options.getBrowserId(), is(ClientSpiderOptions.DEFAULT_BROWSER_ID));
+        assertThat(
+                options.getInitialLoadTimeInSecs(),
+                is(ClientSpiderOptions.DEFAULT_INITIAL_LOAD_TIME));
+        assertThat(options.getPageLoadTimeInSecs(), is(ClientSpiderOptions.DEFAULT_PAGE_LOAD_TIME));
+        assertThat(options.getShutdownTimeInSecs(), is(ClientSpiderOptions.DEFAULT_SHUTDOWN_TIME));
+        assertThat(options.getMaxDepth(), is(ClientSpiderOptions.DEFAULT_MAX_DEPTH));
+        assertThat(options.getMaxChildren(), is(0));
+        assertThat(options.getMaxDuration(), is(0));
+        assertThat(options.getThreadCount(), is(Constants.getDefaultThreadCount()));
+        assertThat(options.isLogoutAvoidance(), is(ClientSpiderOptions.DEFAULT_LOGOUT_AVOIDANCE));
+        assertThat(
+                options.getActionWaitTimeInSecs(),
+                is(ClientSpiderOptions.DEFAULT_ACTION_WAIT_TIME));
+        assertThat(options.getScopeCheck(), is(ClientSpiderOptions.ScopeCheck.getDefault()));
+    }
+
+    @Test
+    void shouldUseTheRightValues() {
+        // Given
+        config.addProperty("client.spider.browserId", "chrome");
+        config.addProperty("client.spider.logoutAvoidance", false);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getInitialLoadTimeInSecs(), is(5));
+        assertThat(options.getMaxChildren(), is(0));
+        assertThat(options.getMaxDepth(), is(5));
+        assertThat(options.getMaxDuration(), is(0));
+        assertThat(options.getPageLoadTimeInSecs(), is(1));
+        assertThat(options.getShutdownTimeInSecs(), is(5));
+        assertThat(options.getThreadCount(), is(Constants.getDefaultThreadCount()));
+        assertThat(options.isLogoutAvoidance(), is(false));
+    }
+
+    @Test
+    void shouldMigrateFromOriginalClientBaseKey() {
+        // Given - config with original "client" spider keys (before the split)
+        config.addProperty("client.browserId", "firefox-headless");
+        config.addProperty("client.threads", 4);
+        config.addProperty("client.maxDepth", 10);
+        config.addProperty("client.logoutAvoidance", false);
+        config.addProperty("client.pscanEnabled", false);
+        // When
+        options.load(config);
+        // Then - spider values migrated to "client.spider" keys
+        assertThat(options.getBrowserId(), is("firefox-headless"));
+        assertThat(options.getThreadCount(), is(4));
+        assertThat(options.getMaxDepth(), is(10));
+        assertThat(options.isLogoutAvoidance(), is(false));
+        // And old spider keys removed
+        assertThat(config.getProperty("client.browserId"), is(nullValue()));
+        assertThat(config.getProperty("client.threads"), is(nullValue()));
+        // Pscan key left untouched
+        assertThat(config.getProperty("client.pscanEnabled"), is(false));
+    }
+
+    @Test
+    void shouldSetOptions() {
+        // Given
+        options.load(config);
+        // When
+        options.setBrowserId("firefox-headless");
+        options.setInitialLoadTimeInSecs(4);
+        options.setMaxChildren(100);
+        options.setMaxDepth(10);
+        options.setMaxDuration(100);
+        options.setPageLoadTimeInSecs(3);
+        options.setShutdownTimeInSecs(10);
+        options.setThreadCount(32);
+        options.setLogoutAvoidance(false);
+        options.setActionWaitTimeInSecs(2);
+        // Then
+        assertThat(config.getProperty("client.spider.browserId"), is("firefox-headless"));
+        assertThat(config.getProperty("client.spider.initialLoadTime"), is(4));
+        assertThat(config.getProperty("client.spider.maxChildren"), is(100));
+        assertThat(config.getProperty("client.spider.maxDepth"), is(10));
+        assertThat(config.getProperty("client.spider.maxDuration"), is(100));
+        assertThat(config.getProperty("client.spider.pageLoadTime"), is(3));
+        assertThat(config.getProperty("client.spider.shutdownTime"), is(10));
+        assertThat(config.getProperty("client.spider.threads"), is(32));
+        assertThat(config.getProperty("client.spider.logoutAvoidance"), is(false));
+        assertThat(config.getProperty("client.spider.actionWaitTime"), is(2));
+
+        assertThat(options.getBrowserId(), is("firefox-headless"));
+        assertThat(options.getInitialLoadTimeInSecs(), is(4));
+        assertThat(options.getMaxChildren(), is(100));
+        assertThat(options.getMaxDepth(), is(10));
+        assertThat(options.getMaxDuration(), is(100));
+        assertThat(options.getPageLoadTimeInSecs(), is(3));
+        assertThat(options.getShutdownTimeInSecs(), is(10));
+        assertThat(options.getThreadCount(), is(32));
+        assertThat(options.isLogoutAvoidance(), is(false));
+        assertThat(options.getActionWaitTimeInSecs(), is(2));
+    }
+}

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/ExtensionClientIntegrationUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/ExtensionClientIntegrationUnitTest.java
@@ -47,6 +47,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.client.spider.ClientSpider;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions;
 import org.zaproxy.addon.client.spider.ScanOptions;
 import org.zaproxy.addon.commonlib.ExtensionCommonlib;
 import org.zaproxy.addon.commonlib.ValueProvider;
@@ -182,7 +183,7 @@ class ExtensionClientIntegrationUnitTest extends TestUtils {
     @Test
     void shouldStartSpiderWithLegacyApi() throws Exception {
         // Given
-        ClientOptions options = new ClientOptions();
+        ClientSpiderOptions options = new ClientSpiderOptions();
         options.load(new ZapXmlConfiguration());
         options.setThreadCount(1);
 
@@ -199,7 +200,7 @@ class ExtensionClientIntegrationUnitTest extends TestUtils {
     @Test
     void shouldStartSpiderWithScanOptions() throws Exception {
         // Given
-        ClientOptions options = new ClientOptions();
+        ClientSpiderOptions options = new ClientSpiderOptions();
         options.load(new ZapXmlConfiguration());
         options.setThreadCount(1);
         ScanOptions scanOptions = ScanOptions.builder().setSubtreeOnly(true).build();
@@ -218,7 +219,7 @@ class ExtensionClientIntegrationUnitTest extends TestUtils {
     @Test
     void shouldStartSpiderWithNewStartScanMethod() throws Exception {
         // Given
-        ClientOptions options = new ClientOptions();
+        ClientSpiderOptions options = new ClientSpiderOptions();
         options.load(new ZapXmlConfiguration());
         options.setThreadCount(1);
         String url = "https://www.example.com";
@@ -243,7 +244,7 @@ class ExtensionClientIntegrationUnitTest extends TestUtils {
     @Test
     void shouldStartSpiderWithExternalControl() throws Exception {
         // Given
-        ClientOptions options = new ClientOptions();
+        ClientSpiderOptions options = new ClientSpiderOptions();
         options.load(new ZapXmlConfiguration());
         options.setThreadCount(1);
         ScanOptions scanOptions = ScanOptions.builder().setExternalControl(true).build();

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/automation/ClientSpiderJobUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/automation/ClientSpiderJobUnitTest.java
@@ -51,10 +51,10 @@ import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob.Order;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.addon.automation.ContextWrapper;
-import org.zaproxy.addon.client.ClientOptions;
-import org.zaproxy.addon.client.ClientOptions.ScopeCheck;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.spider.ClientSpider;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions;
+import org.zaproxy.addon.client.spider.ClientSpiderOptions.ScopeCheck;
 import org.zaproxy.addon.commonlib.Constants;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -147,7 +147,8 @@ public class ClientSpiderJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getUser(), is(equalTo("")));
         assertThat(job.getParameters().getUrl(), is(equalTo("")));
         assertThat(job.getParameters().getMaxDuration(), is(nullValue()));
-        assertThat(job.getParameters().getMaxCrawlDepth(), is(ClientOptions.DEFAULT_MAX_DEPTH));
+        assertThat(
+                job.getParameters().getMaxCrawlDepth(), is(ClientSpiderOptions.DEFAULT_MAX_DEPTH));
         assertThat(job.getParameters().getMaxChildren(), is(nullValue()));
         assertThat(
                 job.getParameters().getNumberOfBrowsers(),
@@ -155,13 +156,17 @@ public class ClientSpiderJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getBrowserId(), is(nullValue()));
         assertThat(
                 job.getParameters().getInitialLoadTime(),
-                is(ClientOptions.DEFAULT_INITIAL_LOAD_TIME));
-        assertThat(job.getParameters().getPageLoadTime(), is(ClientOptions.DEFAULT_PAGE_LOAD_TIME));
-        assertThat(job.getParameters().getShutdownTime(), is(ClientOptions.DEFAULT_SHUTDOWN_TIME));
+                is(ClientSpiderOptions.DEFAULT_INITIAL_LOAD_TIME));
+        assertThat(
+                job.getParameters().getPageLoadTime(),
+                is(ClientSpiderOptions.DEFAULT_PAGE_LOAD_TIME));
+        assertThat(
+                job.getParameters().getShutdownTime(),
+                is(ClientSpiderOptions.DEFAULT_SHUTDOWN_TIME));
         assertThat(job.getParameters().getLogoutAvoidance(), is(true));
         assertThat(
                 job.getParameters().getActionWaitTime(),
-                is(ClientOptions.DEFAULT_ACTION_WAIT_TIME));
+                is(ClientSpiderOptions.DEFAULT_ACTION_WAIT_TIME));
     }
 
     @Test
@@ -219,7 +224,7 @@ public class ClientSpiderJobUnitTest extends TestUtils {
         job.getParameters().setActionWaitTime(value);
 
         // When
-        ClientOptions options = job.paramsToOptions();
+        ClientSpiderOptions options = job.paramsToOptions();
 
         // Then
         assertThat(options.getActionWaitTimeInSecs(), is(value));
@@ -233,7 +238,7 @@ public class ClientSpiderJobUnitTest extends TestUtils {
         job.getParameters().setScopeCheck(value);
 
         // When
-        ClientOptions options = job.paramsToOptions();
+        ClientSpiderOptions options = job.paramsToOptions();
 
         // Then
         assertThat(options.getScopeCheck(), is(ScopeCheck.valueOf(value)));
@@ -247,7 +252,7 @@ public class ClientSpiderJobUnitTest extends TestUtils {
         job.getParameters().setLogoutAvoidance(value);
 
         // When
-        ClientOptions options = job.paramsToOptions();
+        ClientSpiderOptions options = job.paramsToOptions();
 
         // Then
         assertThat(options.isLogoutAvoidance(), is(value));

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderApiUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderApiUnitTest.java
@@ -50,7 +50,6 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.api.API.RequestType;
@@ -82,12 +81,12 @@ class ClientSpiderApiUnitTest extends TestUtils {
 
         mockMessages(new ExtensionClientIntegration());
 
-        clientSpiderAPI = new ClientSpiderApi(extClient);
-
-        ClientOptions clientOptions = new ClientOptions();
+        ClientSpiderOptions clientOptions = new ClientSpiderOptions();
         clientOptions.load(new ZapXmlConfiguration());
-        given(extClient.getClientParam()).willReturn(clientOptions);
+        given(extClient.getClientSpiderParam()).willReturn(clientOptions);
         given(extClient.startScan(any(), any(), any(), any(), anyBoolean())).willReturn(1);
+
+        clientSpiderAPI = new ClientSpiderApi(extClient);
     }
 
     @AfterAll
@@ -108,8 +107,8 @@ class ClientSpiderApiUnitTest extends TestUtils {
         // Given / When
         clientSpiderAPI = new ClientSpiderApi();
         // Then
-        assertThat(clientSpiderAPI.getApiActions(), hasSize(2));
-        assertThat(clientSpiderAPI.getApiViews(), hasSize(1));
+        assertThat(clientSpiderAPI.getApiActions(), hasSize(14));
+        assertThat(clientSpiderAPI.getApiViews(), hasSize(13));
         assertThat(clientSpiderAPI.getApiOthers(), hasSize(0));
     }
 
@@ -189,7 +188,8 @@ class ClientSpiderApiUnitTest extends TestUtils {
         // Given
         JSONObject params = new JSONObject();
         params.put("url", SCAN_URL);
-        ArgumentCaptor<ClientOptions> optionsCaptor = ArgumentCaptor.forClass(ClientOptions.class);
+        ArgumentCaptor<ClientSpiderOptions> optionsCaptor =
+                ArgumentCaptor.forClass(ClientSpiderOptions.class);
 
         // When
         clientSpiderAPI.handleApiAction("scan", params);
@@ -198,7 +198,7 @@ class ClientSpiderApiUnitTest extends TestUtils {
         verify(extClient).startScan(any(), optionsCaptor.capture(), any(), any(), anyBoolean());
         assertThat(
                 optionsCaptor.getValue().getActionWaitTimeInSecs(),
-                is(ClientOptions.DEFAULT_ACTION_WAIT_TIME));
+                is(ClientSpiderOptions.DEFAULT_ACTION_WAIT_TIME));
     }
 
     @Test
@@ -207,7 +207,8 @@ class ClientSpiderApiUnitTest extends TestUtils {
         JSONObject params = new JSONObject();
         params.put("url", SCAN_URL);
         params.put("actionWaitTime", 5);
-        ArgumentCaptor<ClientOptions> optionsCaptor = ArgumentCaptor.forClass(ClientOptions.class);
+        ArgumentCaptor<ClientSpiderOptions> optionsCaptor =
+                ArgumentCaptor.forClass(ClientSpiderOptions.class);
 
         // When
         clientSpiderAPI.handleApiAction("scan", params);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -83,7 +83,6 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.client.internal.ClientMapListener;
@@ -107,7 +106,7 @@ class ClientSpiderUnitTest extends TestUtils {
 
     private List<String> logEvents;
 
-    private ClientOptions clientOptions;
+    private ClientSpiderOptions clientOptions;
     private ClientMapListener mapListener;
     private ClientMap map;
     private String seedUrl;
@@ -183,7 +182,7 @@ class ClientSpiderUnitTest extends TestUtils {
         given(model.getSession()).willReturn(session);
         map = mock(withSettings().strictness(Strictness.LENIENT));
         when(map.getGraph()).thenReturn(new DirectedMultigraph<>(DefaultEdge.class));
-        clientOptions = new ClientOptions();
+        clientOptions = new ClientSpiderOptions();
         clientOptions.load(new ZapXmlConfiguration());
         clientOptions.setThreadCount(1);
         clientOptions.setShutdownTimeInSecs(10);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/SpiderScanControllerUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/SpiderScanControllerUnitTest.java
@@ -52,7 +52,6 @@ import org.parosproxy.paros.extension.option.OptionsParamView;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
-import org.zaproxy.addon.client.ClientOptions;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.commonlib.ValueProvider;
@@ -76,7 +75,7 @@ class SpiderScanControllerUnitTest extends TestUtils {
     private ExtensionClientIntegration extension;
     private ClientMap clientMap;
     private ValueProvider valueProvider;
-    private ClientOptions defaultOptions;
+    private ClientSpiderOptions defaultOptions;
     private SpiderScanController controller;
 
     @BeforeEach
@@ -127,11 +126,11 @@ class SpiderScanControllerUnitTest extends TestUtils {
         when(model.getSession()).thenReturn(session);
         lenient().when(extension.getAuthenticationHandlers()).thenReturn(java.util.List.of());
 
-        defaultOptions = new ClientOptions();
+        defaultOptions = new ClientSpiderOptions();
         defaultOptions.load(new ZapXmlConfiguration());
         defaultOptions.setThreadCount(1);
         defaultOptions.setShutdownTimeInSecs(10);
-        when(extension.getClientParam()).thenReturn(defaultOptions);
+        when(extension.getClientSpiderParam()).thenReturn(defaultOptions);
 
         clientMap = mock(ClientMap.class);
         when(clientMap.getGraph()).thenReturn(new DirectedMultigraph<>(DefaultEdge.class));
@@ -185,7 +184,7 @@ class SpiderScanControllerUnitTest extends TestUtils {
         // Given
         Context context = mock(Context.class);
         User user = mock(User.class);
-        ClientOptions customOptions = new ClientOptions();
+        ClientSpiderOptions customOptions = new ClientSpiderOptions();
         customOptions.load(new ZapXmlConfiguration());
         customOptions.setThreadCount(3);
 


### PR DESCRIPTION
Normally we'd just add the option to the API and be done with it.
But in this case the client has 2 different API endpoints, so we have to add each of the options to the right one "manually".