### PR TITLE
client: show spider icon in sites tree

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Client Spider Options panel.
 - Support for ZAP modes in the Client Spider.
+- Show Client Spider icon in the Sites tree.
 - More option API endpoints.
 
 ### Changed

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -1028,6 +1028,9 @@ public class ClientSpider implements GenericScanner2 {
                                     || state == ResourceState.THIRD_PARTY) {
                                 crawledUrl(
                                         httpMessage.getRequestHeader().getURI().toString(), true);
+                                historyRef.setCustomIcon(
+                                        "org/zaproxy/addon/client/resources/spiderClient.png",
+                                        true);
                                 session.getSiteTree().addPath(historyRef, httpMessage);
                             }
 


### PR DESCRIPTION
Set the icon to the history reference to show the nodes as accessed by the client spider.