### PR TITLE
reports: Allow zipping at generation

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Help content related to the params add-on was updated (Issue 9210).
+- Generation of reports now supports producing a ZIP containing the report file(s) (Issue 7821).
 
 ## [0.45.0] - 2026-05-06
 ### Fixed

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Generation of reports now supports producing a ZIP containing the report file(s) (Issue 7821).
 
 ## [0.46.0] - 2026-07-06
 ### Added

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -25,13 +25,17 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -45,6 +49,8 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.tree.DefaultTreeModel;
@@ -420,64 +426,55 @@ public class ExtensionReports extends ExtensionAdaptor {
             // Handle any resources
             File resourcesDir = template.getResourcesDir();
             if (resourcesDir.exists()) {
-                String subDirName;
-                int dotIndex = reportFilename.lastIndexOf(".");
-                if (dotIndex > 0) {
-                    subDirName = reportFilename.substring(0, dotIndex);
+                if (reportData.isZipReport()) {
+                    context.setVariable("resources", getResourcesEntryName(reportFilename));
                 } else {
-                    subDirName = reportFilename + "_d";
+                    File resourcesSubDir = getUniqueResourcesSubDir(reportFilename);
+                    context.setVariable("resources", resourcesSubDir.getName());
+                    LOGGER.debug(
+                            "Copying resources from {} to {}",
+                            resourcesDir.getAbsolutePath(),
+                            resourcesSubDir.getAbsolutePath());
+                    FileUtils.copyDirectory(resourcesDir, resourcesSubDir);
                 }
-                File subDir = new File(subDirName);
-                int i = 1;
-                while (subDir.exists()) {
-                    i += 1;
-                    subDir = new File(subDirName + i);
-                }
-                LOGGER.debug(
-                        "Copying resources from {} to {}",
-                        resourcesDir.getAbsolutePath(),
-                        subDir.getAbsolutePath());
-                FileUtils.copyDirectory(resourcesDir, subDir);
-                context.setVariable("resources", subDir.getName());
             }
 
-            File file = new File(reportFilename);
-            try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
-                templateEngine.process(
-                        template.getReportTemplateFile().getAbsolutePath(), context, writer);
-                Stats.incCounter("stats.reports.generated." + template.getConfigName());
-            }
+            File file;
+            if (reportData.isZipReport()) {
+                file =
+                        generateZippedReport(
+                                templateEngine, template, context, reportFilename, resourcesDir);
+            } else {
+                file = new File(reportFilename);
+                try (Writer writer =
+                        Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+                    templateEngine.process(
+                            template.getReportTemplateFile().getAbsolutePath(), context, writer);
+                    Stats.incCounter("stats.reports.generated." + template.getConfigName());
+                }
 
-            if ("PDF".equals(template.getFormat())) {
-                // Will have appended ".html" above
-                reportFilename = reportFilename.substring(0, reportFilename.length() - 5);
-                reportFilename += ".pdf";
-                File pdfFile = new File(reportFilename);
-                try (OutputStream outputStream = new FileOutputStream(pdfFile)) {
-                    ITextRenderer renderer = new ITextRenderer(file);
-                    renderer.layout();
-                    try {
-                        renderer.createPDF(outputStream);
-                    } catch (DocumentException e) {
-                        // Throw a standard exception so that add-ons using this method don't need
-                        // to
-                        // import it
-                        throw new IOException("Invalid template: " + template.getConfigName(), e);
+                if ("PDF".equals(template.getFormat())) {
+                    // Will have appended ".html" above
+                    reportFilename = reportFilename.substring(0, reportFilename.length() - 5);
+                    reportFilename += ".pdf";
+                    File pdfFile = new File(reportFilename);
+                    try (OutputStream outputStream = new FileOutputStream(pdfFile)) {
+                        writePdfFromHtml(
+                                file, outputStream, template.getConfigName(), PdfOutput.FILE);
                     }
+                    if (!file.delete()) {
+                        LOGGER.debug("Failed to delete interim report {}", file.getAbsolutePath());
+                    }
+                    file = pdfFile;
                 }
-                if (!file.delete()) {
-                    LOGGER.debug("Failed to delete interim report {}", file.getAbsolutePath());
-                }
-                file = pdfFile;
             }
 
             LOGGER.debug("Generated report {}", file.getAbsolutePath());
-            if (display) {
+            if (display && !reportData.isZipReport()) {
                 if ("HTML".equals(template.getFormat())) {
                     DesktopUtils.openUrlInBrowser(file.toURI());
                 } else {
-                    Desktop desktop = Desktop.getDesktop();
-                    desktop.open(file);
+                    Desktop.getDesktop().open(file);
                 }
             }
             return file;
@@ -499,6 +496,201 @@ public class ExtensionReports extends ExtensionAdaptor {
                                     LOGGER.error("Failed to close the report data:", ex);
                                 }
                             });
+        }
+    }
+
+    private File generateZippedReport(
+            TemplateEngine templateEngine,
+            Template template,
+            Context context,
+            String reportFilename,
+            File resourcesDir)
+            throws IOException {
+        File zipFile = new File(getZipFilePath(getFinalReportPath(reportFilename, template)));
+        String entryName =
+                Paths.get(
+                                "PDF".equals(template.getFormat())
+                                        ? getFinalReportPath(reportFilename, template)
+                                        : reportFilename)
+                        .getFileName()
+                        .toString();
+
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
+            if (resourcesDir.exists()) {
+                addDirectoryToZip(zos, resourcesDir, getResourcesEntryName(reportFilename) + "/");
+            }
+
+            if ("PDF".equals(template.getFormat())) {
+                addPdfReportToZip(zos, templateEngine, template, context, entryName);
+            } else {
+                addGeneratedReportToZip(zos, templateEngine, template, context, entryName);
+            }
+        }
+        Stats.incCounter("stats.reports.generated." + template.getConfigName());
+        Stats.incCounter("stats.reports.zipped");
+        return zipFile;
+    }
+
+    private void addGeneratedReportToZip(
+            ZipOutputStream zos,
+            TemplateEngine templateEngine,
+            Template template,
+            Context context,
+            String entryName)
+            throws IOException {
+        withZipEntry(
+                zos,
+                entryName,
+                entryStream -> {
+                    try (Writer writer =
+                            new OutputStreamWriter(entryStream, StandardCharsets.UTF_8)) {
+                        templateEngine.process(
+                                template.getReportTemplateFile().getAbsolutePath(),
+                                context,
+                                writer);
+                    }
+                });
+    }
+
+    private void addPdfReportToZip(
+            ZipOutputStream zos,
+            TemplateEngine templateEngine,
+            Template template,
+            Context context,
+            String entryName)
+            throws IOException {
+        Path tempHtml = Files.createTempFile("zap-report-", ".html");
+        try {
+            try (Writer writer = Files.newBufferedWriter(tempHtml, StandardCharsets.UTF_8)) {
+                templateEngine.process(
+                        template.getReportTemplateFile().getAbsolutePath(), context, writer);
+            }
+            withZipEntry(
+                    zos,
+                    entryName,
+                    entryStream ->
+                            writePdfFromHtml(
+                                    tempHtml.toFile(),
+                                    entryStream,
+                                    template.getConfigName(),
+                                    PdfOutput.ZIP_ENTRY));
+        } finally {
+            Files.deleteIfExists(tempHtml);
+        }
+    }
+
+    private enum PdfOutput {
+        FILE,
+        ZIP_ENTRY
+    }
+
+    private static void writePdfFromHtml(
+            File htmlSource, OutputStream output, String templateName, PdfOutput outputType)
+            throws IOException {
+        ITextRenderer renderer = new ITextRenderer(htmlSource);
+        renderer.layout();
+        try {
+            renderer.createPDF(output);
+        } catch (DocumentException e) {
+            String prefix =
+                    outputType == PdfOutput.FILE
+                            ? "Failed to write PDF report file"
+                            : "Failed to write PDF report to ZIP";
+            throw new IOException(prefix + " for template: " + templateName, e);
+        }
+    }
+
+    private static void withZipEntry(ZipOutputStream zos, String entryName, ZipEntryWriter writer)
+            throws IOException {
+        OutputStream entryStream = nonClosingZipEntryStream(zos, entryName);
+        try {
+            writer.write(entryStream);
+        } finally {
+            entryStream.close();
+            zos.closeEntry();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ZipEntryWriter {
+        void write(OutputStream entryStream) throws IOException;
+    }
+
+    private static OutputStream nonClosingZipEntryStream(ZipOutputStream zos, String entryName)
+            throws IOException {
+        zos.putNextEntry(new ZipEntry(entryName));
+        return new FilterOutputStream(zos) {
+            @Override
+            public void close() throws IOException {
+                flush();
+            }
+        };
+    }
+
+    private static String getResourcesEntryName(String reportFilename) {
+        String fileName = Paths.get(reportFilename).getFileName().toString();
+        return stemBeforeExtension(fileName, fileName + "_d");
+    }
+
+    private static File getUniqueResourcesSubDir(String reportFilename) {
+        Path parent = Paths.get(reportFilename).getParent();
+        String resourcesEntryName = getResourcesEntryName(reportFilename);
+        File resourcesSubDir =
+                parent == null
+                        ? new File(resourcesEntryName)
+                        : parent.resolve(resourcesEntryName).toFile();
+        String baseName = resourcesSubDir.getName();
+        File parentDir = resourcesSubDir.getParentFile();
+        int i = 1;
+        while (resourcesSubDir.exists()) {
+            String collisionName = baseName + i;
+            resourcesSubDir =
+                    parentDir == null
+                            ? new File(collisionName)
+                            : new File(parentDir, collisionName);
+            i += 1;
+        }
+        return resourcesSubDir;
+    }
+
+    private static String getFinalReportPath(String reportFilename, Template template) {
+        if (!"PDF".equals(template.getFormat())) {
+            return reportFilename;
+        }
+        if (reportFilename.toLowerCase().endsWith(".html")) {
+            return reportFilename.substring(0, reportFilename.length() - 5) + ".pdf";
+        }
+        return reportFilename;
+    }
+
+    private String getZipFilePath(String reportFilename) {
+        Path path = Paths.get(reportFilename);
+        Path parent = path.getParent();
+        String fileName = path.getFileName().toString();
+        String zipFileName = stemBeforeExtension(fileName, fileName) + ".zip";
+        if (parent == null) {
+            return zipFileName;
+        }
+        return parent.resolve(zipFileName).toString();
+    }
+
+    private static String stemBeforeExtension(String fileName, String defaultIfNoExt) {
+        int dotIndex = fileName.lastIndexOf('.');
+        return dotIndex > 0 ? fileName.substring(0, dotIndex) : defaultIfNoExt;
+    }
+
+    private void addDirectoryToZip(ZipOutputStream zos, File dir, String basePath)
+            throws IOException {
+        Path root = dir.toPath();
+        try (var paths = Files.walk(root)) {
+            for (Path path : paths.filter(Files::isRegularFile).toList()) {
+                String entryName = basePath + root.relativize(path).toString().replace('\\', '/');
+                try (var inputStream = Files.newInputStream(path)) {
+                    zos.putNextEntry(new ZipEntry(entryName));
+                    inputStream.transferTo(zos);
+                    zos.closeEntry();
+                }
+            }
         }
     }
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -25,13 +25,17 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -45,6 +49,8 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.tree.DefaultTreeModel;
@@ -420,64 +426,54 @@ public class ExtensionReports extends ExtensionAdaptor {
             // Handle any resources
             File resourcesDir = template.getResourcesDir();
             if (resourcesDir.exists()) {
-                String subDirName;
-                int dotIndex = reportFilename.lastIndexOf(".");
-                if (dotIndex > 0) {
-                    subDirName = reportFilename.substring(0, dotIndex);
+                if (reportData.isZipReport()) {
+                    context.setVariable("resources", getResourcesEntryName(reportFilename));
                 } else {
-                    subDirName = reportFilename + "_d";
+                    File resourcesSubDir = getUniqueResourcesSubDir(reportFilename);
+                    context.setVariable("resources", resourcesSubDir.getName());
+                    LOGGER.debug(
+                            "Copying resources from {} to {}",
+                            resourcesDir.getAbsolutePath(),
+                            resourcesSubDir.getAbsolutePath());
+                    FileUtils.copyDirectory(resourcesDir, resourcesSubDir);
                 }
-                File subDir = new File(subDirName);
-                int i = 1;
-                while (subDir.exists()) {
-                    i += 1;
-                    subDir = new File(subDirName + i);
-                }
-                LOGGER.debug(
-                        "Copying resources from {} to {}",
-                        resourcesDir.getAbsolutePath(),
-                        subDir.getAbsolutePath());
-                FileUtils.copyDirectory(resourcesDir, subDir);
-                context.setVariable("resources", subDir.getName());
             }
 
-            File file = new File(reportFilename);
-            try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
-                templateEngine.process(
-                        template.getReportTemplateFile().getAbsolutePath(), context, writer);
-                Stats.incCounter("stats.reports.generated." + template.getConfigName());
-            }
+            File file;
+            if (reportData.isZipReport()) {
+                file =
+                        generateZippedReport(
+                                templateEngine, template, context, reportFilename, resourcesDir);
+            } else {
+                file = new File(reportFilename);
+                try (Writer writer =
+                        Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+                    templateEngine.process(
+                            template.getReportTemplateFile().getAbsolutePath(), context, writer);
+                    Stats.incCounter("stats.reports.generated." + template.getConfigName());
+                }
 
-            if ("PDF".equals(template.getFormat())) {
-                // Will have appended ".html" above
-                reportFilename = reportFilename.substring(0, reportFilename.length() - 5);
-                reportFilename += ".pdf";
-                File pdfFile = new File(reportFilename);
-                try (OutputStream outputStream = new FileOutputStream(pdfFile)) {
-                    ITextRenderer renderer = new ITextRenderer(file);
-                    renderer.layout();
-                    try {
-                        renderer.createPDF(outputStream);
-                    } catch (DocumentException e) {
-                        // Throw a standard exception so that add-ons using this method don't need
-                        // to
-                        // import it
-                        throw new IOException("Invalid template: " + template.getConfigName(), e);
+                if ("PDF".equals(template.getFormat())) {
+                    // Will have appended ".html" above
+                    reportFilename = reportFilename.substring(0, reportFilename.length() - 5);
+                    reportFilename += ".pdf";
+                    File pdfFile = new File(reportFilename);
+                    try (OutputStream outputStream = new FileOutputStream(pdfFile)) {
+                        writePdfFromHtml(file, outputStream, template.getConfigName(), false);
                     }
+                    if (!file.delete()) {
+                        LOGGER.debug("Failed to delete interim report {}", file.getAbsolutePath());
+                    }
+                    file = pdfFile;
                 }
-                if (!file.delete()) {
-                    LOGGER.debug("Failed to delete interim report {}", file.getAbsolutePath());
-                }
-                file = pdfFile;
             }
 
             LOGGER.debug("Generated report {}", file.getAbsolutePath());
-            if (display) {
+            if (display && !reportData.isZipReport()) {
                 if ("HTML".equals(template.getFormat())) {
                     DesktopUtils.openUrlInBrowser(file.toURI());
                 } else {
-                    Desktop desktop = Desktop.getDesktop();
-                    desktop.open(file);
+                    Desktop.getDesktop().open(file);
                 }
             }
             return file;
@@ -499,6 +495,197 @@ public class ExtensionReports extends ExtensionAdaptor {
                                     LOGGER.error("Failed to close the report data:", ex);
                                 }
                             });
+        }
+    }
+
+    private File generateZippedReport(
+            TemplateEngine templateEngine,
+            Template template,
+            Context context,
+            String reportFilename,
+            File resourcesDir)
+            throws IOException {
+        String finalPath = getFinalReportPath(reportFilename, template);
+        File zipFile = new File(getZipFilePath(finalPath));
+        String entryName = Paths.get(finalPath).getFileName().toString();
+
+        try {
+            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
+                if (resourcesDir.exists()) {
+                    addDirectoryToZip(
+                            zos, resourcesDir, getResourcesEntryName(reportFilename) + "/");
+                }
+
+                if ("PDF".equals(template.getFormat())) {
+                    addPdfReportToZip(zos, templateEngine, template, context, entryName);
+                } else {
+                    addGeneratedReportToZip(zos, templateEngine, template, context, entryName);
+                }
+            }
+        } catch (IOException e) {
+            if (!zipFile.delete()) {
+                LOGGER.debug("Failed to delete incomplete ZIP {}", zipFile.getAbsolutePath());
+            }
+            throw e;
+        }
+        Stats.incCounter("stats.reports.generated." + template.getConfigName());
+        Stats.incCounter("stats.reports.zipped");
+        return zipFile;
+    }
+
+    private void addGeneratedReportToZip(
+            ZipOutputStream zos,
+            TemplateEngine templateEngine,
+            Template template,
+            Context context,
+            String entryName)
+            throws IOException {
+        withZipEntry(
+                zos,
+                entryName,
+                entryStream -> {
+                    try (Writer writer =
+                            new OutputStreamWriter(entryStream, StandardCharsets.UTF_8)) {
+                        templateEngine.process(
+                                template.getReportTemplateFile().getAbsolutePath(),
+                                context,
+                                writer);
+                    }
+                });
+    }
+
+    private void addPdfReportToZip(
+            ZipOutputStream zos,
+            TemplateEngine templateEngine,
+            Template template,
+            Context context,
+            String entryName)
+            throws IOException {
+        Path tempHtml = Files.createTempFile("zap-report-", ".html");
+        try {
+            try (Writer writer = Files.newBufferedWriter(tempHtml, StandardCharsets.UTF_8)) {
+                templateEngine.process(
+                        template.getReportTemplateFile().getAbsolutePath(), context, writer);
+            }
+            withZipEntry(
+                    zos,
+                    entryName,
+                    entryStream ->
+                            writePdfFromHtml(
+                                    tempHtml.toFile(),
+                                    entryStream,
+                                    template.getConfigName(),
+                                    true));
+        } finally {
+            Files.deleteIfExists(tempHtml);
+        }
+    }
+
+    private static void writePdfFromHtml(
+            File htmlSource, OutputStream output, String templateName, boolean toZip)
+            throws IOException {
+        ITextRenderer renderer = new ITextRenderer(htmlSource);
+        renderer.layout();
+        try {
+            renderer.createPDF(output);
+        } catch (DocumentException e) {
+            String prefix =
+                    toZip ? "Failed to write PDF report to ZIP" : "Failed to write PDF report file";
+            throw new IOException(prefix + " for template: " + templateName, e);
+        }
+    }
+
+    private static void withZipEntry(ZipOutputStream zos, String entryName, ZipEntryWriter writer)
+            throws IOException {
+        OutputStream entryStream = nonClosingZipEntryStream(zos, entryName);
+        try {
+            writer.write(entryStream);
+        } finally {
+            entryStream.close();
+            zos.closeEntry();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ZipEntryWriter {
+        void write(OutputStream entryStream) throws IOException;
+    }
+
+    private static OutputStream nonClosingZipEntryStream(ZipOutputStream zos, String entryName)
+            throws IOException {
+        zos.putNextEntry(new ZipEntry(entryName));
+        return new FilterOutputStream(zos) {
+            @Override
+            public void close() throws IOException {
+                flush();
+            }
+        };
+    }
+
+    private static String getResourcesEntryName(String reportFilename) {
+        String fileName = Paths.get(reportFilename).getFileName().toString();
+        return stemBeforeExtension(fileName, fileName + "_d");
+    }
+
+    private static File getUniqueResourcesSubDir(String reportFilename) {
+        Path parent = Paths.get(reportFilename).getParent();
+        String resourcesEntryName = getResourcesEntryName(reportFilename);
+        File resourcesSubDir =
+                parent == null
+                        ? new File(resourcesEntryName)
+                        : parent.resolve(resourcesEntryName).toFile();
+        String baseName = resourcesSubDir.getName();
+        File parentDir = resourcesSubDir.getParentFile();
+        int i = 1;
+        while (resourcesSubDir.exists()) {
+            String collisionName = baseName + i;
+            resourcesSubDir =
+                    parentDir == null
+                            ? new File(collisionName)
+                            : new File(parentDir, collisionName);
+            i += 1;
+        }
+        return resourcesSubDir;
+    }
+
+    private static String getFinalReportPath(String reportFilename, Template template) {
+        if (!"PDF".equals(template.getFormat())) {
+            return reportFilename;
+        }
+        if (reportFilename.toLowerCase().endsWith(".html")) {
+            return reportFilename.substring(0, reportFilename.length() - 5) + ".pdf";
+        }
+        return reportFilename;
+    }
+
+    private String getZipFilePath(String reportFilename) {
+        Path path = Paths.get(reportFilename);
+        Path parent = path.getParent();
+        String fileName = path.getFileName().toString();
+        String zipFileName = stemBeforeExtension(fileName, fileName) + ".zip";
+        if (parent == null) {
+            return zipFileName;
+        }
+        return parent.resolve(zipFileName).toString();
+    }
+
+    private static String stemBeforeExtension(String fileName, String defaultIfNoExt) {
+        int dotIndex = fileName.lastIndexOf('.');
+        return dotIndex > 0 ? fileName.substring(0, dotIndex) : defaultIfNoExt;
+    }
+
+    private void addDirectoryToZip(ZipOutputStream zos, File dir, String basePath)
+            throws IOException {
+        Path root = dir.toPath();
+        try (var paths = Files.walk(root)) {
+            for (Path path : paths.filter(Files::isRegularFile).toList()) {
+                String entryName = basePath + root.relativize(path).toString().replace('\\', '/');
+                try (var inputStream = Files.newInputStream(path)) {
+                    zos.putNextEntry(new ZipEntry(entryName));
+                    inputStream.transferTo(zos);
+                    zos.closeEntry();
+                }
+            }
         }
     }
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportApi.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportApi.java
@@ -73,6 +73,7 @@ public class ReportApi extends ApiImplementor {
     static final String PARAM_THEME = "theme";
     static final String PARAM_TITLE = "title";
     static final String PARAM_DISPLAY = "display";
+    static final String PARAM_ZIP = "zip";
     static final String PARAM_INC_CONFIDENCES = "includedConfidences";
     static final String PARAM_INC_RISKS = "includedRisks";
     static final String PARAM_REPORT_FILE_NAME_PATTERN = "reportFileNamePattern";
@@ -106,6 +107,7 @@ public class ReportApi extends ApiImplementor {
                             PARAM_REPORT_FILE_NAME_PATTERN,
                             PARAM_REPORT_DIRECTORY,
                             PARAM_DISPLAY,
+                            PARAM_ZIP,
                         }));
         this.addApiView(new ApiView(VIEW_TEMPLATES));
         this.addApiView(new ApiView(VIEW_TEMPLATE_DETAILS, new String[] {PARAM_TEMPLATE}));
@@ -252,14 +254,19 @@ public class ReportApi extends ApiImplementor {
                 }
                 String reportFilePath = Paths.get(paramReportDir, reportFileName).toString();
 
-                boolean display = params.optBoolean(PARAM_DISPLAY, false);
+                boolean zipReport = params.optBoolean(PARAM_ZIP, false);
+                boolean display = zipReport ? false : params.optBoolean(PARAM_DISPLAY, false);
+                reportData.setZipReport(zipReport);
 
                 try {
-                    extReports.generateReport(reportData, template, reportFilePath, display);
+                    return new ApiResponseElement(
+                            name,
+                            extReports
+                                    .generateReport(reportData, template, reportFilePath, display)
+                                    .getPath());
                 } catch (Exception e) {
                     throw new ApiException(Type.INTERNAL_ERROR, e);
                 }
-                return new ApiResponseElement(name, reportFilePath);
             default:
                 throw new ApiException(Type.BAD_ACTION);
         }

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportData.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportData.java
@@ -41,6 +41,7 @@ public class ReportData {
     private boolean[] risks = new boolean[Alert.MSG_RISK.length];
     private List<String> sections = new ArrayList<>();
     private String theme;
+    private boolean zipReport;
 
     @Deprecated
     public ReportData() {}
@@ -186,5 +187,13 @@ public class ReportData {
 
     public void setTemplateName(String templateName) {
         this.templateName = templateName;
+    }
+
+    public boolean isZipReport() {
+        return zipReport;
+    }
+
+    public void setZipReport(boolean zipReport) {
+        this.zipReport = zipReport;
     }
 }

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
@@ -72,6 +72,7 @@ public class ReportDialog extends StandardFieldsDialog {
     private static final String FIELD_REPORT_NAME_PATTERN = "reports.dialog.field.namepattern";
     private static final String FIELD_CONFIDENCE_HEADER = "reports.dialog.field.confidence";
     private static final String FIELD_CONFIDENCE_0 = "reports.dialog.field.confidence.0";
+    private static final String FIELD_ZIP_REPORT = "reports.dialog.field.zip";
     private static final String FIELD_CONFIDENCE_1 = "reports.dialog.field.confidence.1";
     private static final String FIELD_CONFIDENCE_2 = "reports.dialog.field.confidence.2";
     private static final String FIELD_CONFIDENCE_3 = "reports.dialog.field.confidence.3";
@@ -230,7 +231,16 @@ public class ReportDialog extends StandardFieldsDialog {
         this.addCustomComponent(
                 TAB_SCOPE, FIELD_SITES, getNewJScrollPane(getSitesSelector(), 400, 100));
         this.addCheckBoxField(TAB_SCOPE, FIELD_GENERATE_ANYWAY, false);
-        this.addCheckBoxField(TAB_SCOPE, FIELD_DISPLAY_REPORT, reportParam.isDisplayReport());
+        boolean zipReport = reportParam.isZipReport();
+        boolean displayReport = reportParam.isDisplayReport();
+        if (zipReport && displayReport) {
+            displayReport = false;
+        }
+        this.addCheckBoxField(TAB_SCOPE, FIELD_ZIP_REPORT, zipReport);
+        this.addCheckBoxField(TAB_SCOPE, FIELD_DISPLAY_REPORT, displayReport);
+        ReportUiUtils.bindMutuallyExclusiveZipAndDisplayCheckBoxes(
+                (JCheckBox) this.getField(FIELD_ZIP_REPORT),
+                (JCheckBox) this.getField(FIELD_DISPLAY_REPORT));
 
         Template defaultTemplate = extension.getTemplateByConfigName(reportParam.getTemplate());
         List<String> templates = extension.getTemplateNames();
@@ -457,6 +467,8 @@ public class ReportDialog extends StandardFieldsDialog {
             }
         }
 
+        reportData.setZipReport(this.getBoolValue(FIELD_ZIP_REPORT));
+
         // Always do this last as it depends on the other fields
         reportData.setAlertTreeRootNode(extension.getFilteredAlertTree(reportData));
         return reportData;
@@ -464,12 +476,14 @@ public class ReportDialog extends StandardFieldsDialog {
 
     @Override
     public void save() {
-        boolean displayReport = this.getBoolValue(FIELD_DISPLAY_REPORT);
+        boolean zipReport = this.getBoolValue(FIELD_ZIP_REPORT);
+        boolean displayReport = zipReport ? false : this.getBoolValue(FIELD_DISPLAY_REPORT);
         Template template = extension.getTemplateByDisplayName(getStringValue(FIELD_TEMPLATE));
         ReportData reportData = getReportData(template);
 
         // Always save all of the options
         ReportParam reportParam = extension.getReportParam();
+        reportParam.setZipReport(zipReport);
         reportParam.setDisplayReport(displayReport);
         reportParam.setTitle(reportData.getTitle());
         reportParam.setDescription(reportData.getDescription());

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
@@ -72,6 +72,7 @@ public class ReportDialog extends StandardFieldsDialog {
     private static final String FIELD_REPORT_NAME_PATTERN = "reports.dialog.field.namepattern";
     private static final String FIELD_CONFIDENCE_HEADER = "reports.dialog.field.confidence";
     private static final String FIELD_CONFIDENCE_0 = "reports.dialog.field.confidence.0";
+    private static final String FIELD_ZIP_REPORT = "reports.dialog.field.zip";
     private static final String FIELD_CONFIDENCE_1 = "reports.dialog.field.confidence.1";
     private static final String FIELD_CONFIDENCE_2 = "reports.dialog.field.confidence.2";
     private static final String FIELD_CONFIDENCE_3 = "reports.dialog.field.confidence.3";
@@ -230,7 +231,13 @@ public class ReportDialog extends StandardFieldsDialog {
         this.addCustomComponent(
                 TAB_SCOPE, FIELD_SITES, getNewJScrollPane(getSitesSelector(), 400, 100));
         this.addCheckBoxField(TAB_SCOPE, FIELD_GENERATE_ANYWAY, false);
-        this.addCheckBoxField(TAB_SCOPE, FIELD_DISPLAY_REPORT, reportParam.isDisplayReport());
+        boolean zipReport = reportParam.isZipReport();
+        boolean displayReport = zipReport ? false : reportParam.isDisplayReport();
+        this.addCheckBoxField(TAB_SCOPE, FIELD_ZIP_REPORT, zipReport);
+        this.addCheckBoxField(TAB_SCOPE, FIELD_DISPLAY_REPORT, displayReport);
+        ReportUiUtils.bindMutuallyExclusiveZipAndDisplayCheckBoxes(
+                (JCheckBox) this.getField(FIELD_ZIP_REPORT),
+                (JCheckBox) this.getField(FIELD_DISPLAY_REPORT));
 
         Template defaultTemplate = extension.getTemplateByConfigName(reportParam.getTemplate());
         List<String> templates = extension.getTemplateNames();
@@ -457,6 +464,8 @@ public class ReportDialog extends StandardFieldsDialog {
             }
         }
 
+        reportData.setZipReport(this.getBoolValue(FIELD_ZIP_REPORT));
+
         // Always do this last as it depends on the other fields
         reportData.setAlertTreeRootNode(extension.getFilteredAlertTree(reportData));
         return reportData;
@@ -464,12 +473,14 @@ public class ReportDialog extends StandardFieldsDialog {
 
     @Override
     public void save() {
-        boolean displayReport = this.getBoolValue(FIELD_DISPLAY_REPORT);
+        boolean zipReport = this.getBoolValue(FIELD_ZIP_REPORT);
+        boolean displayReport = zipReport ? false : this.getBoolValue(FIELD_DISPLAY_REPORT);
         Template template = extension.getTemplateByDisplayName(getStringValue(FIELD_TEMPLATE));
         ReportData reportData = getReportData(template);
 
         // Always save all of the options
         ReportParam reportParam = extension.getReportParam();
+        reportParam.setZipReport(zipReport);
         reportParam.setDisplayReport(displayReport);
         reportParam.setTitle(reportData.getTitle());
         reportParam.setDescription(reportData.getDescription());

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportParam.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportParam.java
@@ -35,6 +35,7 @@ public class ReportParam extends AbstractParam {
     private static final String PARAM_DESCRIPTION = PARAM_BASE_KEY + ".description";
     private static final String PARAM_TEMPLATE = PARAM_BASE_KEY + ".template";
     private static final String PARAM_DISPLAY = PARAM_BASE_KEY + ".display";
+    private static final String PARAM_ZIP = PARAM_BASE_KEY + ".zip";
     private static final String PARAM_TEMPLATE_DIRECTORY = PARAM_BASE_KEY + ".templateDir";
     private static final String PARAM_REPORT_DIRECTORY = PARAM_BASE_KEY + ".reportDir";
     private static final String PARAM_REPORT_NAME_PATTERN = PARAM_BASE_KEY + ".reportPattern";
@@ -61,6 +62,7 @@ public class ReportParam extends AbstractParam {
     private String reportDirectory;
     private String reportNamePattern;
     private boolean displayReport;
+    private boolean zipReport;
     private boolean incConfidence0;
     private boolean incConfidence1;
     private boolean incConfidence2;
@@ -89,6 +91,7 @@ public class ReportParam extends AbstractParam {
         reportDirectory = getString(PARAM_REPORT_DIRECTORY, System.getProperty("user.home"));
         reportNamePattern = getString(PARAM_REPORT_NAME_PATTERN, DEFAULT_NAME_PATTERN);
         displayReport = getBoolean(PARAM_DISPLAY, true);
+        zipReport = getBoolean(PARAM_ZIP, false);
 
         incConfidence0 = getBoolean(PARAM_INC_CONFIDENCE_0, false);
         incConfidence1 = getBoolean(PARAM_INC_CONFIDENCE_1, true);
@@ -163,6 +166,15 @@ public class ReportParam extends AbstractParam {
     public void setDisplayReport(boolean displayReport) {
         this.displayReport = displayReport;
         getConfig().setProperty(PARAM_DISPLAY, displayReport);
+    }
+
+    public boolean isZipReport() {
+        return zipReport;
+    }
+
+    public void setZipReport(boolean zipReport) {
+        this.zipReport = zipReport;
+        getConfig().setProperty(PARAM_ZIP, zipReport);
     }
 
     public boolean isIncConfidence0() {

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportUiUtils.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportUiUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.reports;
+
+import java.awt.event.ItemEvent;
+import javax.swing.JCheckBox;
+
+/** Shared UI helpers for report dialogs. */
+public final class ReportUiUtils {
+
+    private ReportUiUtils() {}
+
+    public static void bindMutuallyExclusiveZipAndDisplayCheckBoxes(
+            JCheckBox zipCheckBox, JCheckBox displayCheckBox) {
+        zipCheckBox.addItemListener(
+                e -> {
+                    if (e.getStateChange() == ItemEvent.SELECTED) {
+                        displayCheckBox.setSelected(false);
+                    }
+                });
+        displayCheckBox.addItemListener(
+                e -> {
+                    if (e.getStateChange() == ItemEvent.SELECTED) {
+                        zipCheckBox.setSelected(false);
+                    }
+                });
+    }
+}

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -56,6 +56,7 @@ public class ReportJob extends AutomationJob {
     private static final String PARAM_REPORT_TITLE = "reportTitle";
     private static final String PARAM_REPORT_DESC = "reportDescription";
     private static final String PARAM_DISPLAY_REPORT = "displayReport";
+    private static final String PARAM_ZIP_REPORT = "zipReport";
 
     private ExtensionReports extReport;
 
@@ -259,6 +260,16 @@ public class ReportJob extends AutomationJob {
         }
 
         reportData.setAlertTreeRootNode(getExtReport().getFilteredAlertTree(reportData));
+        boolean zipReport = JobUtils.unBox(this.getParameters().getZipReport());
+        boolean displayReport = JobUtils.unBox(this.getParameters().getDisplayReport());
+        if (zipReport && displayReport) {
+            String message =
+                    Constant.messages.getString(
+                            "reports.automation.warn.zipanddisplay", this.getName());
+            progress.warn(message);
+            LOGGER.warn(message);
+        }
+        reportData.setZipReport(zipReport);
 
         try {
             file =
@@ -267,7 +278,7 @@ public class ReportJob extends AutomationJob {
                                     reportData,
                                     template,
                                     file.getAbsolutePath(),
-                                    JobUtils.unBox(this.getParameters().getDisplayReport()));
+                                    zipReport ? false : displayReport);
             progress.info(
                     Constant.messages.getString(
                             "reports.automation.info.reportgen",
@@ -398,6 +409,9 @@ public class ReportJob extends AutomationJob {
         map.put(
                 PARAM_DISPLAY_REPORT,
                 Boolean.toString(JobUtils.unBox(this.getParameters().getDisplayReport())));
+        map.put(
+                PARAM_ZIP_REPORT,
+                Boolean.toString(JobUtils.unBox(this.getParameters().getZipReport())));
         return map;
     }
 
@@ -477,5 +491,6 @@ public class ReportJob extends AutomationJob {
         private String reportTitle = "";
         private String reportDescription = "";
         private Boolean displayReport = false;
+        private Boolean zipReport = false;
     }
 }

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -56,6 +56,7 @@ public class ReportJob extends AutomationJob {
     private static final String PARAM_REPORT_TITLE = "reportTitle";
     private static final String PARAM_REPORT_DESC = "reportDescription";
     private static final String PARAM_DISPLAY_REPORT = "displayReport";
+    private static final String PARAM_ZIP_REPORT = "zipReport";
 
     private ExtensionReports extReport;
 
@@ -259,6 +260,14 @@ public class ReportJob extends AutomationJob {
         }
 
         reportData.setAlertTreeRootNode(getExtReport().getFilteredAlertTree(reportData));
+        boolean zipReport = JobUtils.unBox(this.getParameters().getZipReport());
+        boolean displayReport = JobUtils.unBox(this.getParameters().getDisplayReport());
+        if (zipReport && displayReport) {
+            progress.warn(
+                    Constant.messages.getString(
+                            "reports.automation.warn.zipanddisplay", this.getName()));
+        }
+        reportData.setZipReport(zipReport);
 
         try {
             file =
@@ -267,7 +276,7 @@ public class ReportJob extends AutomationJob {
                                     reportData,
                                     template,
                                     file.getAbsolutePath(),
-                                    JobUtils.unBox(this.getParameters().getDisplayReport()));
+                                    zipReport ? false : displayReport);
             progress.info(
                     Constant.messages.getString(
                             "reports.automation.info.reportgen",
@@ -398,6 +407,9 @@ public class ReportJob extends AutomationJob {
         map.put(
                 PARAM_DISPLAY_REPORT,
                 Boolean.toString(JobUtils.unBox(this.getParameters().getDisplayReport())));
+        map.put(
+                PARAM_ZIP_REPORT,
+                Boolean.toString(JobUtils.unBox(this.getParameters().getZipReport())));
         return map;
     }
 
@@ -477,5 +489,6 @@ public class ReportJob extends AutomationJob {
         private String reportTitle = "";
         private String reportDescription = "";
         private Boolean displayReport = false;
+        private Boolean zipReport = false;
     }
 }

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
@@ -46,6 +46,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.addon.reports.ExtensionReports;
 import org.zaproxy.addon.reports.ReflectionUtils;
+import org.zaproxy.addon.reports.ReportUiUtils;
 import org.zaproxy.addon.reports.Template;
 import org.zaproxy.addon.reports.automation.ReportJob.Parameters;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -61,6 +62,7 @@ public class ReportJobDialog extends StandardFieldsDialog {
     private static final String FIELD_REPORT_NAME = "reports.dialog.field.reportname";
     private static final String FIELD_DESCRIPTION = "reports.dialog.field.description";
     private static final String FIELD_DISPLAY_REPORT = "reports.dialog.field.display";
+    private static final String FIELD_ZIP_REPORT = "reports.automation.dialog.field.zip";
     private static final String FIELD_CONFIDENCE_HEADER = "reports.dialog.field.confidence";
     private static final String FIELD_CONFIDENCE_0 = "reports.dialog.field.confidence.0";
     private static final String FIELD_CONFIDENCE_1 = "reports.dialog.field.confidence.1";
@@ -120,8 +122,16 @@ public class ReportJobDialog extends StandardFieldsDialog {
         this.addMultilineField(TAB_SCOPE, FIELD_DESCRIPTION, params.getReportDescription());
         this.addMultilineField(TAB_SCOPE, FIELD_SITES, listToString(job.getData().getSites()));
 
-        this.addCheckBoxField(
-                TAB_SCOPE, FIELD_DISPLAY_REPORT, JobUtils.unBox(params.getDisplayReport()));
+        boolean zipReport = JobUtils.unBox(params.getZipReport());
+        boolean displayReport = JobUtils.unBox(params.getDisplayReport());
+        if (zipReport && displayReport) {
+            displayReport = false;
+        }
+        this.addCheckBoxField(TAB_SCOPE, FIELD_ZIP_REPORT, zipReport);
+        this.addCheckBoxField(TAB_SCOPE, FIELD_DISPLAY_REPORT, displayReport);
+        ReportUiUtils.bindMutuallyExclusiveZipAndDisplayCheckBoxes(
+                (JCheckBox) this.getField(FIELD_ZIP_REPORT),
+                (JCheckBox) this.getField(FIELD_DISPLAY_REPORT));
 
         Template defaultTemplate = extension.getTemplateByConfigName(params.getTemplate());
         List<String> templates = extension.getTemplateNames();
@@ -280,7 +290,11 @@ public class ReportJobDialog extends StandardFieldsDialog {
         job.getData().getParameters().setReportFile(this.getStringValue(FIELD_REPORT_NAME));
         job.getData().getParameters().setReportDir(this.getStringValue(FIELD_REPORT_DIR));
         job.getData().getParameters().setReportDescription(this.getStringValue(FIELD_DESCRIPTION));
-        job.getData().getParameters().setDisplayReport(this.getBoolValue(FIELD_DISPLAY_REPORT));
+        boolean zipReport = this.getBoolValue(FIELD_ZIP_REPORT);
+        job.getData().getParameters().setZipReport(zipReport);
+        job.getData()
+                .getParameters()
+                .setDisplayReport(zipReport ? false : this.getBoolValue(FIELD_DISPLAY_REPORT));
         job.getData()
                 .getParameters()
                 .setTheme(template.getThemeForName(this.getStringValue(FIELD_THEME)));

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
@@ -46,6 +46,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.addon.reports.ExtensionReports;
 import org.zaproxy.addon.reports.ReflectionUtils;
+import org.zaproxy.addon.reports.ReportUiUtils;
 import org.zaproxy.addon.reports.Template;
 import org.zaproxy.addon.reports.automation.ReportJob.Parameters;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -61,6 +62,7 @@ public class ReportJobDialog extends StandardFieldsDialog {
     private static final String FIELD_REPORT_NAME = "reports.dialog.field.reportname";
     private static final String FIELD_DESCRIPTION = "reports.dialog.field.description";
     private static final String FIELD_DISPLAY_REPORT = "reports.dialog.field.display";
+    private static final String FIELD_ZIP_REPORT = "reports.automation.dialog.field.zip";
     private static final String FIELD_CONFIDENCE_HEADER = "reports.dialog.field.confidence";
     private static final String FIELD_CONFIDENCE_0 = "reports.dialog.field.confidence.0";
     private static final String FIELD_CONFIDENCE_1 = "reports.dialog.field.confidence.1";
@@ -120,8 +122,13 @@ public class ReportJobDialog extends StandardFieldsDialog {
         this.addMultilineField(TAB_SCOPE, FIELD_DESCRIPTION, params.getReportDescription());
         this.addMultilineField(TAB_SCOPE, FIELD_SITES, listToString(job.getData().getSites()));
 
-        this.addCheckBoxField(
-                TAB_SCOPE, FIELD_DISPLAY_REPORT, JobUtils.unBox(params.getDisplayReport()));
+        boolean zipReport = JobUtils.unBox(params.getZipReport());
+        boolean displayReport = zipReport ? false : JobUtils.unBox(params.getDisplayReport());
+        this.addCheckBoxField(TAB_SCOPE, FIELD_ZIP_REPORT, zipReport);
+        this.addCheckBoxField(TAB_SCOPE, FIELD_DISPLAY_REPORT, displayReport);
+        ReportUiUtils.bindMutuallyExclusiveZipAndDisplayCheckBoxes(
+                (JCheckBox) this.getField(FIELD_ZIP_REPORT),
+                (JCheckBox) this.getField(FIELD_DISPLAY_REPORT));
 
         Template defaultTemplate = extension.getTemplateByConfigName(params.getTemplate());
         List<String> templates = extension.getTemplateNames();
@@ -280,7 +287,11 @@ public class ReportJobDialog extends StandardFieldsDialog {
         job.getData().getParameters().setReportFile(this.getStringValue(FIELD_REPORT_NAME));
         job.getData().getParameters().setReportDir(this.getStringValue(FIELD_REPORT_DIR));
         job.getData().getParameters().setReportDescription(this.getStringValue(FIELD_DESCRIPTION));
-        job.getData().getParameters().setDisplayReport(this.getBoolValue(FIELD_DISPLAY_REPORT));
+        boolean zipReport = this.getBoolValue(FIELD_ZIP_REPORT);
+        job.getData().getParameters().setZipReport(zipReport);
+        job.getData()
+                .getParameters()
+                .setDisplayReport(zipReport ? false : this.getBoolValue(FIELD_DISPLAY_REPORT));
         job.getData()
                 .getParameters()
                 .setTheme(template.getThemeForName(this.getStringValue(FIELD_THEME)));

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/api.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/api.html
@@ -19,8 +19,8 @@
 	<ul>
 		<li>generate (title* template* theme description contexts sites
 			sections includedConfidences includedRisks reportFileName
-			reportFileNamePattern reportDir display): Generate a report with the
-			supplied parameters.
+			reportFileNamePattern reportDir display zip): Generate a report with
+			the supplied parameters.
 			<ul>
 				<li>title: Report Title</li>
 				<li>template: Report Template</li>
@@ -49,7 +49,12 @@
 				<li>reportDir: Path to directory in which the generated report
 					should be placed.</li>
 				<li>display: Display the generated report. Either "true" or
-					"false".</li>
+					"false". Cannot be used together with zip.</li>
+				<li>zip: ZIP the report output. Either "true" or "false". When
+					"true", the generated report and any template resources are
+					packaged into a single <code>.zip</code> file. Cannot be used
+					together with display.
+				</li>
 			</ul>
 		</li>
 	</ul>

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/automation.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/automation.html
@@ -21,6 +21,7 @@
       reportTitle:                     # String: The report title
       reportDescription:               # String: The report description
       displayReport:                   # Boolean: Display the report when generated, default: false
+      zipReport:                       # Boolean: ZIP the report output, default: false (mutually exclusive with displayReport)
     risks:                             # List: The risks to include in this report, default all
       - high
       - medium

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/reports.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/reports.html
@@ -63,9 +63,19 @@
 	alerts. Select this check box if you do want to generate a report with
 	no alerts.
 
+	<H3>ZIP Report</H3>
+	If selected then the generated report file and any template resources
+	(such as CSS, JavaScript, and images) will be written directly into a
+	single
+	<code>.zip</code>
+	file in the report directory.
+	<p>This option is saved with the other report options. It cannot be
+		selected at the same time as Display Report.</p>
+
 	<H3>Display Report</H3>
 	If selected then ZAP will attempt to open the report using the default
-	program used by your operating system for that report type.
+	program used by your operating system for that report type. It cannot
+	be selected at the same time as ZIP Report.
 
 	<H2>Template Fields</H2>
 	The Template tab has the following fields:

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
@@ -12,6 +12,7 @@ reports.api.action.generate.param.sites = The site URLs that should be included 
 reports.api.action.generate.param.template = Report Template
 reports.api.action.generate.param.theme = Report Theme
 reports.api.action.generate.param.title = Report Title
+reports.api.action.generate.param.zip = ZIP the report. Either "true" or "false". Cannot be used together with display.
 
 reports.api.error.badSections = Invalid sections {0} for template {1}
 reports.api.error.badTheme = Invalid theme {0} for template {1}
@@ -23,6 +24,7 @@ reports.api.view.templates = View available templates.
 
 reports.automation.desc = Report Generation Automation Integration
 reports.automation.dialog.field.name = Job Name:
+reports.automation.dialog.field.zip = ZIP Report:
 reports.automation.dialog.summary = Template: {0}
 reports.automation.dialog.title = Report Job
 reports.automation.error.badconf = Job {0} invalid confidence: {1}
@@ -37,6 +39,7 @@ reports.automation.error.noparent = Job {0} parent directory of summaryFile does
 reports.automation.error.roparent = Job {0} no write access to parent directory of summaryFile {1}
 reports.automation.info.reportgen = Job {0} generated report {1}
 reports.automation.name = Report Generation Automation Integration
+reports.automation.warn.zipanddisplay = Job {0} has both zipReport and displayReport enabled; displayReport will be ignored.
 
 reports.desc = Templated and themed report generation functionality
 
@@ -77,6 +80,7 @@ reports.dialog.field.template = Template:
 reports.dialog.field.templatedir = Template Directory:
 reports.dialog.field.theme = Theme:
 reports.dialog.field.title = Report Title:
+reports.dialog.field.zip = ZIP Report:
 
 reports.dialog.info.reloadtemplates = Loaded {0} templates from {1}
 

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-max.yaml
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-max.yaml
@@ -7,6 +7,7 @@
       reportTitle:                     # String: The report title
       reportDescription:               # String: The report description
       displayReport:                   # Boolean: Display the report when generated, default: false
+      zipReport:                       # Boolean: ZIP the report output, default: false (mutually exclusive with displayReport)
     risks:                             # List: The risks to include in this report, default all
       - high
       - medium

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -20,6 +20,8 @@
 package org.zaproxy.addon.reports;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -32,9 +34,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +47,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -52,10 +60,14 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
@@ -816,6 +828,173 @@ class ExtensionReportsUnitTest extends TestUtils {
         assertThat(report.length(), greaterThan(0));
         assertThat(logEvents, not(hasItem(startsWith("WARN"))));
         assertThat(logEvents, not(hasItem(startsWith("ERROR"))));
+    }
+
+    @Test
+    void shouldGenerateZippedHtmlReportWithResources(@TempDir Path workDir) throws Exception {
+        // Given / When
+        File result =
+                generateReport(
+                        workDir,
+                        "traditional-html-plus",
+                        "report.html",
+                        true,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.zip")));
+        assertThat(Files.exists(workDir.resolve("report.html")), is(false));
+        assertThat(result.getParentFile().toPath(), is(equalTo(workDir)));
+        assertThat(Files.exists(workDir.resolve("report")), is(false));
+        assertZipEntries(result, allOf(hasItem("report.html"), hasItem("report/common.css")));
+    }
+
+    @Test
+    void shouldNotZipWhenDisabled(@TempDir Path workDir) throws Exception {
+        // Given / When
+        File result =
+                generateReport(
+                        workDir,
+                        "traditional-html-plus",
+                        "report.html",
+                        false,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.html")));
+        assertThat(Files.exists(workDir.resolve("report.zip")), is(false));
+        assertThat(Files.exists(workDir.resolve("report.html")), is(true));
+    }
+
+    @Test
+    void shouldGenerateZipInDottedParentDirectory(@TempDir Path workDir) throws Exception {
+        // Given
+        Path reportDir = workDir.resolve("v1.2");
+        Files.createDirectories(reportDir);
+        String reportFileName = "report";
+
+        // When
+        File result =
+                generateReport(
+                        reportDir,
+                        "traditional-md",
+                        reportFileName,
+                        true,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.zip")));
+        assertThat(result.getParentFile().toPath(), is(equalTo(reportDir)));
+        assertZipEntries(result, containsInAnyOrder(reportFileName));
+    }
+
+    @ParameterizedTest
+    @MethodSource("zippedSingleFileReportCases")
+    void shouldGenerateZippedReportWithSingleFile(
+            String templateName, String reportFileName, boolean withAlerts, @TempDir Path workDir)
+            throws Exception {
+        // Given / When
+        File result =
+                withAlerts
+                        ? generateReport(
+                                workDir, templateName, reportFileName, true, setupReportData())
+                        : generateReport(
+                                workDir,
+                                templateName,
+                                reportFileName,
+                                true,
+                                ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.zip")));
+        assertThat(Files.exists(workDir.resolve(reportFileName)), is(false));
+        assertZipEntries(result, containsInAnyOrder(reportFileName));
+    }
+
+    static Stream<Arguments> zippedSingleFileReportCases() {
+        return Stream.of(
+                Arguments.of("traditional-md", "report.md", false),
+                Arguments.of("traditional-pdf", "report.pdf", true));
+    }
+
+    @Test
+    void shouldUseNumberedResourcesSubdirWhenBaseExists(@TempDir Path workDir) throws Exception {
+        // Given
+        Path existingResourcesDir = workDir.resolve("report");
+        Files.createDirectories(existingResourcesDir);
+        Files.writeString(existingResourcesDir.resolve("stale.txt"), "stale");
+
+        // When
+        File result =
+                generateReport(
+                        workDir,
+                        "traditional-html-plus",
+                        "report.html",
+                        false,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.html")));
+        assertThat(Files.exists(workDir.resolve("report.zip")), is(false));
+        assertThat(Files.exists(workDir.resolve("report.html")), is(true));
+        assertThat(Files.exists(workDir.resolve("report1")), is(true));
+        assertThat(Files.exists(workDir.resolve("report1/common.css")), is(true));
+        assertThat(Files.exists(workDir.resolve("report/stale.txt")), is(true));
+        assertThat(
+                Files.readString(result.toPath()),
+                containsString(existingResourcesDir.getFileName() + "1/"));
+    }
+
+    @Test
+    void shouldIgnoreStaleResourcesDirWhenWritingZip(@TempDir Path workDir) throws Exception {
+        // Given
+        Path staleResourcesDir = workDir.resolve("report");
+        Files.createDirectories(staleResourcesDir);
+        Files.writeString(staleResourcesDir.resolve("stale.txt"), "stale");
+
+        // When
+        File result =
+                generateReport(
+                        workDir,
+                        "traditional-html-plus",
+                        "report.html",
+                        true,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(Files.exists(workDir.resolve("report.html")), is(false));
+        assertThat(Files.exists(workDir.resolve("report")), is(true));
+        assertZipEntries(
+                result, allOf(hasItem("report/common.css"), not(hasItem("report/stale.txt"))));
+    }
+
+    private static File generateReport(
+            Path workDir,
+            String templateName,
+            String reportFileName,
+            boolean zipReport,
+            ReportData reportData)
+            throws Exception {
+        ExtensionReports extRep = new ExtensionReports();
+        Template template = ReportTestUtils.getTemplateFromYamlFile(templateName);
+        reportData.setSections(template.getSections());
+        reportData.setZipReport(zipReport);
+        return extRep.generateReport(
+                reportData,
+                template,
+                workDir.resolve(reportFileName).toAbsolutePath().toString(),
+                false);
+    }
+
+    private static void assertZipEntries(
+            File zipFile, Matcher<? super Iterable<? super String>> matcher) throws IOException {
+        assertThat(listZipEntryNames(zipFile), matcher);
+    }
+
+    private static List<String> listZipEntryNames(File zipFile) throws IOException {
+        try (ZipFile zip = new ZipFile(zipFile)) {
+            return zip.stream().map(ZipEntry::getName).sorted().collect(Collectors.toList());
+        }
     }
 
     private static ReportData setupReportData() {

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -20,6 +20,8 @@
 package org.zaproxy.addon.reports;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -32,9 +34,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +47,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -55,7 +63,10 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
@@ -816,6 +827,171 @@ class ExtensionReportsUnitTest extends TestUtils {
         assertThat(report.length(), greaterThan(0));
         assertThat(logEvents, not(hasItem(startsWith("WARN"))));
         assertThat(logEvents, not(hasItem(startsWith("ERROR"))));
+    }
+
+    @Test
+    void shouldGenerateZippedHtmlReportWithResources(@TempDir Path workDir) throws Exception {
+        // Given / When
+        File result =
+                generateReport(
+                        workDir,
+                        "traditional-html-plus",
+                        "report.html",
+                        true,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.zip")));
+        assertThat(Files.exists(workDir.resolve("report.html")), is(false));
+        assertThat(result.getParentFile().toPath(), is(equalTo(workDir)));
+        assertThat(Files.exists(workDir.resolve("report")), is(false));
+        assertThat(
+                listZipEntryNames(result),
+                allOf(hasItem("report.html"), hasItem("report/common.css")));
+    }
+
+    @Test
+    void shouldNotZipWhenDisabled(@TempDir Path workDir) throws Exception {
+        // Given / When
+        File result =
+                generateReport(
+                        workDir,
+                        "traditional-html-plus",
+                        "report.html",
+                        false,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.html")));
+        assertThat(Files.exists(workDir.resolve("report.zip")), is(false));
+        assertThat(Files.exists(workDir.resolve("report.html")), is(true));
+    }
+
+    @Test
+    void shouldGenerateZipInDottedParentDirectory(@TempDir Path workDir) throws Exception {
+        // Given
+        Path reportDir = workDir.resolve("v1.2");
+        Files.createDirectories(reportDir);
+        String reportFileName = "report";
+
+        // When
+        File result =
+                generateReport(
+                        reportDir,
+                        "traditional-md",
+                        reportFileName,
+                        true,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.zip")));
+        assertThat(result.getParentFile().toPath(), is(equalTo(reportDir)));
+        assertThat(listZipEntryNames(result), containsInAnyOrder(reportFileName));
+    }
+
+    @ParameterizedTest
+    @MethodSource("zippedSingleFileReportCases")
+    void shouldGenerateZippedReportWithSingleFile(
+            String templateName, String reportFileName, boolean withAlerts, @TempDir Path workDir)
+            throws Exception {
+        // Given / When
+        File result =
+                withAlerts
+                        ? generateReport(
+                                workDir, templateName, reportFileName, true, setupReportData())
+                        : generateReport(
+                                workDir,
+                                templateName,
+                                reportFileName,
+                                true,
+                                ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.zip")));
+        assertThat(Files.exists(workDir.resolve(reportFileName)), is(false));
+        assertThat(listZipEntryNames(result), containsInAnyOrder(reportFileName));
+    }
+
+    static Stream<Arguments> zippedSingleFileReportCases() {
+        return Stream.of(
+                Arguments.of("traditional-md", "report.md", false),
+                Arguments.of("traditional-pdf", "report.pdf", true));
+    }
+
+    @Test
+    void shouldUseNumberedResourcesSubdirWhenBaseExists(@TempDir Path workDir) throws Exception {
+        // Given
+        Path existingResourcesDir = workDir.resolve("report");
+        Files.createDirectories(existingResourcesDir);
+        Files.writeString(existingResourcesDir.resolve("stale.txt"), "stale");
+
+        // When
+        File result =
+                generateReport(
+                        workDir,
+                        "traditional-html-plus",
+                        "report.html",
+                        false,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(result.getName(), is(equalTo("report.html")));
+        assertThat(Files.exists(workDir.resolve("report.zip")), is(false));
+        assertThat(Files.exists(workDir.resolve("report.html")), is(true));
+        assertThat(Files.exists(workDir.resolve("report1")), is(true));
+        assertThat(Files.exists(workDir.resolve("report1/common.css")), is(true));
+        assertThat(Files.exists(workDir.resolve("report/stale.txt")), is(true));
+        assertThat(
+                Files.readString(result.toPath()),
+                containsString(existingResourcesDir.getFileName() + "1/"));
+    }
+
+    @Test
+    void shouldIgnoreStaleResourcesDirWhenWritingZip(@TempDir Path workDir) throws Exception {
+        // Given
+        Path staleResourcesDir = workDir.resolve("report");
+        Files.createDirectories(staleResourcesDir);
+        Files.writeString(staleResourcesDir.resolve("stale.txt"), "stale");
+
+        // When
+        File result =
+                generateReport(
+                        workDir,
+                        "traditional-html-plus",
+                        "report.html",
+                        true,
+                        ReportTestUtils.getTestReportData());
+
+        // Then
+        assertThat(Files.exists(workDir.resolve("report.html")), is(false));
+        assertThat(Files.exists(workDir.resolve("report")), is(true));
+        assertThat(
+                listZipEntryNames(result),
+                allOf(hasItem("report/common.css"), not(hasItem("report/stale.txt"))));
+    }
+
+    private static File generateReport(
+            Path workDir,
+            String templateName,
+            String reportFileName,
+            boolean zipReport,
+            ReportData reportData)
+            throws Exception {
+        ExtensionReports extRep = new ExtensionReports();
+        Template template = ReportTestUtils.getTemplateFromYamlFile(templateName);
+        reportData.setSections(template.getSections());
+        reportData.setZipReport(zipReport);
+        return extRep.generateReport(
+                reportData,
+                template,
+                workDir.resolve(reportFileName).toAbsolutePath().toString(),
+                false);
+    }
+
+    private static List<String> listZipEntryNames(File zipFile) throws IOException {
+        try (ZipFile zip = new ZipFile(zipFile)) {
+            return zip.stream().map(ZipEntry::getName).sorted().collect(Collectors.toList());
+        }
     }
 
     private static ReportData setupReportData() {

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportApiUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportApiUnitTest.java
@@ -34,19 +34,25 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.stream.Stream;
 import net.sf.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.I18N;
 
@@ -74,6 +80,8 @@ class ReportApiUnitTest {
         params.put(ReportApi.PARAM_TEMPLATE, "traditional-html-plus");
         template = ReportTestUtils.getTemplateFromYamlFile("traditional-html-plus");
         when(extReports.getTemplateByConfigName(anyString())).thenReturn(template);
+        when(extReports.generateReport(any(), any(), anyString(), anyBoolean()))
+                .thenAnswer(invocation -> new File((String) invocation.getArgument(2)));
         reportDataCaptor = ArgumentCaptor.forClass(ReportData.class);
     }
 
@@ -292,6 +300,34 @@ class ReportApiUnitTest {
         assertThat(displayCaptor.getValue(), is(display));
     }
 
+    @ParameterizedTest
+    @MethodSource("zipReportCases")
+    void shouldHandleZipReportOptions(
+            boolean zip, boolean setDisplay, boolean expectedZip, boolean expectedDisplay)
+            throws Exception {
+        // Given
+        params.put(ReportApi.PARAM_ZIP, zip);
+        if (setDisplay) {
+            params.put(ReportApi.PARAM_DISPLAY, true);
+        }
+        ArgumentCaptor<Boolean> displayCaptor = ArgumentCaptor.forClass(boolean.class);
+
+        // When
+        reportApi.handleApiAction(ReportApi.ACTION_GENERATE, params);
+
+        // Then
+        verify(extReports)
+                .generateReport(
+                        reportDataCaptor.capture(), any(), anyString(), displayCaptor.capture());
+        assertThat(reportDataCaptor.getValue().isZipReport(), is(expectedZip));
+        assertThat(displayCaptor.getValue(), is(expectedDisplay));
+    }
+
+    static Stream<Arguments> zipReportCases() {
+        return Stream.of(
+                Arguments.of(true, false, true, false), Arguments.of(true, true, true, false));
+    }
+
     @Test
     void shouldPopulateOptionalParamsWithDefaultValues() throws Exception {
         // Given
@@ -336,7 +372,8 @@ class ReportApiUnitTest {
                 () -> assertThat(reportData.isIncludeRisk(Alert.RISK_MEDIUM), is(true)),
                 () -> assertThat(reportData.isIncludeRisk(Alert.RISK_HIGH), is(true)),
                 () -> assertThat(reportFilePathCaptor.getValue(), is(expectedReportFilePath)),
-                () -> assertThat(displayCaptor.getValue(), is(false)));
+                () -> assertThat(displayCaptor.getValue(), is(false)),
+                () -> assertThat(reportData.isZipReport(), is(false)));
     }
 
     @Test
@@ -483,5 +520,30 @@ class ReportApiUnitTest {
         assertAll(
                 () -> assertThat(reportFilePathCaptor.getValue(), is(fileNamePath)),
                 () -> assertThat(reportFilePathCaptor.getValue(), is(not(fileNamePatternPath))));
+    }
+
+    @Test
+    void shouldReturnGeneratedReportPath() throws Exception {
+        // Given
+        String reportDirectory = System.getProperty("java.io.tmpdir");
+        String reportFileName = "testrpt";
+        String htmlReportPath =
+                Paths.get(reportDirectory, reportFileName + '.' + template.getExtension())
+                        .toString();
+        File zipReport = new File(reportDirectory, reportFileName + ".zip");
+        params.put(ReportApi.PARAM_REPORT_DIRECTORY, reportDirectory);
+        params.put(ReportApi.PARAM_REPORT_FILE_NAME, reportFileName);
+        params.put(ReportApi.PARAM_ZIP, true);
+        when(extReports.generateReport(any(), any(), anyString(), anyBoolean()))
+                .thenReturn(zipReport);
+
+        // When
+        ApiResponseElement response =
+                (ApiResponseElement) reportApi.handleApiAction(ReportApi.ACTION_GENERATE, params);
+
+        // Then
+        assertAll(
+                () -> assertThat(response.getValue(), is(zipReport.getPath())),
+                () -> assertThat(response.getValue(), is(not(htmlReportPath))));
     }
 }

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportApiUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportApiUnitTest.java
@@ -34,19 +34,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.stream.Stream;
 import net.sf.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.I18N;
 
@@ -74,6 +82,8 @@ class ReportApiUnitTest {
         params.put(ReportApi.PARAM_TEMPLATE, "traditional-html-plus");
         template = ReportTestUtils.getTemplateFromYamlFile("traditional-html-plus");
         when(extReports.getTemplateByConfigName(anyString())).thenReturn(template);
+        when(extReports.generateReport(any(), any(), anyString(), anyBoolean()))
+                .thenAnswer(invocation -> new File((String) invocation.getArgument(2)));
         reportDataCaptor = ArgumentCaptor.forClass(ReportData.class);
     }
 
@@ -292,6 +302,34 @@ class ReportApiUnitTest {
         assertThat(displayCaptor.getValue(), is(display));
     }
 
+    @ParameterizedTest
+    @MethodSource("zipReportCases")
+    void shouldHandleZipReportOptions(
+            boolean zip, boolean setDisplay, boolean expectedZip, boolean expectedDisplay)
+            throws Exception {
+        // Given
+        params.put(ReportApi.PARAM_ZIP, zip);
+        if (setDisplay) {
+            params.put(ReportApi.PARAM_DISPLAY, true);
+        }
+        ArgumentCaptor<Boolean> displayCaptor = ArgumentCaptor.forClass(boolean.class);
+
+        // When
+        reportApi.handleApiAction(ReportApi.ACTION_GENERATE, params);
+
+        // Then
+        verify(extReports)
+                .generateReport(
+                        reportDataCaptor.capture(), any(), anyString(), displayCaptor.capture());
+        assertThat(reportDataCaptor.getValue().isZipReport(), is(expectedZip));
+        assertThat(displayCaptor.getValue(), is(expectedDisplay));
+    }
+
+    static Stream<Arguments> zipReportCases() {
+        return Stream.of(
+                Arguments.of(true, false, true, false), Arguments.of(true, true, true, false));
+    }
+
     @Test
     void shouldPopulateOptionalParamsWithDefaultValues() throws Exception {
         // Given
@@ -336,7 +374,8 @@ class ReportApiUnitTest {
                 () -> assertThat(reportData.isIncludeRisk(Alert.RISK_MEDIUM), is(true)),
                 () -> assertThat(reportData.isIncludeRisk(Alert.RISK_HIGH), is(true)),
                 () -> assertThat(reportFilePathCaptor.getValue(), is(expectedReportFilePath)),
-                () -> assertThat(displayCaptor.getValue(), is(false)));
+                () -> assertThat(displayCaptor.getValue(), is(false)),
+                () -> assertThat(reportData.isZipReport(), is(false)));
     }
 
     @Test
@@ -483,5 +522,30 @@ class ReportApiUnitTest {
         assertAll(
                 () -> assertThat(reportFilePathCaptor.getValue(), is(fileNamePath)),
                 () -> assertThat(reportFilePathCaptor.getValue(), is(not(fileNamePatternPath))));
+    }
+
+    @Test
+    void shouldReturnGeneratedReportPath(@TempDir Path workDir) throws Exception {
+        // Given
+        String reportDirectory = workDir.toString();
+        String reportFileName = "testrpt";
+        String htmlReportPath =
+                Paths.get(reportDirectory, reportFileName + '.' + template.getExtension())
+                        .toString();
+        File zipReport = workDir.resolve(reportFileName + ".zip").toFile();
+        params.put(ReportApi.PARAM_REPORT_DIRECTORY, reportDirectory);
+        params.put(ReportApi.PARAM_REPORT_FILE_NAME, reportFileName);
+        params.put(ReportApi.PARAM_ZIP, true);
+        when(extReports.generateReport(any(), any(), anyString(), anyBoolean()))
+                .thenReturn(zipReport);
+
+        // When
+        ApiResponseElement response =
+                (ApiResponseElement) reportApi.handleApiAction(ReportApi.ACTION_GENERATE, params);
+
+        // Then
+        assertAll(
+                () -> assertThat(response.getValue(), is(zipReport.getPath())),
+                () -> assertThat(response.getValue(), is(not(htmlReportPath))));
     }
 }

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportParamUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportParamUnitTest.java
@@ -73,6 +73,7 @@ class ReportParamUnitTest {
                 reportParam.getTemplateDirectory(),
                 is(equalTo(Constant.getZapHome() + "/reports/")));
         assertThat(reportParam.isDisplayReport(), is(equalTo(true)));
+        assertThat(reportParam.isZipReport(), is(equalTo(false)));
     }
 
     @Test
@@ -87,6 +88,7 @@ class ReportParamUnitTest {
         config.addProperty("reports.reportDir", "/test/123/");
         config.addProperty("reports.templateDir", tempDir.getAbsolutePath());
         config.addProperty("reports.display", "false");
+        config.addProperty("reports.zip", "true");
 
         // When
         reportParam.load(config);
@@ -99,6 +101,7 @@ class ReportParamUnitTest {
         assertThat(reportParam.getReportDirectory(), is(equalTo("/test/123/")));
         assertThat(reportParam.getTemplateDirectory(), is(equalTo(tempDir.getAbsolutePath())));
         assertThat(reportParam.isDisplayReport(), is(equalTo(false)));
+        assertThat(reportParam.isZipReport(), is(equalTo(true)));
     }
 
     @Test
@@ -115,6 +118,7 @@ class ReportParamUnitTest {
         reportParam.setReportDirectory("/test/123/");
         reportParam.setTemplateDirectory("/test/123/");
         reportParam.setDisplayReport(false);
+        reportParam.setZipReport(true);
 
         // Then
         assertThat(config.getString("reports.title"), is(equalTo("Report title")));
@@ -124,5 +128,6 @@ class ReportParamUnitTest {
         assertThat(config.getString("reports.reportDir"), is(equalTo("/test/123/")));
         assertThat(config.getString("reports.templateDir"), is(equalTo("/test/123/")));
         assertThat(config.getBoolean("reports.display"), is(equalTo(false)));
+        assertThat(config.getBoolean("reports.zip"), is(equalTo(true)));
     }
 }

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/ReportJobUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/ReportJobUnitTest.java
@@ -146,7 +146,7 @@ class ReportJobUnitTest extends TestUtils {
         Map<String, String> params = job.getCustomConfigParameters();
 
         // Then
-        assertThat(params.size(), is(equalTo(7)));
+        assertThat(params.size(), is(equalTo(8)));
         assertThat(
                 params,
                 allOf(
@@ -156,7 +156,8 @@ class ReportJobUnitTest extends TestUtils {
                         hasKey("reportTitle"),
                         hasKey("reportDescription"),
                         hasKey("theme"),
-                        hasKey("displayReport")));
+                        hasKey("displayReport"),
+                        hasKey("zipReport")));
     }
 
     @Test
@@ -169,29 +170,29 @@ class ReportJobUnitTest extends TestUtils {
         String reportDescription = "reportDescription";
         String theme = "theme";
         Boolean displayReport = Boolean.TRUE;
+        Boolean zipReport = Boolean.TRUE;
         ReportJob job =
                 createReportJob(
-                        "parameters:\n"
-                                + "  template: "
-                                + template
-                                + "\n"
-                                + "  reportFile: "
-                                + reportFile
-                                + "\n"
-                                + "  reportDir: "
-                                + reportDir
-                                + "\n"
-                                + "  reportTitle: "
-                                + reportTitle
-                                + "\n"
-                                + "  reportDescription: "
-                                + reportDescription
-                                + "\n"
-                                + "  theme: "
-                                + theme
-                                + "\n"
-                                + "  displayReport: "
-                                + displayReport);
+                        """
+                        parameters:
+                          template: %s
+                          reportFile: %s
+                          reportDir: %s
+                          reportTitle: %s
+                          reportDescription: %s
+                          theme: %s
+                          displayReport: %s
+                          zipReport: %s
+                        """
+                                .formatted(
+                                        template,
+                                        reportFile,
+                                        reportDir,
+                                        reportTitle,
+                                        reportDescription,
+                                        theme,
+                                        displayReport,
+                                        zipReport));
         AutomationProgress progress = new AutomationProgress();
 
         // When
@@ -205,6 +206,61 @@ class ReportJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getReportDescription(), is(equalTo(reportDescription)));
         assertThat(job.getParameters().getTheme(), is(equalTo(theme)));
         assertThat(job.getParameters().getDisplayReport(), is(equalTo(displayReport)));
+        assertThat(job.getParameters().getZipReport(), is(equalTo(zipReport)));
+    }
+
+    @Test
+    void shouldWarnAndIgnoreDisplayWhenBothEnabled() throws IOException {
+        // Given
+        ReportJob job =
+                createReportJob(
+                        """
+                        parameters:
+                          template: template
+                          reportFile: report-file
+                          reportDir: report-dir
+                          zipReport: true
+                          displayReport: true
+                        """);
+        AutomationPlan plan = new AutomationPlan();
+        AutomationProgress progress = plan.getProgress();
+        AutomationEnvironment env = plan.getEnv();
+        ContextWrapper contextWrapper = mock(ContextWrapper.class);
+        given(contextWrapper.getUrls()).willReturn(Collections.singletonList(""));
+        env.setContexts(Arrays.asList(contextWrapper));
+
+        Template template = mock(Template.class);
+        given(template.getExtension()).willReturn("ext");
+        given(extensionReports.getTemplateByConfigName(anyString())).willReturn(template);
+
+        job.verifyParameters(progress);
+
+        ArgumentCaptor<ReportData> reportDataCapture = ArgumentCaptor.forClass(ReportData.class);
+        ArgumentCaptor<Boolean> displayCaptor = ArgumentCaptor.forClass(boolean.class);
+        given(
+                        extensionReports.generateReport(
+                                reportDataCapture.capture(),
+                                any(),
+                                anyString(),
+                                displayCaptor.capture()))
+                .willReturn(mock(File.class));
+
+        job.setPlan(plan);
+
+        // When
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(reportDataCapture.getValue().isZipReport(), is(equalTo(true)));
+        assertThat(displayCaptor.getValue(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(
+                progress.getWarnings().get(0),
+                is(
+                        equalTo(
+                                Constant.messages.getString(
+                                        "reports.automation.warn.zipanddisplay", job.getName()))));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
     }
 
     @Test


### PR DESCRIPTION
## Overview

Add an option in the GUI, API, and AF to allow users to ZIP the output at generation (generated resources are copied to ZIP, then removed).

## Related Issues

- Fixes zaproxy/zaproxy#7821
