### PR TITLE
client: prevent GUI freeze when stopping spider

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Prevent temporary GUI hang when stopping the Client Spider.
 
 ## [0.27.0] - 2026-06-12
 ### Added

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderPanel.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderPanel.java
@@ -21,6 +21,7 @@ package org.zaproxy.addon.client.spider;
 
 import java.awt.BorderLayout;
 import java.awt.EventQueue;
+import java.awt.event.ActionListener;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -66,6 +67,7 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
     private JPanel mainPanel;
     private JTabbedPane tabbedPane;
     private JButton scanButton;
+    private JButton stopButton;
     private ZapTable addedNodesTable;
     private JScrollPane addedNodesTableScrollPane;
     private JLabel addedCountNameLabel;
@@ -237,6 +239,24 @@ public class ClientSpiderPanel extends ScanPanel2<ClientSpider, ScanController<C
             messagesTable.setModel(EMPTY_MESSAGES_TABLE_MODEL);
         }
         this.updateAddedCount();
+    }
+
+    @Override
+    protected JButton getStopScanButton() {
+        if (stopButton == null) {
+            stopButton = super.getStopScanButton();
+            for (ActionListener al : stopButton.getActionListeners()) {
+                stopButton.removeActionListener(al);
+            }
+            stopButton.addActionListener(
+                    e -> {
+                        ClientSpider scanner = getSelectedScanner();
+                        if (scanner != null) {
+                            new Thread(scanner::stopScan, "ZAP-ClientSpider-GUI-Stop").start();
+                        }
+                    });
+        }
+        return stopButton;
     }
 
     @Override


### PR DESCRIPTION
Stop the spider in a background thread since stopping might take some time (e.g. shutting down browsers).