### PR TITLE
wf: ci-remote - surface errors in workflow summary

### DIFF
--- a/.github/workflows/ci_remote.yml
+++ b/.github/workflows/ci_remote.yml
@@ -24,3 +24,9 @@ jobs:
       - run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g --continue --no-parallel test
         env:
           ZAP_REMOTE_TESTS: 1
+      - name: Publish JUnit report
+        if: always()
+        uses: step-security/action-junit-report@6c33c83bbe7511864f70174ba8275e4ea1174e21 # v6.4.0
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          detailed_summary: true


### PR DESCRIPTION
## Overview

So that maintainers don't have to scroll/search thousands of lines of logs surface the details in the workflow summary.

<details>
<summary>Screenshot</summary>

<img width="1905" height="1847" alt="image" src="https://github.com/user-attachments/assets/a31ed5e1-c52c-48b2-ba3d-e6ca490ad23c" />

</details>
