### PR TITLE
client: allow the spider to wait based on state

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Reduce duplicated accesses while crawling.
+- Use adaptive wait by default for page load and action waits while crawling.
 
 ### Fixed
 - Prevent temporary GUI hang when stopping the Client Spider.

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMap.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMap.java
@@ -390,6 +390,9 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
         String url = event.getUrl();
         if (url != null && !isApiUrl(url)) {
             setVisited(url);
+            if (ClientSideComponent.Type.PAGE_LOAD.getTypeKey().equals(event.getType())) {
+                listeners.forEach(l -> l.pageLoaded(url, source));
+            }
         }
     }
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMapListener.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMapListener.java
@@ -43,4 +43,13 @@ public interface ClientMapListener {
      *     source is unknown.
      */
     void componentAdded(Map<String, String> parameters, int source);
+
+    /**
+     * Called when a page-load event is reported for a URL.
+     *
+     * @param url the URL of the page that loaded.
+     * @param source an identifier for the source that triggered the event, or {@code 0} if the
+     *     source is unknown.
+     */
+    default void pageLoaded(String url, int source) {}
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ActionWaitStrategy.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ActionWaitStrategy.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2024 The ZAP Development Team
+ * Copyright 2026 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,25 @@
  */
 package org.zaproxy.addon.client.spider;
 
-import org.openqa.selenium.WebDriver;
+import java.util.Map;
+import org.zaproxy.addon.client.internal.ClientMapListener;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
 
-public interface SpiderAction {
+public interface ActionWaitStrategy extends ClientMapListener {
 
-    boolean run(ActionWaitStrategy waitStrategy, WebDriver wd);
+    void configure(WebDriverProcess wdp);
+
+    boolean waitAfterPageLoad(String url);
+
+    boolean waitAfterAction();
+
+    default void onRequestStarted(String url) {}
+
+    default void onRequestCompleted(String url) {}
+
+    @Override
+    default void nodeAdded(String url, int depth, int siblings, int source) {}
+
+    @Override
+    default void componentAdded(Map<String, String> parameters, int source) {}
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/AdaptiveWaitStrategy.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/AdaptiveWaitStrategy.java
@@ -1,0 +1,145 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+
+public class AdaptiveWaitStrategy implements ActionWaitStrategy {
+
+    private static final Logger LOGGER = LogManager.getLogger(AdaptiveWaitStrategy.class);
+
+    static final long HARD_TIMEOUT_MS = 15_000;
+    static final long POLL_INTERVAL_MS = 50;
+    static final long QUIESCE_THRESHOLD_FIRST_ACCESS_MS = 2_500;
+    static final long QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS = 100;
+    static final long QUIESCE_THRESHOLD_NO_PAGE_LOAD_MS = 50;
+
+    private final long initialLoadTimeMs;
+    private final Predicate<String> urlInScope;
+    private final AtomicInteger inflightInScopeCount = new AtomicInteger();
+    private final Set<String> visitedUrls;
+
+    private volatile int proxyPort;
+    private volatile boolean pageLoadReceived;
+    private boolean firstAccess;
+
+    public AdaptiveWaitStrategy(
+            Predicate<String> urlInScope, Set<String> visitedUrls, Duration initialLoadTime) {
+        this.urlInScope = urlInScope;
+        this.visitedUrls = visitedUrls;
+        this.initialLoadTimeMs = initialLoadTime.toMillis();
+        firstAccess = !initialLoadTime.isZero();
+    }
+
+    @Override
+    public void configure(WebDriverProcess wdp) {
+        this.proxyPort = wdp.getProxyPort();
+    }
+
+    @Override
+    public void onRequestStarted(String url) {
+        if (urlInScope.test(url)) {
+            inflightInScopeCount.incrementAndGet();
+        }
+    }
+
+    @Override
+    public void onRequestCompleted(String url) {
+        if (urlInScope.test(url)) {
+            inflightInScopeCount.decrementAndGet();
+        }
+    }
+
+    @Override
+    public void pageLoaded(String url, int source) {
+        if (source == proxyPort) {
+            pageLoadReceived = true;
+        }
+    }
+
+    @Override
+    public boolean waitAfterAction() {
+        return waitForStability(false, false);
+    }
+
+    @Override
+    public boolean waitAfterPageLoad(String url) {
+        boolean urlFirstAccess = visitedUrls.add(url);
+        boolean instanceFirst = firstAccess;
+        if (instanceFirst) {
+            firstAccess = false;
+        }
+        return waitForStability(instanceFirst, urlFirstAccess);
+    }
+
+    private boolean waitForStability(boolean instanceFirst, boolean urlFirstAccess) {
+        long start = System.currentTimeMillis();
+        long quiesceStart = -1;
+
+        while (true) {
+            long now = System.currentTimeMillis();
+            if (now - start >= HARD_TIMEOUT_MS) {
+                LOGGER.debug("Adaptive wait hard timeout reached after {}ms", HARD_TIMEOUT_MS);
+                break;
+            }
+
+            int inflight = inflightInScopeCount.get();
+            if (inflight == 0) {
+                if (quiesceStart < 0) {
+                    quiesceStart = now;
+                }
+                long threshold;
+                if (instanceFirst) {
+                    threshold = initialLoadTimeMs;
+                } else if (urlFirstAccess) {
+                    threshold = QUIESCE_THRESHOLD_FIRST_ACCESS_MS;
+                } else {
+                    threshold =
+                            pageLoadReceived
+                                    ? QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS
+                                    : QUIESCE_THRESHOLD_NO_PAGE_LOAD_MS;
+                }
+                if (now - quiesceStart >= threshold) {
+                    break;
+                }
+            } else {
+                quiesceStart = -1;
+            }
+
+            try {
+                Thread.sleep(POLL_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOGGER.debug("Interrupted while waiting for stability.");
+                pageLoadReceived = false;
+                return false;
+            }
+        }
+        inflightInScopeCount.set(0);
+        pageLoadReceived = false;
+        return true;
+    }
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -121,7 +121,6 @@ public class ClientSpider implements GenericScanner2 {
 
     private final ValueProvider valueProvider;
     private ClientSpiderOptions options;
-    private final Duration pageLoadTime;
     private int scanId;
     private String displayName;
 
@@ -140,6 +139,7 @@ public class ClientSpider implements GenericScanner2 {
     private List<WebDriverProcess> webDriverPool = new ArrayList<>();
     private Set<WebDriverProcess> webDriverActive = new HashSet<>();
     private Set<Integer> proxyPorts = ConcurrentHashMap.newKeySet();
+    private Set<String> visitedUrls = ConcurrentHashMap.newKeySet();
     private ClientMapListener clientMapListener;
     private List<ClientSpiderTask> spiderTasks = new ArrayList<>();
     private List<ClientSpiderTask> pausedTasks = new ArrayList<>();
@@ -206,7 +206,6 @@ public class ClientSpider implements GenericScanner2 {
         URI targetUri = createUri(targetUrl);
         targetHost = new String(targetUri.getRawHost());
         this.options = options;
-        this.pageLoadTime = Duration.ofSeconds(options.getPageLoadTimeInSecs());
         this.scanId = id;
         this.tasksTotalCount = new AtomicInteger();
         this.valueProvider = valueProvider;
@@ -294,20 +293,18 @@ public class ClientSpider implements GenericScanner2 {
         addTask(
                 targetUrl,
                 followGraphAction(targetUrl),
-                options.getInitialLoadTimeInSecs(),
                 Constant.messages.getString("client.spider.panel.table.action.get"),
                 "");
 
         // Add all of the known but unvisited URLs otherwise these will get ignored
-        getUnvisitedUrls()
-                .forEach(url -> addFollowGraphTask(url, options.getInitialLoadTimeInSecs()));
+        getUnvisitedUrls().forEach(this::addFollowGraphTask);
     }
 
     private List<SpiderAction> followGraphAction(String url, SpiderAction... additionalActions) {
         List<SpiderAction> actions = new ArrayList<>(5);
-        actions.add(new FollowGraph(clientMap.getGraph(), url, valueProvider, pageLoadTime));
+        actions.add(new FollowGraph(clientMap.getGraph(), url, valueProvider));
         actions.add(
-                wd -> {
+                (ws, wd) -> {
                     checkRedirect(url, wd);
                     return true;
                 });
@@ -317,11 +314,10 @@ public class ClientSpider implements GenericScanner2 {
         return actions;
     }
 
-    private ClientSpiderTask addFollowGraphTask(String url, int loadTimeInSecs) {
+    private ClientSpiderTask addFollowGraphTask(String url) {
         return addTask(
                 url,
                 followGraphAction(url),
-                loadTimeInSecs,
                 Constant.messages.getString("client.spider.panel.table.action.follow"),
                 "");
     }
@@ -365,7 +361,7 @@ public class ClientSpider implements GenericScanner2 {
                 wdp = this.webDriverPool.remove(0);
             } else {
                 try {
-                    wdp = new WebDriverProcess(new ProxyHandler());
+                    wdp = new WebDriverProcess();
                 } catch (IOException e) {
                     throw new RuntimeException("Failed to create WebDriver process:", e);
                 }
@@ -384,22 +380,11 @@ public class ClientSpider implements GenericScanner2 {
     }
 
     private ClientSpiderTask addTask(
-            String url,
-            List<SpiderAction> actions,
-            int loadTimeInSecs,
-            String displayName,
-            String detailsString) {
+            String url, List<SpiderAction> actions, String displayName, String detailsString) {
         int id = tasksTotalCount.incrementAndGet();
         try {
             ClientSpiderTask task =
-                    new ClientSpiderTask(
-                            id,
-                            this,
-                            actions,
-                            loadTimeInSecs,
-                            options.getActionWaitTimeInSecs(),
-                            displayName,
-                            detailsString);
+                    new ClientSpiderTask(id, this, actions, displayName, detailsString);
             this.addTaskToTasksModel(task, url);
             if (paused) {
                 this.pausedTasks.add(task);
@@ -493,7 +478,7 @@ public class ClientSpider implements GenericScanner2 {
             }
 
             Stats.incCounter("stats.client.spider.event.url");
-            addFollowGraphTask(url, options.getPageLoadTimeInSecs());
+            addFollowGraphTask(url);
         }
 
         private boolean isHrefAlreadyHandled(Map<String, String> parameters) {
@@ -542,7 +527,6 @@ public class ClientSpider implements GenericScanner2 {
                         followGraphAction(
                                 url,
                                 new ClickElement(valueProvider, createUri(url), parameters, false)),
-                        options.getPageLoadTimeInSecs(),
                         Constant.messages.getString("client.spider.panel.table.action.click"),
                         paramsToString(parameters));
             } else if (SubmitForm.isSupported(parameters)) {
@@ -551,7 +535,6 @@ public class ClientSpider implements GenericScanner2 {
                         url,
                         followGraphAction(
                                 url, new SubmitForm(valueProvider, createUri(url), parameters)),
-                        options.getPageLoadTimeInSecs(),
                         Constant.messages.getString("client.spider.panel.table.action.submit"),
                         paramsToString(parameters));
             }
@@ -917,8 +900,12 @@ public class ClientSpider implements GenericScanner2 {
         private Server proxy;
         private WebDriver webDriver;
         private final int proxyPort;
+        private final ActionWaitStrategy waitStrategy;
+        private final ProxyHandler proxyHandler;
 
-        private WebDriverProcess(ProxyHandler proxyHandler) throws IOException {
+        private WebDriverProcess() throws IOException {
+            this.waitStrategy = createWaitStrategy();
+            this.proxyHandler = new ProxyHandler(waitStrategy);
             int initiator = scanOptions.getInitiator();
             HttpSender httpSender = scanOptions.getHttpSender();
             if (httpSender == null) {
@@ -934,6 +921,8 @@ public class ClientSpider implements GenericScanner2 {
             proxyPort = proxy.start(Server.ANY_PORT);
             proxyPorts.add(proxyPort);
             extClient.registerPortInitiator(proxyPort, initiator);
+
+            clientMap.addListener(waitStrategy);
 
             DriverConfigurationBuilder driverConfBuilder =
                     DriverConfiguration.builder()
@@ -959,11 +948,27 @@ public class ClientSpider implements GenericScanner2 {
                 closeProxy();
                 throw e;
             }
+
+            waitStrategy.configure(this);
+        }
+
+        private ActionWaitStrategy createWaitStrategy() {
+            if (options.getPageLoadTimeInSecs() == 0 && options.getActionWaitTimeInSecs() == 0) {
+                return new AdaptiveWaitStrategy(
+                        ClientSpider.this::isUrlInScope,
+                        visitedUrls,
+                        Duration.ofSeconds(options.getInitialLoadTimeInSecs()));
+            }
+            return new FixedWaitStrategy(
+                    Duration.ofSeconds(options.getInitialLoadTimeInSecs()),
+                    Duration.ofSeconds(options.getPageLoadTimeInSecs()),
+                    Duration.ofSeconds(options.getActionWaitTimeInSecs()));
         }
 
         private void closeProxy() {
             if (proxy != null) {
                 extClient.unregisterPortInitiator(proxyPort);
+                clientMap.removeListener(waitStrategy);
                 try {
                     proxy.close();
                 } catch (IOException e) {
@@ -989,7 +994,13 @@ public class ClientSpider implements GenericScanner2 {
 
     private class ProxyHandler implements HttpMessageHandler {
 
+        private final ActionWaitStrategy waitStrategy;
+
         private boolean allowAll = true;
+
+        ProxyHandler(ActionWaitStrategy waitStrategy) {
+            this.waitStrategy = waitStrategy;
+        }
 
         public void setAllowAll(boolean allowAll) {
             this.allowAll = allowAll;
@@ -997,6 +1008,13 @@ public class ClientSpider implements GenericScanner2 {
 
         @Override
         public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage httpMessage) {
+            String uri = httpMessage.getRequestHeader().getURI().toString();
+            if (ctx.isFromClient()) {
+                waitStrategy.onRequestStarted(uri);
+            } else {
+                waitStrategy.onRequestCompleted(uri);
+            }
+
             if (!ctx.isFromClient()) {
                 handleRedirection(httpMessage);
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderOptions.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderOptions.java
@@ -40,8 +40,8 @@ public class ClientSpiderOptions extends VersionedAbstractParam {
 
     public static final String DEFAULT_BROWSER_ID = Browser.FIREFOX_HEADLESS.getId();
     public static final int DEFAULT_MAX_DEPTH = 5;
-    public static final int DEFAULT_INITIAL_LOAD_TIME = 5;
-    public static final int DEFAULT_PAGE_LOAD_TIME = 1;
+    public static final int DEFAULT_INITIAL_LOAD_TIME = 0;
+    public static final int DEFAULT_PAGE_LOAD_TIME = 0;
     public static final int DEFAULT_SHUTDOWN_TIME = 5;
     public static final int DEFAULT_ACTION_WAIT_TIME = 0;
     public static final boolean DEFAULT_LOGOUT_AVOIDANCE = true;

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderTask.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderTask.java
@@ -19,10 +19,8 @@
  */
 package org.zaproxy.addon.client.spider;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -55,8 +53,6 @@ public class ClientSpiderTask implements Runnable {
     @Getter private String detailsString;
     private ClientSpider clientSpider;
     private List<SpiderAction> actions;
-    private int timeout;
-    private long actionWaitTimeInMsecs;
     @Getter private Status status;
     @Getter private String error;
     private WebDriverProcess wdp;
@@ -65,8 +61,6 @@ public class ClientSpiderTask implements Runnable {
             int id,
             ClientSpider clientSpider,
             List<SpiderAction> actions,
-            int timeout,
-            int actionWaitTimeInSecs,
             String displayName,
             String detailsString) {
         this.id = id;
@@ -74,8 +68,6 @@ public class ClientSpiderTask implements Runnable {
         this.detailsString = detailsString;
         this.clientSpider = clientSpider;
         this.actions = actions;
-        this.timeout = timeout;
-        this.actionWaitTimeInMsecs = TimeUnit.SECONDS.toMillis(actionWaitTimeInSecs);
         this.status = Status.QUEUED;
     }
 
@@ -118,18 +110,12 @@ public class ClientSpiderTask implements Runnable {
         try {
             wdp = this.clientSpider.getWebDriverProcess();
             WebDriver wd = wdp.getWebDriver();
+            ActionWaitStrategy waitStrategy = wdp.getWaitStrategy();
             startTime = System.currentTimeMillis();
-            wd.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(this.timeout));
             for (SpiderAction action : actions) {
-                action.run(wd);
-                if (actionWaitTimeInMsecs > 0) {
-                    try {
-                        Thread.sleep(actionWaitTimeInMsecs);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        LOGGER.debug("Interrupted while waiting after action.", e);
-                        break;
-                    }
+                action.run(waitStrategy, wd);
+                if (!waitStrategy.waitAfterAction()) {
+                    break;
                 }
             }
             ok = true;

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/FixedWaitStrategy.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/FixedWaitStrategy.java
@@ -1,0 +1,70 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import java.time.Duration;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+
+public class FixedWaitStrategy implements ActionWaitStrategy {
+
+    private final long initialLoadTimeMs;
+    private final Duration pageLoadWait;
+    private final long actionWaitMs;
+    private boolean firstAccess = true;
+
+    public FixedWaitStrategy(
+            Duration initialLoadTime, Duration pageLoadTime, Duration actionWaitTime) {
+        this.initialLoadTimeMs = initialLoadTime.toMillis();
+        this.pageLoadWait = pageLoadTime;
+        this.actionWaitMs = actionWaitTime.toMillis();
+    }
+
+    @Override
+    public void configure(WebDriverProcess wdp) {
+        wdp.getWebDriver().manage().timeouts().pageLoadTimeout(pageLoadWait);
+    }
+
+    @Override
+    public boolean waitAfterPageLoad(String url) {
+        if (firstAccess) {
+            firstAccess = false;
+            return sleep(initialLoadTimeMs);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean waitAfterAction() {
+        return sleep(actionWaitMs);
+    }
+
+    private static boolean sleep(long ms) {
+        if (ms <= 0) {
+            return true;
+        }
+        try {
+            Thread.sleep(ms);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.client.spider.SpiderAction;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.utils.Stats;
@@ -49,7 +50,7 @@ abstract class BaseElementAction implements SpiderAction {
     }
 
     @Override
-    public final boolean run(WebDriver wd) {
+    public final boolean run(ActionWaitStrategy waitStrategy, WebDriver wd) {
         String statsPrefix = getStatsPrefix();
         Stats.incCounter(statsPrefix);
 
@@ -72,14 +73,15 @@ abstract class BaseElementAction implements SpiderAction {
             return false;
         }
 
-        return run(wd, element, statsPrefix);
+        return run(waitStrategy, wd, element, statsPrefix);
     }
 
     protected abstract String getStatsPrefix();
 
     protected abstract By getElementBy();
 
-    protected abstract boolean run(WebDriver wd, WebElement element, String statsPrefix);
+    protected abstract boolean run(
+            ActionWaitStrategy waitStrategy, WebDriver wd, WebElement element, String statsPrefix);
 
     protected void fillInputs(List<WebElement> inputs, String action, String statsPrefix) {
         inputs.forEach(input -> fillInput(input, action, statsPrefix));

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/ClickElement.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/ClickElement.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.utils.Stats;
 
@@ -55,7 +56,8 @@ public class ClickElement extends BaseElementAction {
     }
 
     @Override
-    public boolean run(WebDriver wd, WebElement element, String statsPrefix) {
+    public boolean run(
+            ActionWaitStrategy waitStrategy, WebDriver wd, WebElement element, String statsPrefix) {
         if (!passive) {
             fillInputs(wd.findElements(By.xpath("//input")), getUri().toString(), statsPrefix);
         }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/FollowGraph.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/FollowGraph.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.addon.client.spider.actions;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,6 +34,7 @@ import org.jgrapht.graph.DefaultEdge;
 import org.openqa.selenium.WebDriver;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.graph.ClientGraphVertex;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.client.spider.SpiderAction;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.utils.Stats;
@@ -48,37 +48,27 @@ public class FollowGraph implements SpiderAction {
     private final Graph<ClientGraphVertex, DefaultEdge> graph;
     private final String targetUrl;
     private final ValueProvider valueProvider;
-    private final BooleanSupplier waitAction;
 
     public FollowGraph(
             Graph<ClientGraphVertex, DefaultEdge> graph,
             String targetUrl,
-            ValueProvider valueProvider,
-            Duration waitDuration) {
+            ValueProvider valueProvider) {
         this.graph = Objects.requireNonNull(graph);
         this.targetUrl = Objects.requireNonNull(targetUrl);
         this.valueProvider = Objects.requireNonNull(valueProvider);
-        waitAction = createWaitAction(waitDuration.toMillis());
-    }
-
-    private static BooleanSupplier createWaitAction(long millis) {
-        if (millis <= 0) {
-            return () -> false;
-        }
-        return new WaitAction(millis);
     }
 
     @Override
-    public boolean run(WebDriver wd) {
+    public boolean run(ActionWaitStrategy waitStrategy, WebDriver wd) {
         Stats.incCounter(STATS_PREFIX);
 
         String currentUrl = wd.getCurrentUrl();
-        if (targetUrl.equals(currentUrl)) {
+        if (targetUrl.equals(currentUrl) || targetUrl.equals(currentUrl + "#")) {
             Stats.incCounter(STATS_PREFIX + ".current");
             return true;
         }
 
-        if (followPath(wd, currentUrl, targetUrl)) {
+        if (followPath(waitStrategy, wd, currentUrl, targetUrl)) {
             Stats.incCounter(STATS_PREFIX + ".path");
             return true;
         }
@@ -86,10 +76,11 @@ public class FollowGraph implements SpiderAction {
         Stats.incCounter(STATS_PREFIX + ".fallback");
         LOGGER.debug("No graph path to {}, falling back to direct navigation", targetUrl);
         wd.get(targetUrl);
-        return true;
+        return waitStrategy.waitAfterPageLoad(targetUrl);
     }
 
-    private boolean followPath(WebDriver wd, String fromUrl, String toUrl) {
+    private boolean followPath(
+            ActionWaitStrategy waitStrategy, WebDriver wd, String fromUrl, String toUrl) {
         ClientGraphVertex source = new ClientGraphVertex.Url(fromUrl);
         ClientGraphVertex target = new ClientGraphVertex.Url(toUrl);
 
@@ -105,6 +96,7 @@ public class FollowGraph implements SpiderAction {
             return false;
         }
 
+        BooleanSupplier waitAction = new WaitAction(waitStrategy);
         List<ClientGraphVertex> vertices = path.getVertexList();
         for (ClientGraphVertex vertex : vertices) {
             if (vertex instanceof ClientGraphVertex.Component componentVertex) {
@@ -115,7 +107,8 @@ public class FollowGraph implements SpiderAction {
                 ClientSideComponent component = componentVertex.component();
                 try {
                     URI uri = new URI(component.getParentUrl(), true);
-                    if (!new FollowClickElement(valueProvider, uri, component.getData()).run(wd)) {
+                    if (!new FollowClickElement(valueProvider, uri, component.getData())
+                            .run(waitStrategy, wd)) {
                         return false;
                     }
                 } catch (URIException e) {
@@ -124,7 +117,7 @@ public class FollowGraph implements SpiderAction {
                 }
             }
         }
-        return true;
+        return waitStrategy.waitAfterPageLoad(toUrl);
     }
 
     private static class FollowClickElement extends ClickElement {
@@ -147,11 +140,11 @@ public class FollowGraph implements SpiderAction {
 
     private static class WaitAction implements BooleanSupplier {
 
-        private final long millis;
+        private final ActionWaitStrategy waitStrategy;
         private boolean first;
 
-        WaitAction(long millis) {
-            this.millis = millis;
+        WaitAction(ActionWaitStrategy waitStrategy) {
+            this.waitStrategy = waitStrategy;
             first = true;
         }
 
@@ -162,13 +155,7 @@ public class FollowGraph implements SpiderAction {
                 return false;
             }
 
-            try {
-                Thread.sleep(millis);
-                return false;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            return true;
+            return !waitStrategy.waitAfterAction();
         }
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/SubmitForm.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/SubmitForm.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.utils.Stats;
 
@@ -47,7 +48,8 @@ public class SubmitForm extends BaseElementAction {
     }
 
     @Override
-    public boolean run(WebDriver wd, WebElement form, String statsPrefix) {
+    public boolean run(
+            ActionWaitStrategy waitStrategy, WebDriver wd, WebElement form, String statsPrefix) {
         String action = form.getDomAttribute("action");
         fillInputs(form.findElements(By.xpath("//input")), action, statsPrefix);
 

--- a/addOns/client/src/main/javahelp/org/zaproxy/addon/client/resources/help/contents/automation.html
+++ b/addOns/client/src/main/javahelp/org/zaproxy/addon/client/resources/help/contents/automation.html
@@ -26,8 +26,8 @@ This job supports monitor tests.
       maxChildren:                     # Int: The maximum number of children to add to each node in the tree
       numberOfBrowsers:                # Int: The number of browsers the spider will use, more will be faster but will use up more memory, default: number of cores
       browserId:                       # String: Browser ID to use, default: firefox-headless
-      initialLoadTime:                 # Int: The time in seconds to wait after the initial URL is loaded, default: 5
-      pageLoadTime:                    # Int: The time in seconds to wait after a new URL is loaded, default: 1
+      initialLoadTime:                 # Int: The time in seconds to wait after the initial URL is loaded, default: 0
+      pageLoadTime:                    # Int: The time in seconds to wait after a new URL is loaded, default: 0
       actionWaitTime:                  # Int: The time in seconds to wait after performing an action (e.g. clicking a button), default: 0
       shutdownTime:                    # Int: The time in seconds to wait after no activity before shutting down, default: 5
       scopeCheck:                      # String: The scope check, either Flexible or Strict, default: Flexible

--- a/addOns/client/src/main/javahelp/org/zaproxy/addon/client/resources/help/contents/spider-options.html
+++ b/addOns/client/src/main/javahelp/org/zaproxy/addon/client/resources/help/contents/spider-options.html
@@ -20,8 +20,8 @@ These defaults are used when starting a new spider scan and are also pre-populat
 <li><b>Number of Browser Windows to Open</b> - The number of browser windows the spider uses in parallel. More windows increases speed but uses more memory.</li>
 <li><b>Maximum Crawl Depth</b> - The maximum depth the spider will crawl to. 0 means unlimited.</li>
 <li><b>Maximum Children</b> - The maximum number of child nodes to add under any single node in the tree. 0 means unlimited.</li>
-<li><b>Initial Page Load Time</b> - The number of seconds to wait after the initial URL is loaded. Default: 5.</li>
-<li><b>Page Load Time</b> - The number of seconds to wait after each subsequent URL is loaded. Default: 1.</li>
+<li><b>Initial Page Load Time</b> - The number of seconds to wait after the initial URL is loaded. Default: 0.</li>
+<li><b>Page Load Time</b> - The number of seconds to wait after each subsequent URL is loaded. Default: 0.</li>
 <li><b>Action Wait Time</b> - The number of seconds to wait after performing an action on the browser (e.g. opening a URL, clicking a button, submitting a form). Default: 0.</li>
 <li><b>Shutdown Time</b> - The number of seconds to wait for new events after the last action before the spider shuts down. Default: 5.</li>
 <li><b>Maximum Duration</b> - The maximum number of minutes the spider is allowed to run. 0 means unlimited.</li>
@@ -33,6 +33,8 @@ These defaults are used when starting a new spider scan and are also pre-populat
 </li>
 <li><b>Logout Avoidance</b> - When enabled, the spider will avoid clicking elements that are likely to log the user out.</li>
 </ul>
+
+<p>When both <b>Page Load Time</b> and <b>Action Wait Time</b> are set to 0, the spider uses an adaptive wait strategy instead of fixed delays. The adaptive strategy monitors in-scope network traffic and waits until requests quiesce, up to a hard limit of 15 seconds. It applies a longer quiesce threshold (2.5 seconds) the first time a URL is visited, and shorter thresholds for subsequent visits.
 
 </BODY>
 </HTML>

--- a/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/spiderClient-max.yaml
+++ b/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/spiderClient-max.yaml
@@ -8,8 +8,8 @@
       maxChildren:                     # Int: The maximum number of children to add to each node in the tree
       numberOfBrowsers:                # Int: The number of browsers the spider will use, more will be faster but will use up more memory, default: number of cores
       browserId:                       # String: Browser ID to use, default: firefox-headless
-      initialLoadTime:                 # Int: The time in seconds to wait after the initial URL is loaded, default: 5
-      pageLoadTime:                    # Int: The time in seconds to wait after a new URL is loaded, default: 1
+      initialLoadTime:                 # Int: The time in seconds to wait after the initial URL is loaded, default: 0
+      pageLoadTime:                    # Int: The time in seconds to wait after a new URL is loaded, default: 0
       actionWaitTime:                  # Int: The time in seconds to wait after performing an action (e.g. clicking a button), default: 0
       shutdownTime:                    # Int: The time in seconds to wait after no activity before shutting down, default: 5
       scopeCheck:                      # String: The scope check, either Flexible or Strict, default: Flexible

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
@@ -848,7 +848,7 @@ class ClientMapUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldCallConsumerOnHandleReportEventWhenNodeAbsent() {
+    void shouldCallConsumerAndPageLoadedListenerOnHandleReportEvent() {
         // Given
         String url = "https://www.example.com/page";
         String json = REPORTED_EVENT_JSON.formatted(url);
@@ -860,7 +860,7 @@ class ClientMapUnitTest extends TestUtils {
 
         // Then
         verify(consumer).accept(any(ReportedEvent.class));
-        verifyNoInteractions(listener);
+        verify(listener).pageLoaded(url, 0);
     }
 
     @Test

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/AdaptiveWaitStrategyUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/AdaptiveWaitStrategyUnitTest.java
@@ -1,0 +1,476 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+
+/** Unit test for {@link AdaptiveWaitStrategy}. */
+class AdaptiveWaitStrategyUnitTest {
+
+    private static final String IN_SCOPE_URL = "http://example.com/api";
+    private static final String OUT_OF_SCOPE_URL = "http://other.example.org/resource";
+    private static final long INITIAL_PAGE_LOAD_TIME_MS =
+            AdaptiveWaitStrategy.QUIESCE_THRESHOLD_FIRST_ACCESS_MS + 1234L;
+    private static final int PROXY_PORT = 8080;
+
+    private AdaptiveWaitStrategy strategy;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() {
+        strategy =
+                new AdaptiveWaitStrategy(
+                        url -> url.startsWith("http://example.com"),
+                        ConcurrentHashMap.newKeySet(),
+                        Duration.ofMillis(INITIAL_PAGE_LOAD_TIME_MS));
+
+        WebDriverProcess wdp = mock();
+        given(wdp.getProxyPort()).willReturn(PROXY_PORT);
+
+        strategy.configure(wdp);
+        scheduler = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    void shouldReturnTrueOnceTrafficQuiesces() {
+        // Given / when
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_NO_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS));
+    }
+
+    @Test
+    void shouldUseWithPageLoadThresholdWhenHintReceived() {
+        // Given
+        strategy.pageLoaded(IN_SCOPE_URL, PROXY_PORT);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_FIRST_ACCESS_MS));
+    }
+
+    @Test
+    void shouldWaitUntilInflightRequestCompletes() {
+        // Given
+        strategy.onRequestStarted(IN_SCOPE_URL);
+
+        scheduler.schedule(
+                () -> strategy.onRequestCompleted(IN_SCOPE_URL), 300, TimeUnit.MILLISECONDS);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(elapsed, greaterThanOrEqualTo(300L));
+    }
+
+    @Test
+    void shouldNotCountOutOfScopeRequests() {
+        // Given
+        strategy.onRequestStarted(OUT_OF_SCOPE_URL);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.HARD_TIMEOUT_MS));
+    }
+
+    @Test
+    void shouldResetQuiesceClockWhenTrafficResumes() {
+        // Given
+        strategy.onRequestStarted(IN_SCOPE_URL);
+        scheduler.schedule(
+                () -> {
+                    strategy.onRequestCompleted(IN_SCOPE_URL);
+                    try {
+                        Thread.sleep(30);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    strategy.onRequestStarted(IN_SCOPE_URL);
+                    scheduler.schedule(
+                            () -> strategy.onRequestCompleted(IN_SCOPE_URL),
+                            300,
+                            TimeUnit.MILLISECONDS);
+                },
+                200,
+                TimeUnit.MILLISECONDS);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(elapsed, greaterThanOrEqualTo(500L));
+    }
+
+    @Test
+    void shouldIgnorePageLoadFromDifferentProxyPort() {
+        // Given
+        int otherPort = PROXY_PORT + 1;
+        strategy.pageLoaded(IN_SCOPE_URL, otherPort);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_NO_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS));
+    }
+
+    @Test
+    void shouldOnlyApplyHintFromMatchingProxyPort() {
+        // Given
+        strategy.pageLoaded(IN_SCOPE_URL, PROXY_PORT);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_FIRST_ACCESS_MS));
+    }
+
+    @Test
+    void shouldIgnorePageLoadBeforeOnStartIsCalled() {
+        // Given
+        AdaptiveWaitStrategy uninitialised =
+                new AdaptiveWaitStrategy(
+                        url -> url.startsWith("http://example.com"),
+                        ConcurrentHashMap.newKeySet(),
+                        Duration.ofMillis(INITIAL_PAGE_LOAD_TIME_MS));
+        uninitialised.pageLoaded(IN_SCOPE_URL, PROXY_PORT);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = uninitialised.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_NO_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS));
+    }
+
+    @Test
+    void shouldReturnTrueAfterHardTimeoutEvenIfTrafficNeverQuiesces() {
+        // Given
+        strategy.onRequestStarted(IN_SCOPE_URL);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(elapsed, greaterThanOrEqualTo(AdaptiveWaitStrategy.HARD_TIMEOUT_MS));
+    }
+
+    @Test
+    void shouldReturnFalseWhenInterrupted() throws InterruptedException {
+        // Given
+        strategy.onRequestStarted(IN_SCOPE_URL);
+        AtomicBoolean returnValue = new AtomicBoolean(true);
+
+        // When
+        Thread t = new Thread(() -> returnValue.set(strategy.waitAfterAction()));
+        t.start();
+        Thread.sleep(200);
+        t.interrupt();
+        t.join(2000);
+
+        // Then
+        assertThat(returnValue.get(), is(false));
+    }
+
+    @Test
+    void shouldUseInitialLoadTimeThresholdOnFirstWaitAfterPageLoad() {
+        // Given / When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterPageLoad(IN_SCOPE_URL);
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(elapsed, greaterThanOrEqualTo(INITIAL_PAGE_LOAD_TIME_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.HARD_TIMEOUT_MS));
+    }
+
+    @Test
+    void shouldUseRegularThresholdForSubsequentAccess() {
+        // Given
+        strategy.waitAfterPageLoad(IN_SCOPE_URL);
+
+        //  When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterPageLoad(IN_SCOPE_URL);
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_NO_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_FIRST_ACCESS_MS));
+    }
+
+    @Test
+    void shouldUsePageLoadThresholdForKnownUrl() {
+        // Given
+        strategy.waitAfterPageLoad(IN_SCOPE_URL);
+        strategy.pageLoaded(IN_SCOPE_URL, PROXY_PORT);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterPageLoad(IN_SCOPE_URL);
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_FIRST_ACCESS_MS));
+    }
+
+    @Test
+    void shouldUseInitialLoadTimeOnFirstCallEvenWhenUrlAlreadyVisitedByAnotherStrategy() {
+        // Given
+        Set<String> sharedVisitedUrls = ConcurrentHashMap.newKeySet();
+        Duration initialLoadTime = Duration.ofMillis(INITIAL_PAGE_LOAD_TIME_MS);
+
+        AdaptiveWaitStrategy strategy1 =
+                new AdaptiveWaitStrategy(
+                        url -> url.startsWith("http://example.com"),
+                        sharedVisitedUrls,
+                        initialLoadTime);
+        WebDriverProcess wdp = mock();
+        given(wdp.getProxyPort()).willReturn(PROXY_PORT);
+        strategy1.configure(wdp);
+        strategy1.waitAfterPageLoad(IN_SCOPE_URL);
+
+        AdaptiveWaitStrategy strategy2 =
+                new AdaptiveWaitStrategy(
+                        url -> url.startsWith("http://example.com"),
+                        sharedVisitedUrls,
+                        initialLoadTime);
+        strategy2.configure(wdp);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy2.waitAfterPageLoad(IN_SCOPE_URL);
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(elapsed, greaterThanOrEqualTo(INITIAL_PAGE_LOAD_TIME_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.HARD_TIMEOUT_MS));
+    }
+
+    @Test
+    void shouldResetPageLoadHintAtStartOfEachWait() {
+        // Given
+        strategy.pageLoaded(IN_SCOPE_URL, PROXY_PORT);
+        strategy.waitAfterAction();
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_NO_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS));
+    }
+
+    @Test
+    void shouldApplyHintWhenPageLoadArrivesWhileWaiting() {
+        // Given
+        scheduler.schedule(
+                () -> strategy.pageLoaded(IN_SCOPE_URL, PROXY_PORT), 25, TimeUnit.MILLISECONDS);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_WITH_PAGE_LOAD_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_FIRST_ACCESS_MS));
+    }
+
+    @Test
+    void shouldReleaseWaitWhenFutureRequestCompletes() throws Exception {
+        // Given
+        Future<?> requestFuture =
+                scheduler.schedule(
+                        () -> strategy.onRequestStarted(IN_SCOPE_URL), 0, TimeUnit.MILLISECONDS);
+
+        requestFuture.get(1, TimeUnit.SECONDS);
+
+        scheduler.schedule(
+                () -> strategy.onRequestCompleted(IN_SCOPE_URL), 400, TimeUnit.MILLISECONDS);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(elapsed, greaterThanOrEqualTo(400L));
+    }
+
+    @Test
+    void shouldUseUrlFirstAccessThresholdAfterInstanceFirstAccess() {
+        // Given
+        String secondUrl = "http://example.com/other";
+        strategy.waitAfterPageLoad(IN_SCOPE_URL);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterPageLoad(secondUrl);
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_FIRST_ACCESS_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.HARD_TIMEOUT_MS));
+    }
+
+    @Test
+    void shouldUseUrlFirstAccessThresholdWhenInitialLoadTimeIsZero() {
+        // Given
+        strategy =
+                new AdaptiveWaitStrategy(
+                        url -> url.startsWith("http://example.com"),
+                        ConcurrentHashMap.newKeySet(),
+                        Duration.ofMillis(0L));
+        String secondUrl = "http://example.com/other";
+        strategy.waitAfterPageLoad(IN_SCOPE_URL);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = strategy.waitAfterPageLoad(secondUrl);
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(
+                elapsed,
+                greaterThanOrEqualTo(AdaptiveWaitStrategy.QUIESCE_THRESHOLD_FIRST_ACCESS_MS));
+        assertThat(elapsed, lessThan(AdaptiveWaitStrategy.HARD_TIMEOUT_MS));
+    }
+
+    @Test
+    void shouldNotUseInitialLoadTimeOnSubsequentCallsToSameUrl() {
+        // Given
+        AdaptiveWaitStrategy s =
+                new AdaptiveWaitStrategy(
+                        url -> url.startsWith("http://example.com"),
+                        ConcurrentHashMap.newKeySet(),
+                        Duration.ofMillis(INITIAL_PAGE_LOAD_TIME_MS));
+        WebDriverProcess wdp = mock();
+        given(wdp.getProxyPort()).willReturn(PROXY_PORT);
+        s.configure(wdp);
+        s.waitAfterPageLoad(IN_SCOPE_URL);
+
+        // When
+        long start = System.currentTimeMillis();
+        boolean result = s.waitAfterPageLoad(IN_SCOPE_URL);
+
+        // Then
+        long elapsed = elapsed(start);
+        assertThat(result, is(true));
+        assertThat(elapsed, lessThan(INITIAL_PAGE_LOAD_TIME_MS));
+    }
+
+    private static long elapsed(long start) {
+        return System.currentTimeMillis() - start;
+    }
+}

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderOptionsUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderOptionsUnitTest.java
@@ -68,19 +68,30 @@ class ClientSpiderOptionsUnitTest extends TestUtils {
     @Test
     void shouldUseTheRightValues() {
         // Given
-        config.addProperty("client.spider.browserId", "chrome");
-        config.addProperty("client.spider.logoutAvoidance", false);
+        config.setProperty("client.spider.browserId", "chrome");
+        config.setProperty("client.spider.initialLoadTime", 1);
+        config.setProperty("client.spider.maxChildren", 2);
+        config.setProperty("client.spider.maxDepth", 3);
+        config.setProperty("client.spider.maxDuration", 4);
+        config.setProperty("client.spider.pageLoadTime", 5);
+        config.setProperty("client.spider.shutdownTime", 6);
+        config.setProperty("client.spider.threads", 7);
+        config.setProperty(
+                "client.spider.logoutAvoidance", !ClientSpiderOptions.DEFAULT_LOGOUT_AVOIDANCE);
+        config.setProperty("client.spider.actionWaitTime", 9);
         // When
         options.load(config);
         // Then
-        assertThat(options.getInitialLoadTimeInSecs(), is(5));
-        assertThat(options.getMaxChildren(), is(0));
-        assertThat(options.getMaxDepth(), is(5));
-        assertThat(options.getMaxDuration(), is(0));
-        assertThat(options.getPageLoadTimeInSecs(), is(1));
-        assertThat(options.getShutdownTimeInSecs(), is(5));
-        assertThat(options.getThreadCount(), is(Constants.getDefaultThreadCount()));
-        assertThat(options.isLogoutAvoidance(), is(false));
+        assertThat(options.getBrowserId(), is("chrome"));
+        assertThat(options.getInitialLoadTimeInSecs(), is(1));
+        assertThat(options.getMaxChildren(), is(2));
+        assertThat(options.getMaxDepth(), is(3));
+        assertThat(options.getMaxDuration(), is(4));
+        assertThat(options.getPageLoadTimeInSecs(), is(5));
+        assertThat(options.getShutdownTimeInSecs(), is(6));
+        assertThat(options.getThreadCount(), is(7));
+        assertThat(options.isLogoutAvoidance(), is(!ClientSpiderOptions.DEFAULT_LOGOUT_AVOIDANCE));
+        assertThat(options.getActionWaitTimeInSecs(), is(9));
     }
 
     @Test

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderTaskUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderTaskUnitTest.java
@@ -21,13 +21,11 @@ package org.zaproxy.addon.client.spider;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +44,7 @@ class ClientSpiderTaskUnitTest extends TestUtils {
     private ClientSpider clientSpider;
     private WebDriverProcess wdp;
     private WebDriver wd;
+    private ActionWaitStrategy waitStrategy;
 
     @BeforeAll
     static void setUpAll() {
@@ -57,24 +56,37 @@ class ClientSpiderTaskUnitTest extends TestUtils {
         clientSpider = mock(ClientSpider.class);
         wdp = mock(WebDriverProcess.class);
         wd = mock(WebDriver.class);
-        WebDriver.Options wdOptions = mock(WebDriver.Options.class);
-        WebDriver.Timeouts timeouts =
-                mock(WebDriver.Timeouts.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
 
         given(clientSpider.isStopped()).willReturn(false);
         given(clientSpider.isPaused()).willReturn(false);
         given(clientSpider.getWebDriverProcess()).willReturn(wdp);
         given(wdp.getWebDriver()).willReturn(wd);
-        given(wd.manage()).willReturn(wdOptions);
-        given(wdOptions.timeouts()).willReturn(timeouts);
+        waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(true);
+        given(wdp.getWaitStrategy()).willReturn(waitStrategy);
+    }
+
+    @Test
+    void shouldRunActionWithStateFromWebDriverProcess() {
+        // Given
+        SpiderAction action = mock();
+        ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, List.of(action), "test", "");
+
+        // When
+        task.run();
+
+        // Then
+        verify(action).run(waitStrategy, wd);
+        assertThat(task.getStatus(), is(Status.FINISHED));
     }
 
     @Test
     void shouldRunAllActionsInOrder() {
         // Given
         List<String> ran = new ArrayList<>();
-        List<SpiderAction> actions = List.of(w -> ran.add("first"), w -> ran.add("second"));
-        ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, 5, 0, "test", "");
+        List<SpiderAction> actions =
+                List.of((ws, w) -> ran.add("first"), (ws, w) -> ran.add("second"));
+        ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, "test", "");
 
         // When
         task.run();
@@ -85,46 +97,31 @@ class ClientSpiderTaskUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldWaitAfterEachActionWhenActionWaitTimeIsSet() {
+    void shouldWaitAfterEachAction() {
         // Given
-        List<Long> timestamps = new ArrayList<>();
-        List<SpiderAction> actions =
-                List.of(
-                        w -> timestamps.add(System.currentTimeMillis()),
-                        w -> timestamps.add(System.currentTimeMillis()));
-        ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, 5, 1, "test", "");
+        List<SpiderAction> actions = List.of((ws, w) -> true, (ws, w) -> true);
+        ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, "test", "");
 
         // When
         task.run();
 
         // Then
+        verify(waitStrategy, times(2)).waitAfterAction();
         assertThat(task.getStatus(), is(Status.FINISHED));
-        assertThat(timestamps, hasSize(2));
-        assertThat(timestamps.get(1) - timestamps.get(0), greaterThanOrEqualTo(1000L));
     }
 
     @Test
-    void shouldStopRunningActionsWhenSleepIsInterrupted() {
+    void shouldStopRunningActionsWhenWaitStrategyReturnsFalse() {
         // Given
-        List<String> ran = new ArrayList<>();
-        List<SpiderAction> actions =
-                List.of(
-                        w -> {
-                            ran.add("first");
-                            Thread.currentThread().interrupt();
-                            return true;
-                        },
-                        w -> {
-                            ran.add("second");
-                            return true;
-                        });
-        ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, 5, 1, "test", "");
+        given(waitStrategy.waitAfterAction()).willReturn(false);
+        List<SpiderAction> actions = List.of((ws, w) -> true, (ws, w) -> true);
+        ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, "test", "");
 
         // When
         task.run();
 
         // Then
-        assertThat(ran, contains("first"));
+        verify(waitStrategy).waitAfterAction();
         assertThat(task.getStatus(), is(Status.FINISHED));
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -186,6 +186,7 @@ class ClientSpiderUnitTest extends TestUtils {
         clientOptions.load(new ZapXmlConfiguration());
         clientOptions.setThreadCount(1);
         clientOptions.setShutdownTimeInSecs(10);
+        clientOptions.setPageLoadTimeInSecs(1);
 
         seedUrl = "https://www.example.com/";
         spider =
@@ -228,8 +229,8 @@ class ClientSpiderUnitTest extends TestUtils {
     private ClientMapListener clientMapListener() {
         if (mapListener == null) {
             ArgumentCaptor<ClientMapListener> captor = ArgumentCaptor.captor();
-            verify(map).addListener(captor.capture());
-            mapListener = captor.getValue();
+            verify(map, atLeastOnce()).addListener(captor.capture());
+            mapListener = captor.getAllValues().get(0);
         }
         return mapListener;
     }
@@ -283,7 +284,7 @@ class ClientSpiderUnitTest extends TestUtils {
 
         ArgumentCaptor<ClientMapListener> listenerCaptor = ArgumentCaptor.captor();
         verify(map, atLeastOnce()).addListener(listenerCaptor.capture());
-        ClientMapListener protectListener = listenerCaptor.getValue();
+        ClientMapListener protectListener = listenerCaptor.getAllValues().get(1);
 
         // When
         protectListener.nodeAdded("https://www.example.com/inscope", 0, 0, PROXY_PORT);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/FixedWaitStrategyUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/FixedWaitStrategyUnitTest.java
@@ -1,0 +1,168 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriver.Options;
+import org.openqa.selenium.WebDriver.Timeouts;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+
+/** Unit test for {@link FixedWaitStrategy}. */
+class FixedWaitStrategyUnitTest {
+
+    private FixedWaitStrategy strategy;
+
+    @Test
+    void shouldSleepForInitialLoadTimeOnFirstWaitAfterPageLoad() {
+        // Given
+        strategy = new FixedWaitStrategy(millis(300L), millis(0L), millis(0L));
+        long start = System.currentTimeMillis();
+
+        // When
+        boolean result = strategy.waitAfterPageLoad("http://example.com/");
+
+        // Then
+        assertThat(result, is(true));
+        assertThat(elapsed(start), is(greaterThanOrEqualTo(300L)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0L, 1_000L, 10_000L})
+    void shouldReturnImmediatelyOnSubsequentWaitAfterPageLoad(long time) {
+        // Given
+        strategy = new FixedWaitStrategy(millis(time), millis(2000L), millis(0L));
+        strategy.waitAfterPageLoad("http://example.com/");
+        long start = System.currentTimeMillis();
+
+        // When
+        boolean result = strategy.waitAfterPageLoad("http://example.com/");
+
+        // Then
+        assertThat(result, is(true));
+        assertThat(elapsed(start), is(lessThan(50L)));
+    }
+
+    @Test
+    void shouldReturnImmediatelyWhenInitialLoadTimeIsZero() {
+        // Given
+        strategy = new FixedWaitStrategy(millis(0L), millis(1000L), millis(0L));
+        long start = System.currentTimeMillis();
+
+        // When
+        boolean result = strategy.waitAfterPageLoad("http://example.com/");
+
+        // Then
+        assertThat(result, is(true));
+        assertThat(elapsed(start), is(lessThan(50L)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0L, 1_000L, 10_000L})
+    void shouldConfigureWebDriverPageLoadTimeout(long time) {
+        // Given
+        Duration expectedDuration = millis(time);
+        strategy = new FixedWaitStrategy(millis(0L), expectedDuration, millis(2000L));
+        WebDriverProcess wdp = mock();
+        WebDriver wd = mock();
+        given(wdp.getWebDriver()).willReturn(wd);
+        Options options = mock();
+        given(wd.manage()).willReturn(options);
+        Timeouts timeouts = mock();
+        given(options.timeouts()).willReturn(timeouts);
+
+        // When
+        strategy.configure(wdp);
+
+        // Then
+        verify(timeouts).pageLoadTimeout(expectedDuration);
+    }
+
+    @Test
+    void shouldSleepForActionWaitDuration() {
+        // Given
+        strategy = new FixedWaitStrategy(millis(0L), millis(1000L), millis(500L));
+        long start = System.currentTimeMillis();
+
+        // When
+        boolean result = strategy.waitAfterAction();
+
+        // Then
+        assertThat(result, is(true));
+        assertThat(elapsed(start), is(greaterThanOrEqualTo(500L)));
+    }
+
+    @Test
+    void shouldReturnFalseAndRestoreInterruptOnActionWaitInterruption()
+            throws InterruptedException {
+        // Given
+        strategy = new FixedWaitStrategy(millis(0L), millis(1000L), millis(2000L));
+        AtomicBoolean returnValue = new AtomicBoolean(true);
+        Thread t = new Thread(() -> returnValue.set(strategy.waitAfterAction()));
+
+        t.start();
+        // When
+        t.interrupt();
+        t.join(2000);
+
+        // Then
+        assertThat(returnValue.get(), is(false));
+    }
+
+    @Test
+    void shouldIgnoreTrafficHooks() {
+        // Given
+        strategy = new FixedWaitStrategy(millis(0L), millis(1000L), millis(2000L));
+
+        // When / Then
+        assertDoesNotThrow(() -> strategy.onRequestStarted("http://example.com/"));
+        assertDoesNotThrow(() -> strategy.onRequestCompleted("http://example.com/"));
+    }
+
+    @Test
+    void shouldIgnorePageLoadEvents() {
+        // Given
+        strategy = new FixedWaitStrategy(millis(0L), millis(1000L), millis(2000L));
+
+        // When / Then
+        assertDoesNotThrow(() -> strategy.pageLoaded("http://example.com/", 8080));
+    }
+
+    private static Duration millis(long time) {
+        return Duration.ofMillis(time);
+    }
+
+    private static long elapsed(long start) {
+        return System.currentTimeMillis() - start;
+    }
+}

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
@@ -37,6 +37,7 @@ import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.commonlib.ValueProvider;
 
 /** Unit test for {@link BaseElementAction}. */
@@ -55,7 +56,11 @@ class BaseElementActionUnitTest {
                 new BaseElementAction(valueProvider, uri) {
 
                     @Override
-                    protected boolean run(WebDriver wd, WebElement element, String statsPrefix) {
+                    protected boolean run(
+                            ActionWaitStrategy waitStrategy,
+                            WebDriver wd,
+                            WebElement element,
+                            String statsPrefix) {
                         return true;
                     }
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
@@ -51,6 +51,7 @@ import org.mockito.InOrder;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.utils.Stats;
@@ -60,11 +61,13 @@ class ClickElementUnitTest {
 
     private ValueProvider valueProvider;
     private URI uri;
+    private ActionWaitStrategy waitStrategy;
     private InMemoryStats stats;
 
     @BeforeEach
     void setUp() throws IOException {
         valueProvider = mock(ValueProvider.class);
+        waitStrategy = mock();
         uri = new URI("http://example.com/test", true);
         stats = new InMemoryStats();
         Stats.addListener(stats);
@@ -93,7 +96,7 @@ class ClickElementUnitTest {
         given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -119,7 +122,7 @@ class ClickElementUnitTest {
                 .willReturn("value2");
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -147,7 +150,7 @@ class ClickElementUnitTest {
                 .willReturn("value2");
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -167,7 +170,7 @@ class ClickElementUnitTest {
         willThrow(RuntimeException.class).given(element).click();
 
         // When / Then
-        boolean result = assertDoesNotThrow(() -> action.run(wd));
+        boolean result = assertDoesNotThrow(() -> action.run(waitStrategy, wd));
         assertThat(result, is(equalTo(false)));
         assertThat(stats.getStat("stats.client.spider.action.click.tag.A"), is(1L));
         assertThat(stats.getStat("stats.client.spider.action.click.tag.A.exception"), is(1L));
@@ -182,7 +185,7 @@ class ClickElementUnitTest {
         given(wd.findElement(any(By.class))).willThrow(RuntimeException.class);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -201,7 +204,7 @@ class ClickElementUnitTest {
         given(element.isDisplayed()).willReturn(false);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -222,7 +225,7 @@ class ClickElementUnitTest {
         given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -242,7 +245,7 @@ class ClickElementUnitTest {
         given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -262,7 +265,7 @@ class ClickElementUnitTest {
         given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -281,7 +284,7 @@ class ClickElementUnitTest {
         given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
@@ -21,7 +21,6 @@ package org.zaproxy.addon.client.spider.actions;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,8 +31,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.withSettings;
 
-import java.time.Duration;
 import java.util.Map;
 import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultEdge;
@@ -42,12 +41,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.quality.Strictness;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.graph.ClientGraphVertex;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -63,7 +64,7 @@ class FollowGraphUnitTest extends TestUtils {
     private WebDriver wd;
     private Graph<ClientGraphVertex, DefaultEdge> graph;
     private ValueProvider valueProvider;
-    private Duration waitDuration;
+    private ActionWaitStrategy waitStrategy;
     private InMemoryStats stats;
 
     @BeforeAll
@@ -76,7 +77,9 @@ class FollowGraphUnitTest extends TestUtils {
         wd = mock();
         graph = new DirectedMultigraph<>(DefaultEdge.class);
         valueProvider = mock();
-        waitDuration = Duration.ofSeconds(0);
+        waitStrategy = mock(withSettings().strictness(Strictness.LENIENT));
+        given(waitStrategy.waitAfterPageLoad(any())).willReturn(true);
+        given(waitStrategy.waitAfterAction()).willReturn(true);
         stats = new InMemoryStats();
         Stats.addListener(stats);
     }
@@ -90,13 +93,30 @@ class FollowGraphUnitTest extends TestUtils {
     void shouldDoNothingWhenAlreadyAtTarget() {
         // Given
         given(wd.getCurrentUrl()).willReturn(URL_A);
-        FollowGraph action = new FollowGraph(graph, URL_A, valueProvider, waitDuration);
+        FollowGraph action = new FollowGraph(graph, URL_A, valueProvider);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertCommonState(wd, result);
+        verify(waitStrategy, never()).waitAfterPageLoad(any());
+        verify(wd, never()).get(any());
+        assertThat(stats.getStat("stats.client.spider.action.follow"), is(1L));
+    }
+
+    @Test
+    void shouldDoNothingWhenAlreadyAtTargetWithEmptyFragment() {
+        // Given
+        given(wd.getCurrentUrl()).willReturn(URL_A);
+        FollowGraph action = new FollowGraph(graph, URL_A + "#", valueProvider);
+
+        // When
+        boolean result = action.run(waitStrategy, wd);
+
+        // Then
+        assertCommonState(wd, result);
+        verify(waitStrategy, never()).waitAfterPageLoad(any());
         verify(wd, never()).get(any());
         assertThat(stats.getStat("stats.client.spider.action.follow"), is(1L));
     }
@@ -111,15 +131,16 @@ class FollowGraphUnitTest extends TestUtils {
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
 
-        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider, waitDuration);
+        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertCommonState(wd, result);
         verify(element).click();
         verify(wd, never()).get(any());
+        verify(waitStrategy).waitAfterPageLoad(URL_B);
         assertThat(stats.getStat("stats.client.spider.action.follow"), is(1L));
         assertThat(stats.getStat("stats.client.spider.action.follow.path"), is(1L));
     }
@@ -134,14 +155,15 @@ class FollowGraphUnitTest extends TestUtils {
 
         given(wd.getCurrentUrl()).willReturn(URL_A);
 
-        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider, waitDuration);
+        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertCommonState(wd, result);
         verify(wd).get(URL_B);
+        verify(waitStrategy).waitAfterPageLoad(URL_B);
         assertThat(stats.getStat("stats.client.spider.action.follow"), is(1L));
         assertThat(stats.getStat("stats.client.spider.action.follow.fallback"), is(1L));
     }
@@ -158,15 +180,17 @@ class FollowGraphUnitTest extends TestUtils {
         WebElement element = visibleElement();
         given(wd.findElement(any())).willReturn(element);
 
-        FollowGraph action = new FollowGraph(graph, URL_C, valueProvider, waitDuration);
+        FollowGraph action = new FollowGraph(graph, URL_C, valueProvider);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertCommonState(wd, result);
         verify(element, times(2)).click();
         verify(wd, never()).get(any());
+        verify(waitStrategy).waitAfterAction();
+        verify(waitStrategy).waitAfterPageLoad(URL_C);
         assertThat(stats.getStat("stats.client.spider.action.follow"), is(1L));
         assertThat(stats.getStat("stats.client.spider.action.follow.path"), is(1L));
     }
@@ -178,21 +202,23 @@ class FollowGraphUnitTest extends TestUtils {
         ClientSideComponent link2 = createLinkComponent(URL_B, URL_C);
         addGraphEdge(URL_A, link1, URL_B);
         addGraphEdge(URL_B, link2, URL_C);
+        String urlD = "http://example.com/d";
+        ClientSideComponent link3 = createLinkComponent(URL_C, urlD);
+        addGraphEdge(URL_C, link3, urlD);
 
         given(wd.getCurrentUrl()).willReturn(URL_A);
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
 
-        waitDuration = Duration.ofMillis(950);
-        FollowGraph action = new FollowGraph(graph, URL_C, valueProvider, waitDuration);
+        FollowGraph action = new FollowGraph(graph, urlD, valueProvider);
 
-        long start = System.currentTimeMillis();
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
-        assertThat(System.currentTimeMillis() - start, is(greaterThanOrEqualTo(950L)));
         assertCommonState(wd, result);
+        verify(waitStrategy, times(2)).waitAfterAction();
+        verify(waitStrategy).waitAfterPageLoad(urlD);
     }
 
     @Test
@@ -207,10 +233,10 @@ class FollowGraphUnitTest extends TestUtils {
 
         willThrow(RuntimeException.class).given(element).click();
 
-        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider, waitDuration);
+        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider);
 
         // When / Then
-        boolean result = assertDoesNotThrow(() -> action.run(wd));
+        boolean result = assertDoesNotThrow(() -> action.run(waitStrategy, wd));
         assertCommonState(wd, result);
         assertThat(stats.getStat("stats.client.spider.action.follow"), is(1L));
     }
@@ -220,10 +246,10 @@ class FollowGraphUnitTest extends TestUtils {
         // Given
         given(wd.getCurrentUrl()).willReturn(URL_A);
 
-        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider, waitDuration);
+        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertCommonState(wd, result);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
@@ -49,6 +49,7 @@ import org.mockito.InOrder;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.utils.Stats;
@@ -58,11 +59,13 @@ class SubmitFormUnitTest {
 
     private ValueProvider valueProvider;
     private URI uri;
+    private ActionWaitStrategy waitStrategy;
     private InMemoryStats stats;
 
     @BeforeEach
     void setUp() throws IOException {
         valueProvider = mock(ValueProvider.class);
+        waitStrategy = mock();
         uri = new URI("http://example.com/test", true);
         stats = new InMemoryStats();
         Stats.addListener(stats);
@@ -89,7 +92,7 @@ class SubmitFormUnitTest {
         given(form.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -114,7 +117,7 @@ class SubmitFormUnitTest {
                 .willReturn("value2");
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -137,7 +140,7 @@ class SubmitFormUnitTest {
         willThrow(RuntimeException.class).given(form).submit();
 
         // When / Then
-        boolean result = assertDoesNotThrow(() -> action.run(wd));
+        boolean result = assertDoesNotThrow(() -> action.run(waitStrategy, wd));
         assertThat(result, is(equalTo(false)));
         assertThat(stats.getStat("stats.client.spider.action.form.0"), is(1L));
         assertThat(stats.getStat("stats.client.spider.action.form.0.exception"), is(1L));
@@ -152,7 +155,7 @@ class SubmitFormUnitTest {
         given(wd.findElement(any(By.class))).willThrow(RuntimeException.class);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -171,7 +174,7 @@ class SubmitFormUnitTest {
         given(form.isDisplayed()).willReturn(false);
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -191,7 +194,7 @@ class SubmitFormUnitTest {
         given(visibleForm.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(wd);
+        boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));


### PR DESCRIPTION
Allow to use adaptive wait based on page load and network activity instead of fixed page load and action waits.
Wait longer on first URL visit to allow any events to be triggered.
Use adaptive wait by default (initial page load and page load waits are now zero by default).