### PR TITLE
commonlib: Add test to verify all vulnerabilities have solutions

### DIFF
--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerabilitiesUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/internal/vulns/DefaultVulnerabilitiesUnitTest.java
@@ -20,6 +20,7 @@
 package org.zaproxy.addon.commonlib.internal.vulns;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -28,6 +29,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 import java.util.Locale;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.addon.commonlib.vulnerabilities.Vulnerability;
 
@@ -42,6 +44,9 @@ class DefaultVulnerabilitiesUnitTest {
         DefaultVulnerabilities vulnerabilities = new DefaultVulnerabilities(locale);
         // Then
         assertDefaults(vulnerabilities);
+        vulnerabilities
+                .getAll()
+                .forEach(DefaultVulnerabilitiesUnitTest::assertDefaultVulnerabilityData);
     }
 
     private static void assertDefaults(DefaultVulnerabilities vulnerabilities) {
@@ -51,13 +56,24 @@ class DefaultVulnerabilitiesUnitTest {
         assertVulnerability(vulnerabilities.get("wasc_49"), 49, 3);
     }
 
+    private static void assertDefaultVulnerabilityData(Vulnerability vulnerability) {
+        assertThat(vulnerability, is(notNullValue()));
+        assertNonNullAndNot(vulnerability.getName(), emptyString());
+        assertNonNullAndNot(vulnerability.getDescription(), emptyString());
+        assertNonNullAndNot(vulnerability.getSolution(), emptyString());
+        assertNonNullAndNot(vulnerability.getReferences(), empty());
+    }
+
+    private static <T> void assertNonNullAndNot(T value, Matcher<T> matcher) {
+        assertThat(value, is(notNullValue()));
+        assertThat(value, is(not(matcher)));
+    }
+
     private static void assertVulnerability(
             Vulnerability vulnerability, int id, int numberOfReferences) {
-        assertThat(vulnerability, is(notNullValue()));
+        assertDefaultVulnerabilityData(vulnerability);
+
         assertThat(vulnerability.getWascId(), is(equalTo(id)));
-        assertThat(vulnerability.getName(), is(not(emptyString())));
-        assertThat(vulnerability.getDescription(), is(not(emptyString())));
-        assertThat(vulnerability.getSolution(), is(not(emptyString())));
         assertThat(vulnerability.getReferences(), hasSize(numberOfReferences));
     }
 


### PR DESCRIPTION
## Summary

All 52 entries in `vulnerabilities.xml` already have `<solution>` content, but the existing unit test only spot-checks 3 of them (wasc_1, wasc_13, wasc_49). This adds a test that iterates over all vulnerabilities and asserts each has a non-empty solution, preventing future regressions where a new entry could be added without one.

## Changes

- Added `shouldHaveSolutionsForAllDefaultVulnerabilities()` to `DefaultVulnerabilitiesUnitTest`

## Test plan

- [ ] New test passes: `./gradlew :addOns:commonlib:test --tests "org.zaproxy.addon.commonlib.internal.vulns.DefaultVulnerabilitiesUnitTest"`
- [ ] Existing tests unaffected