### PR TITLE
client: skip same page links while crawling

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -503,6 +503,10 @@ public class ClientSpider implements GenericScanner2 {
             }
 
             String sourceUrl = parameters.get(ClientMap.URL_KEY);
+            if (sourceUrl.equals(href)) {
+                return true;
+            }
+
             synchronized (crawledGraph) {
                 ClientGraphVertex target = new ClientGraphVertex.Url(href);
                 if (crawledGraph.containsVertex(target)) {

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -680,6 +680,33 @@ class ClientSpiderUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldSkipClickForLinkComponentForSamePage() {
+        // Given
+        spider.run();
+        waitForProxy();
+
+        // When
+        clientMapListener()
+                .componentAdded(
+                        Map.of(
+                                ClientMap.URL_KEY,
+                                seedUrl,
+                                "tagName",
+                                "A",
+                                "href",
+                                seedUrl,
+                                "text",
+                                "Same Page Link",
+                                "depth",
+                                "1"),
+                        PROXY_PORT);
+        sleep();
+
+        // Then
+        verify(wd, never()).findElement(any());
+    }
+
+    @Test
     void shouldSkipClickForLinkComponentWithAlreadyHandledHref() {
         // Given
         String href = "https://www.example.com/queued-once";


### PR DESCRIPTION
Skip the own page which is already being processed.