### PR TITLE
scripts: Add run action failureLevel support

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Functionality to store script diagnostics and provides them to Reports. Depends on the database add-on.
+- The Script Job Run action now supports a `failureLevel` parameter (`info`, `warning`, `error`) to control the Automation Framework progress level used when a script or chain execution fails (defaults to `error`).
 
 ### Changed
 - Update dependency.

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/FailureLevel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/FailureLevel.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts.automation;
+
+import org.zaproxy.addon.automation.AutomationProgress;
+
+public enum FailureLevel {
+    INFO {
+        @Override
+        public void report(AutomationProgress progress, String message) {
+            progress.info(message);
+        }
+    },
+    WARNING {
+        @Override
+        public void report(AutomationProgress progress, String message) {
+            progress.warn(message);
+        }
+    },
+    ERROR {
+        @Override
+        public void report(AutomationProgress progress, String message) {
+            progress.error(message);
+        }
+    };
+
+    public abstract void report(AutomationProgress progress, String message);
+}

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ScriptJobParameters.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ScriptJobParameters.java
@@ -31,6 +31,7 @@ import org.zaproxy.addon.automation.AutomationData;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ScriptJobParameters extends AutomationData {
+
     private String action;
     private String type;
     private String engine;
@@ -41,9 +42,14 @@ public class ScriptJobParameters extends AutomationData {
     private String context = "";
     private String user = "";
     private List<String> chain;
+    private FailureLevel failureLevel = FailureLevel.ERROR;
 
     public ScriptJobParameters(String action) {
         this.action = action;
+    }
+
+    public FailureLevel getFailureLevel() {
+        return failureLevel != null ? failureLevel : FailureLevel.ERROR;
     }
 
     // For backwards compatibility

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptAction.java
@@ -373,6 +373,10 @@ public class RunScriptAction extends ScriptAction {
         }
     }
 
+    private void reportToProgress(AutomationProgress progress, String message) {
+        parameters.getFailureLevel().report(progress, message);
+    }
+
     private void reportScriptError(
             AutomationProgress progress,
             String jobName,
@@ -380,7 +384,8 @@ public class RunScriptAction extends ScriptAction {
             ScriptRunDiagnosticsSession.RunContext context,
             Exception e) {
         RunFailure failure = ScriptRunRecordBuilder.resolveFailure(script, e);
-        progress.error(
+        reportToProgress(
+                progress,
                 Constant.messages.getString(
                         "scripts.automation.error.scriptError",
                         jobName,
@@ -396,7 +401,8 @@ public class RunScriptAction extends ScriptAction {
             ScriptRunDiagnosticsSession.RunContext context,
             Exception e) {
         RunFailure failure = ScriptRunRecordBuilder.resolveFailure(chainScript, e);
-        progress.error(
+        reportToProgress(
+                progress,
                 Constant.messages.getString(
                         "scripts.automation.error.chainExecutionFailed",
                         jobName,

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ui/ScriptJobDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ui/ScriptJobDialog.java
@@ -302,7 +302,9 @@ public class ScriptJobDialog extends StandardFieldsDialog {
                         this.getStringValue(SCRIPT_INLINE_PARAM),
                         this.getStringValue(SCRIPT_CONTEXT_PARAM),
                         this.getStringValue(SCRIPT_USER_PARAM),
-                        null); // chain parameter - not currently supported in UI dialog
+                        // not currently supported in UI dialog
+                        null,
+                        null);
         sa = ScriptJob.createScriptAction(params, null);
         List<String> issues = sa.verifyParameters(this.getStringValue(NAME_PARAM), params, null);
         if (issues.isEmpty()) {

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/automation.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/automation.html
@@ -46,6 +46,7 @@
 	<li>target: mandatory, if type is 'targeted', the target URL to be invoked for 'targeted' script
 	<li>context: optional, the name of the context to use when running the script
 	<li>user: optional, the name of the user when running the Zest standalone script or chain (requires context). See Script Chaining for authentication with chains.
+	<li>failureLevel: optional, controls the Automation Framework progress level used when the script or chain execution fails: <code>info</code>, <code>warning</code>, or <code>error</code> (default: <code>error</code>).
 	</ul>
 
 	<H3>Authentication</H3>
@@ -79,7 +80,8 @@
 	<H4>Error Handling</H4>
 	<p>
 	If chain preparation fails (e.g. Zest not loaded), the job reports an error and the chain does not run.
-	If any script in the chain fails during execution, the job reports an error and stops; later scripts in the chain are not run.
+	If any script in the chain fails during execution, the job stops and reports the failure at the level set by <code>failureLevel</code> (default: <code>error</code>); later scripts in the chain are not run.
+	If the failure is reported as an <code>error</code>, the plan is considered failed. Using <code>warning</code> or <code>info</code> allows the plan to continue even when a script fails.
 	In this case, browser windows opened by the chain might not be closed immediately and are closed when ZAP shuts down.
 	</p>
 
@@ -141,6 +143,7 @@
       target:                    # String: The URL to be invoked for "targeted" script type
       context:                   # String: The name of the context to use when running the script (optional)
       user:                      # String: The name of the user to use when running the Zest standalone script or chain (optional, requires context)
+      failureLevel:              # String: The progress level at which script execution failures are reported: info, warning, error (default: error)
 	</pre>
 
 	The <code>source</code> parameter was previously called <code>file</code>, both will work.

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/script-max.yaml
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/script-max.yaml
@@ -10,3 +10,4 @@
       target:                    # String: The URL to be invoked for "targeted" script type
       context:                   # String: The name of the context to use when running the script (optional)
       user:                      # String: The name of the user to use when running the Zest standalone script or chain (optional, requires context)
+      failureLevel:              # String: Only for action 'run'. Automation Framework level at which script execution failures are reported: info, warning, error (default: error)

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/ScriptJobUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/ScriptJobUnitTest.java
@@ -21,7 +21,9 @@ package org.zaproxy.zap.extension.scripts.automation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -1364,6 +1366,27 @@ class ScriptJobUnitTest extends TestUtils {
         assertThat(
                 progress.getWarnings(),
                 contains("!scripts.automation.warn.userParameterSetButActionNotRun!"));
+    }
+
+    @Test
+    void shouldErrorOnInvalidFailureLevelInYaml() {
+        // Given
+        ScriptJob job = new ScriptJob();
+        setJobData(
+                job,
+                """
+                parameters:
+                  action: run
+                  failureLevel: critical
+                """);
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(
+                progress.getErrors(),
+                hasItem(containsString("!automation.error.options.badenum!")));
     }
 
     @Test

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/actions/AddScriptActionUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/actions/AddScriptActionUnitTest.java
@@ -77,7 +77,7 @@ class AddScriptActionUnitTest extends TestUtils {
         progress = mock(AutomationProgress.class);
         parameters =
                 new ScriptJobParameters(
-                        AddScriptAction.NAME, null, null, "", "", "", "", "", "", null);
+                        AddScriptAction.NAME, null, null, "", "", "", "", "", "", null, null);
 
         action = new AddScriptAction(parameters);
     }

--- a/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptActionUnitTest.java
+++ b/addOns/scripts/src/test/java/org/zaproxy/zap/extension/scripts/automation/actions/RunScriptActionUnitTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.jdo.PersistenceManager;
 import javax.jdo.PersistenceManagerFactory;
 import javax.jdo.Transaction;
@@ -44,6 +45,9 @@ import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.parosproxy.paros.Constant;
@@ -63,10 +67,10 @@ import org.zaproxy.zap.extension.script.ScriptEngineWrapper;
 import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.scripts.ExtensionScriptsUI;
+import org.zaproxy.zap.extension.scripts.automation.FailureLevel;
 import org.zaproxy.zap.extension.scripts.automation.ScriptJobParameters;
 import org.zaproxy.zap.extension.scripts.automation.diagnostics.ScriptRunRecordBuilder.RunFailure;
 import org.zaproxy.zap.extension.scripts.diagnostics.ScriptDiagnosticSource;
-import org.zaproxy.zap.extension.scripts.diagnostics.ScriptDiagnosticSource.RunDiagnostics;
 import org.zaproxy.zap.extension.scripts.diagnostics.ScriptDiagnosticSource.RunFailureDiagnostic;
 import org.zaproxy.zap.extension.scripts.internal.db.ScriptsRun;
 import org.zaproxy.zap.extension.scripts.internal.db.TableJdo;
@@ -140,6 +144,7 @@ class RunScriptActionUnitTest extends TestUtils {
                         "",
                         "",
                         "",
+                        null,
                         null);
         action = new RunScriptAction(parameters);
     }
@@ -601,6 +606,7 @@ class RunScriptActionUnitTest extends TestUtils {
                         "",
                         "",
                         "",
+                        null,
                         null);
         targetedParams.setChain(List.of("script1", "script2"));
         given(extScript.getEngineWrapper(ZEST_ENGINE_NAME))
@@ -621,7 +627,7 @@ class RunScriptActionUnitTest extends TestUtils {
         // Given
         ScriptJobParameters nullTypeParams =
                 new ScriptJobParameters(
-                        RunScriptAction.NAME, null, null, "", "", "", "", "", "", null);
+                        RunScriptAction.NAME, null, null, "", "", "", "", "", "", null, null);
         nullTypeParams.setChain(List.of("script1", "script2"));
         RunScriptAction nullTypeAction = new RunScriptAction(nullTypeParams);
 
@@ -765,6 +771,76 @@ class RunScriptActionUnitTest extends TestUtils {
             assertThat(run.getScripts().get(0).getSteps(), hasSize(1));
             assertThat(run.getScripts().get(0).getSteps().get(0).getOutputs(), hasSize(1));
         }
+    }
+
+    /** FailureLevel dispatch — single standalone script */
+    static Stream<Arguments> singleScriptFailureLevelCases() {
+        return Stream.of(
+                Arguments.of(null, 1, 0, 0),
+                Arguments.of(FailureLevel.ERROR, 1, 0, 0),
+                Arguments.of(FailureLevel.WARNING, 0, 1, 0),
+                Arguments.of(FailureLevel.INFO, 0, 0, 1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleScriptFailureLevelCases")
+    void shouldDispatchSingleScriptFailureToCorrectProgressLevel(
+            FailureLevel failureLevel, int errors, int warnings, int infos) throws Exception {
+        // Given
+        ScriptWrapper script = createMockZestWrapper("myScript");
+        given(extScript.getScript("myScript")).willReturn(script);
+        parameters.setName("myScript");
+        parameters.setFailureLevel(failureLevel);
+        when(extScript.invokeScript(script)).thenThrow(new RuntimeException("script failed"));
+
+        // When
+        action.runJob(JOB_NAME, env, progress);
+
+        // Then
+        assertThat(progress.getErrors(), hasSize(errors));
+        assertThat(progress.getWarnings(), hasSize(warnings));
+        assertThat(progress.getInfos(), hasSize(infos));
+        List<String> target =
+                errors > 0
+                        ? progress.getErrors()
+                        : warnings > 0 ? progress.getWarnings() : progress.getInfos();
+        assertThat(target, hasItem(containsString("script failed")));
+    }
+
+    /** FailureLevel dispatch — chain execution (infos includes the "chainExecuting" message) */
+    static Stream<Arguments> chainFailureLevelCases() {
+        return Stream.of(
+                Arguments.of(null, 1, 0, 1),
+                Arguments.of(FailureLevel.ERROR, 1, 0, 1),
+                Arguments.of(FailureLevel.WARNING, 0, 1, 1),
+                Arguments.of(FailureLevel.INFO, 0, 0, 2));
+    }
+
+    @ParameterizedTest
+    @MethodSource("chainFailureLevelCases")
+    void shouldDispatchChainFailureToCorrectProgressLevel(
+            FailureLevel failureLevel, int errors, int warnings, int infos) throws Exception {
+        // Given
+        ScriptWrapper script1 = createMockZestWrapper("script1");
+        ScriptWrapper script2 = createMockZestWrapper("script2");
+        given(extScript.getScript("script1")).willReturn(script1);
+        given(extScript.getScript("script2")).willReturn(script2);
+        when(extScript.invokeScript(CHAIN_SCRIPT)).thenThrow(new RuntimeException("chain failed"));
+        parameters.setChain(List.of("script1", "script2"));
+        parameters.setFailureLevel(failureLevel);
+
+        // When
+        action.runJob(JOB_NAME, env, progress);
+
+        // Then
+        assertThat(progress.getErrors(), hasSize(errors));
+        assertThat(progress.getWarnings(), hasSize(warnings));
+        assertThat(progress.getInfos(), hasSize(infos));
+        List<String> target =
+                errors > 0
+                        ? progress.getErrors()
+                        : warnings > 0 ? progress.getWarnings() : progress.getInfos();
+        assertThat(target, hasItem(containsString("chain failed")));
     }
 
     private static final class ScriptWrapperWithZestDiagnostic extends ScriptWrapper


### PR DESCRIPTION
## Overview
Adds a failureLevel parameter (info, warning, error) to the script job's run action, controlling which AF progress level is used when a script or chain execution fails. When omitted, behaviour is unchanged — failures are reported as errors. This allows plans to continue (or report non-critically) when a script failure is expected or non-blocking.

