### PR TITLE
pscanrules: remove OWASP tags from modern rule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update dependency.
 - Updated a reference link for the Sub Resource Integrity Attribute Missing scan rule.
 - Remove reference link which is no longer available for the Script Served From Malicious Domain (polyfill) scan rule.
+- Remove OWASP Top 10 Security Misconfiguration tags from the Modern Web Application scan rule, it only informs about the likely type of the website.
 
 ## [73] - 2026-04-14
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java
@@ -44,12 +44,7 @@ public class ModernAppDetectionScanRule extends PluginPassiveScanner
 
     static {
         Map<String, String> alertTags =
-                new HashMap<>(
-                        CommonAlertTag.toMap(
-                                CommonAlertTag.OWASP_2025_A02_SEC_MISCONFIG,
-                                CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG,
-                                CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG,
-                                CommonAlertTag.SYSTEMIC));
+                new HashMap<>(CommonAlertTag.toMap(CommonAlertTag.SYSTEMIC));
         alertTags.put(PolicyTag.PENTEST.getTag(), "");
         alertTags.put(PolicyTag.DEV_STD.getTag(), "");
         alertTags.put(PolicyTag.QA_STD.getTag(), "");

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -359,7 +359,7 @@ Alert ID: <a href="https://www.zaproxy.org/docs/alerts/10040/">10040</a>.
 
 <H2 id="id-10109">Modern Web Application</H2>
 This raises an informational alert if a site appears to be a modern web application.<br>
-It does not indicate any potential vulnerabilities but it could indicate that the ajax spider might be more effective at exploring this site compared to the traditional spider.
+It does not indicate any potential vulnerabilities but it could indicate that the modern spider might be more effective at exploring this site compared to the traditional spider.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRule.java">ModernAppDetectionScanRule.java</a>
 <br>

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ModernAppDetectionScanRuleUnitTest.java
@@ -179,29 +179,11 @@ class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDet
         // Given / When
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(tags.size(), is(equalTo(7)));
-        assertThat(
-                tags.containsKey(CommonAlertTag.OWASP_2025_A02_SEC_MISCONFIG.getTag()),
-                is(equalTo(true)));
-        assertThat(
-                tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),
-                is(equalTo(true)));
-        assertThat(
-                tags.containsKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
-                is(equalTo(true)));
+        assertThat(tags.size(), is(equalTo(4)));
         assertThat(tags.containsKey(CommonAlertTag.SYSTEMIC.getTag()), is(equalTo(true)));
         assertThat(tags.containsKey(PolicyTag.PENTEST.getTag()), is(equalTo(true)));
         assertThat(tags.containsKey(PolicyTag.DEV_STD.getTag()), is(equalTo(true)));
         assertThat(tags.containsKey(PolicyTag.QA_STD.getTag()), is(equalTo(true)));
-        assertThat(
-                tags.get(CommonAlertTag.OWASP_2025_A02_SEC_MISCONFIG.getTag()),
-                is(equalTo(CommonAlertTag.OWASP_2025_A02_SEC_MISCONFIG.getValue())));
-        assertThat(
-                tags.get(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),
-                is(equalTo(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getValue())));
-        assertThat(
-                tags.get(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
-                is(equalTo(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getValue())));
         assertThat(
                 tags.get(CommonAlertTag.SYSTEMIC.getTag()),
                 is(equalTo(CommonAlertTag.SYSTEMIC.getValue())));


### PR DESCRIPTION
The rule only informs about the likely type of the website not of any potential misconfigurations.