### PR TITLE
client: Add existingOnly option to not crawl new content

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Client Spider existingOnly option, e.g. for scan rules.
+ 
 ### Changed
 - Reduce duplicated accesses while crawling.
 - Use adaptive wait by default for page load and action waits while crawling.

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -71,6 +71,7 @@ import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.client.internal.ClientMapListener;
 import org.zaproxy.addon.client.internal.ClientNode;
+import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.ClientSideDetails;
 import org.zaproxy.addon.client.internal.graph.ClientGraphVertex;
 import org.zaproxy.addon.client.spider.ClientSpiderOptions.ScopeCheck;
@@ -293,14 +294,18 @@ public class ClientSpider implements GenericScanner2 {
                         new ClientSpiderThreadFactory(
                                 scanOptions.getThreadPrefix() + scanId + "-thread-"));
 
-        addTask(
-                targetUrl,
-                followGraphAction(targetUrl),
-                Constant.messages.getString("client.spider.panel.table.action.get"),
-                "");
+        if (scanOptions.isExistingOnly()) {
+            addExistingTasks(clientMap.getRoot());
+        } else {
+            addTask(
+                    targetUrl,
+                    followGraphAction(targetUrl),
+                    Constant.messages.getString("client.spider.panel.table.action.get"),
+                    "");
 
-        // Add all of the known but unvisited URLs otherwise these will get ignored
-        getUnvisitedUrls().forEach(this::addFollowGraphTask);
+            // Add all of the known but unvisited URLs otherwise these will get ignored
+            getUnvisitedUrls().forEach(this::addFollowGraphTask);
+        }
     }
 
     private List<SpiderAction> followGraphAction(String url, SpiderAction... additionalActions) {
@@ -357,6 +362,27 @@ public class ClientSpider implements GenericScanner2 {
         }
     }
 
+    private void addExistingTasks(ClientNode node) {
+        if (!node.isRoot()) {
+            ClientSideDetails details = node.getUserObject();
+            String nodeUrl = details.getUrl();
+            if (!node.isStorage()
+                    && (details.isVisited() || details.isContentLoaded())
+                    && isUrlInScope(nodeUrl)) {
+                addFollowGraphTask(nodeUrl);
+                for (ClientSideComponent component : details.getComponents()) {
+                    Map<String, String> data = component.getData();
+                    if (SubmitForm.isSupported(data)) {
+                        addSubmitTask(nodeUrl, data);
+                    }
+                }
+            }
+        }
+        for (int i = 0; i < node.getChildCount(); i++) {
+            addExistingTasks(node.getChildAt(i));
+        }
+    }
+
     public WebDriverProcess getWebDriverProcess() {
         WebDriverProcess wdp;
         synchronized (this.webDriverPool) {
@@ -380,6 +406,14 @@ public class ClientSpider implements GenericScanner2 {
             this.webDriverActive.remove(wdp);
             this.webDriverPool.add(wdp);
         }
+    }
+
+    private void addSubmitTask(String nodeUrl, Map<String, String> data) {
+        addTask(
+                nodeUrl,
+                followGraphAction(nodeUrl, new SubmitForm(valueProvider, createUri(nodeUrl), data)),
+                Constant.messages.getString("client.spider.panel.table.action.submit"),
+                paramsToString(data));
     }
 
     private ClientSpiderTask addTask(
@@ -508,6 +542,9 @@ public class ClientSpider implements GenericScanner2 {
 
         @Override
         public void nodeAdded(String url, int depth, int siblings, int source) {
+            if (scanOptions.isExistingOnly()) {
+                return;
+            }
             if (shouldIgnore(url, source, () -> depth, () -> siblings)) {
                 return;
             }
@@ -543,6 +580,9 @@ public class ClientSpider implements GenericScanner2 {
 
         @Override
         public void componentAdded(Map<String, String> parameters, int source) {
+            if (scanOptions.isExistingOnly()) {
+                return;
+            }
             String url = parameters.get(ClientMap.URL_KEY);
             if (shouldIgnore(
                     url,
@@ -566,12 +606,7 @@ public class ClientSpider implements GenericScanner2 {
                         paramsToString(parameters));
             } else if (SubmitForm.isSupported(parameters)) {
                 Stats.incCounter("stats.client.spider.event.component.form");
-                addTask(
-                        url,
-                        followGraphAction(
-                                url, new SubmitForm(valueProvider, createUri(url), parameters)),
-                        Constant.messages.getString("client.spider.panel.table.action.submit"),
-                        paramsToString(parameters));
+                addSubmitTask(url, parameters);
             }
         }
     }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ScanOptions.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ScanOptions.java
@@ -75,6 +75,13 @@ public class ScanOptions {
      */
     @Builder.Default private final List<String> excludeExtensions = Collections.emptyList();
 
+    /**
+     * When {@code true} the spider revisits all nodes already in the Client Map without discovering
+     * or queuing any new URLs or components. Use this when active scan rules need a live browser
+     * session for known pages without triggering further crawling.
+     */
+    @Builder.Default private final boolean existingOnly = false;
+
     /** A builder of options. */
     public static class Builder {
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -43,6 +44,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -88,6 +90,7 @@ import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.client.internal.ClientMapListener;
 import org.zaproxy.addon.client.internal.ClientNode;
+import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.ClientSideDetails;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.addon.commonlib.http.HttpFieldsNames;
@@ -863,6 +866,103 @@ class ClientSpiderUnitTest extends TestUtils {
             HttpMessageHandlerContext ctx,
             HttpMessage redirectMessage) {}
 
+    @Test
+    void shouldVisitVisitedAndContentLoadedNodesWhenExistingOnly() {
+        // Given
+        String visitedUrl = "https://www.example.com/visited";
+        String loadedUrl = "https://www.example.com/loaded";
+        String unvisitedUrl = "https://www.example.com/unvisited";
+
+        ClientNode root =
+                mockRootNode(
+                        mockClientNode(visitedUrl, false, true, false),
+                        mockClientNode(loadedUrl, false, false, true),
+                        mockClientNode(unvisitedUrl, false, false, false));
+        given(map.getRoot()).willReturn(root);
+        useExistingOnlySpider();
+
+        // When
+        spider.run();
+        sleep();
+
+        // Then
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+        verify(wd, atLeastOnce()).get(argument.capture());
+        assertThat(argument.getAllValues(), contains(visitedUrl, loadedUrl));
+    }
+
+    @Test
+    void shouldNotFollowNewUrlsDiscoveredDuringExistingOnlyScan() {
+        // Given
+        String existingUrl = "https://www.example.com/existing";
+        String newUrl = "https://www.example.com/new";
+
+        ClientNode root = mockRootNode(mockClientNode(existingUrl, false, true, false));
+        given(map.getRoot()).willReturn(root);
+        useExistingOnlySpider();
+        spider.run();
+        waitForProxy();
+
+        // When
+        clientMapListener().nodeAdded(newUrl, 0, 0, PROXY_PORT);
+        sleep();
+
+        // Then
+        verify(wd, never()).get(newUrl);
+    }
+
+    @Test
+    void shouldNotProcessComponentsDiscoveredDuringExistingOnlyScan() {
+        // Given
+        String existingUrl = "https://www.example.com/existing";
+
+        ClientNode root = mockRootNode(mockClientNode(existingUrl, false, true, false));
+        given(map.getRoot()).willReturn(root);
+        useExistingOnlySpider();
+        spider.run();
+        waitForProxy();
+
+        // When
+        clientMapListener()
+                .componentAdded(
+                        Map.of(
+                                ClientMap.URL_KEY,
+                                existingUrl,
+                                "tagName",
+                                "A",
+                                "text",
+                                "Some Link",
+                                "depth",
+                                "1"),
+                        PROXY_PORT);
+        sleep();
+
+        // Then
+        verify(wd, never()).findElement(any());
+    }
+
+    @Test
+    void shouldSubmitKnownFormComponentsWhenExistingOnly() {
+        // Given
+        String pageUrl = "https://www.example.com/form-page";
+
+        ClientNode pageNode = mockClientNode(pageUrl, false, true, false);
+        ClientSideComponent form = mockFormComponent(0);
+        ClientSideDetails pageDetails = pageNode.getUserObject();
+        given(pageDetails.getComponents()).willReturn(Set.of(form));
+
+        ClientNode root = mockRootNode(pageNode);
+        given(map.getRoot()).willReturn(root);
+        useExistingOnlySpider();
+
+        // When
+        spider.run();
+        sleep();
+
+        // Then - FollowGraph navigates to the page, then SubmitForm finds and submits the form
+        verify(wd).findElement(By.xpath("(//FORM)[1]"));
+    }
+
     class SpiderStatus {
         private boolean running;
         private boolean paused;
@@ -905,6 +1005,41 @@ class ClientSpiderUnitTest extends TestUtils {
 
     private static void mockChild(ClientNode parent, int index, ClientNode child) {
         given(parent.getChildAt(index)).willReturn(child);
+    }
+
+    private void useExistingOnlySpider() {
+        clearInvocations(map);
+        mapListener = null;
+        spider =
+                new ClientSpider(
+                        extClient,
+                        map,
+                        "",
+                        seedUrl,
+                        clientOptions,
+                        ScanOptions.builder()
+                                .setExistingOnly(true)
+                                .setExternalControl(true)
+                                .build(),
+                        mock(ValueProvider.class),
+                        1);
+    }
+
+    private static ClientNode mockRootNode(ClientNode... children) {
+        ClientNode root = mock(withSettings().strictness(Strictness.LENIENT));
+        given(root.isRoot()).willReturn(true);
+        given(root.getChildCount()).willReturn(children.length);
+        for (int i = 0; i < children.length; i++) {
+            given(root.getChildAt(i)).willReturn(children[i]);
+        }
+        return root;
+    }
+
+    private static ClientSideComponent mockFormComponent(int formId) {
+        ClientSideComponent component = mock(withSettings().strictness(Strictness.LENIENT));
+        given(component.getData())
+                .willReturn(Map.of("formId", String.valueOf(formId), "tagName", "FORM"));
+        return component;
     }
 
     private static void sleep() {


### PR DESCRIPTION
## Overview
- Client Spider existingOnly option, e.g. for scan rules.
