### PR TITLE
client: add spider's task context

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -307,12 +307,16 @@ public class ClientSpider implements GenericScanner2 {
         }
     }
 
+    TaskContext createTaskContext() {
+        return new TaskContext(getWebDriverProcess(), valueProvider, clientMap.getGraph());
+    }
+
     private List<SpiderAction> followGraphAction(String url, SpiderAction... additionalActions) {
         List<SpiderAction> actions = new ArrayList<>(5);
-        actions.add(new FollowGraph(clientMap.getGraph(), url, valueProvider));
+        actions.add(new FollowGraph(url));
         actions.add(
-                (ws, wd) -> {
-                    checkRedirect(url, wd);
+                context -> {
+                    checkRedirect(url, context.getWebDriver());
                     return true;
                 });
         if (additionalActions != null) {
@@ -381,7 +385,7 @@ public class ClientSpider implements GenericScanner2 {
         }
     }
 
-    public WebDriverProcess getWebDriverProcess() {
+    private WebDriverProcess getWebDriverProcess() {
         WebDriverProcess wdp;
         synchronized (this.webDriverPool) {
             if (!this.webDriverPool.isEmpty()) {
@@ -409,8 +413,7 @@ public class ClientSpider implements GenericScanner2 {
     private void addSubmitTask(String nodeUrl, ClientSideComponent component) {
         addTask(
                 nodeUrl,
-                followGraphAction(
-                        nodeUrl, new SubmitForm(valueProvider, createUri(nodeUrl), component)),
+                followGraphAction(nodeUrl, new SubmitForm(createUri(nodeUrl), component)),
                 Constant.messages.getString("client.spider.panel.table.action.submit"),
                 paramsToString(component));
     }
@@ -597,9 +600,7 @@ public class ClientSpider implements GenericScanner2 {
                 Stats.incCounter("stats.client.spider.event.component.click");
                 addTask(
                         url,
-                        followGraphAction(
-                                url,
-                                new ClickElement(valueProvider, createUri(url), component, false)),
+                        followGraphAction(url, new ClickElement(createUri(url), component, false)),
                         Constant.messages.getString("client.spider.panel.table.action.click"),
                         paramsToString(component));
             } else if (SubmitForm.isSupported(component)) {
@@ -962,7 +963,7 @@ public class ClientSpider implements GenericScanner2 {
     }
 
     @Getter
-    class WebDriverProcess {
+    public class WebDriverProcess {
 
         private static final String LOCAL_PROXY_IP = "127.0.0.1";
 

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderTask.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderTask.java
@@ -24,9 +24,7 @@ import java.util.Locale;
 import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.Constant;
-import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
 import org.zaproxy.zap.utils.Stats;
 
 public class ClientSpiderTask implements Runnable {
@@ -55,7 +53,7 @@ public class ClientSpiderTask implements Runnable {
     private List<SpiderAction> actions;
     @Getter private Status status;
     @Getter private String error;
-    private WebDriverProcess wdp;
+    private TaskContext context;
 
     public ClientSpiderTask(
             int id,
@@ -81,9 +79,9 @@ public class ClientSpiderTask implements Runnable {
     }
 
     void cleanup() {
-        if (wdp != null) {
-            clientSpider.returnWebDriverProcess(wdp);
-            wdp = null;
+        if (context != null) {
+            clientSpider.returnWebDriverProcess(context.getWebDriverProcess());
+            context = null;
         }
         clientSpider.postTaskExecution(this);
     }
@@ -108,13 +106,11 @@ public class ClientSpiderTask implements Runnable {
         this.status = Status.RUNNING;
         this.clientSpider.taskStateChange(this);
         try {
-            wdp = this.clientSpider.getWebDriverProcess();
-            WebDriver wd = wdp.getWebDriver();
-            ActionWaitStrategy waitStrategy = wdp.getWaitStrategy();
+            context = this.clientSpider.createTaskContext();
             startTime = System.currentTimeMillis();
             for (SpiderAction action : actions) {
-                action.run(waitStrategy, wd);
-                if (!waitStrategy.waitAfterAction()) {
+                action.run(context);
+                if (!context.getWaitStrategy().waitAfterAction()) {
                     break;
                 }
             }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/SpiderAction.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/SpiderAction.java
@@ -19,9 +19,7 @@
  */
 package org.zaproxy.addon.client.spider;
 
-import org.openqa.selenium.WebDriver;
-
 public interface SpiderAction {
 
-    boolean run(ActionWaitStrategy waitStrategy, WebDriver wd);
+    boolean run(TaskContext context);
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/TaskContext.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/TaskContext.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.client.spider;
+
+import lombok.Getter;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.openqa.selenium.WebDriver;
+import org.zaproxy.addon.client.internal.graph.ClientGraphVertex;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+import org.zaproxy.addon.commonlib.ValueProvider;
+
+@Getter
+public class TaskContext {
+
+    private final ActionWaitStrategy waitStrategy;
+    private final WebDriver webDriver;
+    private final ValueProvider valueProvider;
+    private final Graph<ClientGraphVertex, DefaultEdge> graph;
+    private final WebDriverProcess webDriverProcess;
+
+    public TaskContext(
+            WebDriverProcess webDriverProcess,
+            ValueProvider valueProvider,
+            Graph<ClientGraphVertex, DefaultEdge> graph) {
+        this.webDriverProcess = webDriverProcess;
+        this.waitStrategy = webDriverProcess.getWaitStrategy();
+        this.webDriver = webDriverProcess.getWebDriver();
+        this.valueProvider = valueProvider;
+        this.graph = graph;
+    }
+}

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
@@ -26,26 +26,20 @@ import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
-import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
-import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.client.spider.SpiderAction;
-import org.zaproxy.addon.commonlib.ValueProvider;
+import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.zap.utils.Stats;
 
 abstract class BaseElementAction implements SpiderAction {
 
     private static final Logger LOGGER = LogManager.getLogger(BaseElementAction.class);
 
-    private final ValueProvider valueProvider;
     private final URI uri;
     protected final ClientSideComponent component;
 
-    protected BaseElementAction(
-            ValueProvider valueProvider, URI uri, ClientSideComponent component) {
-        this.valueProvider = Objects.requireNonNull(valueProvider);
+    protected BaseElementAction(URI uri, ClientSideComponent component) {
         this.uri = Objects.requireNonNull(uri);
         this.component = Objects.requireNonNull(component);
     }
@@ -55,7 +49,7 @@ abstract class BaseElementAction implements SpiderAction {
     }
 
     @Override
-    public final boolean run(ActionWaitStrategy waitStrategy, WebDriver wd) {
+    public final boolean run(TaskContext context) {
         String statsPrefix = getStatsPrefix();
         Stats.incCounter(statsPrefix);
 
@@ -67,7 +61,7 @@ abstract class BaseElementAction implements SpiderAction {
 
         WebElement element;
         try {
-            element = wd.findElement(by);
+            element = context.getWebDriver().findElement(by);
         } catch (Exception e) {
             Stats.incCounter(statsPrefix + ".notfound");
             return false;
@@ -78,23 +72,21 @@ abstract class BaseElementAction implements SpiderAction {
             return false;
         }
 
-        return run(waitStrategy, wd, element, statsPrefix);
+        return run(context, element, statsPrefix);
     }
 
     protected abstract String getStatsPrefix();
 
-    protected abstract boolean run(
-            ActionWaitStrategy waitStrategy, WebDriver wd, WebElement element, String statsPrefix);
+    protected abstract boolean run(TaskContext context, WebElement element, String statsPrefix);
 
-    protected void fillComponents(SearchContext context, String action, String statsPrefix) {
-        fillInputs(context.findElements(By.xpath("//input | //textarea")), action, statsPrefix);
+    protected void fillComponents(TaskContext context, String action, String statsPrefix) {
+        context.getWebDriver()
+                .findElements(By.xpath("//input | //textarea"))
+                .forEach(input -> fillInput(context, input, action, statsPrefix));
     }
 
-    protected void fillInputs(List<WebElement> inputs, String action, String statsPrefix) {
-        inputs.forEach(input -> fillInput(input, action, statsPrefix));
-    }
-
-    protected void fillInput(WebElement input, String action, String statsPrefix) {
+    protected void fillInput(
+            TaskContext context, WebElement input, String action, String statsPrefix) {
         if (!input.isDisplayed()) {
             Stats.incCounter(statsPrefix + ".input.notdisplayed");
             return;
@@ -115,14 +107,15 @@ abstract class BaseElementAction implements SpiderAction {
         }
 
         String value =
-                valueProvider.getValue(
-                        uri,
-                        action,
-                        getAttribute(input, "name"),
-                        getAttribute(input, "value"),
-                        List.of(),
-                        Map.of(),
-                        Map.of("Control Type", controlType, "type", type));
+                context.getValueProvider()
+                        .getValue(
+                                uri,
+                                action,
+                                getAttribute(input, "name"),
+                                getAttribute(input, "value"),
+                                List.of(),
+                                Map.of(),
+                                Map.of("Control Type", controlType, "type", type));
 
         try {
             input.clear();
@@ -144,9 +137,5 @@ abstract class BaseElementAction implements SpiderAction {
 
     private static String getControlType(String type) {
         return !"password".equalsIgnoreCase(type) && !"file".equalsIgnoreCase(type) ? "text" : type;
-    }
-
-    protected static String getTagName(Map<String, String> data) {
-        return data.get("tagName");
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/ClickElement.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/ClickElement.java
@@ -23,12 +23,10 @@ import java.util.function.Predicate;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.InteractableState;
-import org.zaproxy.addon.client.spider.ActionWaitStrategy;
-import org.zaproxy.addon.commonlib.ValueProvider;
+import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.zap.utils.Stats;
 
 public class ClickElement extends BaseElementAction {
@@ -39,18 +37,16 @@ public class ClickElement extends BaseElementAction {
 
     private final boolean passive;
 
-    public ClickElement(
-            ValueProvider valueProvider, URI uri, ClientSideComponent component, boolean passive) {
-        super(valueProvider, uri, component);
+    public ClickElement(URI uri, ClientSideComponent component, boolean passive) {
+        super(uri, component);
 
         this.passive = passive;
     }
 
     @Override
-    public boolean run(
-            ActionWaitStrategy waitStrategy, WebDriver wd, WebElement element, String statsPrefix) {
+    public boolean run(TaskContext context, WebElement element, String statsPrefix) {
         if (!passive) {
-            fillComponents(wd, getUri().toString(), statsPrefix);
+            fillComponents(context, getUri().toString(), statsPrefix);
         }
 
         try {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/FollowGraph.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/FollowGraph.java
@@ -26,16 +26,13 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jgrapht.Graph;
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.shortestpath.BFSShortestPath;
 import org.jgrapht.graph.DefaultEdge;
-import org.openqa.selenium.WebDriver;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.graph.ClientGraphVertex;
-import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.client.spider.SpiderAction;
-import org.zaproxy.addon.commonlib.ValueProvider;
+import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.zap.utils.Stats;
 
 public class FollowGraph implements SpiderAction {
@@ -44,58 +41,51 @@ public class FollowGraph implements SpiderAction {
 
     private static final String STATS_PREFIX = "stats.client.spider.action.follow";
 
-    private final Graph<ClientGraphVertex, DefaultEdge> graph;
     private final String targetUrl;
-    private final ValueProvider valueProvider;
 
-    public FollowGraph(
-            Graph<ClientGraphVertex, DefaultEdge> graph,
-            String targetUrl,
-            ValueProvider valueProvider) {
-        this.graph = Objects.requireNonNull(graph);
+    public FollowGraph(String targetUrl) {
         this.targetUrl = Objects.requireNonNull(targetUrl);
-        this.valueProvider = Objects.requireNonNull(valueProvider);
     }
 
     @Override
-    public boolean run(ActionWaitStrategy waitStrategy, WebDriver wd) {
+    public boolean run(TaskContext context) {
         Stats.incCounter(STATS_PREFIX);
 
-        String currentUrl = wd.getCurrentUrl();
+        String currentUrl = context.getWebDriver().getCurrentUrl();
         if (targetUrl.equals(currentUrl) || targetUrl.equals(currentUrl + "#")) {
             Stats.incCounter(STATS_PREFIX + ".current");
             return true;
         }
 
-        if (followPath(waitStrategy, wd, currentUrl, targetUrl)) {
+        if (followPath(context, currentUrl, targetUrl)) {
             Stats.incCounter(STATS_PREFIX + ".path");
             return true;
         }
 
         Stats.incCounter(STATS_PREFIX + ".fallback");
         LOGGER.debug("No graph path to {}, falling back to direct navigation", targetUrl);
-        wd.get(targetUrl);
-        return waitStrategy.waitAfterPageLoad(targetUrl);
+        context.getWebDriver().get(targetUrl);
+        return context.getWaitStrategy().waitAfterPageLoad(targetUrl);
     }
 
-    private boolean followPath(
-            ActionWaitStrategy waitStrategy, WebDriver wd, String fromUrl, String toUrl) {
+    private boolean followPath(TaskContext context, String fromUrl, String toUrl) {
         ClientGraphVertex source = new ClientGraphVertex.Url(fromUrl);
         ClientGraphVertex target = new ClientGraphVertex.Url(toUrl);
 
         GraphPath<ClientGraphVertex, DefaultEdge> path;
-        synchronized (graph) {
-            if (!graph.containsVertex(source) || !graph.containsVertex(target)) {
+        synchronized (context.getGraph()) {
+            if (!context.getGraph().containsVertex(source)
+                    || !context.getGraph().containsVertex(target)) {
                 return false;
             }
-            path = BFSShortestPath.findPathBetween(graph, source, target);
+            path = BFSShortestPath.findPathBetween(context.getGraph(), source, target);
         }
 
         if (path == null) {
             return false;
         }
 
-        BooleanSupplier waitAction = new WaitAction(waitStrategy);
+        BooleanSupplier waitAction = new WaitAction(context);
         List<ClientGraphVertex> vertices = path.getVertexList();
         for (ClientGraphVertex vertex : vertices) {
             if (vertex instanceof ClientGraphVertex.Component componentVertex) {
@@ -106,8 +96,7 @@ public class FollowGraph implements SpiderAction {
                 ClientSideComponent component = componentVertex.component();
                 try {
                     URI uri = new URI(component.getParentUrl(), true);
-                    if (!new FollowClickElement(valueProvider, uri, component)
-                            .run(waitStrategy, wd)) {
+                    if (!new FollowClickElement(uri, component).run(context)) {
                         return false;
                     }
                 } catch (URIException e) {
@@ -116,16 +105,15 @@ public class FollowGraph implements SpiderAction {
                 }
             }
         }
-        return waitStrategy.waitAfterPageLoad(toUrl);
+        return context.getWaitStrategy().waitAfterPageLoad(toUrl);
     }
 
     private static class FollowClickElement extends ClickElement {
 
         private static final String STATS_PREFIX = FollowGraph.STATS_PREFIX + ".click";
 
-        public FollowClickElement(
-                ValueProvider valueProvider, URI uri, ClientSideComponent component) {
-            super(valueProvider, uri, component, true);
+        public FollowClickElement(URI uri, ClientSideComponent component) {
+            super(uri, component, true);
         }
 
         @Override
@@ -136,11 +124,11 @@ public class FollowGraph implements SpiderAction {
 
     private static class WaitAction implements BooleanSupplier {
 
-        private final ActionWaitStrategy waitStrategy;
+        private final TaskContext context;
         private boolean first;
 
-        WaitAction(ActionWaitStrategy waitStrategy) {
-            this.waitStrategy = waitStrategy;
+        WaitAction(TaskContext context) {
+            this.context = context;
             first = true;
         }
 
@@ -151,7 +139,7 @@ public class FollowGraph implements SpiderAction {
                 return false;
             }
 
-            return !waitStrategy.waitAfterAction();
+            return !context.getWaitStrategy().waitAfterAction();
         }
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/SubmitForm.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/SubmitForm.java
@@ -22,11 +22,9 @@ package org.zaproxy.addon.client.spider.actions;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
-import org.zaproxy.addon.client.spider.ActionWaitStrategy;
-import org.zaproxy.addon.commonlib.ValueProvider;
+import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.zap.utils.Stats;
 
 public class SubmitForm extends BaseElementAction {
@@ -37,16 +35,15 @@ public class SubmitForm extends BaseElementAction {
 
     private final int formIndex;
 
-    public SubmitForm(ValueProvider valueProvider, URI uri, ClientSideComponent component) {
-        super(valueProvider, uri, component);
+    public SubmitForm(URI uri, ClientSideComponent component) {
+        super(uri, component);
         this.formIndex = component.getFormId();
     }
 
     @Override
-    public boolean run(
-            ActionWaitStrategy waitStrategy, WebDriver wd, WebElement form, String statsPrefix) {
+    public boolean run(TaskContext context, WebElement form, String statsPrefix) {
         String action = form.getDomAttribute("action");
-        fillComponents(wd, action, statsPrefix);
+        fillComponents(context, action, statsPrefix);
 
         try {
             form.submit();

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderTaskUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderTaskUnitTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.WebDriver;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
 import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
 import org.zaproxy.addon.client.spider.ClientSpiderTask.Status;
@@ -42,9 +41,8 @@ import org.zaproxy.zap.testutils.TestUtils;
 class ClientSpiderTaskUnitTest extends TestUtils {
 
     private ClientSpider clientSpider;
-    private WebDriverProcess wdp;
-    private WebDriver wd;
     private ActionWaitStrategy waitStrategy;
+    private TaskContext context;
 
     @BeforeAll
     static void setUpAll() {
@@ -54,16 +52,15 @@ class ClientSpiderTaskUnitTest extends TestUtils {
     @BeforeEach
     void setUp() {
         clientSpider = mock(ClientSpider.class);
-        wdp = mock(WebDriverProcess.class);
-        wd = mock(WebDriver.class);
 
         given(clientSpider.isStopped()).willReturn(false);
         given(clientSpider.isPaused()).willReturn(false);
-        given(clientSpider.getWebDriverProcess()).willReturn(wdp);
-        given(wdp.getWebDriver()).willReturn(wd);
         waitStrategy = mock();
         given(waitStrategy.waitAfterAction()).willReturn(true);
+        WebDriverProcess wdp = mock(WebDriverProcess.class);
         given(wdp.getWaitStrategy()).willReturn(waitStrategy);
+        context = new TaskContext(wdp, null, null);
+        given(clientSpider.createTaskContext()).willReturn(context);
     }
 
     @Test
@@ -76,7 +73,7 @@ class ClientSpiderTaskUnitTest extends TestUtils {
         task.run();
 
         // Then
-        verify(action).run(waitStrategy, wd);
+        verify(action).run(context);
         assertThat(task.getStatus(), is(Status.FINISHED));
     }
 
@@ -84,8 +81,7 @@ class ClientSpiderTaskUnitTest extends TestUtils {
     void shouldRunAllActionsInOrder() {
         // Given
         List<String> ran = new ArrayList<>();
-        List<SpiderAction> actions =
-                List.of((ws, w) -> ran.add("first"), (ws, w) -> ran.add("second"));
+        List<SpiderAction> actions = List.of(ctx -> ran.add("first"), ctx -> ran.add("second"));
         ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, "test", "");
 
         // When
@@ -99,7 +95,7 @@ class ClientSpiderTaskUnitTest extends TestUtils {
     @Test
     void shouldWaitAfterEachAction() {
         // Given
-        List<SpiderAction> actions = List.of((ws, w) -> true, (ws, w) -> true);
+        List<SpiderAction> actions = List.of(ctx -> true, ctx -> true);
         ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, "test", "");
 
         // When
@@ -114,7 +110,7 @@ class ClientSpiderTaskUnitTest extends TestUtils {
     void shouldStopRunningActionsWhenWaitStrategyReturnsFalse() {
         // Given
         given(waitStrategy.waitAfterAction()).willReturn(false);
-        List<SpiderAction> actions = List.of((ws, w) -> true, (ws, w) -> true);
+        List<SpiderAction> actions = List.of(ctx -> true, ctx -> true);
         ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, "test", "");
 
         // When

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.client.spider.actions;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -38,7 +39,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
-import org.zaproxy.addon.client.spider.ActionWaitStrategy;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.addon.commonlib.ValueProvider;
 
 /** Unit test for {@link BaseElementAction}. */
@@ -55,14 +57,11 @@ class BaseElementActionUnitTest {
         ClientSideComponent component = mock();
 
         action =
-                new BaseElementAction(valueProvider, uri, component) {
+                new BaseElementAction(uri, component) {
 
                     @Override
                     protected boolean run(
-                            ActionWaitStrategy waitStrategy,
-                            WebDriver wd,
-                            WebElement element,
-                            String statsPrefix) {
+                            TaskContext context, WebElement element, String statsPrefix) {
                         return true;
                     }
 
@@ -86,11 +85,11 @@ class BaseElementActionUnitTest {
         // Given
         String name = "input-name";
         String value = "input-value";
-        List<WebElement> inputElements = List.of(new TestWebElement("input", type, name, value));
+        TaskContext context = context(List.of(new TestWebElement("input", type, name, value)));
         String formAction = "formaction";
 
         // When
-        action.fillInputs(inputElements, formAction, "statsprefix");
+        action.fillComponents(context, formAction, "statsprefix");
 
         // Then
         verify(valueProvider)
@@ -108,11 +107,11 @@ class BaseElementActionUnitTest {
     @CsvSource({"textarea-name, textarea-value"})
     void shouldCallValueProviderWithExpectedValuesForTextArea(String name, String value) {
         // Given
-        List<WebElement> elements = List.of(new TestWebElement("textarea", null, name, value));
+        TaskContext context = context(List.of(new TestWebElement("textarea", null, name, value)));
         String formAction = "formaction";
 
         // When
-        action.fillInputs(elements, formAction, "statsprefix");
+        action.fillComponents(context, formAction, "statsprefix");
 
         // Then
         verify(valueProvider)
@@ -124,6 +123,14 @@ class BaseElementActionUnitTest {
                         List.of(),
                         Map.of(),
                         Map.of("Control Type", "text", "type", "textarea"));
+    }
+
+    private TaskContext context(List<WebElement> elements) {
+        WebDriverProcess wdp = mock(WebDriverProcess.class);
+        WebDriver wd = mock(WebDriver.class);
+        given(wd.findElements(By.xpath("//input | //textarea"))).willReturn(elements);
+        given(wdp.getWebDriver()).willReturn(wd);
+        return new TaskContext(wdp, valueProvider, null);
     }
 
     class TestWebElement implements WebElement {

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
@@ -55,6 +55,8 @@ import org.zaproxy.addon.client.internal.ClientSideComponent.Type;
 import org.zaproxy.addon.client.internal.ElementLocator;
 import org.zaproxy.addon.client.internal.InteractableState;
 import org.zaproxy.addon.client.spider.ActionWaitStrategy;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.utils.Stats;
@@ -83,23 +85,21 @@ class ClickElementUnitTest {
 
     @Test
     void shouldThrowIfComponentIsNull() {
-        assertThrows(
-                NullPointerException.class,
-                () -> new ClickElement(valueProvider, uri, null, false));
+        assertThrows(NullPointerException.class, () -> new ClickElement(uri, null, false));
     }
 
     @Test
     void shouldClickElementOnRun() {
         // Given
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
-        ClickElement action = new ClickElement(valueProvider, uri, component, false);
+        ClickElement action = new ClickElement(uri, component, false);
         WebDriver wd = mock(WebDriver.class);
         WebElement element = visibleElement();
         given(wd.findElement(By.id("btn"))).willReturn(element);
         given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -112,7 +112,7 @@ class ClickElementUnitTest {
     void shouldFillInputsAndTextAreasBeforeClicking() {
         // Given
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
-        ClickElement action = new ClickElement(valueProvider, uri, component, false);
+        ClickElement action = new ClickElement(uri, component, false);
         WebDriver wd = mock(WebDriver.class);
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
@@ -128,7 +128,7 @@ class ClickElementUnitTest {
                 .willReturn("value3");
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -145,7 +145,7 @@ class ClickElementUnitTest {
     void shouldNotFillInputsBeforeClickingWhenPassive() {
         // Given
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
-        ClickElement action = new ClickElement(valueProvider, uri, component, true);
+        ClickElement action = new ClickElement(uri, component, true);
         WebDriver wd = mock(WebDriver.class);
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
@@ -155,7 +155,7 @@ class ClickElementUnitTest {
         given(wd.findElements(any(By.class))).willReturn(List.of(input1, input2, textarea));
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -168,7 +168,7 @@ class ClickElementUnitTest {
     void shouldHandleClickExceptionGracefully() {
         // Given
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
-        ClickElement action = new ClickElement(valueProvider, uri, component, false);
+        ClickElement action = new ClickElement(uri, component, false);
         WebDriver wd = mock(WebDriver.class);
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
@@ -176,7 +176,7 @@ class ClickElementUnitTest {
         willThrow(RuntimeException.class).given(element).click();
 
         // When / Then
-        boolean result = assertDoesNotThrow(() -> action.run(waitStrategy, wd));
+        boolean result = assertDoesNotThrow(() -> action.run(context(wd)));
         assertThat(result, is(equalTo(false)));
         assertThat(stats.getStat("stats.client.spider.action.click.tag.A"), is(1L));
         assertThat(stats.getStat("stats.client.spider.action.click.tag.A.exception"), is(1L));
@@ -186,12 +186,12 @@ class ClickElementUnitTest {
     void shouldIncrementStatsWhenElementNotFound() {
         // Given
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
-        ClickElement action = new ClickElement(valueProvider, uri, component, false);
+        ClickElement action = new ClickElement(uri, component, false);
         WebDriver wd = mock(WebDriver.class);
         given(wd.findElement(any(By.class))).willThrow(RuntimeException.class);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -203,14 +203,14 @@ class ClickElementUnitTest {
     void shouldIncrementStatsWhenElementNotDisplayed() {
         // Given
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
-        ClickElement action = new ClickElement(valueProvider, uri, component, false);
+        ClickElement action = new ClickElement(uri, component, false);
         WebDriver wd = mock(WebDriver.class);
         WebElement element = mock(WebElement.class);
         given(wd.findElement(any(By.class))).willReturn(element);
         given(element.isDisplayed()).willReturn(false);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -222,11 +222,11 @@ class ClickElementUnitTest {
     void shouldYieldNoByWhenNoElementLocator() {
         // Given
         ClientSideComponent component = component("A", null);
-        ClickElement action = new ClickElement(valueProvider, uri, component, false);
+        ClickElement action = new ClickElement(uri, component, false);
         WebDriver wd = mock(WebDriver.class);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -315,6 +315,13 @@ class ClickElementUnitTest {
         ClientSideComponent c = component(tagName, tagType);
         c.setInteractable(interactable);
         return c;
+    }
+
+    private TaskContext context(WebDriver wd) {
+        WebDriverProcess wdp = mock(WebDriverProcess.class);
+        given(wdp.getWaitStrategy()).willReturn(waitStrategy);
+        given(wdp.getWebDriver()).willReturn(wd);
+        return new TaskContext(wdp, valueProvider, null);
     }
 
     private static ClientSideComponent componentWithLocator(

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
@@ -50,6 +50,8 @@ import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.ElementLocator;
 import org.zaproxy.addon.client.internal.graph.ClientGraphVertex;
 import org.zaproxy.addon.client.spider.ActionWaitStrategy;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -66,6 +68,7 @@ class FollowGraphUnitTest extends TestUtils {
     private Graph<ClientGraphVertex, DefaultEdge> graph;
     private ValueProvider valueProvider;
     private ActionWaitStrategy waitStrategy;
+    private TaskContext context;
     private InMemoryStats stats;
 
     @BeforeAll
@@ -81,6 +84,10 @@ class FollowGraphUnitTest extends TestUtils {
         waitStrategy = mock(withSettings().strictness(Strictness.LENIENT));
         given(waitStrategy.waitAfterPageLoad(any())).willReturn(true);
         given(waitStrategy.waitAfterAction()).willReturn(true);
+        WebDriverProcess wdp = mock(withSettings().strictness(Strictness.LENIENT));
+        given(wdp.getWaitStrategy()).willReturn(waitStrategy);
+        given(wdp.getWebDriver()).willReturn(wd);
+        context = new TaskContext(wdp, valueProvider, graph);
         stats = new InMemoryStats();
         Stats.addListener(stats);
     }
@@ -94,10 +101,10 @@ class FollowGraphUnitTest extends TestUtils {
     void shouldDoNothingWhenAlreadyAtTarget() {
         // Given
         given(wd.getCurrentUrl()).willReturn(URL_A);
-        FollowGraph action = new FollowGraph(graph, URL_A, valueProvider);
+        FollowGraph action = new FollowGraph(URL_A);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context);
 
         // Then
         assertCommonState(wd, result);
@@ -110,10 +117,10 @@ class FollowGraphUnitTest extends TestUtils {
     void shouldDoNothingWhenAlreadyAtTargetWithEmptyFragment() {
         // Given
         given(wd.getCurrentUrl()).willReturn(URL_A);
-        FollowGraph action = new FollowGraph(graph, URL_A + "#", valueProvider);
+        FollowGraph action = new FollowGraph(URL_A + "#");
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context);
 
         // Then
         assertCommonState(wd, result);
@@ -132,10 +139,10 @@ class FollowGraphUnitTest extends TestUtils {
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
 
-        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider);
+        FollowGraph action = new FollowGraph(URL_B);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context);
 
         // Then
         assertCommonState(wd, result);
@@ -156,10 +163,10 @@ class FollowGraphUnitTest extends TestUtils {
 
         given(wd.getCurrentUrl()).willReturn(URL_A);
 
-        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider);
+        FollowGraph action = new FollowGraph(URL_B);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context);
 
         // Then
         assertCommonState(wd, result);
@@ -181,10 +188,10 @@ class FollowGraphUnitTest extends TestUtils {
         WebElement element = visibleElement();
         given(wd.findElement(any())).willReturn(element);
 
-        FollowGraph action = new FollowGraph(graph, URL_C, valueProvider);
+        FollowGraph action = new FollowGraph(URL_C);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context);
 
         // Then
         assertCommonState(wd, result);
@@ -211,10 +218,10 @@ class FollowGraphUnitTest extends TestUtils {
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
 
-        FollowGraph action = new FollowGraph(graph, urlD, valueProvider);
+        FollowGraph action = new FollowGraph(urlD);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context);
 
         // Then
         assertCommonState(wd, result);
@@ -234,10 +241,10 @@ class FollowGraphUnitTest extends TestUtils {
 
         willThrow(RuntimeException.class).given(element).click();
 
-        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider);
+        FollowGraph action = new FollowGraph(URL_B);
 
         // When / Then
-        boolean result = assertDoesNotThrow(() -> action.run(waitStrategy, wd));
+        boolean result = assertDoesNotThrow(() -> action.run(context));
         assertCommonState(wd, result);
         assertThat(stats.getStat("stats.client.spider.action.follow"), is(1L));
     }
@@ -247,10 +254,10 @@ class FollowGraphUnitTest extends TestUtils {
         // Given
         given(wd.getCurrentUrl()).willReturn(URL_A);
 
-        FollowGraph action = new FollowGraph(graph, URL_B, valueProvider);
+        FollowGraph action = new FollowGraph(URL_B);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context);
 
         // Then
         assertCommonState(wd, result);

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
@@ -53,6 +53,8 @@ import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.ClientSideComponent.Type;
 import org.zaproxy.addon.client.internal.ElementLocator;
 import org.zaproxy.addon.client.spider.ActionWaitStrategy;
+import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
+import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.addon.commonlib.ValueProvider;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.utils.Stats;
@@ -81,21 +83,21 @@ class SubmitFormUnitTest {
 
     @Test
     void shouldThrowIfComponentIsNull() {
-        assertThrows(NullPointerException.class, () -> new SubmitForm(valueProvider, uri, null));
+        assertThrows(NullPointerException.class, () -> new SubmitForm(uri, null));
     }
 
     @Test
     void shouldSubmitFormOnRun() {
         // Given
         ClientSideComponent component = formComponent(0, "xpath", "//FORM");
-        SubmitForm action = new SubmitForm(valueProvider, uri, component);
+        SubmitForm action = new SubmitForm(uri, component);
         WebDriver wd = mock(WebDriver.class);
         WebElement form = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(form);
         given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -107,7 +109,7 @@ class SubmitFormUnitTest {
     void shouldFillInputsAndTextAreasFromFormBeforeSubmitting() {
         // Given
         ClientSideComponent component = formComponent(0, "xpath", "//FORM");
-        SubmitForm action = new SubmitForm(valueProvider, uri, component);
+        SubmitForm action = new SubmitForm(uri, component);
         WebDriver wd = mock(WebDriver.class);
         WebElement form = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(form);
@@ -123,7 +125,7 @@ class SubmitFormUnitTest {
                 .willReturn("value3");
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -140,7 +142,7 @@ class SubmitFormUnitTest {
     void shouldHandleSubmitExceptionGracefully() {
         // Given
         ClientSideComponent component = formComponent(0, "xpath", "//FORM");
-        SubmitForm action = new SubmitForm(valueProvider, uri, component);
+        SubmitForm action = new SubmitForm(uri, component);
         WebDriver wd = mock(WebDriver.class);
         WebElement form = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(form);
@@ -148,7 +150,7 @@ class SubmitFormUnitTest {
         willThrow(RuntimeException.class).given(form).submit();
 
         // When / Then
-        boolean result = assertDoesNotThrow(() -> action.run(waitStrategy, wd));
+        boolean result = assertDoesNotThrow(() -> action.run(context(wd)));
         assertThat(result, is(equalTo(false)));
         assertThat(stats.getStat("stats.client.spider.action.form.0"), is(1L));
         assertThat(stats.getStat("stats.client.spider.action.form.0.exception"), is(1L));
@@ -158,12 +160,12 @@ class SubmitFormUnitTest {
     void shouldIncrementStatsWhenFormNotFound() {
         // Given
         ClientSideComponent component = formComponent(0, "xpath", "//FORM");
-        SubmitForm action = new SubmitForm(valueProvider, uri, component);
+        SubmitForm action = new SubmitForm(uri, component);
         WebDriver wd = mock(WebDriver.class);
         given(wd.findElement(any(By.class))).willThrow(RuntimeException.class);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -175,14 +177,14 @@ class SubmitFormUnitTest {
     void shouldIncrementStatsWhenFormNotDisplayed() {
         // Given
         ClientSideComponent component = formComponent(0, "xpath", "//FORM");
-        SubmitForm action = new SubmitForm(valueProvider, uri, component);
+        SubmitForm action = new SubmitForm(uri, component);
         WebDriver wd = mock(WebDriver.class);
         WebElement form = mock(WebElement.class);
         given(wd.findElement(any(By.class))).willReturn(form);
         given(form.isDisplayed()).willReturn(false);
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(false)));
@@ -194,7 +196,7 @@ class SubmitFormUnitTest {
     void shouldUseByFromElementLocator() {
         // Given
         ClientSideComponent component = formComponent(1, "xpath", "(//FORM)[2]");
-        SubmitForm action = new SubmitForm(valueProvider, uri, component);
+        SubmitForm action = new SubmitForm(uri, component);
         WebDriver wd = mock(WebDriver.class);
         WebElement visibleForm = visibleElement();
         ArgumentCaptor<By> byCaptor = ArgumentCaptor.forClass(By.class);
@@ -202,7 +204,7 @@ class SubmitFormUnitTest {
         given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
-        boolean result = action.run(waitStrategy, wd);
+        boolean result = action.run(context(wd));
 
         // Then
         assertThat(result, is(equalTo(true)));
@@ -226,6 +228,13 @@ class SubmitFormUnitTest {
                 arguments(componentForTag("FORM", Type.FORM, 1), true),
                 arguments(componentForTag("DIV", Type.BUTTON, 0), false),
                 arguments(componentForTag("A", Type.LINK, 0), false));
+    }
+
+    private TaskContext context(WebDriver wd) {
+        WebDriverProcess wdp = mock(WebDriverProcess.class);
+        given(wdp.getWaitStrategy()).willReturn(waitStrategy);
+        given(wdp.getWebDriver()).willReturn(wd);
+        return new TaskContext(wdp, valueProvider, null);
     }
 
     private static ClientSideComponent formComponent(


### PR DESCRIPTION
Introduce an object to hold the data necessary for the spider tasks to reduce the number of objects that need to be passed around.