### PR TITLE
client: fill text areas when crawling

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Use new functionality from the browser extension for crawling.
+- Fill text areas while crawling.
 
 ## [0.28.0] - 2026-06-26
 ### Added

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
@@ -26,6 +26,7 @@ import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
@@ -85,6 +86,10 @@ abstract class BaseElementAction implements SpiderAction {
     protected abstract boolean run(
             ActionWaitStrategy waitStrategy, WebDriver wd, WebElement element, String statsPrefix);
 
+    protected void fillComponents(SearchContext context, String action, String statsPrefix) {
+        fillInputs(context.findElements(By.xpath("//input | //textarea")), action, statsPrefix);
+    }
+
     protected void fillInputs(List<WebElement> inputs, String action, String statsPrefix) {
         inputs.forEach(input -> fillInput(input, action, statsPrefix));
     }
@@ -95,10 +100,18 @@ abstract class BaseElementAction implements SpiderAction {
             return;
         }
 
-        String type = getAttribute(input, "type");
-        if (type == null) {
-            Stats.incCounter(statsPrefix + ".input.notype");
-            return;
+        String type;
+        String controlType;
+        if ("textarea".equalsIgnoreCase(input.getTagName())) {
+            type = "textarea";
+            controlType = "text";
+        } else {
+            type = getAttribute(input, "type");
+            if (type == null) {
+                Stats.incCounter(statsPrefix + ".input.notype");
+                return;
+            }
+            controlType = getControlType(type);
         }
 
         String value =
@@ -109,7 +122,7 @@ abstract class BaseElementAction implements SpiderAction {
                         getAttribute(input, "value"),
                         List.of(),
                         Map.of(),
-                        Map.of("Control Type", getControlType(type), "type", type));
+                        Map.of("Control Type", controlType, "type", type));
 
         try {
             input.clear();

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/ClickElement.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/ClickElement.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
@@ -50,7 +49,7 @@ public class ClickElement extends BaseElementAction {
     public boolean run(
             ActionWaitStrategy waitStrategy, WebDriver wd, WebElement element, String statsPrefix) {
         if (!passive) {
-            fillInputs(wd.findElements(By.xpath("//input")), getUri().toString(), statsPrefix);
+            fillComponents(wd, getUri().toString(), statsPrefix);
         }
 
         try {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/SubmitForm.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/SubmitForm.java
@@ -22,7 +22,6 @@ package org.zaproxy.addon.client.spider.actions;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
@@ -47,7 +46,7 @@ public class SubmitForm extends BaseElementAction {
     public boolean run(
             ActionWaitStrategy waitStrategy, WebDriver wd, WebElement form, String statsPrefix) {
         String action = form.getDomAttribute("action");
-        fillInputs(form.findElements(By.xpath("//input")), action, statsPrefix);
+        fillComponents(wd, action, statsPrefix);
 
         try {
             form.submit();

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
@@ -104,6 +104,28 @@ class BaseElementActionUnitTest {
                         Map.of("Control Type", controlType, "type", type));
     }
 
+    @ParameterizedTest
+    @CsvSource({"textarea-name, textarea-value"})
+    void shouldCallValueProviderWithExpectedValuesForTextArea(String name, String value) {
+        // Given
+        List<WebElement> elements = List.of(new TestWebElement("textarea", null, name, value));
+        String formAction = "formaction";
+
+        // When
+        action.fillInputs(elements, formAction, "statsprefix");
+
+        // Then
+        verify(valueProvider)
+                .getValue(
+                        uri,
+                        formAction,
+                        name,
+                        value,
+                        List.of(),
+                        Map.of(),
+                        Map.of("Control Type", "text", "type", "textarea"));
+    }
+
     class TestWebElement implements WebElement {
 
         private String tag;

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
@@ -108,7 +108,7 @@ class ClickElementUnitTest {
     }
 
     @Test
-    void shouldFillInputsBeforeClicking() {
+    void shouldFillInputsAndTextAreasBeforeClicking() {
         // Given
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
         ClickElement action = new ClickElement(valueProvider, uri, component, false);
@@ -117,22 +117,27 @@ class ClickElementUnitTest {
         given(wd.findElement(any(By.class))).willReturn(element);
         WebElement input1 = visibleInput("inputA", "text");
         WebElement input2 = visibleInput("inputB", "text");
-        given(wd.findElements(any(By.class))).willReturn(List.of(input1, input2));
+        WebElement textarea = visibleTextArea("textareaA");
+        given(wd.findElements(any(By.class))).willReturn(List.of(input1, input2, textarea));
         given(valueProvider.getValue(any(), any(), eq("inputA"), any(), any(), any(), any()))
                 .willReturn("value1");
         given(valueProvider.getValue(any(), any(), eq("inputB"), any(), any(), any(), any()))
                 .willReturn("value2");
+        given(valueProvider.getValue(any(), any(), eq("textareaA"), any(), any(), any(), any()))
+                .willReturn("value3");
 
         // When
         boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
-        InOrder inOrder = inOrder(input1, input2);
+        InOrder inOrder = inOrder(input1, input2, textarea);
         inOrder.verify(input1).clear();
         inOrder.verify(input1).sendKeys("value1");
         inOrder.verify(input2).clear();
         inOrder.verify(input2).sendKeys("value2");
+        inOrder.verify(textarea).clear();
+        inOrder.verify(textarea).sendKeys("value3");
     }
 
     @Test
@@ -145,11 +150,8 @@ class ClickElementUnitTest {
         given(wd.findElement(any(By.class))).willReturn(element);
         WebElement input1 = visibleInput("inputA", "text");
         WebElement input2 = visibleInput("inputB", "text");
-        given(wd.findElements(any(By.class))).willReturn(List.of(input1, input2));
-        given(valueProvider.getValue(any(), any(), eq("inputA"), any(), any(), any(), any()))
-                .willReturn("value1");
-        given(valueProvider.getValue(any(), any(), eq("inputB"), any(), any(), any(), any()))
-                .willReturn("value2");
+        WebElement textarea = visibleTextArea("textareaA");
+        given(wd.findElements(any(By.class))).willReturn(List.of(input1, input2, textarea));
 
         // When
         boolean result = action.run(waitStrategy, wd);
@@ -158,6 +160,7 @@ class ClickElementUnitTest {
         assertThat(result, is(equalTo(true)));
         verifyNoInteractions(input1);
         verifyNoInteractions(input2);
+        verifyNoInteractions(textarea);
     }
 
     @Test
@@ -325,5 +328,13 @@ class ClickElementUnitTest {
         given(input.getDomAttribute("name")).willReturn(name);
         given(input.getDomAttribute("type")).willReturn(type);
         return input;
+    }
+
+    private static WebElement visibleTextArea(String name) {
+        WebElement textarea = mock(WebElement.class);
+        given(textarea.isDisplayed()).willReturn(true);
+        given(textarea.getTagName()).willReturn("textarea");
+        given(textarea.getDomAttribute("name")).willReturn(name);
+        return textarea;
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
@@ -92,7 +92,7 @@ class SubmitFormUnitTest {
         WebDriver wd = mock(WebDriver.class);
         WebElement form = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(form);
-        given(form.findElements(any(By.class))).willReturn(List.of());
+        given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
         boolean result = action.run(waitStrategy, wd);
@@ -104,7 +104,7 @@ class SubmitFormUnitTest {
     }
 
     @Test
-    void shouldFillInputsFromFormBeforeSubmitting() {
+    void shouldFillInputsAndTextAreasFromFormBeforeSubmitting() {
         // Given
         ClientSideComponent component = formComponent(0, "xpath", "//FORM");
         SubmitForm action = new SubmitForm(valueProvider, uri, component);
@@ -113,22 +113,27 @@ class SubmitFormUnitTest {
         given(wd.findElement(any(By.class))).willReturn(form);
         WebElement input1 = visibleInput("inputA", "text");
         WebElement input2 = visibleInput("inputB", "text");
-        given(form.findElements(any(By.class))).willReturn(List.of(input1, input2));
+        WebElement textarea = visibleTextArea("textareaA");
+        given(wd.findElements(any(By.class))).willReturn(List.of(input1, input2, textarea));
         given(valueProvider.getValue(any(), any(), eq("inputA"), any(), any(), any(), any()))
                 .willReturn("value1");
         given(valueProvider.getValue(any(), any(), eq("inputB"), any(), any(), any(), any()))
                 .willReturn("value2");
+        given(valueProvider.getValue(any(), any(), eq("textareaA"), any(), any(), any(), any()))
+                .willReturn("value3");
 
         // When
         boolean result = action.run(waitStrategy, wd);
 
         // Then
         assertThat(result, is(equalTo(true)));
-        InOrder inOrder = inOrder(input1, input2);
+        InOrder inOrder = inOrder(input1, input2, textarea);
         inOrder.verify(input1).clear();
         inOrder.verify(input1).sendKeys("value1");
         inOrder.verify(input2).clear();
         inOrder.verify(input2).sendKeys("value2");
+        inOrder.verify(textarea).clear();
+        inOrder.verify(textarea).sendKeys("value3");
     }
 
     @Test
@@ -139,7 +144,7 @@ class SubmitFormUnitTest {
         WebDriver wd = mock(WebDriver.class);
         WebElement form = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(form);
-        given(form.findElements(any(By.class))).willReturn(List.of());
+        given(wd.findElements(any(By.class))).willReturn(List.of());
         willThrow(RuntimeException.class).given(form).submit();
 
         // When / Then
@@ -194,7 +199,7 @@ class SubmitFormUnitTest {
         WebElement visibleForm = visibleElement();
         ArgumentCaptor<By> byCaptor = ArgumentCaptor.forClass(By.class);
         given(wd.findElement(byCaptor.capture())).willReturn(visibleForm);
-        given(visibleForm.findElements(any(By.class))).willReturn(List.of());
+        given(wd.findElements(any(By.class))).willReturn(List.of());
 
         // When
         boolean result = action.run(waitStrategy, wd);
@@ -247,5 +252,13 @@ class SubmitFormUnitTest {
         given(input.getDomAttribute("name")).willReturn(name);
         given(input.getDomAttribute("type")).willReturn(type);
         return input;
+    }
+
+    private static WebElement visibleTextArea(String name) {
+        WebElement textarea = mock(WebElement.class);
+        given(textarea.isDisplayed()).willReturn(true);
+        given(textarea.getTagName()).willReturn("textarea");
+        given(textarea.getDomAttribute("name")).willReturn(name);
+        return textarea;
     }
 }


### PR DESCRIPTION
Fill text areas along inputs, also, fill all inputs available before submitting a form.