### PR TITLE
client: wait always after component navigation

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Wait always after component navigation while crawling.
 
 ## [0.29.0] - 2026-06-30
 ### Changed

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderTask.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpiderTask.java
@@ -110,9 +110,6 @@ public class ClientSpiderTask implements Runnable {
             startTime = System.currentTimeMillis();
             for (SpiderAction action : actions) {
                 action.run(context);
-                if (!context.getWaitStrategy().waitAfterAction()) {
-                    break;
-                }
             }
             ok = true;
             this.status = Status.FINISHED;

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
@@ -72,7 +72,17 @@ abstract class BaseElementAction implements SpiderAction {
             return false;
         }
 
-        return run(context, element, statsPrefix);
+        String urlBeforeAction = context.getWebDriver().getCurrentUrl();
+        if (!run(context, element, statsPrefix) || !context.getWaitStrategy().waitAfterAction()) {
+            return false;
+        }
+
+        String currentUrl = context.getWebDriver().getCurrentUrl();
+        if (!urlBeforeAction.equals(currentUrl)) {
+            return context.getWaitStrategy().waitAfterPageLoad(currentUrl);
+        }
+
+        return true;
     }
 
     protected abstract String getStatsPrefix();

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/FollowGraph.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/FollowGraph.java
@@ -21,7 +21,6 @@ package org.zaproxy.addon.client.spider.actions;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BooleanSupplier;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
@@ -85,14 +84,9 @@ public class FollowGraph implements SpiderAction {
             return false;
         }
 
-        BooleanSupplier waitAction = new WaitAction(context);
         List<ClientGraphVertex> vertices = path.getVertexList();
         for (ClientGraphVertex vertex : vertices) {
             if (vertex instanceof ClientGraphVertex.Component componentVertex) {
-                if (waitAction.getAsBoolean()) {
-                    return false;
-                }
-
                 ClientSideComponent component = componentVertex.component();
                 try {
                     URI uri = new URI(component.getParentUrl(), true);
@@ -119,27 +113,6 @@ public class FollowGraph implements SpiderAction {
         @Override
         protected String getStatsPrefix() {
             return STATS_PREFIX + ".tag." + component.getTagName();
-        }
-    }
-
-    private static class WaitAction implements BooleanSupplier {
-
-        private final TaskContext context;
-        private boolean first;
-
-        WaitAction(TaskContext context) {
-            this.context = context;
-            first = true;
-        }
-
-        @Override
-        public boolean getAsBoolean() {
-            if (first) {
-                first = false;
-                return false;
-            }
-
-            return !context.getWaitStrategy().waitAfterAction();
         }
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderTaskUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderTaskUnitTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
@@ -56,7 +56,6 @@ class ClientSpiderTaskUnitTest extends TestUtils {
         given(clientSpider.isStopped()).willReturn(false);
         given(clientSpider.isPaused()).willReturn(false);
         waitStrategy = mock();
-        given(waitStrategy.waitAfterAction()).willReturn(true);
         WebDriverProcess wdp = mock(WebDriverProcess.class);
         given(wdp.getWaitStrategy()).willReturn(waitStrategy);
         context = new TaskContext(wdp, null, null);
@@ -93,7 +92,7 @@ class ClientSpiderTaskUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldWaitAfterEachAction() {
+    void shouldNotWaitAfterActions() {
         // Given
         List<SpiderAction> actions = List.of(ctx -> true, ctx -> true);
         ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, "test", "");
@@ -102,22 +101,7 @@ class ClientSpiderTaskUnitTest extends TestUtils {
         task.run();
 
         // Then
-        verify(waitStrategy, times(2)).waitAfterAction();
-        assertThat(task.getStatus(), is(Status.FINISHED));
-    }
-
-    @Test
-    void shouldStopRunningActionsWhenWaitStrategyReturnsFalse() {
-        // Given
-        given(waitStrategy.waitAfterAction()).willReturn(false);
-        List<SpiderAction> actions = List.of(ctx -> true, ctx -> true);
-        ClientSpiderTask task = new ClientSpiderTask(1, clientSpider, actions, "test", "");
-
-        // When
-        task.run();
-
-        // Then
-        verify(waitStrategy).waitAfterAction();
+        verify(waitStrategy, never()).waitAfterAction();
         assertThat(task.getStatus(), is(Status.FINISHED));
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
@@ -19,8 +19,13 @@
  */
 package org.zaproxy.addon.client.spider.actions;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
@@ -28,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.openqa.selenium.By;
@@ -39,6 +45,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
+import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
 import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.addon.commonlib.ValueProvider;
@@ -123,6 +130,135 @@ class BaseElementActionUnitTest {
                         List.of(),
                         Map.of(),
                         Map.of("Control Type", "text", "type", "textarea"));
+    }
+
+    @Test
+    void shouldWaitAfterAction() throws IOException {
+        // Given
+        ActionWaitStrategy waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(true);
+        String url = "http://localhost:1234/test";
+        TaskContext context = runContext(waitStrategy, url, url, true);
+
+        // When
+        boolean result = action.run(context);
+
+        // Then
+        assertThat(result, is(equalTo(true)));
+        verify(waitStrategy).waitAfterAction();
+        verify(waitStrategy, never()).waitAfterPageLoad(url);
+    }
+
+    @Test
+    void shouldWaitAfterPageLoadWhenUrlChanges() throws IOException {
+        // Given
+        ActionWaitStrategy waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(true);
+        given(waitStrategy.waitAfterPageLoad("http://localhost:1234/other")).willReturn(true);
+        TaskContext context =
+                runContext(
+                        waitStrategy,
+                        "http://localhost:1234/test",
+                        "http://localhost:1234/other",
+                        true);
+
+        // When
+        boolean result = action.run(context);
+
+        // Then
+        assertThat(result, is(equalTo(true)));
+        verify(waitStrategy).waitAfterAction();
+        verify(waitStrategy).waitAfterPageLoad("http://localhost:1234/other");
+    }
+
+    @Test
+    void shouldNotWaitAfterPageLoadWhenUrlUnchanged() throws IOException {
+        // Given
+        ActionWaitStrategy waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(true);
+        String url = "http://localhost:1234/test";
+        TaskContext context = runContext(waitStrategy, url, url, true);
+
+        // When
+        action.run(context);
+
+        // Then
+        verify(waitStrategy, never()).waitAfterPageLoad(url);
+    }
+
+    @Test
+    void shouldNotWaitWhenActionReturnsFalse() throws IOException {
+        // Given
+        ActionWaitStrategy waitStrategy = mock();
+        TaskContext context =
+                runContext(
+                        waitStrategy,
+                        "http://localhost:1234/test",
+                        "http://localhost:1234/test",
+                        false);
+
+        // When
+        boolean result = action.run(context);
+
+        // Then
+        assertThat(result, is(equalTo(false)));
+        verify(waitStrategy, never()).waitAfterAction();
+        verify(waitStrategy, never()).waitAfterPageLoad(any());
+    }
+
+    @Test
+    void shouldReturnFalseWhenWaitAfterActionInterrupted() throws IOException {
+        // Given
+        ActionWaitStrategy waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(false);
+        String url = "http://localhost:1234/test";
+        TaskContext context = runContext(waitStrategy, url, url, true);
+
+        // When
+        boolean result = action.run(context);
+
+        // Then
+        assertThat(result, is(equalTo(false)));
+        verify(waitStrategy).waitAfterAction();
+        verify(waitStrategy, never()).waitAfterPageLoad(url);
+    }
+
+    private TaskContext runContext(
+            ActionWaitStrategy waitStrategy,
+            String urlBefore,
+            String urlAfter,
+            boolean actionResult)
+            throws IOException {
+        URI actionUri = new URI("http://localhost:1234/test", true);
+        ClientSideComponent component = mock();
+        given(component.getBy()).willReturn(By.id("elem"));
+
+        BaseElementAction runAction =
+                new BaseElementAction(actionUri, component) {
+                    @Override
+                    protected boolean run(
+                            TaskContext context, WebElement element, String statsPrefix) {
+                        return actionResult;
+                    }
+
+                    @Override
+                    protected String getStatsPrefix() {
+                        return "run.prefix";
+                    }
+                };
+
+        WebDriverProcess wdp = mock(WebDriverProcess.class);
+        WebDriver wd = mock(WebDriver.class);
+        WebElement element = mock(WebElement.class);
+        given(element.isDisplayed()).willReturn(true);
+        given(wd.findElement(By.id("elem"))).willReturn(element);
+        given(wd.getCurrentUrl()).willReturn(urlBefore, urlAfter);
+        given(wdp.getWebDriver()).willReturn(wd);
+        given(wdp.getWaitStrategy()).willReturn(waitStrategy);
+
+        action = runAction;
+
+        return new TaskContext(wdp, valueProvider, null);
     }
 
     private TaskContext context(List<WebElement> elements) {

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
@@ -73,6 +73,7 @@ class ClickElementUnitTest {
     void setUp() throws IOException {
         valueProvider = mock(ValueProvider.class);
         waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(true);
         uri = new URI("http://example.com/test", true);
         stats = new InMemoryStats();
         Stats.addListener(stats);
@@ -97,6 +98,7 @@ class ClickElementUnitTest {
         WebElement element = visibleElement();
         given(wd.findElement(By.id("btn"))).willReturn(element);
         given(wd.findElements(any(By.class))).willReturn(List.of());
+        given(wd.getCurrentUrl()).willReturn("http://example.com/test");
 
         // When
         boolean result = action.run(context(wd));
@@ -116,6 +118,7 @@ class ClickElementUnitTest {
         WebDriver wd = mock(WebDriver.class);
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
+        given(wd.getCurrentUrl()).willReturn("http://example.com/test");
         WebElement input1 = visibleInput("inputA", "text");
         WebElement input2 = visibleInput("inputB", "text");
         WebElement textarea = visibleTextArea("textareaA");
@@ -149,6 +152,7 @@ class ClickElementUnitTest {
         WebDriver wd = mock(WebDriver.class);
         WebElement element = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(element);
+        given(wd.getCurrentUrl()).willReturn("http://example.com/test");
         WebElement input1 = visibleInput("inputA", "text");
         WebElement input2 = visibleInput("inputB", "text");
         WebElement textarea = visibleTextArea("textareaA");

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
@@ -197,36 +197,10 @@ class FollowGraphUnitTest extends TestUtils {
         assertCommonState(wd, result);
         verify(element, times(2)).click();
         verify(wd, never()).get(any());
-        verify(waitStrategy).waitAfterAction();
+        verify(waitStrategy, times(2)).waitAfterAction();
         verify(waitStrategy).waitAfterPageLoad(URL_C);
         assertThat(stats.getStat("stats.client.spider.action.follow"), is(1L));
         assertThat(stats.getStat("stats.client.spider.action.follow.path"), is(1L));
-    }
-
-    @Test
-    void shouldFollowMultiHopPathWaitingAfterFirstHop() {
-        // Given
-        ClientSideComponent link1 = createLinkComponent(URL_A, URL_B);
-        ClientSideComponent link2 = createLinkComponent(URL_B, URL_C);
-        addGraphEdge(URL_A, link1, URL_B);
-        addGraphEdge(URL_B, link2, URL_C);
-        String urlD = "http://example.com/d";
-        ClientSideComponent link3 = createLinkComponent(URL_C, urlD);
-        addGraphEdge(URL_C, link3, urlD);
-
-        given(wd.getCurrentUrl()).willReturn(URL_A);
-        WebElement element = visibleElement();
-        given(wd.findElement(any(By.class))).willReturn(element);
-
-        FollowGraph action = new FollowGraph(urlD);
-
-        // When
-        boolean result = action.run(context);
-
-        // Then
-        assertCommonState(wd, result);
-        verify(waitStrategy, times(2)).waitAfterAction();
-        verify(waitStrategy).waitAfterPageLoad(urlD);
     }
 
     @Test

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
@@ -71,6 +71,7 @@ class SubmitFormUnitTest {
     void setUp() throws IOException {
         valueProvider = mock(ValueProvider.class);
         waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(true);
         uri = new URI("http://example.com/test", true);
         stats = new InMemoryStats();
         Stats.addListener(stats);
@@ -95,6 +96,7 @@ class SubmitFormUnitTest {
         WebElement form = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(form);
         given(wd.findElements(any(By.class))).willReturn(List.of());
+        given(wd.getCurrentUrl()).willReturn("http://example.com/test");
 
         // When
         boolean result = action.run(context(wd));
@@ -113,6 +115,7 @@ class SubmitFormUnitTest {
         WebDriver wd = mock(WebDriver.class);
         WebElement form = visibleElement();
         given(wd.findElement(any(By.class))).willReturn(form);
+        given(wd.getCurrentUrl()).willReturn("http://example.com/test");
         WebElement input1 = visibleInput("inputA", "text");
         WebElement input2 = visibleInput("inputB", "text");
         WebElement textarea = visibleTextArea("textareaA");
@@ -202,6 +205,7 @@ class SubmitFormUnitTest {
         ArgumentCaptor<By> byCaptor = ArgumentCaptor.forClass(By.class);
         given(wd.findElement(byCaptor.capture())).willReturn(visibleForm);
         given(wd.findElements(any(By.class))).willReturn(List.of());
+        given(wd.getCurrentUrl()).willReturn("http://example.com/test");
 
         // When
         boolean result = action.run(context(wd));


### PR DESCRIPTION
Change the base element action to check and wait after navigation.
Remove action wait from the task and follow graph, they are now all done by actions themselves.