### PR TITLE
client: follow any components when crawling

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Wait always after component navigation while crawling.
+- Follow any navigation component while crawling.
 
 ### Fixed
 - Normalise behaviour of Delete context menu item.

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMap.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/internal/ClientMap.java
@@ -367,6 +367,17 @@ public class ClientMap extends SortedTreeModel implements EventPublisher {
                 || "A".equals(component.getTagName());
     }
 
+    public void addNavigationEdge(
+            String urlBefore, ClientSideComponent component, String urlAfter) {
+        ClientGraphVertex componentVertex = new ClientGraphVertex.Component(component);
+        synchronized (graph) {
+            if (graph.containsVertex(componentVertex)) {
+                return;
+            }
+            addGraphEdge(urlBefore, urlAfter, component);
+        }
+    }
+
     private void addGraphEdge(String sourceUrl, String targetUrl, ClientSideComponent component) {
         ClientGraphVertex source = new ClientGraphVertex.Url(sourceUrl);
         ClientGraphVertex target = new ClientGraphVertex.Url(targetUrl);

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/ClientSpider.java
@@ -312,8 +312,7 @@ public class ClientSpider implements GenericScanner2 {
     }
 
     TaskContext createTaskContext() {
-        return new TaskContext(
-                this::isStopped, getWebDriverProcess(), valueProvider, clientMap.getGraph());
+        return new TaskContext(this::isStopped, getWebDriverProcess(), valueProvider, clientMap);
     }
 
     private List<SpiderAction> followGraphAction(String url, SpiderAction... additionalActions) {

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/TaskContext.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/TaskContext.java
@@ -24,6 +24,8 @@ import lombok.Getter;
 import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultEdge;
 import org.openqa.selenium.WebDriver;
+import org.zaproxy.addon.client.internal.ClientMap;
+import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.graph.ClientGraphVertex;
 import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
 import org.zaproxy.addon.commonlib.ValueProvider;
@@ -35,23 +37,32 @@ public class TaskContext {
     private final ActionWaitStrategy waitStrategy;
     private final WebDriver webDriver;
     private final ValueProvider valueProvider;
-    private final Graph<ClientGraphVertex, DefaultEdge> graph;
+    private final ClientMap clientMap;
     private final WebDriverProcess webDriverProcess;
 
     public TaskContext(
             BooleanSupplier stopped,
             WebDriverProcess webDriverProcess,
             ValueProvider valueProvider,
-            Graph<ClientGraphVertex, DefaultEdge> graph) {
+            ClientMap clientMap) {
         this.stopped = stopped;
         this.webDriverProcess = webDriverProcess;
         this.waitStrategy = webDriverProcess.getWaitStrategy();
         this.webDriver = webDriverProcess.getWebDriver();
         this.valueProvider = valueProvider;
-        this.graph = graph;
+        this.clientMap = clientMap;
     }
 
     public boolean isStopped() {
         return stopped.getAsBoolean();
+    }
+
+    public Graph<ClientGraphVertex, DefaultEdge> getGraph() {
+        return clientMap.getGraph();
+    }
+
+    public void addNavigationEdge(
+            String urlBefore, ClientSideComponent component, String urlAfter) {
+        clientMap.addNavigationEdge(urlBefore, component, urlAfter);
     }
 }

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
@@ -83,6 +83,7 @@ abstract class BaseElementAction implements SpiderAction {
 
         String currentUrl = context.getWebDriver().getCurrentUrl();
         if (!urlBeforeAction.equals(currentUrl)) {
+            context.addNavigationEdge(urlBeforeAction, component, currentUrl);
             return !context.isStopped() && context.getWaitStrategy().waitAfterPageLoad(currentUrl);
         }
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/internal/ClientMapUnitTest.java
@@ -997,6 +997,23 @@ class ClientMapUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldNotAddDuplicateNavigationEdgeForSameComponent() {
+        // Given
+        String urlBefore = "https://www.example.com/page";
+        String urlAfter = "https://www.example.com/other";
+        ClientSideComponent component = mock(ClientSideComponent.class);
+
+        // When
+        map.addNavigationEdge(urlBefore, component, urlAfter);
+        map.addNavigationEdge(urlBefore, component, urlAfter);
+
+        // Then
+        var graph = map.getGraph();
+        assertThat(graph.vertexSet().size(), is(3));
+        assertThat(graph.edgeSet().size(), is(2));
+    }
+
+    @Test
     void shouldClearGraph() {
         // Given
         String url = "https://www.example.com/page";

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
@@ -27,6 +27,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.io.IOException;
 import java.util.List;
@@ -45,6 +46,7 @@ import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.spider.ActionWaitStrategy;
 import org.zaproxy.addon.client.spider.ClientSpider.WebDriverProcess;
@@ -258,6 +260,58 @@ class BaseElementActionUnitTest {
         verify(waitStrategy, never()).waitAfterPageLoad(urlAfter);
     }
 
+    @Test
+    void shouldNotAddNavigationEdgeWhenUrlUnchanged() throws IOException {
+        // Given
+        ActionWaitStrategy waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(true);
+        String url = "http://localhost:1234/test";
+        ClientMap clientMap = mock(ClientMap.class);
+        TaskContext context = runContext(waitStrategy, url, url, true, () -> false, clientMap);
+
+        // When
+        action.run(context);
+
+        // Then
+        verifyNoInteractions(clientMap);
+    }
+
+    @Test
+    void shouldAddNavigationEdgeWhenUrlChanges() throws IOException {
+        // Given
+        ActionWaitStrategy waitStrategy = mock();
+        given(waitStrategy.waitAfterAction()).willReturn(true);
+        given(waitStrategy.waitAfterPageLoad(any())).willReturn(true);
+        String urlBefore = "http://localhost:1234/test";
+        String urlAfter = "http://localhost:1234/other";
+        ClientMap clientMap = mock(ClientMap.class);
+        TaskContext context =
+                runContext(waitStrategy, urlBefore, urlAfter, true, () -> false, clientMap);
+
+        // When
+        action.run(context);
+
+        // Then
+        verify(clientMap).addNavigationEdge(urlBefore, action.component, urlAfter);
+    }
+
+    @Test
+    void shouldNotAddNavigationEdgeWhenActionReturnsFalse() throws IOException {
+        // Given
+        ActionWaitStrategy waitStrategy = mock();
+        String urlBefore = "http://localhost:1234/test";
+        String urlAfter = "http://localhost:1234/other";
+        ClientMap clientMap = mock(ClientMap.class);
+        TaskContext context =
+                runContext(waitStrategy, urlBefore, urlAfter, false, () -> false, clientMap);
+
+        // When
+        action.run(context);
+
+        // Then
+        verifyNoInteractions(clientMap);
+    }
+
     private TaskContext runContext(
             ActionWaitStrategy waitStrategy,
             String urlBefore,
@@ -273,6 +327,17 @@ class BaseElementActionUnitTest {
             String urlAfter,
             boolean actionResult,
             BooleanSupplier stopped)
+            throws IOException {
+        return runContext(waitStrategy, urlBefore, urlAfter, actionResult, stopped, mock());
+    }
+
+    private TaskContext runContext(
+            ActionWaitStrategy waitStrategy,
+            String urlBefore,
+            String urlAfter,
+            boolean actionResult,
+            BooleanSupplier stopped,
+            ClientMap clientMap)
             throws IOException {
         URI actionUri = new URI("http://localhost:1234/test", true);
         ClientSideComponent component = mock();
@@ -303,7 +368,7 @@ class BaseElementActionUnitTest {
 
         action = runAction;
 
-        return new TaskContext(stopped, wdp, valueProvider, null);
+        return new TaskContext(stopped, wdp, valueProvider, clientMap);
     }
 
     private TaskContext context(List<WebElement> elements) {

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
@@ -48,6 +48,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.ExtensionClientIntegration;
+import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.ElementLocator;
 import org.zaproxy.addon.client.internal.graph.ClientGraphVertex;
@@ -89,7 +90,7 @@ class FollowGraphUnitTest extends TestUtils {
         WebDriverProcess wdp = mock(withSettings().strictness(Strictness.LENIENT));
         given(wdp.getWaitStrategy()).willReturn(waitStrategy);
         given(wdp.getWebDriver()).willReturn(wd);
-        context = new TaskContext(() -> false, wdp, valueProvider, graph);
+        context = new TaskContext(() -> false, wdp, valueProvider, mockClientMap());
         stats = new InMemoryStats();
         Stats.addListener(stats);
     }
@@ -299,7 +300,13 @@ class FollowGraphUnitTest extends TestUtils {
         WebDriverProcess wdp = mock(withSettings().strictness(Strictness.LENIENT));
         given(wdp.getWaitStrategy()).willReturn(waitStrategy);
         given(wdp.getWebDriver()).willReturn(wd);
-        return new TaskContext(stopped, wdp, valueProvider, graph);
+        return new TaskContext(stopped, wdp, valueProvider, mockClientMap());
+    }
+
+    private ClientMap mockClientMap() {
+        ClientMap clientMap = mock(withSettings().strictness(Strictness.LENIENT));
+        given(clientMap.getGraph()).willReturn(graph);
+        return clientMap;
     }
 
     private void assertCommonState(WebDriver wd, boolean result) {


### PR DESCRIPTION
Add an edge between any component that causes a navigation to be able to follow those components to other states.