### PR TITLE
client: wait for components' state while crawling

### DIFF
--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/BaseElementAction.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.client.spider.actions;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -26,7 +27,10 @@ import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.spider.SpiderAction;
 import org.zaproxy.addon.client.spider.TaskContext;
@@ -61,14 +65,20 @@ abstract class BaseElementAction implements SpiderAction {
 
         WebElement element;
         try {
-            element = context.getWebDriver().findElement(by);
+            element =
+                    new WebDriverWait(context.getWebDriver(), Duration.ofMillis(2_500))
+                            .until(getExpectedCondition(by));
         } catch (Exception e) {
+            if (e instanceof TimeoutException) {
+                try {
+                    context.getWebDriver().findElement(by);
+                    Stats.incCounter(statsPrefix + ".expectationmismatch");
+                    return false;
+                } catch (Exception ex) {
+                    // Ignore.
+                }
+            }
             Stats.incCounter(statsPrefix + ".notfound");
-            return false;
-        }
-
-        if (!element.isDisplayed()) {
-            Stats.incCounter(statsPrefix + ".notdisplayed");
             return false;
         }
 
@@ -93,6 +103,8 @@ abstract class BaseElementAction implements SpiderAction {
     protected abstract String getStatsPrefix();
 
     protected abstract boolean run(TaskContext context, WebElement element, String statsPrefix);
+
+    protected abstract ExpectedCondition<WebElement> getExpectedCondition(By by);
 
     protected void fillComponents(TaskContext context, String action, String statsPrefix) {
         context.getWebDriver()

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/ClickElement.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/ClickElement.java
@@ -23,7 +23,10 @@ import java.util.function.Predicate;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.internal.InteractableState;
 import org.zaproxy.addon.client.spider.TaskContext;
@@ -58,6 +61,11 @@ public class ClickElement extends BaseElementAction {
             LOGGER.debug("An error occurred while clicking the element:", e);
         }
         return false;
+    }
+
+    @Override
+    protected ExpectedCondition<WebElement> getExpectedCondition(By by) {
+        return ExpectedConditions.elementToBeClickable(by);
     }
 
     @Override

--- a/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/SubmitForm.java
+++ b/addOns/client/src/main/java/org/zaproxy/addon/client/spider/actions/SubmitForm.java
@@ -22,7 +22,10 @@ package org.zaproxy.addon.client.spider.actions;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.spider.TaskContext;
 import org.zaproxy.zap.utils.Stats;
@@ -54,6 +57,11 @@ public class SubmitForm extends BaseElementAction {
             LOGGER.debug("An error occurred while submitting the form:", e);
         }
         return false;
+    }
+
+    @Override
+    protected ExpectedCondition<WebElement> getExpectedCondition(By by) {
+        return ExpectedConditions.visibilityOfElementLocated(by);
     }
 
     @Override

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/ClientSpiderUnitTest.java
@@ -165,7 +165,11 @@ class ClientSpiderUnitTest extends TestUtils {
         given(network.createHttpServer(any(HttpServerConfig.class))).willReturn(serverMock);
 
         wd = mock(withSettings().strictness(Strictness.LENIENT));
-        given(wd.findElement(any())).willReturn(mock(WebElement.class));
+        WebElement wdElement =
+                mock(WebElement.class, withSettings().strictness(Strictness.LENIENT));
+        given(wdElement.isDisplayed()).willReturn(true);
+        given(wdElement.isEnabled()).willReturn(true);
+        given(wd.findElement(any())).willReturn(wdElement);
         Options options = mock(withSettings().strictness(Strictness.LENIENT));
         doAnswer(
                         answer -> {

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/BaseElementActionUnitTest.java
@@ -46,6 +46,8 @@ import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.zaproxy.addon.client.internal.ClientMap;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
 import org.zaproxy.addon.client.spider.ActionWaitStrategy;
@@ -78,6 +80,11 @@ class BaseElementActionUnitTest {
                     @Override
                     protected String getStatsPrefix() {
                         return "prefix";
+                    }
+
+                    @Override
+                    protected ExpectedCondition<WebElement> getExpectedCondition(By by) {
+                        return ExpectedConditions.presenceOfElementLocated(by);
                     }
                 };
     }
@@ -354,6 +361,11 @@ class BaseElementActionUnitTest {
                     @Override
                     protected String getStatsPrefix() {
                         return "run.prefix";
+                    }
+
+                    @Override
+                    protected ExpectedCondition<WebElement> getExpectedCondition(By by) {
+                        return ExpectedConditions.presenceOfElementLocated(by);
                     }
                 };
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/ClickElementUnitTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InOrder;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
@@ -192,6 +193,23 @@ class ClickElementUnitTest {
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
         ClickElement action = new ClickElement(uri, component, false);
         WebDriver wd = mock(WebDriver.class);
+        given(wd.findElement(any(By.class))).willThrow(NoSuchElementException.class);
+
+        // When
+        boolean result = action.run(context(wd));
+
+        // Then
+        assertThat(result, is(equalTo(false)));
+        assertThat(stats.getStat("stats.client.spider.action.click.tag.A"), is(1L));
+        assertThat(stats.getStat("stats.client.spider.action.click.tag.A.notfound"), is(1L));
+    }
+
+    @Test
+    void shouldIncrementNotFoundWhenExceptionThrownByFindElement() {
+        // Given
+        ClientSideComponent component = componentWithLocator("A", "id", "btn");
+        ClickElement action = new ClickElement(uri, component, false);
+        WebDriver wd = mock(WebDriver.class);
         given(wd.findElement(any(By.class))).willThrow(RuntimeException.class);
 
         // When
@@ -204,14 +222,15 @@ class ClickElementUnitTest {
     }
 
     @Test
-    void shouldIncrementStatsWhenElementNotDisplayed() {
+    void shouldIncrementExpectationMismatchWhenElementFoundButNotClickable() {
         // Given
         ClientSideComponent component = componentWithLocator("A", "id", "btn");
         ClickElement action = new ClickElement(uri, component, false);
         WebDriver wd = mock(WebDriver.class);
         WebElement element = mock(WebElement.class);
         given(wd.findElement(any(By.class))).willReturn(element);
-        given(element.isDisplayed()).willReturn(false);
+        given(element.isDisplayed()).willReturn(true);
+        given(element.isEnabled()).willReturn(false);
 
         // When
         boolean result = action.run(context(wd));
@@ -219,7 +238,9 @@ class ClickElementUnitTest {
         // Then
         assertThat(result, is(equalTo(false)));
         assertThat(stats.getStat("stats.client.spider.action.click.tag.A"), is(1L));
-        assertThat(stats.getStat("stats.client.spider.action.click.tag.A.notdisplayed"), is(1L));
+        assertThat(
+                stats.getStat("stats.client.spider.action.click.tag.A.expectationmismatch"),
+                is(1L));
     }
 
     @Test
@@ -351,6 +372,7 @@ class ClickElementUnitTest {
     private static WebElement visibleElement() {
         WebElement element = mock(WebElement.class);
         given(element.isDisplayed()).willReturn(true);
+        given(element.isEnabled()).willReturn(true);
         return element;
     }
 

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/FollowGraphUnitTest.java
@@ -345,6 +345,7 @@ class FollowGraphUnitTest extends TestUtils {
     private static WebElement visibleElement() {
         WebElement element = mock(WebElement.class);
         given(element.isDisplayed()).willReturn(true);
+        given(element.isEnabled()).willReturn(true);
         return element;
     }
 }

--- a/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
+++ b/addOns/client/src/test/java/org/zaproxy/addon/client/spider/actions/SubmitFormUnitTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zaproxy.addon.client.internal.ClientSideComponent;
@@ -165,7 +166,7 @@ class SubmitFormUnitTest {
         ClientSideComponent component = formComponent(0, "xpath", "//FORM");
         SubmitForm action = new SubmitForm(uri, component);
         WebDriver wd = mock(WebDriver.class);
-        given(wd.findElement(any(By.class))).willThrow(RuntimeException.class);
+        given(wd.findElement(any(By.class))).willThrow(NoSuchElementException.class);
 
         // When
         boolean result = action.run(context(wd));
@@ -177,7 +178,7 @@ class SubmitFormUnitTest {
     }
 
     @Test
-    void shouldIncrementStatsWhenFormNotDisplayed() {
+    void shouldIncrementExpectationMismatchWhenFormNotVisible() {
         // Given
         ClientSideComponent component = formComponent(0, "xpath", "//FORM");
         SubmitForm action = new SubmitForm(uri, component);
@@ -192,7 +193,7 @@ class SubmitFormUnitTest {
         // Then
         assertThat(result, is(equalTo(false)));
         assertThat(stats.getStat("stats.client.spider.action.form.0"), is(1L));
-        assertThat(stats.getStat("stats.client.spider.action.form.0.notdisplayed"), is(1L));
+        assertThat(stats.getStat("stats.client.spider.action.form.0.expectationmismatch"), is(1L));
     }
 
     @Test


### PR DESCRIPTION
Wait for the components to be in the expected state before acting on them.