### PR TITLE
zest: Prevent NPE when script loaded before associated engine

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix exception when adding/editing Zest non-standalone type scripts through the GUI.
+- Prevent exception with scripts when their engine isn't installed or present, which may be encountered when the zest add-on is uninstalled/updated.
 
 ## [48.13.0] - 2026-03-31
 ### Added

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -337,7 +337,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
         // Convert zest scripts into "plain" scripts
         for (ScriptType type : this.getExtScript().getScriptTypes()) {
             for (ScriptWrapper script : this.getExtScript().getScripts(type)) {
-                if (script.getEngineName().equals(ZestScriptEngineFactory.NAME)) {
+                if (ZestScriptEngineFactory.NAME.equals(script.getEngineName())) {
                     ScriptNode node = this.getExtScript().getTreeModel().getNodeForScript(script);
                     if (script instanceof ZestScriptWrapper) {
                         ZestScriptWrapper zsw = (ZestScriptWrapper) script;

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ExtensionZestUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ExtensionZestUnitTest.java
@@ -94,6 +94,29 @@ class ExtensionZestUnitTest {
         assertThat(element, is(nullValue()));
     }
 
+    @Test
+    void shouldHandleUnloadWithScriptWithNoEngineName() {
+        initWithScriptWithoutEngine();
+        assertDoesNotThrow(() -> extension.unload());
+    }
+
+    @Test
+    void shouldHandleOptionsLoadedWithScriptWithNoEngineName() {
+        initWithScriptWithoutEngine();
+        assertDoesNotThrow(() -> extension.optionsLoaded());
+    }
+
+    private void initWithScriptWithoutEngine() {
+        ExtensionScript extensionScript = mock();
+        ExtensionLoader extLoader = mock();
+        Control.initSingletonForTesting(any(), extLoader);
+        given(extLoader.getExtension(ExtensionScript.NAME)).willReturn(extensionScript);
+
+        ScriptType scriptType = mock();
+        given(extensionScript.getScriptTypes()).willReturn(List.of(scriptType));
+        given(extensionScript.getScripts(scriptType)).willReturn(List.of(new ScriptWrapper()));
+    }
+
     @Nested
     class ScriptCreation {
 


### PR DESCRIPTION
## Overview
Prevent an NPE which may occur if a script doesn't have a defined engine, or if it engine (add-on) has not yet been loaded/installed.
