### PR TITLE
openapi: fix file/URI bug

### DIFF
--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportDialog.java
@@ -340,7 +340,10 @@ public class ImportDialog extends AbstractDialog {
                             getSelectedContextId(),
                             getSelectedUser())
                     == null;
-        } catch (URIException | MalformedURLException | java.net.URISyntaxException ignored) {
+        } catch (URIException
+                | MalformedURLException
+                | IllegalArgumentException
+                | java.net.URISyntaxException ignored) {
             // Not a valid URI, try to import as a file
         } catch (InvalidUrlException e) {
             ThreadUtils.invokeAndWaitHandled(


### PR DESCRIPTION
the bug was introduced by
https://github.com/zaproxy/zap-extensions/pull/7507/

A different error is now thrown when a file is specified instead of a URL.
