### PR TITLE
openapi: Allow limiting number of messages imported

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Allow Automation Framework users to limit the number of OpenAPI messages to import (`maxMessages`). Ex: If testing authentication, access, etc.
 
 ## [57] - 2026-07-06
 ### Changed

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -152,7 +152,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             if (openApiSpecs != null && !openApiSpecs.isEmpty()) {
                 for (TableOpenApiReadResult spec : openApiSpecs) {
                     importOpenApiDefinition(
-                            spec.definition, spec.target, null, false, null, contextId, true);
+                            spec.definition, spec.target, null, false, null, contextId, true, 0);
                 }
             }
         } catch (DatabaseException e) {
@@ -251,6 +251,16 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
     public OpenApiResults importOpenApiDefinitionV2(
             final URI uri, final String targetUrl, boolean initViaUi, int contextId, User user) {
+        return importOpenApiDefinitionV2(uri, targetUrl, initViaUi, contextId, user, 0);
+    }
+
+    public OpenApiResults importOpenApiDefinitionV2(
+            final URI uri,
+            final String targetUrl,
+            boolean initViaUi,
+            int contextId,
+            User user,
+            int maxMessages) {
         OpenApiResults results = new OpenApiResults();
         Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
         requestor.setUser(user);
@@ -268,7 +278,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                             initViaUi,
                             requestor,
                             contextId,
-                            false));
+                            false,
+                            maxMessages));
         } catch (IOException e) {
             if (initViaUi) {
                 ThreadUtils.invokeAndWaitHandled(
@@ -347,6 +358,16 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
     public OpenApiResults importOpenApiDefinitionV2(
             final File file, final String targetUrl, boolean initViaUi, int contextId, User user) {
+        return importOpenApiDefinitionV2(file, targetUrl, initViaUi, contextId, user, 0);
+    }
+
+    public OpenApiResults importOpenApiDefinitionV2(
+            final File file,
+            final String targetUrl,
+            boolean initViaUi,
+            int contextId,
+            User user,
+            int maxMessages) {
         OpenApiResults results = new OpenApiResults();
         try {
             Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
@@ -389,7 +410,14 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
             List<String> errors =
                     importOpenApiDefinition(
-                            openApiString, targetUrl, null, initViaUi, requestor, contextId, false);
+                            openApiString,
+                            targetUrl,
+                            null,
+                            initViaUi,
+                            requestor,
+                            contextId,
+                            false,
+                            maxMessages);
             results.setErrors(errors);
         } catch (IOException e) {
             if (initViaUi) {
@@ -412,7 +440,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             boolean initViaUi,
             final Requestor requestor,
             int contextId,
-            boolean existsInDb) {
+            boolean existsInDb,
+            int maxMessages) {
         if (defn == null || defn.isEmpty()) {
             throw new OpenApiExceptions.EmptyDefinitionException();
         }
@@ -428,7 +457,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                         ProgressPane currentImportPane = null;
                         try {
                             Context context = getModel().getSession().getContext(contextId);
-                            List<RequestModel> requestModels = converter.getRequestModels(context);
+                            List<RequestModel> requestModels =
+                                    converter.getRequestModels(context, maxMessages);
                             if (context != null) {
                                 converter.updateVariantChecks(
                                         context,

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
@@ -56,6 +56,8 @@ public class OpenApiJob extends AutomationJob {
     private static final String PARAM_CONTEXT = "context";
     private static final String PARAM_USER = "user";
 
+    private static final String PARAM_MAX_MESSAGES = "maxMessages";
+
     private ExtensionOpenApi extOpenApi;
 
     private Parameters parameters = new Parameters();
@@ -89,6 +91,13 @@ public class OpenApiJob extends AutomationJob {
                 progress);
 
         verifyUser(getParameters().getUser(), progress);
+        if (getParameters().getMaxMessages() < 0) {
+            progress.warn(
+                    Constant.messages.getString(
+                            "openapi.automation.warn.maxMessages",
+                            getName(),
+                            getParameters().getMaxMessages()));
+        }
     }
 
     @Override
@@ -104,6 +113,7 @@ public class OpenApiJob extends AutomationJob {
         map.put(PARAM_TARGET_URL, "");
         map.put(PARAM_CONTEXT, "");
         map.put(PARAM_USER, "");
+        map.put(PARAM_MAX_MESSAGES, "0");
         return map;
     }
 
@@ -129,6 +139,8 @@ public class OpenApiJob extends AutomationJob {
 
         User user = getUser(this.getParameters().getUser(), progress);
 
+        int maxMessages = getParameters().getMaxMessages();
+
         if (!StringUtils.isEmpty(apiFile)) {
             File file = JobUtils.getFile(apiFile, getPlan());
             if (file.exists() && file.canRead()) {
@@ -137,7 +149,7 @@ public class OpenApiJob extends AutomationJob {
                     results =
                             getExtOpenApi()
                                     .importOpenApiDefinitionV2(
-                                            file, targetUrl, false, contextId, user);
+                                            file, targetUrl, false, contextId, user, maxMessages);
                 } catch (EmptyDefinitionException | InvalidDefinitionException e) {
                     progress.error(e.getLocalizedMessage());
                     return;
@@ -170,7 +182,8 @@ public class OpenApiJob extends AutomationJob {
                 URI uri = new URI(apiUrl, true);
                 OpenApiResults results =
                         getExtOpenApi()
-                                .importOpenApiDefinitionV2(uri, targetUrl, false, contextId, user);
+                                .importOpenApiDefinitionV2(
+                                        uri, targetUrl, false, contextId, user, maxMessages);
                 List<String> errors = results.getErrors();
                 if (errors != null && errors.size() > 0) {
                     for (String error : errors) {
@@ -286,5 +299,6 @@ public class OpenApiJob extends AutomationJob {
         private String targetUrl = "";
         private String context = "";
         private String user = "";
+        private int maxMessages;
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
@@ -199,15 +199,32 @@ public class SwaggerConverter implements Converter {
 
     @Override
     public List<RequestModel> getRequestModels(Context context) throws SwaggerException {
-        return convertToRequest(context, getOperationModels());
+        return getRequestModels(context, 0);
     }
 
-    private List<RequestModel> convertToRequest(Context context, List<OperationModel> operations) {
+    /**
+     * Gets the request models, optionally limiting how many are generated.
+     *
+     * @param context the context used to exclude URLs, might be {@code null}.
+     * @param maxMessages the maximum number of request models to generate, {@code 0} for no limit.
+     * @return the request models.
+     * @throws SwaggerException if an error occurred while converting the definition.
+     */
+    public List<RequestModel> getRequestModels(Context context, int maxMessages)
+            throws SwaggerException {
+        return convertToRequest(context, getOperationModels(), maxMessages);
+    }
+
+    private List<RequestModel> convertToRequest(
+            Context context, List<OperationModel> operations, int maxMessages) {
         List<RequestModel> requests = new LinkedList<>();
         for (OperationModel operation : operations) {
             var model = requestConverter.convert(operation, generators);
             if (context == null || !context.isExcluded(model.getUrl())) {
                 requests.add(model);
+                if (maxMessages > 0 && requests.size() >= maxMessages) {
+                    break;
+                }
             }
         }
         return requests;

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
@@ -26,6 +26,7 @@ It is covered in the video: <a href="https://youtu.be/xuP00Ri460k">ZAP Chat 11 A
       context:                         # String: Context to use when importing the OpenAPI definition, default: first context.
       user:                            # String: An optional user to use for authentication, must be defined in the env.
       targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden
+      maxMessages:                     # Int: Maximum number of messages to import, default: 0, import all messages
 </pre>
 
 </BODY>

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -24,6 +24,7 @@ openapi.automation.error.misc = Job {0} target: {1} error: {2}
 openapi.automation.error.nofile = Cannot access file: {0}
 openapi.automation.info.urlsadded = Job {0} added {1} URLs
 openapi.automation.name = OpenAPI Automation
+openapi.automation.warn.maxMessages = Job {0} maxMessages must be zero or greater, was: {1}
 
 openapi.cmdline.contextid.help = The Context ID used to associate data driven nodes generated from path parameters in the OpenAPI definition
 openapi.cmdline.file.help = Imports an OpenAPI definition from the specified file name

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
@@ -5,3 +5,4 @@
       context:                         # String: Context to use when importing the OpenAPI definition, default: first context.
       user:                            # String: An optional user to use for authentication, must be defined in the env.
       targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden
+      maxMessages:                     # Int: Maximum number of messages to import, default: 0, import all messages

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApiTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApiTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.mockito.quality.Strictness;
 import org.parosproxy.paros.Constant;
@@ -280,6 +281,45 @@ class ExtensionOpenApiTest extends AbstractServerTest {
         return localDefinition.toFile();
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3})
+    void shouldLimitMessagesFromFileWhenMaxMessagesSet(int maxMessages) throws Exception {
+        // Given
+        this.nano.addHandler(new EmptyServerHandler());
+        File file = createLocalDefinition("v3/PetStore_defn.json").toFile();
+        givenHistoryCanBePersisted();
+        // When
+        OpenApiResults results =
+                extensionOpenApi.importOpenApiDefinitionV2(
+                        file, null, false, -1, null, maxMessages);
+        // Then
+        assertThat(results.getHistoryReferences(), hasSize(maxMessages));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3})
+    void shouldLimitMessagesFromUrlWhenMaxMessagesSet(int maxMessages) throws Exception {
+        // Given
+        String path = "/PetStore/";
+        String defnName = "defn.json";
+        this.nano.addHandler(new DefnServerHandler(path, defnName, "v3/PetStore_defn.json"));
+        URI uri =
+                new URI("http://localhost:" + this.nano.getListeningPort() + path + defnName, true);
+        givenHistoryCanBePersisted();
+        // When
+        OpenApiResults results =
+                extensionOpenApi.importOpenApiDefinitionV2(uri, null, false, -1, null, maxMessages);
+        // Then - also includes the definition fetch
+        assertThat(results.getHistoryReferences(), hasSize(maxMessages + 1));
+    }
+
+    private void givenHistoryCanBePersisted() throws Exception {
+        RecordHistory recordHistory = mock(RecordHistory.class);
+        given(tableHistory.write(anyLong(), anyInt(), any()))
+                .willReturn(recordHistory, recordHistory);
+        given(model.getVariantFactory()).willReturn(new VariantFactory());
+    }
+
     @Test
     void shouldUseJsonMapperForOpenApi30Definition() throws Exception {
         // Given
@@ -318,6 +358,31 @@ class ExtensionOpenApiTest extends AbstractServerTest {
             // Then
             json31Mock.verify(Json31::mapper, atLeastOnce());
             verify(spyMapper, atLeastOnce()).writeValueAsString(any(OpenAPI.class));
+        }
+    }
+
+    private class DefnServerHandler extends NanoServerHandler {
+
+        private final String defnName;
+        private final String defnFileName;
+        private final String port;
+
+        DefnServerHandler(String name, String defnName, String defnFileName) {
+            super(name);
+            this.defnName = defnName;
+            this.defnFileName = defnFileName;
+            this.port = String.valueOf(nano.getListeningPort());
+        }
+
+        @Override
+        protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
+            String response;
+            if (session.getUri().endsWith(defnName)) {
+                response = getHtml(defnFileName, new String[][] {{"PORT", port}});
+            } else {
+                response = "";
+            }
+            return newFixedLengthResponse(response);
         }
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
@@ -91,12 +91,13 @@ class OpenApiJobUnitTest extends TestUtils {
         Map<String, String> params = job.getCustomConfigParameters();
 
         // Then
-        assertThat(params.size(), is(equalTo(5)));
+        assertThat(params.size(), is(equalTo(6)));
         assertThat(params.get("apiFile"), is(equalTo("")));
         assertThat(params.get("apiUrl"), is(equalTo("")));
         assertThat(params.get("targetUrl"), is(equalTo("")));
         assertThat(params.get("context"), is(equalTo("")));
         assertThat(params.get("user"), is(equalTo("")));
+        assertThat(params.get("maxMessages"), is(equalTo("0")));
     }
 
     @Test
@@ -108,6 +109,7 @@ class OpenApiJobUnitTest extends TestUtils {
         String targetUrl = "https://example.com/endpoint/";
         String context = "My Context";
         String user = "My User";
+        int maxMessages = 1;
         String yamlStr =
                 "parameters:\n"
                         + "  apiUrl: "
@@ -123,7 +125,10 @@ class OpenApiJobUnitTest extends TestUtils {
                         + context
                         + "\n"
                         + "  user: "
-                        + user;
+                        + user
+                        + "\n"
+                        + "  maxMessages: "
+                        + maxMessages;
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
 
@@ -144,8 +149,31 @@ class OpenApiJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getTargetUrl(), is(equalTo(targetUrl)));
         assertThat(job.getParameters().getContext(), is(equalTo(context)));
         assertThat(job.getParameters().getUser(), is(equalTo(user)));
+        assertThat(job.getParameters().getMaxMessages(), is(equalTo(maxMessages)));
         assertThat(progress.hasErrors(), is(equalTo(false)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldWarnIfNegativeMaxMessages() {
+        // Given
+        mockMessages(new ExtensionOpenApi());
+        AutomationProgress progress = new AutomationProgress();
+        String yamlStr = "parameters:\n" + "  maxMessages: -1";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        OpenApiJob job = new OpenApiJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(
+                progress.getWarnings().get(0),
+                is(equalTo("Job openapi maxMessages must be zero or greater, was: -1")));
     }
 
     @Test

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverterUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverterUnitTest.java
@@ -1242,6 +1242,21 @@ class SwaggerConverterUnitTest extends AbstractOpenApiTest {
                         "http://server.localhost/path/c/2/"));
     }
 
+    @Test
+    void shouldLimitRequestModelsWhenMaxMessagesSet() throws Exception {
+        // Given
+        String definition = getHtml("openapi_paths_misc.yaml");
+        SwaggerConverter converter = new SwaggerConverter(definition, null);
+        // When
+        List<RequestModel> requests = converter.getRequestModels(null, 2);
+        // Then
+        assertThat(converter.getErrorMessages(), is(empty()));
+        assertThat(requests, hasSize(2));
+        assertThat(
+                urlsOf(requests),
+                contains("http://server.localhost/path/a/", "http://server.localhost/path/b/"));
+    }
+
     private static List<String> urlsOf(List<RequestModel> requests) {
         return requests.stream().map(RequestModel::getUrl).collect(Collectors.toList());
     }


### PR DESCRIPTION
## Overview

Allow automation framework (AF) users to limit the number of OpenAPI endpoints to import. Ex: If testing authentication, access, etc.

I tested with: <https://petstore3.swagger.io/>, this saved def'n: <https://petstore3.swagger.io/api/v3/openapi.json>

<details>
<summary>and this af plan</summary>

```yml
env:
  contexts:
  - name: Default Context
    urls:
    - https://petstore3.swagger.io
    includePaths:
    - https:\/\/petstore3\.swagger\.io.*
    authentication:
      verification:
        method: response
        pollFrequency: 60
        pollUnits: requests
    sessionManagement:
      method: cookie
    technology: {}
    structure: {}
  parameters: {}
jobs:
- type: openapi
  parameters:
    apiFile: ./openapi.json
    targetUrl: https://petstore3.swagger.io/api/v3/
    maxEndpoints: 1

```

</details>
