### PR TITLE
authhelper: add zest statement index to step name

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update dependency.
+- Include the Zest statement index in the authentication diagnostics' steps.
 
 ## [0.40.0] - 2026-06-12
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -322,6 +322,7 @@ return getSelector(arguments[0], document)
                 screenshotDiag.setDescription(
                         Constant.messages.getString(
                                 "authhelper.auth.method.diags.zest.interaction",
+                                element.getIndex(),
                                 ZestZapUtils.toUiString(element, false)));
                 i += 1;
                 zestScript.getStatements().add(i, screenshotDiag);

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -90,7 +90,7 @@ authhelper.auth.method.diags.steps.start = URL Accessed
 authhelper.auth.method.diags.steps.unauthenticated = Unauthenticated Message
 authhelper.auth.method.diags.steps.username = Auto Fill Username
 authhelper.auth.method.diags.zest.close = Browser Closed
-authhelper.auth.method.diags.zest.interaction = Interaction: {0}
+authhelper.auth.method.diags.zest.interaction = Interaction ({0}): {1}
 authhelper.auth.method.diags.zest.open = Browser Opened
 
 authhelper.auth.test.dialog.button.copy = Copy


### PR DESCRIPTION
Include the index of the Zest statement to make it easier to map them.