### PR TITLE
Use custom caching for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,22 @@ jobs:
           java-version: ${{ matrix.java }}
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
+          cache-disabled: true
           gradle-home-cache-includes: |
             caches
             caches/zap-wd
             notifications
+      - uses: actions/cache@v6
+        with:
+          path: |
+           ${{ env.GRADLE_USER_HOME }}/caches
+           ${{ env.GRADLE_USER_HOME }}/wrapper
+          key: ${{ runner.os }}-gradle-${{ matrix.java }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-${{ matrix.java }}-
+            ${{ runner.os }}-gradle-
       - run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx4g" assemble
         env:
           ZAP_WD_CACHE: 1
       - run: ./gradlew check
+      - run: ./gradlew --stop


### PR DESCRIPTION
Workaround issue in setup-gradle which no longer creates caches for Windows.