### PR TITLE
authhelper: Add AF diagnostics job

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Automation Framework `diagnostics` job to start and stop plan-level recording of authentication related diagnostics.
+
 ### Changed
 - Update dependency.
 - Include the Zest statement index in the authentication diagnostics' steps.

--- a/addOns/authhelper/authhelper.gradle.kts
+++ b/addOns/authhelper/authhelper.gradle.kts
@@ -53,6 +53,18 @@ zapAddOn {
                     }
                 }
             }
+            register("org.zaproxy.addon.authhelper.automation.ExtensionAuthhelperAutomation") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.addon.authhelper.automation"))
+                }
+                dependencies {
+                    addOns {
+                        register("automation") {
+                            version.set(">=0.60.0")
+                        }
+                    }
+                }
+            }
         }
         dependencies {
             addOns {

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/automation/DiagnosticsJob.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/automation/DiagnosticsJob.java
@@ -1,0 +1,217 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper.automation;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Setter;
+import org.parosproxy.paros.CommandLine;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.authhelper.AuthenticationDiagnostics;
+import org.zaproxy.addon.automation.AutomationData;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationPlan;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.jobs.JobData;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+
+public class DiagnosticsJob extends AutomationJob {
+
+    public static final String JOB_NAME = "diagnostics";
+
+    private static final String RESOURCES_DIR = "/org/zaproxy/addon/authhelper/resources/";
+
+    private static final Map<AutomationPlan, AuthenticationDiagnostics> recordings =
+            new ConcurrentHashMap<>();
+
+    private final Parameters parameters = new Parameters();
+    private final Data data;
+
+    public DiagnosticsJob() {
+        this.data = new Data(this, parameters);
+    }
+
+    @Override
+    public void verifyParameters(AutomationProgress progress) {
+        Map<?, ?> jobData = getJobData();
+        if (jobData == null) {
+            return;
+        }
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                parameters,
+                getName(),
+                null,
+                progress);
+    }
+
+    @Override
+    public void applyParameters(AutomationProgress progress) {
+        // Nothing to do.
+    }
+
+    @Override
+    public Map<String, String> getCustomConfigParameters() {
+        Map<String, String> map = super.getCustomConfigParameters();
+        map.put("enabled", "false");
+        return map;
+    }
+
+    @Override
+    public void runJob(AutomationEnvironment env, AutomationProgress progress) {
+        AutomationPlan plan = env.getPlan();
+        if (parameters.isEnabled()) {
+            if (recordings.containsKey(plan)) {
+                progress.warn(
+                        Constant.messages.getString(
+                                "authhelper.automation.diagnostics.warn.alreadyenabled",
+                                getName()));
+                return;
+            }
+            recordings.put(
+                    plan,
+                    new AuthenticationDiagnostics(
+                            true,
+                            Constant.messages.getString(
+                                    "authhelper.automation.diagnostics.authmethod"),
+                            env.getDefaultContext().getName(),
+                            ""));
+            progress.info(
+                    Constant.messages.getString(
+                            "authhelper.automation.diagnostics.info.enabled", getName()));
+        } else if (stopRecording(plan)) {
+            progress.info(
+                    Constant.messages.getString(
+                            "authhelper.automation.diagnostics.info.disabled", getName()));
+        } else {
+            progress.warn(
+                    Constant.messages.getString(
+                            "authhelper.automation.diagnostics.warn.notenabled", getName()));
+        }
+    }
+
+    @Override
+    public void planFinished() {
+        stopRecording(getPlan());
+    }
+
+    private static boolean stopRecording(AutomationPlan plan) {
+        if (plan == null) {
+            return false;
+        }
+        AuthenticationDiagnostics recording = recordings.remove(plan);
+        if (recording == null) {
+            return false;
+        }
+        recording.recordStep(Constant.messages.getString("authhelper.automation.diagnostics.step"));
+        recording.close();
+        return true;
+    }
+
+    @Override
+    public void showDialog() {
+        new DiagnosticsJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getTemplateDataMin() {
+        return getResourceAsString(JOB_NAME + "-min.yaml");
+    }
+
+    @Override
+    public String getTemplateDataMax() {
+        return getResourceAsString(JOB_NAME + "-max.yaml");
+    }
+
+    private static String getResourceAsString(String name) {
+        try (InputStream in = DiagnosticsJob.class.getResourceAsStream(RESOURCES_DIR + name)) {
+            return new BufferedReader(new InputStreamReader(in))
+                            .lines()
+                            .collect(Collectors.joining("\n"))
+                    + "\n";
+        } catch (Exception e) {
+            CommandLine.error(
+                    Constant.messages.getString(
+                            "authhelper.automation.diagnostics.error.nofile",
+                            RESOURCES_DIR + name));
+        }
+        return "";
+    }
+
+    @Override
+    public Order getOrder() {
+        return Order.CONFIGS;
+    }
+
+    @Override
+    public String getType() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public Object getParamMethodObject() {
+        return null;
+    }
+
+    @Override
+    public String getParamMethodName() {
+        return null;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "authhelper.automation.diagnostics.summary", parameters.isEnabled());
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    @Getter
+    @Setter
+    public static class Data extends JobData {
+        private Parameters parameters;
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class Parameters extends AutomationData {
+        private boolean enabled;
+    }
+}

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/automation/DiagnosticsJobDialog.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/automation/DiagnosticsJobDialog.java
@@ -1,0 +1,57 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper.automation;
+
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+@SuppressWarnings("serial")
+public class DiagnosticsJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "authhelper.automation.diagnostics.dialog.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String ENABLED_PARAM = "authhelper.automation.diagnostics.dialog.enabled";
+
+    private final DiagnosticsJob job;
+
+    public DiagnosticsJobDialog(DiagnosticsJob job) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(400, 180));
+        this.job = job;
+
+        this.addTextField(NAME_PARAM, this.job.getData().getName());
+        this.addCheckBoxField(ENABLED_PARAM, this.job.getParameters().isEnabled());
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setEnabled(this.getBoolValue(ENABLED_PARAM));
+        this.job.resetAndSetChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        return null;
+    }
+}

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/automation/ExtensionAuthhelperAutomation.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/automation/ExtensionAuthhelperAutomation.java
@@ -1,0 +1,85 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper.automation;
+
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.addon.authhelper.ExtensionAuthhelper;
+import org.zaproxy.addon.automation.ExtensionAutomation;
+
+public class ExtensionAuthhelperAutomation extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtensionAuthhelperAutomation";
+
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            List.of(ExtensionAuthhelper.class, ExtensionAutomation.class);
+
+    private DiagnosticsJob diagnosticsJob;
+
+    public ExtensionAuthhelperAutomation() {
+        super(NAME);
+        setI18nPrefix("authhelper");
+    }
+
+    @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+        ExtensionAutomation extAuto =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutomation.class);
+        diagnosticsJob = new DiagnosticsJob();
+        extAuto.registerAutomationJob(diagnosticsJob);
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        ExtensionAutomation extAuto =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutomation.class);
+        extAuto.unregisterAutomationJob(diagnosticsJob);
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("authhelper.automation.ext.desc");
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("authhelper.automation.ext.name");
+    }
+}

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/auth-report-json.html
@@ -225,7 +225,8 @@
 	<H3>Diagnostics</H3>
 	The <a href="browser-auth.html">Browser Based</a> and <a href="client-script.html">Client Script</a> authentication methods allow to record diagnostic data, which can be included in the Authentication Report, to help diagnose authentication problems.
 	<p>
-	Diagnostic data can also be recorded with the <a href="auth-tester.html">Authentication Tester Dialog</a>.
+	Diagnostic data can also be recorded with the <a href="auth-tester.html">Authentication Tester Dialog</a>
+	or the Automation Framework <a href="automation.html">diagnostics</a> job.
 	<p>
 	The report will contain an array of diagnostic objects, one for each recorded authentication attempt. The diagnostic objet has the authentication method used, the name of the context and user, the script if Client Script Authentication, the Automation Framework plan, and each step performed during the authentication.
 <pre>

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/authhelper.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/authhelper.html
@@ -31,6 +31,7 @@ The features currently supported are:
 <li><a href="session-header.html">Header Based Session Management</a>
 <li><a href="verification-id.html">Verification Identification</a>
 <li><a href="auth-report-json.html">Authentication Report (JSON)</a>
+<li><a href="automation.html">Automation Framework Support</a>
 </ul>
 
 <p>

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/automation.html
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/contents/automation.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>
+Authentication Helper Automation Framework Support
+</TITLE>
+</HEAD>
+<BODY>
+<H1>Authentication Helper Automation Framework Support</H1>
+This add-on supports the Automation Framework.
+
+<H2>Job: diagnostics</H2>
+The diagnostics job starts or stops plan-level recording of authentication related diagnostics.
+Recorded diagnostics appear in the Authentication Diagnostics UI and can be included in the
+<a href="reports.html">Authentication Report</a>.
+<p>
+A plan may include multiple diagnostics jobs. Recording starts when <code>enabled</code> is <code>true</code>
+and stops (and is persisted) when <code>enabled</code> is <code>false</code>.
+If recording is still on at plan finish, it is stopped and persisted automatically.
+<pre>
+  - type: diagnostics                  # Enable or disable plan-level diagnostics recording
+    parameters:
+      enabled:                         # Bool: If true, start diagnostics recording, default: false
+</pre>
+<p>
+Enabling both this job and <code>env</code> authentication diagnostics (browser/client
+<code>authentication.parameters.diagnostics</code>) in the same plan is not recommended and may cause
+duplicate diagnostic records. Prefer using one diagnostics mechanism per plan.
+</BODY>
+</HTML>

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/index.xml
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/index.xml
@@ -16,4 +16,5 @@
 	<indexitem text="Verification Identification" target="authhelper.verification-id" />
 	<indexitem text="Authentication Tester Dialog" target="authhelper.auth-tester" />
 	<indexitem text="Report Templates" target="authhelper.report-templates" />
+	<indexitem text="Authentication Helper Automation Framework" target="authhelper.automation" />
 </index>

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/map.jhm
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/map.jhm
@@ -16,4 +16,5 @@
     <mapID target="authhelper.verification-id" url="contents/verification-id.html" />
     <mapID target="authhelper.auth-tester" url="contents/auth-tester.html" />
     <mapID target="authhelper.report-templates" url="contents/reports.html" />
+    <mapID target="authhelper.automation" url="contents/automation.html" />
 </map>

--- a/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/toc.xml
+++ b/addOns/authhelper/src/main/javahelp/org/zaproxy/addon/authhelper/resources/help/toc.xml
@@ -17,6 +17,7 @@
 				<tocitem text="Verification Identification" target="authhelper.verification-id"/>
 				<tocitem text="Authentication Tester Dialog" target="authhelper.auth-tester"/>
 				<tocitem text="Report Templates" target="authhelper.report-templates"/>
+				<tocitem text="Automation Framework Support" target="authhelper.automation"/>
 			</tocitem>
 		</tocitem>
 	</tocitem>

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -228,6 +228,19 @@ authhelper.authreport.summary.username.pass = Username field identified
 authhelper.authreport.summary.verif.fail = Verification URL not identified
 authhelper.authreport.summary.verif.pass = Verification URL identified
 
+authhelper.automation.diagnostics.authmethod = Diagnostics
+authhelper.automation.diagnostics.dialog.enabled = Enabled:
+authhelper.automation.diagnostics.dialog.title = Diagnostics Job
+authhelper.automation.diagnostics.error.nofile = Cannot access file: {0}
+authhelper.automation.diagnostics.info.disabled = Job {0} stopped diagnostics recording
+authhelper.automation.diagnostics.info.enabled = Job {0} started diagnostics recording
+authhelper.automation.diagnostics.step = Diagnostics Recording
+authhelper.automation.diagnostics.summary = Enabled: {0}
+authhelper.automation.diagnostics.warn.alreadyenabled = Job {0}: diagnostics recording is already enabled
+authhelper.automation.diagnostics.warn.notenabled = Job {0}: diagnostics recording is not enabled
+authhelper.automation.ext.desc = Authentication Helper Automation Framework Integration
+authhelper.automation.ext.name = Authentication Helper Automation
+
 authhelper.client.desc = Enables browser based authentication when performing an authenticated Client Spider scan.
 authhelper.client.name = Client Spider Browser Based Authentication Support
 

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/diagnostics-max.yaml
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/diagnostics-max.yaml
@@ -1,0 +1,3 @@
+  - type: diagnostics                  # Enable or disable plan-level diagnostics recording
+    parameters:
+      enabled:                         # Bool: If true, start diagnostics recording, default: false

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/diagnostics-min.yaml
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/diagnostics-min.yaml
@@ -1,0 +1,3 @@
+  - type: diagnostics                  # Enable or disable plan-level diagnostics recording
+    parameters:
+      enabled:                         # Bool: If true, start diagnostics recording, default: false

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/automation/DiagnosticsJobUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/automation/DiagnosticsJobUnitTest.java
@@ -1,0 +1,236 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.authhelper.automation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.LinkedHashMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.MockedConstruction;
+import org.yaml.snakeyaml.Yaml;
+import org.zaproxy.addon.authhelper.AuthenticationDiagnostics;
+import org.zaproxy.addon.authhelper.ExtensionAuthhelper;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationPlan;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class DiagnosticsJobUnitTest extends TestUtils {
+
+    private AutomationEnvironment env;
+    private AutomationPlan plan;
+    private AutomationProgress progress;
+    private Context context;
+
+    @BeforeEach
+    void setUp() {
+        mockMessages(new ExtensionAuthhelper());
+        plan = mock(AutomationPlan.class);
+        env = mock(AutomationEnvironment.class);
+        context = mock(Context.class);
+        lenient().when(context.getName()).thenReturn("Default Context");
+        lenient().when(env.getDefaultContext()).thenReturn(context);
+        lenient().when(env.getPlan()).thenReturn(plan);
+        progress = new AutomationProgress();
+    }
+
+    @AfterEach
+    void tearDown() {
+        DiagnosticsJob cleanup = new DiagnosticsJob();
+        cleanup.setPlan(plan);
+        cleanup.planFinished();
+    }
+
+    private static DiagnosticsJob jobFor(AutomationPlan plan) {
+        DiagnosticsJob job = new DiagnosticsJob();
+        job.setPlan(plan);
+        return job;
+    }
+
+    @Test
+    void shouldApplyEnabledParamAndExposeTypeTemplates() {
+        // Given
+        DiagnosticsJob job = new DiagnosticsJob();
+        Object data = new Yaml().load("parameters:\n  enabled: true");
+        job.setJobData((LinkedHashMap<?, ?>) data);
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(job.getType(), is(equalTo("diagnostics")));
+        assertThat(job.getTemplateDataMin(), containsString("type: diagnostics"));
+        assertThat(job.getTemplateDataMax(), containsString("enabled:"));
+        assertThat(job.getParameters().isEnabled(), is(equalTo(true)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldStartRecordingWhenEnabledTrueAndOff() {
+        try (MockedConstruction<AuthenticationDiagnostics> diags =
+                mockConstruction(AuthenticationDiagnostics.class)) {
+            // Given
+            DiagnosticsJob job = jobFor(plan);
+            job.getParameters().setEnabled(true);
+
+            // When
+            job.runJob(env, progress);
+
+            // Then
+            assertThat(diags.constructed(), hasSize(1));
+            assertThat(progress.hasErrors(), is(equalTo(false)));
+            assertThat(
+                    progress.getInfos().toString(),
+                    containsString("started diagnostics recording"));
+        }
+    }
+
+    @Test
+    void shouldWarnWhenEnabledTrueAndAlreadyOn() {
+        try (MockedConstruction<AuthenticationDiagnostics> diags =
+                mockConstruction(AuthenticationDiagnostics.class)) {
+            // Given
+            DiagnosticsJob job = jobFor(plan);
+            job.getParameters().setEnabled(true);
+            job.runJob(env, progress);
+            progress = new AutomationProgress();
+
+            // When
+            job.runJob(env, progress);
+
+            // Then
+            assertThat(diags.constructed(), hasSize(1));
+            verify(diags.constructed().get(0), never()).close();
+            assertThat(progress.hasWarnings(), is(equalTo(true)));
+            assertThat(
+                    progress.getWarnings().toString(),
+                    containsString("diagnostics recording is already enabled"));
+        }
+    }
+
+    @Test
+    void shouldStopRecordingWhenEnabledFalseAndOn() {
+        try (MockedConstruction<AuthenticationDiagnostics> diags =
+                mockConstruction(AuthenticationDiagnostics.class)) {
+            // Given
+            DiagnosticsJob start = jobFor(plan);
+            start.getParameters().setEnabled(true);
+            start.runJob(env, progress);
+            DiagnosticsJob stop = jobFor(plan);
+            stop.getParameters().setEnabled(false);
+            progress = new AutomationProgress();
+
+            // When
+            stop.runJob(env, progress);
+
+            // Then
+            AuthenticationDiagnostics recording = diags.constructed().get(0);
+            InOrder inOrder = inOrder(recording);
+            inOrder.verify(recording).recordStep("Diagnostics Recording");
+            inOrder.verify(recording).close();
+            assertThat(
+                    progress.getInfos().toString(),
+                    containsString("stopped diagnostics recording"));
+        }
+    }
+
+    @Test
+    void shouldWarnWhenEnabledFalseAndAlreadyOff() {
+        // Given
+        DiagnosticsJob job = jobFor(plan);
+        job.getParameters().setEnabled(false);
+
+        // When
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(
+                progress.getWarnings().toString(),
+                containsString("diagnostics recording is not enabled"));
+    }
+
+    @Test
+    void shouldStopOnPlanFinished() {
+        try (MockedConstruction<AuthenticationDiagnostics> diags =
+                mockConstruction(AuthenticationDiagnostics.class)) {
+            // Given
+            DiagnosticsJob job = jobFor(plan);
+            job.getParameters().setEnabled(true);
+            job.runJob(env, progress);
+
+            // When
+            job.planFinished();
+
+            // Then
+            AuthenticationDiagnostics recording = diags.constructed().get(0);
+            InOrder inOrder = inOrder(recording);
+            inOrder.verify(recording).recordStep("Diagnostics Recording");
+            inOrder.verify(recording).close();
+        }
+    }
+
+    @Test
+    void shouldKeepRecordingsIndependentPerPlan() {
+        try (MockedConstruction<AuthenticationDiagnostics> diags =
+                mockConstruction(AuthenticationDiagnostics.class)) {
+            // Given
+            AutomationPlan otherPlan = mock(AutomationPlan.class);
+            AutomationEnvironment otherEnv = mock(AutomationEnvironment.class);
+            lenient().when(otherEnv.getDefaultContext()).thenReturn(context);
+            lenient().when(otherEnv.getPlan()).thenReturn(otherPlan);
+
+            DiagnosticsJob job1 = jobFor(plan);
+            job1.getParameters().setEnabled(true);
+            job1.runJob(env, progress);
+
+            DiagnosticsJob job2 = jobFor(otherPlan);
+            job2.getParameters().setEnabled(true);
+            job2.runJob(otherEnv, progress);
+
+            try {
+                // When
+                job1.planFinished();
+
+                // Then
+                assertThat(diags.constructed(), hasSize(2));
+                verify(diags.constructed().get(0)).close();
+                verify(diags.constructed().get(1), never()).close();
+            } finally {
+                job2.planFinished();
+            }
+            verify(diags.constructed().get(1)).close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Automation Framework `diagnostics` job to start/stop **per-plan** recording of authentication related diagnostics (plan default/first context; simple job UI).
- On stop (or plan finish): `recordStep(...)` then `close()` — no AuthDiagnostics API changes. Warns on noop enable/disable.
- Register via authhelper automation sub-extension; templates, i18n, help (coexistence note with env `authentication.parameters.diagnostics`; links Authentication Report help).

Independent of #7556 (auth report). Previous companion #7554 closed as unnecessary.