### PR TITLE
postman: Allow limiting the number of messages imported

### DIFF
--- a/addOns/postman/CHANGELOG.md
+++ b/addOns/postman/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Allow Automation Framework users to limit the number of Postman messages to import (`maxMessages`). Ex: If testing authentication, access, etc.
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanParser.java
@@ -78,6 +78,12 @@ public class PostmanParser {
     public boolean importFromFile(
             final String filePath, final String variables, final boolean initViaUi)
             throws IOException {
+        return importFromFile(filePath, variables, initViaUi, 0);
+    }
+
+    public boolean importFromFile(
+            final String filePath, final String variables, final boolean initViaUi, int maxMessages)
+            throws IOException {
         File file = new File(filePath);
         if (!file.exists()) {
             throw new FileNotFoundException(
@@ -90,10 +96,16 @@ public class PostmanParser {
 
         String collectionJson = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
         Stats.incCounter("stats.postman.import.file");
-        return importCollection(collectionJson, variables, initViaUi);
+        return importCollection(collectionJson, variables, initViaUi, maxMessages);
     }
 
     public boolean importFromUrl(final String url, final String variables, final boolean initViaUi)
+            throws IllegalArgumentException, IOException {
+        return importFromUrl(url, variables, initViaUi, 0);
+    }
+
+    public boolean importFromUrl(
+            final String url, final String variables, final boolean initViaUi, int maxMessages)
             throws IllegalArgumentException, IOException {
         if (url.isEmpty()) {
             throw new IllegalArgumentException(
@@ -109,11 +121,11 @@ public class PostmanParser {
 
         String collectionJson = requestor.getResponseBody(uri);
         Stats.incCounter("stats.postman.import.url");
-        return importCollection(collectionJson, variables, initViaUi);
+        return importCollection(collectionJson, variables, initViaUi, maxMessages);
     }
 
     List<HttpMessage> getHttpMessages(
-            String collection, final String variables, List<String> errors)
+            String collection, final String variables, List<String> errors, int maxMessages)
             throws JsonProcessingException {
         collection = replaceVariables(collection, variables);
 
@@ -121,7 +133,11 @@ public class PostmanParser {
         List<HttpMessage> httpMessages = new ArrayList<>();
 
         extractHttpMessages(
-                postmanCollection.getItem(), httpMessages, errors, postmanCollection.getVariable());
+                postmanCollection.getItem(),
+                httpMessages,
+                errors,
+                postmanCollection.getVariable(),
+                maxMessages);
         if (httpMessages.isEmpty()) {
             errors.add(Constant.messages.getString("postman.import.error.noItem"));
             Stats.incCounter("stats.postman.error.nomsgs");
@@ -132,8 +148,15 @@ public class PostmanParser {
     public boolean importCollection(
             String collection, final String variables, final boolean initViaUi)
             throws JsonProcessingException {
+        return importCollection(collection, variables, initViaUi, 0);
+    }
+
+    public boolean importCollection(
+            String collection, final String variables, final boolean initViaUi, int maxMessages)
+            throws JsonProcessingException {
         List<String> errors = new ArrayList<>();
-        List<HttpMessage> httpMessages = getHttpMessages(collection, variables, errors);
+        List<HttpMessage> httpMessages =
+                getHttpMessages(collection, variables, errors, maxMessages);
 
         requestor.run(httpMessages, errors);
 
@@ -209,7 +232,7 @@ public class PostmanParser {
     }
 
     static void extractHttpMessages(List<AbstractItem> items, List<HttpMessage> httpMessages) {
-        extractHttpMessages(items, httpMessages, new ArrayList<>(), null);
+        extractHttpMessages(items, httpMessages, new ArrayList<>(), null, 0);
     }
 
     static List<KeyValueData> getCombinedVarList(
@@ -231,9 +254,13 @@ public class PostmanParser {
             List<AbstractItem> items,
             List<HttpMessage> httpMessages,
             List<String> errors,
-            List<KeyValueData> parentVariables) {
+            List<KeyValueData> parentVariables,
+            int maxMessages) {
         if (items != null) {
             for (AbstractItem item : items) {
+                if (maxMessages > 0 && httpMessages.size() >= maxMessages) {
+                    return;
+                }
                 if (item instanceof Item) {
                     HttpMessage httpMessage =
                             extractHttpMessage((Item) item, errors, parentVariables);
@@ -247,7 +274,8 @@ public class PostmanParser {
                             itemGroup.getItem(),
                             httpMessages,
                             errors,
-                            getCombinedVarList(itemGroup.getVariable(), parentVariables));
+                            getCombinedVarList(itemGroup.getVariable(), parentVariables),
+                            maxMessages);
                 }
             }
         }

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/automation/PostmanJob.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/automation/PostmanJob.java
@@ -46,6 +46,7 @@ public class PostmanJob extends AutomationJob {
     private static final String PARAM_COLLECTION_URL = "collectionUrl";
     private static final String PARAM_COLLECTION_FILE = "collectionFile";
     private static final String PARAM_VARS = "variables";
+    private static final String PARAM_MAX_MESSAGES = "maxMessages";
 
     private Parameters parameters = new Parameters();
     private Data data;
@@ -66,6 +67,14 @@ public class PostmanJob extends AutomationJob {
                 this.getName(),
                 null,
                 progress);
+
+        if (getParameters().getMaxMessages() < 0) {
+            progress.warn(
+                    Constant.messages.getString(
+                            "postman.automation.warn.maxMessages",
+                            getName(),
+                            getParameters().getMaxMessages()));
+        }
     }
 
     @Override
@@ -79,6 +88,7 @@ public class PostmanJob extends AutomationJob {
         map.put(PARAM_COLLECTION_URL, "");
         map.put(PARAM_COLLECTION_FILE, "");
         map.put(PARAM_VARS, "");
+        map.put(PARAM_MAX_MESSAGES, "0");
         return map;
     }
 
@@ -87,6 +97,7 @@ public class PostmanJob extends AutomationJob {
         String collectionFile = this.getParameters().getCollectionFile();
         String collectionStr = this.getParameters().getCollectionUrl();
         String variables = this.getParameters().getVariables();
+        int maxMessages = getParameters().getMaxMessages();
 
         PostmanParser parser = new PostmanParser();
 
@@ -94,7 +105,7 @@ public class PostmanJob extends AutomationJob {
             File file = JobUtils.getFile(collectionFile, getPlan());
 
             try {
-                parser.importFromFile(file.getAbsolutePath(), variables, false);
+                parser.importFromFile(file.getAbsolutePath(), variables, false, maxMessages);
             } catch (IOException e) {
                 progress.error(
                         Constant.messages.getString("postman.automation.error", e.getMessage()));
@@ -108,7 +119,7 @@ public class PostmanJob extends AutomationJob {
             try {
                 UriUtils.isValid(collectionUrl);
 
-                parser.importFromUrl(collectionUrl, variables, false);
+                parser.importFromUrl(collectionUrl, variables, false, maxMessages);
             } catch (ZapUriException | IOException e) {
                 progress.error(
                         Constant.messages.getString("postman.automation.error", e.getMessage()));
@@ -196,5 +207,6 @@ public class PostmanJob extends AutomationJob {
         private String collectionFile = "";
         private String collectionUrl = "";
         private String variables = "";
+        private int maxMessages;
     }
 }

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/automation/PostmanJobDialog.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/automation/PostmanJobDialog.java
@@ -37,11 +37,12 @@ public class PostmanJobDialog extends StandardFieldsDialog {
     private static final String COLLECTION_FILE_PARAM = "postman.automation.dialog.collectionfile";
     private static final String COLLECTION_URL_PARAM = "postman.automation.dialog.collectionurl";
     private static final String VARS_PARAM = "postman.automation.dialog.vars";
+    private static final String MAX_MESSAGES_PARAM = "postman.automation.dialog.maxmessages";
 
     private PostmanJob job;
 
     public PostmanJobDialog(PostmanJob job) {
-        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 250));
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 280));
         this.job = job;
 
         this.addTextField(NAME_PARAM, this.job.getData().getName());
@@ -59,6 +60,11 @@ public class PostmanJobDialog extends StandardFieldsDialog {
         }
 
         this.addTextField(VARS_PARAM, this.job.getParameters().getVariables());
+        this.addNumberField(
+                MAX_MESSAGES_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                this.job.getParameters().getMaxMessages());
         this.addPadding();
     }
 
@@ -68,6 +74,7 @@ public class PostmanJobDialog extends StandardFieldsDialog {
         this.job.getParameters().setCollectionFile((this.getStringValue(COLLECTION_FILE_PARAM)));
         this.job.getParameters().setCollectionUrl(this.getStringValue(COLLECTION_URL_PARAM));
         this.job.getParameters().setVariables(this.getStringValue(VARS_PARAM));
+        this.job.getParameters().setMaxMessages(this.getIntValue(MAX_MESSAGES_PARAM));
         this.job.resetAndSetChanged();
     }
 

--- a/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/automation.html
+++ b/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/automation.html
@@ -22,7 +22,11 @@ The postman job allows you to import Postman collections via a URL or file.
       collectionFile:     # String: Local file containing the Postman collection, default: null, no collection will be imported
       collectionUrl:      # String: URL containing the Postman collection, default: null, no collection will be imported
       variables:          # String: Comma-separated list of variables as key-value pairs in the format <code>key1=value1,key2=value2,...</code>, these variables will have precedence over the collection ones
+      maxMessages:        # Int: Maximum number of messages to import, default: 0, import all messages
 </pre>
+<p>
+Note that redirects are followed, so <code>maxMessages</code> is a soft limit - more messages may be imported than the value specified.
+</p>
 
 </BODY>
 </HTML>

--- a/addOns/postman/src/main/resources/org/zaproxy/addon/postman/automation/postman-max.yaml
+++ b/addOns/postman/src/main/resources/org/zaproxy/addon/postman/automation/postman-max.yaml
@@ -3,3 +3,4 @@
       collectionFile:     # String: Local file containing the Postman collection, default: null, no collection will be imported
       collectionUrl:      # String: URL containing the Postman collection, default: null, no collection will be imported
       variables:          # String: Comma-separated list of variables as key-value pairs in the format key1=value1,key2=value2,..., these variables will have precedence over the collection ones
+      maxMessages:        # Int: Maximum number of messages to import, default: 0, import all messages

--- a/addOns/postman/src/main/resources/org/zaproxy/addon/postman/resources/Messages.properties
+++ b/addOns/postman/src/main/resources/org/zaproxy/addon/postman/resources/Messages.properties
@@ -7,12 +7,14 @@ postman.api.desc = Functionality for importing Postman collections.
 postman.automation.desc = Postman Automation Framework Integration
 postman.automation.dialog.collectionfile = Collection File:
 postman.automation.dialog.collectionurl = Collection URL:
+postman.automation.dialog.maxmessages = Max Messages:
 postman.automation.dialog.name = Job Name:
 postman.automation.dialog.summary = URL: {0}, File: {1}
 postman.automation.dialog.title = Postman Job
 postman.automation.dialog.vars = Variables
 postman.automation.error = Job postman error: {0}
 postman.automation.name = Postman Automation
+postman.automation.warn.maxMessages = Job {0} maxMessages must be zero or greater, was: {1}
 
 postman.cmdline.endpointurl.help = The endpoint URL, to override the base URLs present in the Postman collection.
 postman.cmdline.file.help = Imports a Postman collection from the specified file name.

--- a/addOns/postman/src/test/java/org/zaproxy/addon/postman/PostmanParserUnitTest.java
+++ b/addOns/postman/src/test/java/org/zaproxy/addon/postman/PostmanParserUnitTest.java
@@ -298,6 +298,19 @@ class PostmanParserUnitTest extends TestUtils {
                 httpMessages.size() == 0 ? null : (long) httpMessages.size());
     }
 
+    @Test
+    void shouldLimitHttpMessagesWhenMaxMessagesSet() {
+        Item item = new Item(new Request("https://example.com"));
+        List<AbstractItem> items =
+                new ArrayList<>(
+                        List.of(item, item, new ItemGroup(new ArrayList<>(List.of(item, item)))));
+        List<HttpMessage> httpMessages = new ArrayList<>();
+
+        PostmanParser.extractHttpMessages(items, httpMessages, new ArrayList<>(), null, 2);
+
+        assertEquals(2, httpMessages.size());
+    }
+
     // The 'Content-Type' header gets set according to the mode of the request body, but if it's
     // explicitly defined in the request, that value will take precedence
     @Test
@@ -376,7 +389,7 @@ class PostmanParserUnitTest extends TestUtils {
         PostmanParser parser = new PostmanParser();
         List<String> errors = new ArrayList<>();
 
-        parser.getHttpMessages(collectionJson, "", errors);
+        parser.getHttpMessages(collectionJson, "", errors, 0);
 
         assertEquals(expectedErrors.size(), errors.size());
         for (int i = 0; i < errors.size(); i++) {
@@ -437,7 +450,8 @@ class PostmanParserUnitTest extends TestUtils {
         String collectionJson =
                 "{\"item\":{\"request\":{\"url\":{\"raw\":\"https://example.com/:someKey\",\"variable\":{\"key\":\"someKey\",\"value\":\"somePath\"}}}}}";
         PostmanParser parser = new PostmanParser();
-        List<HttpMessage> messages = parser.getHttpMessages(collectionJson, "", new ArrayList<>());
+        List<HttpMessage> messages =
+                parser.getHttpMessages(collectionJson, "", new ArrayList<>(), 0);
 
         assertEquals(
                 "https://example.com/somePath",
@@ -503,7 +517,7 @@ class PostmanParserUnitTest extends TestUtils {
     @MethodSource("jsonVarsTestData")
     void shouldReplaceJsonVars(String collection, String value) throws JsonProcessingException {
         PostmanParser parser = new PostmanParser();
-        List<HttpMessage> messages = parser.getHttpMessages(collection, "", new ArrayList<>());
+        List<HttpMessage> messages = parser.getHttpMessages(collection, "", new ArrayList<>(), 0);
         HttpMessage message = messages.get(0);
 
         assertEquals(
@@ -534,7 +548,7 @@ class PostmanParserUnitTest extends TestUtils {
         PostmanParser parser = new PostmanParser();
 
         // When
-        List<HttpMessage> messages = parser.getHttpMessages(collection, "", new ArrayList<>());
+        List<HttpMessage> messages = parser.getHttpMessages(collection, "", new ArrayList<>(), 0);
 
         // Then
         HttpMessage message = messages.get(0);

--- a/addOns/postman/src/test/java/org/zaproxy/addon/postman/automation/PostmanJobUnitTest.java
+++ b/addOns/postman/src/test/java/org/zaproxy/addon/postman/automation/PostmanJobUnitTest.java
@@ -108,10 +108,11 @@ class PostmanJobUnitTest extends TestUtils {
         Map<String, String> params = job.getCustomConfigParameters();
 
         // Then
-        assertThat(params.size(), is(equalTo(3)));
+        assertThat(params.size(), is(equalTo(4)));
         assertThat(params.get("collectionFile"), is(equalTo("")));
         assertThat(params.get("collectionUrl"), is(equalTo("")));
         assertThat(params.get("variables"), is(equalTo("")));
+        assertThat(params.get("maxMessages"), is(equalTo("0")));
     }
 
     @Test
@@ -121,6 +122,7 @@ class PostmanJobUnitTest extends TestUtils {
         String collectionFile = "C:\\Users\\ZAPBot\\Documents\\test file.json";
         String collectionUrl = "https://example.com/test%20file.json";
         String variables = "key1=value1,key2=value2";
+        int maxMessages = 1;
         String yamlStr =
                 "parameters:\n"
                         + "  collectionUrl: "
@@ -130,7 +132,10 @@ class PostmanJobUnitTest extends TestUtils {
                         + collectionFile
                         + "\n"
                         + "  variables: "
-                        + variables;
+                        + variables
+                        + "\n"
+                        + "  maxMessages: "
+                        + maxMessages;
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
 
@@ -145,8 +150,31 @@ class PostmanJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getCollectionFile(), is(equalTo(collectionFile)));
         assertThat(job.getParameters().getCollectionUrl(), is(equalTo(collectionUrl)));
         assertThat(job.getParameters().getVariables(), is(equalTo(variables)));
+        assertThat(job.getParameters().getMaxMessages(), is(equalTo(maxMessages)));
         assertThat(progress.hasErrors(), is(equalTo(false)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldWarnIfNegativeMaxMessages() {
+        // Given
+        mockMessages(new ExtensionPostman());
+        AutomationProgress progress = new AutomationProgress();
+        String yamlStr = "parameters:\n" + "  maxMessages: -1";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        PostmanJob job = new PostmanJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(
+                progress.getWarnings().get(0),
+                is(equalTo("Job postman maxMessages must be zero or greater, was: -1")));
     }
 
     @Test
@@ -230,6 +258,10 @@ class PostmanJobUnitTest extends TestUtils {
         assertThat(
                 generatedTemplate,
                 stringContainsInOrder(
-                        "- type: postman", "collectionFile:", "collectionUrl:", "variables:"));
+                        "- type: postman",
+                        "collectionFile:",
+                        "collectionUrl:",
+                        "variables:",
+                        "maxMessages:"));
     }
 }


### PR DESCRIPTION
Allow automation framework (AF) users to limit the number of postman messages to import. Ex: If testing authentication, access, etc.

Related to: https://github.com/zaproxy/zap-extensions/pull/7537

Tested with: https://go.postman.co/collection/14574125-2e916d97-e26f-42d5-a20d-4b34b25498f8?source=collection_link (Might require creating an account then exporting the collection 😞 )

<details>

<summary>Using this af plan</summary>

```yaml
env:
  contexts:
  - name: Default Context
    urls:
    - https://petstore3.swagger.io
    includePaths:
    - https:\/\/petstore3\.swagger\.io.*
    authentication:
      verification:
        method: response
        pollFrequency: 60
        pollUnits: requests
    sessionManagement:
      method: cookie
    technology: {}
    structure: {}
  parameters: {}
jobs:
- type: postman
  parameters:
    collectionFile: postman.json
    maxMessages: 3
```