### PR TITLE
soap: Allow limiting the number of messages imported

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Allow Automation Framework users to limit the number of SOAP messages to import (`maxMessages`). Ex: If testing authentication, access, etc.
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -156,11 +156,19 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
     }
 
     public void syncImportWsdlUrl(final String url) {
-        parser.syncImportWsdlUrl(url);
+        syncImportWsdlUrl(url, 0);
+    }
+
+    public void syncImportWsdlUrl(final String url, int maxMessages) {
+        parser.syncImportWsdlUrl(url, maxMessages);
     }
 
     public void syncImportWsdlFile(final File file) {
-        parser.syncImportWsdlFile(file);
+        syncImportWsdlFile(file, 0);
+    }
+
+    public void syncImportWsdlFile(final File file, int maxMessages) {
+        parser.syncImportWsdlFile(file, maxMessages);
     }
 
     /* Called from external classes in a threaded mode. */

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -104,13 +104,13 @@ public class WSDLCustomParser {
     }
 
     /* Import a WSDL document from a URL synchronously. */
-    public void syncImportWsdlUrl(final String url) {
-        parseWSDLUrl(url);
+    public void syncImportWsdlUrl(final String url, int maxMessages) {
+        parseWSDLUrl(url, maxMessages);
     }
 
     /* Import a WSDL document from a local file synchronously. */
-    public void syncImportWsdlFile(final File file) {
-        parseWSDLFile(file);
+    public void syncImportWsdlFile(final File file, int maxMessages) {
+        parseWSDLFile(file, maxMessages);
     }
 
     /* Method called from external classes to import a WSDL file from an URL. */
@@ -123,7 +123,7 @@ public class WSDLCustomParser {
                     public void run() {
                         // Thread name: THREAD_PREFIX + threadId++
                         this.setName(threadName);
-                        parseWSDLUrl(url);
+                        parseWSDLUrl(url, 0);
                     }
                 };
         t.start();
@@ -137,7 +137,7 @@ public class WSDLCustomParser {
     }
 
     public boolean extContentWSDLImport(final String content, final boolean sendMessages) {
-        return parseWSDLContent(content, sendMessages);
+        return parseWSDLContent(content, sendMessages, 0);
     }
 
     /*
@@ -149,7 +149,7 @@ public class WSDLCustomParser {
                     @Override
                     public void run() {
                         this.setName(threadName);
-                        parseWSDLFile(file);
+                        parseWSDLFile(file, 0);
                     }
                 };
         t.start();
@@ -177,7 +177,7 @@ public class WSDLCustomParser {
      * Generates WSDL definitions from a WSDL file and then it calls parsing
      * functions.
      */
-    private void parseWSDLFile(File file) {
+    private void parseWSDLFile(File file, int maxMessages) {
         if (file == null) return;
         try {
             if (View.isInitialised()) {
@@ -189,7 +189,7 @@ public class WSDLCustomParser {
             WSDLParser parser = new WSDLParser();
             final String path = file.getAbsolutePath();
             Definitions wsdl = parser.parse(path);
-            parseWSDL(wsdl, true);
+            parseWSDL(wsdl, true, maxMessages);
 
         } catch (ResourceDownloadException rde) {
             String exMsg =
@@ -208,7 +208,7 @@ public class WSDLCustomParser {
      * Generates WSDL definitions from a WSDL string and then it calls parsing
      * functions.
      */
-    private void parseWSDLUrl(String url) {
+    private void parseWSDLUrl(String url, int maxMessages) {
         if (url == null || url.trim().equals("")) return;
         try {
             if (View.isInitialised()) {
@@ -245,14 +245,14 @@ public class WSDLCustomParser {
             if (content.trim().isEmpty()) {
                 LOGGER.debug("Response from WSDL file request has no body content, url: {}", url);
             } else {
-                parseWSDLContent(content);
+                parseWSDLContent(content, true, maxMessages);
             }
         } catch (Exception e) {
             LOGGER.error("There was an error while parsing WSDL from URL. ", e);
         }
     }
 
-    private boolean parseWSDLContent(String content, boolean sendMessages) {
+    private boolean parseWSDLContent(String content, boolean sendMessages, int maxMessages) {
         if (content == null || content.trim().length() <= 0) {
             return false;
         } else {
@@ -263,7 +263,7 @@ public class WSDLCustomParser {
                         new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
                 Definitions wsdl = parser.parse(contentI);
                 contentI.close();
-                parseWSDL(wsdl, sendMessages);
+                parseWSDL(wsdl, sendMessages, maxMessages);
                 return true;
             } catch (WrongGrammarException wge) {
                 LOGGER.warn("Are you sure this is a WSDL? {}", wge.getMessage());
@@ -276,14 +276,15 @@ public class WSDLCustomParser {
     }
 
     private boolean parseWSDLContent(String content) {
-        return parseWSDLContent(content, true);
+        return parseWSDLContent(content, true, 0);
     }
 
     /* Parses WSDL definitions and identifies endpoints and operations. */
-    private void parseWSDL(Definitions wsdl, boolean sendMessages) {
+    private void parseWSDL(Definitions wsdl, boolean sendMessages, int maxMessages) {
         StringBuilder sb = new StringBuilder();
         List<Service> services = wsdl.getServices();
         keyIndex++;
+        int messages = 0;
 
         /* Endpoint identification. */
         for (Service service : services) {
@@ -309,6 +310,10 @@ public class WSDLCustomParser {
 
                     /* Identifies operations for each endpoint.. */
                     for (BindingOperation bindOp : operations) {
+                        if (maxMessages > 0 && messages >= maxMessages) {
+                            printOutput(sb);
+                            return;
+                        }
                         sb.append("|\t|-- SOAP 1.")
                                 .append(soapVersion)
                                 .append(" Operation: ")
@@ -331,6 +336,9 @@ public class WSDLCustomParser {
                                 new SOAPMsgConfig(wsdl, soapVersion, formParams, port, bindOp);
                         lastConfig = soapConfig;
                         HttpMessage requestMessage = createSoapRequest(soapConfig);
+                        if (requestMessage != null) {
+                            messages++;
+                        }
                         if (sendMessages) sendSoapRequest(requestMessage, sb);
                     } // bindingOperations loop
                 } // Binding check if

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJob.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJob.java
@@ -48,6 +48,7 @@ public class SoapJob extends AutomationJob {
 
     private static final String PARAM_WSDL_FILE = "wsdlFile";
     private static final String PARAM_WSDL_URL = "wsdlUrl";
+    private static final String PARAM_MAX_MESSAGES = "maxMessages";
 
     private ExtensionImportWSDL extSoap;
 
@@ -80,6 +81,14 @@ public class SoapJob extends AutomationJob {
                 this.getName(),
                 null,
                 progress);
+
+        if (getParameters().getMaxMessages() < 0) {
+            progress.warn(
+                    Constant.messages.getString(
+                            "soap.automation.warn.maxMessages",
+                            getName(),
+                            getParameters().getMaxMessages()));
+        }
     }
 
     @Override
@@ -92,11 +101,13 @@ public class SoapJob extends AutomationJob {
         Map<String, String> map = super.getCustomConfigParameters();
         map.put(PARAM_WSDL_FILE, "");
         map.put(PARAM_WSDL_URL, "");
+        map.put(PARAM_MAX_MESSAGES, "0");
         return map;
     }
 
     @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
+        int maxMessages = getParameters().getMaxMessages();
 
         String wsdlFile = this.getParameters().getWsdlFile();
         if (!StringUtils.isEmpty(wsdlFile)) {
@@ -104,7 +115,7 @@ public class SoapJob extends AutomationJob {
             if (!file.exists() || !file.canRead()) {
                 progress.error(Constant.messages.getString("soap.automation.error.file", wsdlFile));
             } else {
-                getExtSoap().syncImportWsdlFile(file);
+                getExtSoap().syncImportWsdlFile(file, maxMessages);
             }
         }
 
@@ -113,7 +124,7 @@ public class SoapJob extends AutomationJob {
             String wsdlUrl = env.replaceVars(wsdlStr);
             try {
                 new URI(wsdlUrl, true);
-                getExtSoap().syncImportWsdlUrl(wsdlUrl);
+                getExtSoap().syncImportWsdlUrl(wsdlUrl, maxMessages);
             } catch (Exception e) {
                 progress.error(Constant.messages.getString("soap.automation.error.url", wsdlUrl));
             }
@@ -202,5 +213,6 @@ public class SoapJob extends AutomationJob {
     public static class Parameters extends AutomationData {
         private String wsdlFile = "";
         private String wsdlUrl = "";
+        private int maxMessages;
     }
 }

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJobDialog.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJobDialog.java
@@ -36,11 +36,12 @@ public class SoapJobDialog extends StandardFieldsDialog {
     private static final String NAME_PARAM = "soap.automation.dialog.name";
     private static final String WSDL_FILE_PARAM = "soap.automation.dialog.wsdlfile";
     private static final String WSDL_URL_PARAM = "soap.automation.dialog.wsdlurl";
+    private static final String MAX_MESSAGES_PARAM = "soap.automation.dialog.maxmessages";
 
     private SoapJob job;
 
     public SoapJobDialog(SoapJob job) {
-        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 200));
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 230));
         this.job = job;
 
         this.addTextField(NAME_PARAM, this.job.getData().getName());
@@ -56,6 +57,11 @@ public class SoapJobDialog extends StandardFieldsDialog {
         if (urlField instanceof JTextField) {
             ((JTextField) urlField).setText(this.job.getParameters().getWsdlUrl());
         }
+        this.addNumberField(
+                MAX_MESSAGES_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                this.job.getParameters().getMaxMessages());
         this.addPadding();
     }
 
@@ -64,6 +70,7 @@ public class SoapJobDialog extends StandardFieldsDialog {
         this.job.getData().setName(this.getStringValue(NAME_PARAM));
         this.job.getParameters().setWsdlFile(this.getStringValue(WSDL_FILE_PARAM));
         this.job.getParameters().setWsdlUrl(this.getStringValue(WSDL_URL_PARAM));
+        this.job.getParameters().setMaxMessages(this.getIntValue(MAX_MESSAGES_PARAM));
         this.job.resetAndSetChanged();
     }
 

--- a/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/automation.html
+++ b/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/automation.html
@@ -22,7 +22,11 @@ It is covered in the video: <a href="https://youtu.be/xuP00Ri460k">ZAP Chat 11 A
     parameters:
       wsdlFile:                        # String: Local file path of the WSDL, default: null, no definition will be imported
       wsdlUrl:                         # String: URL pointing to the WSDL, default: null, no definition will be imported
+      maxMessages:                     # Int: Maximum number of messages to import, default: 0, import all messages
 </pre>
+<p>
+Redirects are followed when importing, so <code>maxMessages</code> is a soft limit — more messages may appear in the history if redirects occur.
+</p>
 
 </BODY>
 </HTML>

--- a/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
+++ b/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
@@ -2,6 +2,7 @@ soap.api.action.importFile = Import a WSDL definition from local file.
 soap.api.action.importUrl = Import a WSDL definition from a URL.
 
 soap.automation.desc = SOAP Automation Framework Integration
+soap.automation.dialog.maxmessages = Max Messages:
 soap.automation.dialog.name = Job Name:
 soap.automation.dialog.summary = URL: {0}, File: {1}
 soap.automation.dialog.title = SOAP Job
@@ -10,6 +11,7 @@ soap.automation.dialog.wsdlurl = WSDL URL:
 soap.automation.error.file = Job soap cannot read file: {0}
 soap.automation.error.url = Job soap invalid URL: {0}
 soap.automation.name = SOAP Automation
+soap.automation.warn.maxMessages = Job {0} maxMessages must be zero or greater, was: {1}
 
 soap.desc = Allows you to import a WSDL file containing operations which ZAP will access, adding them to the Sites tree.
 

--- a/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/soap-max.yaml
+++ b/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/soap-max.yaml
@@ -2,3 +2,4 @@
     parameters:
       wsdlFile:                        # String: Local file path of the WSDL, default: null, no definition will be imported
       wsdlUrl:                         # String: URL pointing to the WSDL, default: null, no definition will be imported
+      maxMessages:                     # Int: Maximum number of messages to import, default: 0, import all messages

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -122,6 +122,16 @@ class WSDLCustomParserTestCase extends TestUtils {
         assertNull(result);
     }
 
+    @Test
+    void shouldLimitMessagesWhenMaxMessagesSet() throws Exception {
+        Path wsdl = Files.createTempFile("soap-max-messages", ".wsdl");
+        Files.writeString(wsdl, wsdlContent);
+
+        parser.syncImportWsdlFile(wsdl.toFile(), 1);
+
+        assertThat(parser.getLastConfig().getBindOp().getName(), is(equalTo("sayByeWorld")));
+    }
+
     @ParameterizedTest
     @EmptySource
     @ValueSource(strings = {"generated"})

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/automation/SoapJobUnitTest.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/automation/SoapJobUnitTest.java
@@ -44,9 +44,10 @@ import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationPlan;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.zap.extension.soap.ExtensionImportWSDL;
+import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.I18N;
 
-class SoapJobUnitTest {
+class SoapJobUnitTest extends TestUtils {
 
     private ExtensionImportWSDL extSoap;
 
@@ -86,9 +87,10 @@ class SoapJobUnitTest {
         Map<String, String> params = job.getCustomConfigParameters();
 
         // Then
-        assertThat(params.size(), is(equalTo(2)));
+        assertThat(params.size(), is(equalTo(3)));
         assertThat(params.get("wsdlFile"), is(equalTo("")));
         assertThat(params.get("wsdlUrl"), is(equalTo("")));
+        assertThat(params.get("maxMessages"), is(equalTo("0")));
     }
 
     @Test
@@ -98,8 +100,17 @@ class SoapJobUnitTest {
         AutomationProgress progress = new AutomationProgress();
         String wsdlFile = "C:\\Users\\ZAPBot\\Documents\\test file.wsdl";
         String wsdlUrl = "https://example.com/test%20file.wsdl";
+        int maxMessages = 1;
         String yamlStr =
-                "parameters:\n" + "  wsdlUrl: " + wsdlUrl + "\n" + "  wsdlFile: " + wsdlFile;
+                "parameters:\n"
+                        + "  wsdlUrl: "
+                        + wsdlUrl
+                        + "\n"
+                        + "  wsdlFile: "
+                        + wsdlFile
+                        + "\n"
+                        + "  maxMessages: "
+                        + maxMessages;
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
 
@@ -113,8 +124,31 @@ class SoapJobUnitTest {
         // Then
         assertThat(job.getParameters().getWsdlFile(), is(equalTo(wsdlFile)));
         assertThat(job.getParameters().getWsdlUrl(), is(equalTo(wsdlUrl)));
+        assertThat(job.getParameters().getMaxMessages(), is(equalTo(maxMessages)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldWarnIfNegativeMaxMessages() {
+        // Given
+        mockMessages(new ExtensionImportWSDL());
+        AutomationProgress progress = new AutomationProgress();
+        String yamlStr = "parameters:\n" + "  maxMessages: -1";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        SoapJob job = new SoapJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(
+                progress.getWarnings().get(0),
+                is(equalTo("Job soap maxMessages must be zero or greater, was: -1")));
     }
 
     @Test


### PR DESCRIPTION
Allow automation framework (AF) users to limit the number of soap/wsdl endpoints to import. Ex: If testing authentication, access, etc.

Related to: zaproxy/zap-extensions#7537

Tested with: https://demo.totalshiftleft.ai/soap?wsdl

<details>

<summary>Using this af plan</summary>

```yaml
env:
  contexts:
  - name: Default Context
    urls:
    - https://demo.totalshiftleft.ai/
    includePaths:
    - https:\/\/demo.totalshiftleft.ai\/.*
    authentication:
      verification:
        method: response
        pollFrequency: 60
        pollUnits: requests
    sessionManagement:
      method: cookie
    technology: {}
    structure: {}
  parameters: {}
jobs:
- type: soap
  parameters:
    wsdlUrl: https://demo.totalshiftleft.ai/soap?wsdl
    maxMessages: 2
```
