### PR TITLE
graphql: Allow limiting the number of messages imported

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Allow Automation Framework users to limit the number of GraphQL messages to import (`maxMessages`). Ex: If testing authentication, access, etc.
+
 ### Changed
 - Update dependency.
 - Maintenance changes.

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlGenerator.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlGenerator.java
@@ -64,25 +64,34 @@ public class GraphQlGenerator {
     }
 
     private final ValueProvider valueProvider;
+    private final int maxMessages;
+    private int messagesSent;
 
     public GraphQlGenerator(
-            ValueProvider valueProvider, String sdl, Requestor requestor, GraphQlParam param) {
+            ValueProvider valueProvider,
+            String sdl,
+            Requestor requestor,
+            GraphQlParam param,
+            int maxMessages) {
         this(
                 valueProvider,
                 UnExecutableSchemaGenerator.makeUnExecutableSchema(new SchemaParser().parse(sdl)),
                 requestor,
-                param);
+                param,
+                maxMessages);
     }
 
     public GraphQlGenerator(
             ValueProvider valueProvider,
             GraphQLSchema schema,
             Requestor requestor,
-            GraphQlParam param) {
+            GraphQlParam param,
+            int maxMessages) {
         this.valueProvider = valueProvider;
         this.schema = schema;
         this.requestor = requestor;
         this.param = param;
+        this.maxMessages = maxMessages;
         this.inlineArgsEnabled = param.getArgsType() == GraphQlParam.ArgsTypeOption.INLINE;
     }
 
@@ -180,8 +189,7 @@ public class GraphQlGenerator {
             StringBuilder query = new StringBuilder();
             JSONObject variables = new JSONObject();
             generate(query, variables, getRequestTypeObject(requestType), 0);
-            prefixRequestType(query, requestType);
-            requestor.sendQuery(query.toString(), variables.toString(), param.getRequestMethod());
+            sendGeneratedQuery(query, variables, requestType);
         } catch (InterruptedException e) {
             // Do nothing.
         }
@@ -222,9 +230,23 @@ public class GraphQlGenerator {
                 return;
             }
             query.append('}');
-            prefixRequestType(query, requestType);
-            requestor.sendQuery(query.toString(), variables.toString(), param.getRequestMethod());
+            try {
+                sendGeneratedQuery(query, variables, requestType);
+            } catch (InterruptedException e) {
+                return;
+            }
         }
+    }
+
+    private void sendGeneratedQuery(
+            StringBuilder query, JSONObject variables, RequestType requestType)
+            throws InterruptedException {
+        if (maxMessages > 0 && messagesSent >= maxMessages) {
+            throw new InterruptedException();
+        }
+        prefixRequestType(query, requestType);
+        requestor.sendQuery(query.toString(), variables.toString(), param.getRequestMethod());
+        messagesSent++;
     }
 
     private GraphQLObjectType getRequestTypeObject(RequestType requestType) {
@@ -285,9 +307,7 @@ public class GraphQlGenerator {
                 query.append(getFirstLeafQuery(type, variables, variableName));
                 if (requestor != null) {
                     query.append(StringUtils.repeat("} ", depth));
-                    prefixRequestType(query, requestType);
-                    requestor.sendQuery(
-                            query.toString(), variables.toString(), param.getRequestMethod());
+                    sendGeneratedQuery(query, variables, requestType);
                 }
             } else if (getFirstLeafField(type) == null) {
                 LOGGER.warn(
@@ -318,9 +338,7 @@ public class GraphQlGenerator {
                     variableName.setLength(variableName.length() - field.getName().length() - 1);
                     if (requestor != null) {
                         query.append("} ".repeat(depth + 1));
-                        prefixRequestType(query, requestType);
-                        requestor.sendQuery(
-                                query.toString(), variables.toString(), param.getRequestMethod());
+                        sendGeneratedQuery(query, variables, requestType);
                     }
                 } else {
                     query.append(field.getName()).append(' ');

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -76,6 +76,7 @@ public class GraphQlParser {
     private final ExtensionGraphQl extensionGraphQl;
     private final GraphQlParam param;
     private boolean syncParse;
+    private int maxMessages;
 
     // For Unit Tests
     protected GraphQlParser(String endpointUrlStr) throws URIException {
@@ -176,9 +177,15 @@ public class GraphQlParser {
                 UnExecutableSchemaGenerator.makeUnExecutableSchema(new SchemaParser().parse(sdl));
         var generator =
                 new GraphQlGenerator(
-                        extensionGraphQl.getValueGenerator(), schema, requestor, param);
+                        extensionGraphQl.getValueGenerator(),
+                        schema,
+                        requestor,
+                        param,
+                        maxMessages);
         if (syncParse) {
-            fingerprint();
+            if (maxMessages <= 0) {
+                fingerprint();
+            }
             detectCycles(schema, generator);
             if (param.getQueryGenEnabled()) {
                 generate(generator);
@@ -189,7 +196,9 @@ public class GraphQlParser {
                 new ParserThread(THREAD_PREFIX + threadId.incrementAndGet()) {
                     @Override
                     public void run() {
-                        fingerprint();
+                        if (maxMessages <= 0) {
+                            fingerprint();
+                        }
                         detectCycles(schema, generator);
                         if (param.getQueryGenEnabled()) {
                             generate(generator);
@@ -198,6 +207,10 @@ public class GraphQlParser {
                 };
         extensionGraphQl.addParserThread(t);
         t.startParser();
+    }
+
+    public void setMaxMessages(int maxMessages) {
+        this.maxMessages = maxMessages;
     }
 
     private void fingerprint() {
@@ -210,7 +223,9 @@ public class GraphQlParser {
 
     private void generate(GraphQlGenerator generator) {
         try {
-            generator.checkServiceMethods();
+            if (maxMessages <= 0) {
+                generator.checkServiceMethods();
+            }
             generator.generateAndSend();
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
@@ -50,6 +50,7 @@ public class GraphQlJob extends AutomationJob {
     private static final String PARAM_ENDPOINT = "endpoint";
     private static final String PARAM_SCHEMA_URL = "schemaUrl";
     private static final String PARAM_SCHEMA_FILE = "schemaFile";
+    private static final String PARAM_MAX_MESSAGES = "maxMessages";
 
     private static final String RESOURCES_DIR = "/org/zaproxy/addon/graphql/resources/";
 
@@ -72,6 +73,14 @@ public class GraphQlJob extends AutomationJob {
                 this.getName(),
                 null,
                 progress);
+
+        if (getParameters().getMaxMessages() < 0) {
+            progress.warn(
+                    Constant.messages.getString(
+                            "graphql.automation.warn.maxMessages",
+                            getName(),
+                            getParameters().getMaxMessages()));
+        }
     }
 
     @Override
@@ -80,7 +89,9 @@ public class GraphQlJob extends AutomationJob {
                 this.parameters,
                 JobUtils.getJobOptions(this, progress),
                 this.getName(),
-                new String[] {PARAM_ENDPOINT, PARAM_SCHEMA_URL, PARAM_SCHEMA_FILE},
+                new String[] {
+                    PARAM_ENDPOINT, PARAM_SCHEMA_URL, PARAM_SCHEMA_FILE, PARAM_MAX_MESSAGES
+                },
                 progress,
                 this.getPlan().getEnv());
     }
@@ -91,6 +102,7 @@ public class GraphQlJob extends AutomationJob {
         map.put(PARAM_ENDPOINT, "");
         map.put(PARAM_SCHEMA_URL, "");
         map.put(PARAM_SCHEMA_FILE, "");
+        map.put(PARAM_MAX_MESSAGES, "0");
         return map;
     }
 
@@ -108,6 +120,7 @@ public class GraphQlJob extends AutomationJob {
             GraphQlParser parser =
                     new GraphQlParser(endpointUrl, HttpSender.MANUAL_REQUEST_INITIATOR, true);
             parser.addRequesterListener(new HistoryPersister());
+            parser.setMaxMessages(getParameters().getMaxMessages());
 
             String schemaFile = this.getParameters().getSchemaFile();
             String schemaUrl = this.getParameters().getSchemaUrl();
@@ -217,6 +230,7 @@ public class GraphQlJob extends AutomationJob {
         private String endpoint;
         private String schemaUrl;
         private String schemaFile;
+        private int maxMessages;
         private Boolean queryGenEnabled = GraphQlParam.DEFAULT_QUERY_GEN_ENABLED;
         private Integer maxQueryDepth = GraphQlParam.DEFAULT_MAX_QUERY_DEPTH;
         private Boolean lenientMaxQueryDepthEnabled = GraphQlParam.DEFAULT_LENIENT_MAX_QUERY_DEPTH;

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
@@ -47,6 +47,7 @@ public class GraphQlJobDialog extends StandardFieldsDialog {
     private static final String ENDPOINT_PARAM = "graphql.automation.dialog.endpoint";
     private static final String SCHEMA_URL_PARAM = "graphql.automation.dialog.schemaurl";
     private static final String SCHEMA_FILE_PARAM = "graphql.automation.dialog.schemafile";
+    private static final String MAX_MESSAGES_PARAM = "graphql.automation.dialog.maxmessages";
 
     private static final String QUERY_GEN_ENABLED_PARAM = "graphql.automation.dialog.querygen";
     private static final String MAX_QUERY_DEPTH_PARAM = "graphql.automation.dialog.maxquerydepth";
@@ -103,6 +104,12 @@ public class GraphQlJobDialog extends StandardFieldsDialog {
         if (fileName != null && JobUtils.containsVars(fileName)) {
             setFieldValue(SCHEMA_FILE_PARAM, fileName);
         }
+        this.addNumberField(
+                0,
+                MAX_MESSAGES_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                this.job.getParameters().getMaxMessages());
 
         this.addCheckBoxField(
                 0,
@@ -197,6 +204,7 @@ public class GraphQlJobDialog extends StandardFieldsDialog {
         this.job.getParameters().setEndpoint(this.getStringValue(ENDPOINT_PARAM));
         this.job.getParameters().setSchemaUrl(this.getStringValue(SCHEMA_URL_PARAM));
         this.job.getParameters().setSchemaFile(this.getStringValue(SCHEMA_FILE_PARAM));
+        this.job.getParameters().setMaxMessages(this.getIntValue(MAX_MESSAGES_PARAM));
 
         boolean queryGenEnabled = getBoolValue(QUERY_GEN_ENABLED_PARAM);
         this.job.getParameters().setQueryGenEnabled(queryGenEnabled);

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/automation.html
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/automation.html
@@ -34,7 +34,14 @@ It is covered in the video: <a href="https://youtu.be/xuP00Ri460k">ZAP Chat 11 A
       requestMethod:                   # Enum [post_json, post_graphql, get]: The request method, default: post_json
       cycleDetectionMode:              # Enum [disabled, quick, exhaustive]: The cycle detection mode, default: quick
       maxCycleDetectionAlerts:         # Int: The maximum number of alerts to raise for detected cycles, default: 100
+      maxMessages:                     # Int: Maximum number of messages to import, default: 0, import all messages
 </pre>
+<p>
+When <code>maxMessages</code> is set (greater than 0), <a href="alerts.html">fingerprinting</a> and service method checks are skipped.
+</p>
+<p>
+This limit is soft: redirects are followed, so the number of messages persisted may exceed the configured value.
+</p>
 
 <H2>See also</H2>
 <table>

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -46,6 +46,7 @@ graphql.automation.dialog.lenientmaxquery = Lenient Max Query Depth Enabled:
 graphql.automation.dialog.maxCycleAlerts = Max Alerts:
 graphql.automation.dialog.maxaddquerydepth = Max Additional Query Depth:
 graphql.automation.dialog.maxargsdepth = Max Arguments Depth:
+graphql.automation.dialog.maxmessages = Max Messages:
 graphql.automation.dialog.maxquerydepth = Max Query Depth:
 graphql.automation.dialog.name = Job Name:
 graphql.automation.dialog.optargsenabled = Optional Arguments Enabled:
@@ -64,6 +65,7 @@ graphql.automation.info.import.file = Job graphql importing schema from file: {0
 graphql.automation.info.import.introspect = Job graphql importing schema using introspection from: {0}
 graphql.automation.info.import.url = Job graphql importing schema from URL: {0} target: {1}
 graphql.automation.name = GraphQL Automation
+graphql.automation.warn.maxMessages = Job {0} maxMessages must be zero or greater, was: {1}
 
 graphql.cmdline.endurl.help = Sets the Endpoint URL
 graphql.cmdline.file.help = Imports a GraphQL Schema from a File

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/graphql-max.yaml
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/graphql-max.yaml
@@ -14,3 +14,4 @@
       requestMethod:                   # Enum [post_json, post_graphql, get]: The request method, default: post_json
       cycleDetectionMode:              # Enum [disabled, quick, exhaustive]: The cycle detection mode, default: quick
       maxCycleDetectionAlerts:         # Int: The maximum number of alerts to raise for detected cycles, default: 100
+      maxMessages:                     # Int: Maximum number of messages to import, default: 0, import all messages

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlCycleDetectorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlCycleDetectorUnitTest.java
@@ -77,7 +77,7 @@ class GraphQlCycleDetectorUnitTest extends TestUtils {
         String sdl = getHtml("circularRelationship.graphql");
         GraphQLSchema schema =
                 UnExecutableSchemaGenerator.makeUnExecutableSchema(new SchemaParser().parse(sdl));
-        var generator = new GraphQlGenerator(valueProvider, schema, null, param);
+        var generator = new GraphQlGenerator(valueProvider, schema, null, param, 0);
         var cyclesDetector = new GraphQlCycleDetector(schema, generator, null, param);
         List<GraphQlCycleDetectionResult> results = new ArrayList<>();
         // When
@@ -104,7 +104,7 @@ class GraphQlCycleDetectorUnitTest extends TestUtils {
         String sdl = getHtml("circularRelationship.graphql");
         GraphQLSchema schema =
                 UnExecutableSchemaGenerator.makeUnExecutableSchema(new SchemaParser().parse(sdl));
-        var generator = new GraphQlGenerator(valueProvider, schema, null, param);
+        var generator = new GraphQlGenerator(valueProvider, schema, null, param, 0);
         var queryMsgBuilder =
                 new GraphQlQueryMessageBuilder(UrlBuilder.build("https://example.com/graphql"));
         var cyclesDetector = new GraphQlCycleDetector(schema, generator, queryMsgBuilder, param);

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
@@ -20,7 +20,11 @@
 package org.zaproxy.addon.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.SchemaParser;
@@ -28,6 +32,8 @@ import graphql.schema.idl.UnExecutableSchemaGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.addon.commonlib.ValueProvider;
+import org.zaproxy.addon.graphql.GraphQlParam.ArgsTypeOption;
+import org.zaproxy.addon.graphql.GraphQlParam.QuerySplitOption;
 import org.zaproxy.zap.testutils.TestUtils;
 
 class GraphQlGeneratorUnitTest extends TestUtils {
@@ -48,7 +54,39 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     private GraphQlGenerator createGraphQlGenerator(String sdl) {
-        return new GraphQlGenerator(valueProvider, sdl, null, param);
+        return new GraphQlGenerator(valueProvider, sdl, null, param, 0);
+    }
+
+    @Test
+    void shouldLimitMessagesWhenMaxMessagesSet() {
+        // Given
+        Requestor requestor = mock(Requestor.class);
+        GraphQlParam limitedParam =
+                new GraphQlParam(
+                        true,
+                        5,
+                        true,
+                        5,
+                        5,
+                        true,
+                        ArgsTypeOption.INLINE,
+                        QuerySplitOption.LEAF,
+                        GraphQlParam.RequestMethodOption.POST_JSON,
+                        GraphQlParam.CycleDetectionModeOption.DISABLED,
+                        0);
+        GraphQlGenerator limitedGenerator =
+                new GraphQlGenerator(
+                        valueProvider,
+                        getHtml("scalarFieldsOnly.graphql"),
+                        requestor,
+                        limitedParam,
+                        2);
+
+        // When
+        limitedGenerator.generateAndSend();
+
+        // Then
+        verify(requestor, times(2)).sendQuery(anyString(), anyString(), any());
     }
 
     @Test
@@ -124,7 +162,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
                 };
         generator =
                 new GraphQlGenerator(
-                        vg, getHtml("nonNullableScalarArguments.graphql"), null, param);
+                        vg, getHtml("nonNullableScalarArguments.graphql"), null, param, 0);
         // When
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         // Then

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
@@ -112,10 +112,11 @@ class GraphQlJobUnitTest extends TestUtils {
         Map<String, String> params = job.getCustomConfigParameters();
 
         // Then
-        assertThat(params.size(), is(equalTo(3)));
+        assertThat(params.size(), is(equalTo(4)));
         assertThat(params.get("endpoint"), is(equalTo("")));
         assertThat(params.get("schemaUrl"), is(equalTo("")));
         assertThat(params.get("schemaFile"), is(equalTo("")));
+        assertThat(params.get("maxMessages"), is(equalTo("0")));
     }
 
     @Test
@@ -126,6 +127,7 @@ class GraphQlJobUnitTest extends TestUtils {
         String endpoint = "https://example.com/graphql/";
         String schemaFile = "C:\\Users\\ZAPBot\\Documents\\test schema.graphql";
         String schemaUrl = "https://example.com/test%20file.graphql";
+        int maxMessages = 1;
         String yamlStr =
                 "parameters:\n"
                         + "  endpoint: "
@@ -135,7 +137,10 @@ class GraphQlJobUnitTest extends TestUtils {
                         + schemaFile
                         + "\n"
                         + "  schemaUrl: "
-                        + schemaUrl;
+                        + schemaUrl
+                        + "\n"
+                        + "  maxMessages: "
+                        + maxMessages;
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
 
@@ -149,6 +154,30 @@ class GraphQlJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getEndpoint(), is(equalTo(endpoint)));
         assertThat(job.getParameters().getSchemaFile(), is(equalTo(schemaFile)));
         assertThat(job.getParameters().getSchemaUrl(), is(equalTo(schemaUrl)));
+        assertThat(job.getParameters().getMaxMessages(), is(equalTo(maxMessages)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldWarnIfNegativeMaxMessages() {
+        // Given
+        mockMessages(new ExtensionGraphQl());
+        AutomationProgress progress = new AutomationProgress();
+        String yamlStr = "parameters:\n" + "  maxMessages: -1";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        GraphQlJob job = new GraphQlJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(
+                progress.getWarnings().get(0),
+                is(equalTo("Job graphql maxMessages must be zero or greater, was: -1")));
     }
 
     @Test


### PR DESCRIPTION
Allow automation framework (AF) users to limit the number of graphql endpoints to import. Ex: If testing authentication, access, etc.

Related to: zaproxy/zap-extensions#7537

Tested with: https://demo.totalshiftleft.ai/graphql

<details>

<summary>Using this af plan</summary>

```yaml
env:
  contexts:
  - name: Default Context
    urls:
    - https://demo.totalshiftleft.ai/
    includePaths:
    - https:\/\/demo.totalshiftleft.ai\/.*
    authentication:
      verification:
        method: response
        pollFrequency: 60
        pollUnits: requests
    sessionManagement:
      method: cookie
    technology: {}
    structure: {}
  parameters: {}
jobs:
- type: graphql
  parameters:
    endpoint: https://demo.totalshiftleft.ai/graphql
    maxMessages: 2
```
