### PR TITLE
params: correct migration

### DIFF
--- a/addOns/params/src/main/java/org/zaproxy/addon/params/ExtensionParams2.java
+++ b/addOns/params/src/main/java/org/zaproxy/addon/params/ExtensionParams2.java
@@ -40,7 +40,6 @@ import org.parosproxy.paros.core.scanner.VariantMultipartFormParameters;
 import org.parosproxy.paros.db.Database;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.DatabaseUnsupportedException;
-import org.parosproxy.paros.db.RecordParam;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -55,6 +54,7 @@ import org.parosproxy.paros.network.HttpHeaderField;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.params.internal.db.ParamsDao;
 import org.zaproxy.addon.params.internal.db.ParamsTableJdo;
+import org.zaproxy.addon.params.internal.db.RecordParam;
 import org.zaproxy.addon.pscan.ExtensionPassiveScan2;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.ExtensionFactory;
@@ -368,7 +368,7 @@ public class ExtensionParams2 extends ExtensionAdaptor {
                                 param.getTimesUsed(),
                                 setToString(param.getFlags()),
                                 setToString(param.getValues()));
-                param.setId(rp.getParamId());
+                param.setId(rp.paramId());
             } else {
                 ParamsDao.update(
                         pmf,
@@ -699,8 +699,8 @@ public class ExtensionParams2 extends ExtensionAdaptor {
                 List<RecordParam> params = ParamsDao.getAll(pmf);
 
                 for (RecordParam param : params) {
-                    SiteParameters sps = getSiteParameters(param.getSite());
-                    sps.addParam(param.getSite(), param);
+                    SiteParameters sps = getSiteParameters(param.site());
+                    sps.addParam(param.site(), param);
                 }
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);

--- a/addOns/params/src/main/java/org/zaproxy/addon/params/SiteParameters.java
+++ b/addOns/params/src/main/java/org/zaproxy/addon/params/SiteParameters.java
@@ -25,10 +25,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.parosproxy.paros.db.RecordParam;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HtmlParameter.Type;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.params.internal.db.RecordParam;
 import org.zaproxy.zap.extension.httpsessions.ExtensionHttpSessions;
 import org.zaproxy.zap.utils.ThreadUtils;
 
@@ -192,7 +192,7 @@ public class SiteParameters {
     public synchronized void addParam(String site2, RecordParam param) {
         Map<String, HtmlParameterStats> params = null;
 
-        HtmlParameter.Type type = HtmlParameter.Type.valueOf(param.getType());
+        HtmlParameter.Type type = HtmlParameter.Type.valueOf(param.type());
         switch (type) {
             case cookie:
                 params = cookieParams;
@@ -213,15 +213,15 @@ public class SiteParameters {
         // These should all be new
         HtmlParameterStats p =
                 new HtmlParameterStats(
-                        param.getParamId(),
+                        param.paramId(),
                         site,
-                        param.getName(),
-                        param.getType(),
-                        param.getUsed(),
-                        stringToSet(param.getValues()),
-                        stringToSet(param.getFlags()));
+                        param.name(),
+                        param.type(),
+                        param.used(),
+                        stringToSet(param.values()),
+                        stringToSet(param.flags()));
         if (params != null) {
-            params.put(param.getName(), p);
+            params.put(param.name(), p);
             ThreadUtils.invokeLater(() -> model.addHtmlParameterStats(p));
         }
     }

--- a/addOns/params/src/main/java/org/zaproxy/addon/params/internal/db/ParamsDao.java
+++ b/addOns/params/src/main/java/org/zaproxy/addon/params/internal/db/ParamsDao.java
@@ -25,7 +25,6 @@ import javax.jdo.PersistenceManager;
 import javax.jdo.PersistenceManagerFactory;
 import javax.jdo.Query;
 import javax.jdo.Transaction;
-import org.parosproxy.paros.db.RecordParam;
 
 /** Persistence for tracked parameters in the Params add-on session table {@code PARAMS_PARAM}. */
 public final class ParamsDao {

--- a/addOns/params/src/main/java/org/zaproxy/addon/params/internal/db/RecordParam.java
+++ b/addOns/params/src/main/java/org/zaproxy/addon/params/internal/db/RecordParam.java
@@ -1,0 +1,29 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.params.internal.db;
+
+public record RecordParam(
+        long paramId,
+        String site,
+        String type,
+        String name,
+        int used,
+        String flags,
+        String values) {}


### PR DESCRIPTION
Add a `RecordParam` to replace usage of the deprecated core one.