### PR TITLE
mcp: Add tools which map to resources

### DIFF
--- a/addOns/mcp/CHANGELOG.md
+++ b/addOns/mcp/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+- `zap_list_resources` and `zap_read_resource` tools for clients that only support tools (e.g. the LLM bridge).
+- `zap_get_history` tool to fetch selected history fields with body paging via `body_offset` / `max_body_chars`.
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/ExtensionMcp.java
+++ b/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/ExtensionMcp.java
@@ -52,9 +52,12 @@ import org.zaproxy.addon.mcp.tools.ZapCreateContextTool;
 import org.zaproxy.addon.mcp.tools.ZapGenerateReportTool;
 import org.zaproxy.addon.mcp.tools.ZapGetActiveScanStatusTool;
 import org.zaproxy.addon.mcp.tools.ZapGetAjaxSpiderStatusTool;
+import org.zaproxy.addon.mcp.tools.ZapGetHistoryTool;
 import org.zaproxy.addon.mcp.tools.ZapGetPassiveScanStatusTool;
 import org.zaproxy.addon.mcp.tools.ZapGetSpiderStatusTool;
 import org.zaproxy.addon.mcp.tools.ZapInfoTool;
+import org.zaproxy.addon.mcp.tools.ZapListResourcesTool;
+import org.zaproxy.addon.mcp.tools.ZapReadResourceTool;
 import org.zaproxy.addon.mcp.tools.ZapStartActiveScanTool;
 import org.zaproxy.addon.mcp.tools.ZapStartAjaxSpiderTool;
 import org.zaproxy.addon.mcp.tools.ZapStartSpiderTool;
@@ -151,6 +154,9 @@ public class ExtensionMcp extends ExtensionAdaptor {
         toolRegistry.registerTool(new ZapGetActiveScanStatusTool());
         toolRegistry.registerTool(new ZapGetPassiveScanStatusTool());
         toolRegistry.registerTool(new ZapGenerateReportTool());
+        toolRegistry.registerTool(new ZapGetHistoryTool());
+        toolRegistry.registerTool(new ZapListResourcesTool(resourceRegistry));
+        toolRegistry.registerTool(new ZapReadResourceTool(resourceRegistry));
 
         resourceRegistry.registerResource(new AlertsResource());
         resourceRegistry.registerResource(new AlertInstancesResource());

--- a/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/tools/ZapGetHistoryTool.java
+++ b/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/tools/ZapGetHistoryTool.java
@@ -1,0 +1,253 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.mcp.tools;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.mcp.McpResource;
+import org.zaproxy.addon.mcp.McpTool;
+import org.zaproxy.addon.mcp.McpToolException;
+import org.zaproxy.addon.mcp.McpToolResult;
+
+/**
+ * MCP tool that returns selected parts of a history entry, with optional windowing for request and
+ * response bodies.
+ */
+public class ZapGetHistoryTool implements McpTool {
+
+    static final String FIELD_REQUEST_HEADER = "requestHeader";
+    static final String FIELD_REQUEST_BODY = "requestBody";
+    static final String FIELD_RESPONSE_HEADER = "responseHeader";
+    static final String FIELD_RESPONSE_BODY = "responseBody";
+
+    static final List<String> DEFAULT_FIELDS = List.of(FIELD_REQUEST_HEADER, FIELD_RESPONSE_HEADER);
+    static final Set<String> ALLOWED_FIELDS =
+            new LinkedHashSet<>(
+                    List.of(
+                            FIELD_REQUEST_HEADER,
+                            FIELD_REQUEST_BODY,
+                            FIELD_RESPONSE_HEADER,
+                            FIELD_RESPONSE_BODY));
+
+    /** Default maximum characters returned for each included body. */
+    static final int DEFAULT_MAX_BODY_CHARS = 4000;
+
+    private static final Logger LOGGER = LogManager.getLogger(ZapGetHistoryTool.class);
+
+    @Override
+    public String getName() {
+        return "zap_get_history";
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("mcp.tool.gethistory.desc");
+    }
+
+    @Override
+    public InputSchema getInputSchema() {
+        Map<String, InputSchema.PropertyDef> properties = new LinkedHashMap<>();
+        properties.put(
+                "id",
+                InputSchema.PropertyDef.ofString(
+                        Constant.messages.getString("mcp.tool.gethistory.param.id")));
+        properties.put(
+                "fields",
+                InputSchema.PropertyDef.ofStringArray(
+                        Constant.messages.getString("mcp.tool.gethistory.param.fields")));
+        properties.put(
+                "body_offset",
+                InputSchema.PropertyDef.ofString(
+                        Constant.messages.getString("mcp.tool.gethistory.param.bodyoffset")));
+        properties.put(
+                "max_body_chars",
+                InputSchema.PropertyDef.ofString(
+                        Constant.messages.getString("mcp.tool.gethistory.param.maxbodychars")));
+        return new InputSchema(properties, List.of("id"));
+    }
+
+    @Override
+    public McpToolResult execute(ToolArguments arguments) throws McpToolException {
+        int id = parseId(arguments.getString("id"));
+        Set<String> fields = parseFields(arguments.getList("fields"));
+        int bodyOffset = parseOptionalInt(arguments.getString("body_offset"), 0, "body_offset");
+        Integer maxBodyCharsArg =
+                parseOptionalIntOrNull(arguments.getString("max_body_chars"), "max_body_chars");
+        if (maxBodyCharsArg != null && maxBodyCharsArg <= 0) {
+            throw new McpToolException(
+                    Constant.messages.getString("mcp.tool.gethistory.error.invalidmaxbodychars"));
+        }
+        int maxBodyChars = maxBodyCharsArg != null ? maxBodyCharsArg : DEFAULT_MAX_BODY_CHARS;
+
+        ExtensionHistory extHist =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+        HistoryReference href = extHist.getHistoryReference(id);
+        if (href == null) {
+            throw new McpToolException(
+                    Constant.messages.getString("mcp.tool.gethistory.error.notfound", id));
+        }
+
+        HttpMessage msg;
+        try {
+            msg = href.getHttpMessage();
+        } catch (HttpMalformedHeaderException | DatabaseException e) {
+            LOGGER.debug("Could not read history id {}: {}", id, e.getMessage());
+            throw new McpToolException(
+                    Constant.messages.getString("mcp.tool.gethistory.error.readfailed", id));
+        }
+
+        ObjectNode result = McpResource.OBJECT_MAPPER.createObjectNode();
+        result.put("id", id);
+
+        if (fields.contains(FIELD_REQUEST_HEADER)) {
+            result.put(FIELD_REQUEST_HEADER, msg.getRequestHeader().toString());
+        }
+        if (fields.contains(FIELD_RESPONSE_HEADER)) {
+            result.put(FIELD_RESPONSE_HEADER, msg.getResponseHeader().toString());
+        }
+        if (fields.contains(FIELD_REQUEST_BODY)) {
+            putBodyWindow(
+                    result,
+                    FIELD_REQUEST_BODY,
+                    msg.getRequestBody().toString(),
+                    bodyOffset,
+                    maxBodyChars);
+        }
+        if (fields.contains(FIELD_RESPONSE_BODY)) {
+            putBodyWindow(
+                    result,
+                    FIELD_RESPONSE_BODY,
+                    msg.getResponseBody().toString(),
+                    bodyOffset,
+                    maxBodyChars);
+        }
+
+        return McpToolResult.success(result.toString());
+    }
+
+    private static void putBodyWindow(
+            ObjectNode result, String fieldName, String body, int bodyOffset, int maxBodyChars) {
+        BodyWindow window = BodyWindow.of(body, bodyOffset, maxBodyChars);
+        result.put(fieldName, window.text());
+        result.put(fieldName + "Length", window.length());
+        result.put(fieldName + "Offset", window.offset());
+        result.put(fieldName + "Returned", window.returned());
+        result.put(fieldName + "Truncated", window.truncated());
+    }
+
+    private static int parseId(String idValue) throws McpToolException {
+        if (idValue == null || idValue.isBlank()) {
+            throw new McpToolException(
+                    Constant.messages.getString("mcp.tool.gethistory.error.missingid"));
+        }
+        try {
+            return Integer.parseInt(idValue.trim());
+        } catch (NumberFormatException e) {
+            throw new McpToolException(
+                    Constant.messages.getString("mcp.tool.gethistory.error.invalidid"));
+        }
+    }
+
+    private static Set<String> parseFields(List<String> fieldsArg) throws McpToolException {
+        if (fieldsArg == null || fieldsArg.isEmpty()) {
+            return new LinkedHashSet<>(DEFAULT_FIELDS);
+        }
+        Set<String> fields = new LinkedHashSet<>();
+        for (String field : fieldsArg) {
+            if (field == null || field.isBlank()) {
+                continue;
+            }
+            String normalized = field.trim();
+            if (!ALLOWED_FIELDS.contains(normalized)) {
+                throw new McpToolException(
+                        Constant.messages.getString(
+                                "mcp.tool.gethistory.error.unknownfield",
+                                normalized,
+                                String.join(", ", ALLOWED_FIELDS)));
+            }
+            fields.add(normalized);
+        }
+        if (fields.isEmpty()) {
+            return new LinkedHashSet<>(DEFAULT_FIELDS);
+        }
+        return fields;
+    }
+
+    private static int parseOptionalInt(String value, int defaultValue, String paramName)
+            throws McpToolException {
+        Integer parsed = parseOptionalIntOrNull(value, paramName);
+        return parsed != null ? parsed : defaultValue;
+    }
+
+    private static Integer parseOptionalIntOrNull(String value, String paramName)
+            throws McpToolException {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new McpToolException(
+                    Constant.messages.getString(
+                            "mcp.tool.gethistory.error.invalidint", paramName, value.trim()));
+        }
+    }
+
+    /**
+     * A window into a body string.
+     *
+     * @param text the returned body slice
+     * @param offset the effective start index after clamping
+     * @param length the full body length
+     * @param returned the number of characters returned
+     * @param truncated {@code true} if the full body was not returned
+     */
+    record BodyWindow(String text, int offset, int length, int returned, boolean truncated) {
+
+        static BodyWindow of(String body, int bodyOffset, int maxChars) {
+            String safeBody = body != null ? body : "";
+            int length = safeBody.length();
+            int start;
+            if (bodyOffset >= 0) {
+                start = Math.min(bodyOffset, length);
+            } else {
+                start = Math.max(0, length + bodyOffset);
+            }
+            int end = Math.min(start + Math.max(maxChars, 0), length);
+            String text = safeBody.substring(start, end);
+            int returned = end - start;
+            boolean truncated = returned < length;
+            return new BodyWindow(text, start, length, returned, truncated);
+        }
+    }
+}

--- a/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/tools/ZapListResourcesTool.java
+++ b/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/tools/ZapListResourcesTool.java
@@ -1,0 +1,91 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.mcp.tools;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.mcp.McpResource;
+import org.zaproxy.addon.mcp.McpResourceRegistry;
+import org.zaproxy.addon.mcp.McpTool;
+import org.zaproxy.addon.mcp.McpToolException;
+import org.zaproxy.addon.mcp.McpToolResult;
+
+/**
+ * MCP tool that lists registered resources. Intended for clients that only support tools (e.g. the
+ * LLM bridge); clients that support the resources capability can use {@code resources/list}
+ * instead.
+ */
+public class ZapListResourcesTool implements McpTool {
+
+    private static final Logger LOGGER = LogManager.getLogger(ZapListResourcesTool.class);
+
+    private final McpResourceRegistry registry;
+
+    public ZapListResourcesTool(McpResourceRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public String getName() {
+        return "zap_list_resources";
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("mcp.tool.listresources.desc");
+    }
+
+    @Override
+    public InputSchema getInputSchema() {
+        return new InputSchema(Map.of(), List.of());
+    }
+
+    @Override
+    public McpToolResult execute(ToolArguments arguments) throws McpToolException {
+        try {
+            ArrayNode resourcesArray = McpResource.OBJECT_MAPPER.createArrayNode();
+            registry.getResources().stream()
+                    .sorted(Comparator.comparing(McpResource::getUri))
+                    .forEach(
+                            resource -> {
+                                ObjectNode entry = resourcesArray.addObject();
+                                entry.put("uri", resource.getUriTemplate());
+                                entry.put("name", resource.getName());
+                                entry.put("description", resource.getDescription());
+                                entry.put("mimeType", resource.getMimeType());
+                            });
+            ObjectNode result = McpResource.OBJECT_MAPPER.createObjectNode();
+            result.set("resources", resourcesArray);
+            return McpToolResult.success(result.toString());
+        } catch (Exception e) {
+            LOGGER.error("Failed to list resources", e);
+            throw new McpToolException(
+                    Constant.messages.getString(
+                            "mcp.tool.listresources.error.failed",
+                            Constant.messages.getString("mcp.tool.error.unknown")));
+        }
+    }
+}

--- a/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/tools/ZapReadResourceTool.java
+++ b/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/tools/ZapReadResourceTool.java
@@ -1,0 +1,96 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.mcp.tools;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.mcp.McpResource;
+import org.zaproxy.addon.mcp.McpResourceRegistry;
+import org.zaproxy.addon.mcp.McpTool;
+import org.zaproxy.addon.mcp.McpToolException;
+import org.zaproxy.addon.mcp.McpToolResult;
+
+/**
+ * MCP tool that reads a registered resource by URI. Intended for clients that only support tools
+ * (e.g. the LLM bridge); clients that support the resources capability can use {@code
+ * resources/read} instead.
+ */
+public class ZapReadResourceTool implements McpTool {
+
+    private static final Logger LOGGER = LogManager.getLogger(ZapReadResourceTool.class);
+
+    private final McpResourceRegistry registry;
+
+    public ZapReadResourceTool(McpResourceRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public String getName() {
+        return "zap_read_resource";
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("mcp.tool.readresource.desc");
+    }
+
+    @Override
+    public InputSchema getInputSchema() {
+        Map<String, InputSchema.PropertyDef> properties = new LinkedHashMap<>();
+        properties.put(
+                "uri",
+                InputSchema.PropertyDef.ofString(
+                        Constant.messages.getString("mcp.tool.readresource.param.uri")));
+        return new InputSchema(properties, List.of("uri"));
+    }
+
+    @Override
+    public McpToolResult execute(ToolArguments arguments) throws McpToolException {
+        String uri = arguments.getString("uri");
+        if (uri == null || uri.isBlank()) {
+            throw new McpToolException(
+                    Constant.messages.getString("mcp.tool.readresource.error.missinguri"));
+        }
+        uri = uri.trim();
+
+        McpResource resource = registry.getResource(uri);
+        if (resource == null) {
+            throw new McpToolException(
+                    Constant.messages.getString("mcp.tool.readresource.error.unknownuri", uri));
+        }
+
+        try {
+            return McpToolResult.success(resource.readContent(uri));
+        } catch (Exception e) {
+            LOGGER.error("Failed to read resource {}", uri, e);
+            throw new McpToolException(
+                    Constant.messages.getString(
+                            "mcp.tool.readresource.error.failed",
+                            e.getMessage() != null
+                                    ? e.getMessage()
+                                    : Constant.messages.getString("mcp.tool.error.unknown")));
+        }
+    }
+}

--- a/addOns/mcp/src/main/javahelp/org/zaproxy/addon/mcp/resources/help/contents/mcp-tools.html
+++ b/addOns/mcp/src/main/javahelp/org/zaproxy/addon/mcp/resources/help/contents/mcp-tools.html
@@ -71,10 +71,32 @@ Get the passive scan queue status. Returns the number of HTTP records waiting to
 <p>
 No parameters.
 
+<H2>zap_get_history</H2>
+Get selected parts of a ZAP history entry. Prefer this over <code>zap://history/{id}</code> when response or request bodies may be large.
+<p>
+Parameters:
+<ul>
+<li><code>id</code> - history entry ID (e.g. <code>123</code>)
+<li><code>fields</code> - optional list of <code>requestHeader</code>, <code>requestBody</code>, <code>responseHeader</code>, <code>responseBody</code> (defaults to both headers)
+<li><code>body_offset</code> - optional start index into each included body (0-based; negative values count from the end)
+<li><code>max_body_chars</code> - optional maximum characters per included body (default 4000)
+</ul>
+When a body field is included the result also provides <code>*Length</code>, <code>*Offset</code>, <code>*Returned</code>, and <code>*Truncated</code> metadata (e.g. <code>responseBodyTruncated</code>, <code>requestBodyTruncated</code>).
+
 <H2>zap_generate_report</H2>
 Generate a ZAP report. Use the <code>zap://report-templates</code> resource to discover available template names. Requires the reports add-on.
 <p>
 Parameters: <code>file_path</code> - full path for the output file (e.g. <code>/tmp/report.html</code>), <code>template</code> - template config name (e.g. <code>traditional-html</code>), optionally <code>title</code> - report title
+
+<H2>zap_list_resources</H2>
+List available ZAP MCP resources (URI, name, description). Useful for clients that only support tools; clients that support the resources capability can use <code>resources/list</code> instead.
+<p>
+No parameters. Use <code>zap_read_resource</code> to read a listed resource.
+
+<H2>zap_read_resource</H2>
+Read a ZAP MCP resource by URI. Use <code>zap_list_resources</code> to discover available URIs (including templates such as <code>zap://history/{id}</code>). Clients that support the resources capability can use <code>resources/read</code> instead.
+<p>
+Parameters: <code>uri</code> - the resource URI (e.g. <code>zap://alerts</code> or <code>zap://history/123</code>)
 
 <H2>See Also</H2>
 

--- a/addOns/mcp/src/main/resources/org/zaproxy/addon/mcp/resources/Messages.properties
+++ b/addOns/mcp/src/main/resources/org/zaproxy/addon/mcp/resources/Messages.properties
@@ -115,6 +115,19 @@ mcp.tool.getajaxspiderstatus.running = running
 mcp.tool.getajaxspiderstatus.status = Scan {0}: {1}
 mcp.tool.getajaxspiderstatus.stopped = stopped
 
+mcp.tool.gethistory.desc = Get selected parts of a ZAP history entry. Defaults to request and response headers. Use fields to include bodies, and body_offset/max_body_chars to page through large bodies (negative body_offset counts from the end). Prefer this over zap://history/{id} when bodies may be large.
+mcp.tool.gethistory.error.invalidid = The id parameter must be a number
+mcp.tool.gethistory.error.invalidint = The {0} parameter must be an integer: {1}
+mcp.tool.gethistory.error.invalidmaxbodychars = The max_body_chars parameter must be greater than 0
+mcp.tool.gethistory.error.missingid = The id parameter is required
+mcp.tool.gethistory.error.notfound = History ID {0} not found
+mcp.tool.gethistory.error.readfailed = Failed to read history ID {0}
+mcp.tool.gethistory.error.unknownfield = Unknown field: {0}. Allowed fields: {1}
+mcp.tool.gethistory.param.bodyoffset = Optional start index into each included body (0-based). Negative values count from the end (e.g. -2000 returns the last 2000 characters when used with max_body_chars).
+mcp.tool.gethistory.param.fields = Optional list of fields to include: requestHeader, requestBody, responseHeader, responseBody. Defaults to requestHeader and responseHeader.
+mcp.tool.gethistory.param.id = The history entry ID (e.g. 123 from zap://history/123)
+mcp.tool.gethistory.param.maxbodychars = Optional maximum characters to return for each included body (default 4000). Applies with body_offset to both request and response bodies.
+
 mcp.tool.getpassivescanstatus.desc = Get the passive scan queue status. Returns the number of records waiting to be passively scanned.
 mcp.tool.getpassivescanstatus.idle = idle
 mcp.tool.getpassivescanstatus.records = Records to scan: {0}
@@ -135,6 +148,15 @@ mcp.tool.getspiderstatus.status = Scan {0}: {1}
 mcp.tool.getspiderstatus.stopped = stopped
 mcp.tool.getspiderstatus.warnings = Warnings ({0}):
 mcp.tool.info.desc = Get basic ZAP information
+
+mcp.tool.listresources.desc = List available ZAP MCP resources (URI, name, description). Useful for clients that only support tools. Use zap_read_resource to read a resource by URI.
+mcp.tool.listresources.error.failed = Failed to list resources: {0}
+
+mcp.tool.readresource.desc = Read a ZAP MCP resource by URI. Use zap_list_resources to discover available URIs (including templates such as zap://history/{id}).
+mcp.tool.readresource.error.failed = Failed to read resource: {0}
+mcp.tool.readresource.error.missinguri = The uri parameter is required
+mcp.tool.readresource.error.unknownuri = Unknown resource: {0}
+mcp.tool.readresource.param.uri = The resource URI to read (e.g. zap://alerts or zap://history/123)
 
 mcp.tool.startactivescan.desc = Start the active scan. The target can be a URL (creates a temporary context) or the name of an existing context. Optionally specify a scan policy. Returns a scan_id for use with zap_stop_active_scan and zap_get_active_scan_status. The target URL should be in the sites tree (e.g. spider first).
 mcp.tool.startactivescan.error.contextnotfound = Context not found: {0}

--- a/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/tools/ZapGetHistoryToolUnitTest.java
+++ b/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/tools/ZapGetHistoryToolUnitTest.java
@@ -1,0 +1,273 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.mcp.tools;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.quality.Strictness;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.mcp.ExtensionMcp;
+import org.zaproxy.addon.mcp.McpTool;
+import org.zaproxy.addon.mcp.McpToolException;
+import org.zaproxy.addon.mcp.McpToolResult;
+import org.zaproxy.addon.mcp.tools.ZapGetHistoryTool.BodyWindow;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit tests for {@link ZapGetHistoryTool}. */
+class ZapGetHistoryToolUnitTest extends TestUtils {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ExtensionHistory extHistory;
+    private ZapGetHistoryTool tool;
+
+    @BeforeEach
+    void setUp() {
+        mockMessages(new ExtensionMcp());
+        ExtensionLoader extensionLoader =
+                mock(ExtensionLoader.class, withSettings().strictness(Strictness.LENIENT));
+        extHistory = mock(ExtensionHistory.class, withSettings().strictness(Strictness.LENIENT));
+        given(extensionLoader.getExtension(ExtensionHistory.class)).willReturn(extHistory);
+        Control.initSingletonForTesting(mock(Model.class), extensionLoader);
+        tool = new ZapGetHistoryTool();
+    }
+
+    @Test
+    void shouldHaveExpectedNameAndRequiredId() {
+        // Given / When / Then
+        assertThat(tool.getName(), is(equalTo("zap_get_history")));
+        assertThat(tool.getInputSchema().required(), is(equalTo(List.of("id"))));
+        assertThat(tool.getInputSchema().properties().containsKey("fields"), is(true));
+        assertThat(tool.getInputSchema().properties().containsKey("body_offset"), is(true));
+        assertThat(tool.getInputSchema().properties().containsKey("max_body_chars"), is(true));
+    }
+
+    @Test
+    void shouldDefaultToHeadersOnly() throws Exception {
+        // Given
+        givenHistory(123, "req-body", "resp-body-content");
+
+        // When
+        McpToolResult result = tool.execute(args(Map.of("id", "123"), Map.of()));
+        JsonNode json = MAPPER.readTree(result.text());
+
+        // Then
+        assertThat(json.get("id").asInt(), is(equalTo(123)));
+        assertThat(json.has("requestHeader"), is(true));
+        assertThat(json.has("responseHeader"), is(true));
+        assertThat(json.has("requestBody"), is(false));
+        assertThat(json.has("responseBody"), is(false));
+    }
+
+    @Test
+    void shouldReturnWindowedBodiesWithMetadata() throws Exception {
+        // Given
+        givenHistory(7, "ABCDEFGHIJ", "0123456789");
+
+        // When
+        McpToolResult result =
+                tool.execute(
+                        args(
+                                Map.of("id", "7", "body_offset", "2", "max_body_chars", "4"),
+                                Map.of("fields", List.of("requestBody", "responseBody"))));
+        JsonNode json = MAPPER.readTree(result.text());
+
+        // Then
+        assertThat(json.get("requestBody").asText(), is(equalTo("CDEF")));
+        assertThat(json.get("requestBodyLength").asInt(), is(equalTo(10)));
+        assertThat(json.get("requestBodyOffset").asInt(), is(equalTo(2)));
+        assertThat(json.get("requestBodyReturned").asInt(), is(equalTo(4)));
+        assertThat(json.get("requestBodyTruncated").asBoolean(), is(true));
+
+        assertThat(json.get("responseBody").asText(), is(equalTo("2345")));
+        assertThat(json.get("responseBodyLength").asInt(), is(equalTo(10)));
+        assertThat(json.get("responseBodyOffset").asInt(), is(equalTo(2)));
+        assertThat(json.get("responseBodyReturned").asInt(), is(equalTo(4)));
+        assertThat(json.get("responseBodyTruncated").asBoolean(), is(true));
+    }
+
+    @Test
+    void shouldSupportNegativeBodyOffsetFromEnd() throws Exception {
+        // Given
+        givenHistory(1, "ABCDEFGHIJ", "0123456789");
+
+        // When
+        McpToolResult result =
+                tool.execute(
+                        args(
+                                Map.of("id", "1", "body_offset", "-3", "max_body_chars", "10"),
+                                Map.of("fields", List.of("responseBody"))));
+        JsonNode json = MAPPER.readTree(result.text());
+
+        // Then
+        assertThat(json.get("responseBody").asText(), is(equalTo("789")));
+        assertThat(json.get("responseBodyOffset").asInt(), is(equalTo(7)));
+        assertThat(json.get("responseBodyReturned").asInt(), is(equalTo(3)));
+        assertThat(json.get("responseBodyTruncated").asBoolean(), is(true));
+    }
+
+    @Test
+    void shouldMarkBodiesNotTruncatedWhenFullyReturned() throws Exception {
+        // Given
+        givenHistory(1, "abc", "xyz");
+
+        // When
+        McpToolResult result =
+                tool.execute(
+                        args(
+                                Map.of("id", "1", "max_body_chars", "100"),
+                                Map.of("fields", List.of("requestBody", "responseBody"))));
+        JsonNode json = MAPPER.readTree(result.text());
+
+        // Then
+        assertThat(json.get("requestBody").asText(), is(equalTo("abc")));
+        assertThat(json.get("requestBodyTruncated").asBoolean(), is(false));
+        assertThat(json.get("responseBody").asText(), is(equalTo("xyz")));
+        assertThat(json.get("responseBodyTruncated").asBoolean(), is(false));
+    }
+
+    @Test
+    void shouldRejectMissingId() {
+        // Given / When
+        McpToolException e =
+                assertThrows(McpToolException.class, () -> tool.execute(args(Map.of(), Map.of())));
+
+        // Then
+        assertThat(e.getMessage(), containsString("id"));
+    }
+
+    @Test
+    void shouldRejectInvalidId() {
+        // Given / When
+        McpToolException e =
+                assertThrows(
+                        McpToolException.class,
+                        () -> tool.execute(args(Map.of("id", "abc"), Map.of())));
+
+        // Then
+        assertThat(e.getMessage(), containsString("number"));
+    }
+
+    @Test
+    void shouldRejectUnknownField() {
+        // Given / When
+        McpToolException e =
+                assertThrows(
+                        McpToolException.class,
+                        () ->
+                                tool.execute(
+                                        args(
+                                                Map.of("id", "1"),
+                                                Map.of("fields", List.of("cookies")))));
+
+        // Then
+        assertThat(e.getMessage(), containsString("cookies"));
+    }
+
+    @Test
+    void shouldRejectNonPositiveMaxBodyChars() {
+        // Given / When
+        McpToolException e =
+                assertThrows(
+                        McpToolException.class,
+                        () ->
+                                tool.execute(
+                                        args(
+                                                Map.of("id", "1", "max_body_chars", "0"),
+                                                Map.of("fields", List.of("responseBody")))));
+
+        // Then
+        assertThat(e.getMessage(), containsString("max_body_chars"));
+    }
+
+    @Test
+    void shouldRejectMissingHistoryEntry() {
+        // Given / When
+        given(extHistory.getHistoryReference(99)).willReturn(null);
+
+        // Then
+        McpToolException e =
+                assertThrows(
+                        McpToolException.class,
+                        () -> tool.execute(args(Map.of("id", "99"), Map.of())));
+        assertThat(e.getMessage(), containsString("99"));
+    }
+
+    @Test
+    void shouldClampPositiveOffsetPastEndOfBodyWindow() {
+        // Given / When
+        BodyWindow window = BodyWindow.of("abcd", 10, 4);
+
+        // Then
+        assertThat(window.text(), is(equalTo("")));
+        assertThat(window.offset(), is(equalTo(4)));
+        assertThat(window.length(), is(equalTo(4)));
+        assertThat(window.returned(), is(equalTo(0)));
+        assertThat(window.truncated(), is(true));
+    }
+
+    @Test
+    void shouldClampNegativeOffsetBeforeStartOfBodyWindow() {
+        // Given / When
+        BodyWindow window = BodyWindow.of("abcd", -100, 2);
+
+        // Then
+        assertThat(window.text(), is(equalTo("ab")));
+        assertThat(window.offset(), is(equalTo(0)));
+        assertThat(window.returned(), is(equalTo(2)));
+        assertThat(window.truncated(), is(true));
+    }
+
+    private void givenHistory(int id, String requestBody, String responseBody) throws Exception {
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET /test HTTP/1.1\r\nHost: example.com\r\n");
+        msg.setRequestBody(requestBody);
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n");
+        msg.setResponseBody(responseBody);
+
+        HistoryReference href =
+                mock(HistoryReference.class, withSettings().strictness(Strictness.LENIENT));
+        given(href.getHttpMessage()).willReturn(msg);
+        given(extHistory.getHistoryReference(id)).willReturn(href);
+    }
+
+    private static McpTool.ToolArguments args(
+            Map<String, String> strings, Map<String, List<String>> lists) {
+        return new McpTool.ToolArguments(strings, lists);
+    }
+}

--- a/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/tools/ZapResourceToolsUnitTest.java
+++ b/addOns/mcp/src/test/java/org/zaproxy/addon/mcp/tools/ZapResourceToolsUnitTest.java
@@ -1,0 +1,202 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.mcp.tools;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.mcp.ExtensionMcp;
+import org.zaproxy.addon.mcp.McpResource;
+import org.zaproxy.addon.mcp.McpResourceRegistry;
+import org.zaproxy.addon.mcp.McpTool;
+import org.zaproxy.addon.mcp.McpToolException;
+import org.zaproxy.addon.mcp.McpToolResult;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit tests for {@link ZapListResourcesTool} and {@link ZapReadResourceTool}. */
+class ZapResourceToolsUnitTest extends TestUtils {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private McpResourceRegistry registry;
+    private ZapListResourcesTool listTool;
+    private ZapReadResourceTool readTool;
+
+    @BeforeEach
+    void setUp() {
+        mockMessages(new ExtensionMcp());
+        registry = new McpResourceRegistry();
+        listTool = new ZapListResourcesTool(registry);
+        readTool = new ZapReadResourceTool(registry);
+    }
+
+    @Test
+    void shouldHaveExpectedNamesAndSchemas() {
+        // Given / When / Then
+        assertThat(listTool.getName(), is(equalTo("zap_list_resources")));
+        assertThat(listTool.getInputSchema().required().isEmpty(), is(true));
+
+        assertThat(readTool.getName(), is(equalTo("zap_read_resource")));
+        assertThat(readTool.getInputSchema().required(), is(equalTo(java.util.List.of("uri"))));
+        assertThat(readTool.getInputSchema().properties().containsKey("uri"), is(true));
+    }
+
+    @Test
+    void shouldListEmptyResources() throws Exception {
+        // Given / When
+        McpToolResult result = listTool.execute(emptyArgs());
+        // Then
+        assertThat(result.isError(), is(false));
+        JsonNode json = MAPPER.readTree(result.text());
+        assertThat(json.get("resources").isArray(), is(true));
+        assertThat(json.get("resources").size(), is(equalTo(0)));
+    }
+
+    @Test
+    void shouldListResourcesSortedByUri() throws Exception {
+        // Given
+        registry.registerResource(resource("zap://b", "b-res", "B", "zap://b"));
+        registry.registerResource(resource("zap://a/", "a-res", "A", "zap://a/{id}"));
+
+        // When
+        McpToolResult result = listTool.execute(emptyArgs());
+
+        // Then
+        assertThat(result.isError(), is(false));
+        JsonNode resources = MAPPER.readTree(result.text()).get("resources");
+        assertThat(resources.size(), is(equalTo(2)));
+        assertThat(resources.get(0).get("uri").asText(), is(equalTo("zap://a/{id}")));
+        assertThat(resources.get(0).get("name").asText(), is(equalTo("a-res")));
+        assertThat(resources.get(0).get("description").asText(), is(equalTo("A")));
+        assertThat(resources.get(0).get("mimeType").asText(), is(equalTo("application/json")));
+        assertThat(resources.get(1).get("uri").asText(), is(equalTo("zap://b")));
+        assertThat(resources.get(1).get("name").asText(), is(equalTo("b-res")));
+    }
+
+    @Test
+    void shouldReadResourceByExactUri() throws Exception {
+        // Given
+        registry.registerResource(resource("zap://alerts", "alerts", "Alerts", "zap://alerts"));
+
+        // When
+        McpToolResult result = readTool.execute(args("uri", "zap://alerts"));
+
+        // Then
+        assertThat(result.isError(), is(false));
+        assertThat(result.text(), is(equalTo("{\"data\":\"zap://alerts\"}")));
+    }
+
+    @Test
+    void shouldReadResourceByTemplateUri() throws Exception {
+        // Given
+        registry.registerResource(
+                resource("zap://history/", "history-entry", "History entry", "zap://history/{id}"));
+
+        // When
+        McpToolResult result = readTool.execute(args("uri", "zap://history/42"));
+
+        // Then
+        assertThat(result.isError(), is(false));
+        assertThat(result.text(), is(equalTo("{\"data\":\"zap://history/42\"}")));
+    }
+
+    @Test
+    void shouldRejectMissingUri() {
+        // Given / When
+        McpToolException e =
+                assertThrows(McpToolException.class, () -> readTool.execute(emptyArgs()));
+
+        // Then
+        assertThat(e.getMessage(), containsString("uri"));
+    }
+
+    @Test
+    void shouldRejectBlankUri() {
+        // Given / When
+        McpToolException e =
+                assertThrows(McpToolException.class, () -> readTool.execute(args("uri", "   ")));
+
+        // Then
+        assertThat(e.getMessage(), containsString("uri"));
+    }
+
+    @Test
+    void shouldRejectUnknownUri() {
+        // Given / When
+        McpToolException e =
+                assertThrows(
+                        McpToolException.class,
+                        () -> readTool.execute(args("uri", "zap://unknown")));
+
+        // Then
+        assertThat(e.getMessage(), containsString("zap://unknown"));
+    }
+
+    private static McpTool.ToolArguments emptyArgs() {
+        return new McpTool.ToolArguments(Map.of(), Map.of());
+    }
+
+    private static McpTool.ToolArguments args(String key, String value) {
+        return new McpTool.ToolArguments(Map.of(key, value), Map.of());
+    }
+
+    private static McpResource resource(
+            String uri, String name, String description, String uriTemplate) {
+        return new McpResource() {
+            @Override
+            public String getUri() {
+                return uri;
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getDescription() {
+                return description;
+            }
+
+            @Override
+            public String getUriTemplate() {
+                return uriTemplate;
+            }
+
+            @Override
+            public String readContent() {
+                return "{\"data\":\"" + name + "\"}";
+            }
+
+            @Override
+            public String readContent(String requestedUri) {
+                return "{\"data\":\"" + requestedUri + "\"}";
+            }
+        };
+    }
+}


### PR DESCRIPTION
Our LLM/MCP integration only works for tools, as LangChain4j does not have first class support for resources or prompts ☹️ 
This PR adds a simple mapping from tools to resources, and a new specific tool which gives finer grained control over getting history messages. 