### PR TITLE
authhelper: handle exceptions parsing JSON

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Include the Zest statement index in the authentication diagnostics' steps.
 - Include Origin header when doing authentication verification.
 
+### Fixed
+- Handle exception while extracting session tokens.
+
 ## [0.40.0] - 2026-06-12
 ### Added
 - Support for handling the Microsoft login "Permissions requested" user consent screen.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -1192,7 +1192,7 @@ public class AuthUtils {
                 } catch (JSONException e) {
                     AuthUtils.extractJsonTokens(JSONArray.fromObject(responseData), "", tokens);
                 }
-            } catch (JSONException e) {
+            } catch (Exception e) {
                 LOGGER.debug(
                         "Unable to parse authentication response body from {} as JSON: {}",
                         msg.getRequestHeader().getURI(),

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -562,6 +563,25 @@ class AuthUtilsUnitTest extends TestUtils {
         assertThat(
                 tokens.get("json:auth.accessToken").getValue(),
                 is(equalTo("example-session-token")));
+    }
+
+    @Test
+    void shouldHandleParsingExceptions() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage(new URI("https://example.com/test", true));
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "blah-blah-json");
+        msg.getResponseBody()
+                .setBody(
+                        """
+                        {"auth": {"{}": "123"}}
+                        """);
+
+        // When
+        Map<String, SessionToken> tokens =
+                assertDoesNotThrow(() -> AuthUtils.getResponseSessionTokens(msg));
+
+        // Then
+        assertThat(tokens.size(), is(equalTo(0)));
     }
 
     @Test


### PR DESCRIPTION
Catch Exception since the lib used can throw other exceptions (e.g. ClassCastException) than their own.

---
e.g.:
```
368438 [ZAP-PassiveScan-9] ERROR org.zaproxy.addon.pscan.internal.scanner.PassiveScanTask - Scan rule 'Session Management Response Identified' failed on record 156 from History table: GET https://www.example.org/path
java.lang.ClassCastException: JSON keys must be strings.
	at net.sf.json.JSONObject._fromJSONObject(JSONObject.java:927)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:155)
	at net.sf.json.JSONSerializer.toJSON(JSONSerializer.java:108)
	at net.sf.json.AbstractJSON._processValue(AbstractJSON.java:238)
	at net.sf.json.JSONObject._processValue(JSONObject.java:2655)
	at net.sf.json.JSONObject.processValue(JSONObject.java:2721)
	at net.sf.json.JSONObject.element(JSONObject.java:1786)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:1036)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:159)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:1008)
	at net.sf.json.JSONObject._fromString(JSONObject.java:1201)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:165)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:134)
	at org.zaproxy.addon.authhelper.AuthUtils.addResponseBodyTokens(AuthUtils.java:1191)
	at org.zaproxy.addon.authhelper.AuthUtils.getResponseSessionTokens(AuthUtils.java:1043)
	at org.zaproxy.addon.authhelper.SessionDetectionScanRule.scanHttpResponseReceive(SessionDetectionScanRule.java:61)
	at org.zaproxy.addon.pscan.internal.scanner.PassiveScanTask.run(PassiveScanTask.java:152)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```