### PR TITLE
sse: handle read timeouts

### DIFF
--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Handle read timeouts.
 
 ## [14] - 2026-07-13
 ### Added

--- a/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/EventStreamListener.java
+++ b/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/EventStreamListener.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.sse;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,14 +45,14 @@ public class EventStreamListener implements Runnable {
         try {
             String firstEventLine;
             String line;
-            while ((firstEventLine = reader.readLine()) != null) {
+            while ((firstEventLine = readLineWithTimeout()) != null) {
                 if (firstEventLine.equals("")) {
                     // blank line before any event data (e.g. keep-alive) - not an event
                     continue;
                 }
 
                 StringBuilder rawEvent = new StringBuilder(firstEventLine);
-                while ((line = reader.readLine()) != null) {
+                while ((line = readLineWithTimeout()) != null) {
                     if (line.equals("")) {
                         // event finishes on newline => trigger dispatch
                         proxy.processEvent(rawEvent.toString());
@@ -61,15 +62,25 @@ public class EventStreamListener implements Runnable {
                     rawEvent.append(line);
                 }
             }
+        } catch (IOException e) {
+            LOGGER.debug("I/O exception while handling Server-Sent Event:", e);
         } catch (Exception e) {
-            // includes SocketException
-            // no more reading possible
             LOGGER.warn(
                     "An exception occurred while reading Server-Sent Events: {}",
                     e.getMessage(),
                     e);
         } finally {
             this.proxy.stop();
+        }
+    }
+
+    private String readLineWithTimeout() throws IOException {
+        while (true) {
+            try {
+                return reader.readLine();
+            } catch (SocketTimeoutException e) {
+                LOGGER.debug("Socket timed out waiting for Server-Sent Event, continuing.");
+            }
         }
     }
 

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamListenerUnitTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamListenerUnitTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -138,6 +139,46 @@ class EventStreamListenerUnitTest {
 
         // Then
         verify(proxyMock, never()).processEvent(anyString());
+    }
+
+    @Test
+    void shouldContinueReadingAfterSocketTimeoutBeforeEvent() throws IOException {
+        // Given
+        String event = "data:blub";
+        BufferedReader readerMock = mock();
+        when(readerMock.readLine())
+                .thenThrow(new SocketTimeoutException())
+                .thenReturn(event)
+                .thenReturn("")
+                .thenReturn(null);
+        EventStreamProxy proxyMock = mock();
+        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock, mock());
+
+        // When
+        listener.run();
+
+        // Then
+        verify(proxyMock).processEvent(event);
+    }
+
+    @Test
+    void shouldContinueReadingAfterSocketTimeoutDuringEvent() throws IOException {
+        // Given
+        BufferedReader readerMock = mock();
+        when(readerMock.readLine())
+                .thenReturn("event: foo")
+                .thenThrow(new SocketTimeoutException())
+                .thenReturn("data: bar")
+                .thenReturn("")
+                .thenReturn(null);
+        EventStreamProxy proxyMock = mock();
+        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock, mock());
+
+        // When
+        listener.run();
+
+        // Then
+        verify(proxyMock).processEvent("event: foo\ndata: bar");
     }
 
     @Test


### PR DESCRIPTION
Continue reading if there's a timeout, the server might not send any during the configured timeout.
Also, reduce logging level for IO exceptions since those are expected.

---
e.g.
```
1401224 [ZAP-SSE-Listener] WARN  org.zaproxy.zap.extension.sse.EventStreamListener - An exception occurred while reading Server-Sent Events: Read timed out
java.net.SocketTimeoutException: Read timed out
	at java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:277)
	at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:302)
	at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:354)
	at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:798)
	at java.base/java.net.Socket$SocketInputStream.implRead(Socket.java:974)
	at java.base/java.net.Socket$SocketInputStream.read(Socket.java:964)
	at java.base/sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:489)
	at java.base/sun.security.ssl.SSLSocketInputRecord.readHeader(SSLSocketInputRecord.java:483)
	at java.base/sun.security.ssl.SSLSocketInputRecord.bytesInCompletePacket(SSLSocketInputRecord.java:70)
	at java.base/sun.security.ssl.SSLSocketImpl.readApplicationRecord(SSLSocketImpl.java:1461)
	at java.base/sun.security.ssl.SSLSocketImpl$AppInputStream.read(SSLSocketImpl.java:1068)
	at org.apache.hc.core5.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:149)
	at org.apache.hc.core5.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:280)
	at org.apache.hc.core5.http.impl.io.ChunkedInputStream.getChunkSize(ChunkedInputStream.java:261)
	at org.apache.hc.core5.http.impl.io.ChunkedInputStream.nextChunk(ChunkedInputStream.java:222)
	at org.apache.hc.core5.http.impl.io.ChunkedInputStream.read(ChunkedInputStream.java:183)
	at java.base/sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:279)
	at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:322)
	at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:186)
	at java.base/java.io.InputStreamReader.read(InputStreamReader.java:183)
	at java.base/java.io.BufferedReader.fill(BufferedReader.java:166)
	at java.base/java.io.BufferedReader.readLine(BufferedReader.java:333)
	at java.base/java.io.BufferedReader.readLine(BufferedReader.java:400)
	at org.zaproxy.zap.extension.sse.EventStreamListener.run(EventStreamListener.java:47)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```