### PR TITLE
network: fix cert gen for long domain names

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update dependencies.
 
+### Fixed
+- Correct the generation of server certificates for domain names with more than 64 characters.
+
 ## [0.28.0] - 2026-05-21
 ### Changed
 - Update dependencies (Issue 9337).

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
@@ -130,6 +130,8 @@ public final class CertificateUtils {
      */
     private static final Duration SERVER_CERTIFICATE_START_ADJUSTMENT = Duration.ofDays(30);
 
+    private static final int CN_MAX_LENGTH = 64;
+
     private CertificateUtils() {}
 
     public static char[] getPassphrase() {
@@ -280,8 +282,10 @@ public final class CertificateUtils {
         PublicKey publicKey = keyPair.getPublic();
 
         X500NameBuilder namebld = new X500NameBuilder(BCStyle.INSTANCE);
-        if (certData.getCommonName() != null) {
-            namebld.addRDN(BCStyle.CN, certData.getCommonName());
+        String commonName = certData.getCommonName();
+        boolean cnAdded = commonName != null && commonName.length() <= CN_MAX_LENGTH;
+        if (cnAdded) {
+            namebld.addRDN(BCStyle.CN, commonName);
         }
         namebld.addRDN(BCStyle.OU, "Zed Attack Proxy Project");
         namebld.addRDN(BCStyle.O, "ZAP");
@@ -316,7 +320,7 @@ public final class CertificateUtils {
         if (subjectAlternativeNames.length > 0) {
             certGen.addExtension(
                     Extension.subjectAlternativeName,
-                    certData.isSubjectAlternativeNameIsCritical(),
+                    certData.isSubjectAlternativeNameIsCritical() || !cnAdded,
                     new GeneralNames(subjectAlternativeNames));
         }
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -127,6 +128,32 @@ class CertificateUtilsUnitTest {
         assertThat(
                 serverCert.getSubjectAlternativeNames().toString(),
                 containsString("[[2, example.org], [7, 127.0.0.1]]"));
+    }
+
+    @Test
+    void shouldOmitCnWhenDomainNameExceedsLimit() throws Exception {
+        // Given
+        CertConfig config = new CertConfig(Duration.ofDays(60));
+        KeyStore rootCaKeyStore =
+                CertificateUtils.stringToKeystore(NetworkTestUtils.FISH_CERT_BASE64_STR);
+        X509Certificate rootCaCert = CertificateUtils.getCertificate(rootCaKeyStore);
+        PublicKey rootCaPublicKey = rootCaCert.getPublicKey();
+        PrivateKey rooCaPrivateKey = CertificateUtils.getPrivateKey(rootCaKeyStore);
+        String longHostname = "a".repeat(65) + ".example.org";
+        CertData certData = new CertData(longHostname);
+        // When
+        KeyStore keyStore =
+                CertificateUtils.createServerKeyStore(
+                        rootCaCert, rootCaPublicKey, rooCaPrivateKey, certData, 1L, config);
+        // Then
+        X509Certificate serverCert = CertificateUtils.getCertificate(keyStore);
+        assertThat(serverCert.getSubjectX500Principal().getName(), not(containsString("CN=")));
+        assertThat(
+                serverCert.getSubjectAlternativeNames().toString(),
+                containsString("[2, " + longHostname + "]"));
+        assertThat(
+                serverCert.getCriticalExtensionOIDs(),
+                hasItem(Extension.subjectAlternativeName.getId()));
     }
 
     @Test


### PR DESCRIPTION
Omit the CN when it exceeds the limit, let it use the SAN.