### PR TITLE
network: improve server exception handling

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to control how browser background requests should be handled, default to hide.
 
 ### Changed
+- Improve server exception handling.
 - Update dependencies.
 
 ### Fixed

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/cert/CertificateUtils.java
@@ -252,7 +252,8 @@ public final class CertificateUtils {
                     rootCaCert, rootCaPublicKey, rootCaPrivateKey, certData, serial, config);
         } catch (Exception e) {
             throw new GenerationException(
-                    "An error occurred while generating the server certificate:", e);
+                    "An error occurred while generating the server certificate: " + e.getMessage(),
+                    e);
         }
     }
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
@@ -76,6 +76,10 @@ public class ServerExceptionHandler extends ChannelInboundHandlerAdapter {
             return;
         }
 
+        if (handleSslRelatedException(cause)) {
+            return;
+        }
+
         if (cause instanceof IOException) {
             LOGGER.debug(cause, cause);
             return;
@@ -92,30 +96,68 @@ public class ServerExceptionHandler extends ChannelInboundHandlerAdapter {
             return;
         }
 
-        if (nestedCause instanceof SSLHandshakeException
-                || (nestedCause instanceof SSLException && isUnknownCa(nestedCause))) {
-            Level level = Level.WARN;
-            String causeMessage = nestedCause.getMessage();
-            if (isUnknownCa(nestedCause)) {
-                causeMessage = "the client does not trust ZAP's Root CA Certificate.";
-                level = Level.DEBUG;
-            }
-
-            LOGGER.log(
-                    level, "Failed while establishing secure connection, cause: {}", causeMessage);
-            return;
-        }
-
-        if (nestedCause instanceof GenerationException) {
-            LOGGER.warn("Failed while creating certificate, cause: {}", nestedCause.getMessage());
+        if (handleSslRelatedException(nestedCause)) {
             return;
         }
 
         LOGGER.error(nestedCause, nestedCause);
     }
 
-    private static boolean isUnknownCa(Throwable nestedCause) {
+    private static boolean handleSslRelatedException(Throwable cause) {
+        if (cause instanceof SSLHandshakeException
+                || (cause instanceof SSLException && isUnknownCa(cause))) {
+            Level level = Level.WARN;
+            String causeMessage = cause.getMessage();
+            if (isUnknownCa(cause)) {
+                causeMessage = "the client does not trust ZAP's Root CA Certificate.";
+                level = Level.DEBUG;
+            }
+
+            LOGGER.log(
+                    level, "Failed while establishing secure connection, cause: {}", causeMessage);
+            return true;
+        }
+
+        if (cause instanceof SSLException && isInternalError(cause)) {
+            Throwable nestedCause = cause.getCause();
+            if (nestedCause != null && handleGenerationException(nestedCause)) {
+                return true;
+            }
+
+            LOGGER.warn("SSL/TLS internal error:", cause);
+            return true;
+        }
+
+        if (handleGenerationException(cause)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static boolean handleGenerationException(Throwable cause) {
+        if (cause instanceof GenerationException) {
+            String message = "Failed while creating certificate, cause: {}";
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(message, cause.getMessage(), cause);
+            } else {
+                LOGGER.warn(message, cause.getMessage());
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isUnknownCa(Throwable cause) {
+        return containsMessage(cause, "unknown_ca");
+    }
+
+    private static boolean isInternalError(Throwable cause) {
+        return containsMessage(cause, "internal_error");
+    }
+
+    private static boolean containsMessage(Throwable nestedCause, String value) {
         String causeMessage = nestedCause.getMessage();
-        return causeMessage != null && causeMessage.contains("unknown_ca");
+        return causeMessage != null && causeMessage.contains(value);
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
@@ -22,6 +22,8 @@ package org.zaproxy.addon.network.internal.handlers;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
@@ -33,6 +35,8 @@ import io.netty.handler.timeout.ReadTimeoutException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import org.apache.logging.log4j.Level;
@@ -42,6 +46,8 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.addon.network.TestLogAppender;
 import org.zaproxy.addon.network.internal.cert.GenerationException;
@@ -89,11 +95,16 @@ class ServerExceptionHandlerUnitTest {
         assertThat(logEvents, hasItem(startsWith("DEBUG Timed out while reading")));
     }
 
-    @Test
-    void shouldLogSslHandshakeExceptionAsWarn() throws Exception {
+    static Stream<UnaryOperator<Exception>> exceptionsSource() {
+        return Stream.of(DecoderException::new, e -> e);
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionsSource")
+    void shouldLogSslHandshakeExceptionAsWarn(UnaryOperator<Exception> source) throws Exception {
         // Given
         Exception cause = new SSLHandshakeException("missing protocol");
-        Exception exception = new DecoderException(cause);
+        Exception exception = source.apply(cause);
         // When
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
@@ -104,11 +115,13 @@ class ServerExceptionHandlerUnitTest {
                                 "WARN Failed while establishing secure connection, cause: missing protocol")));
     }
 
-    @Test
-    void shouldLogUnknownCaSslHandshakeExceptionAsDebug() throws Exception {
+    @ParameterizedTest
+    @MethodSource("exceptionsSource")
+    void shouldLogUnknownCaSslHandshakeExceptionAsDebug(UnaryOperator<Exception> source)
+            throws Exception {
         // Given
         Exception cause = new SSLHandshakeException("unknown_ca");
-        Exception exception = new DecoderException(cause);
+        Exception exception = source.apply(cause);
         // When
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
@@ -119,11 +132,12 @@ class ServerExceptionHandlerUnitTest {
                                 "DEBUG Failed while establishing secure connection, cause: the client does not trust ZAP's Root CA Certificate.")));
     }
 
-    @Test
-    void shouldLogUnknownCaSslExceptionAsDebug() throws Exception {
+    @ParameterizedTest
+    @MethodSource("exceptionsSource")
+    void shouldLogUnknownCaSslExceptionAsDebug(UnaryOperator<Exception> source) throws Exception {
         // Given
         Exception cause = new SSLException("unknown_ca");
-        Exception exception = new DecoderException(cause);
+        Exception exception = source.apply(cause);
         // When
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
@@ -134,11 +148,14 @@ class ServerExceptionHandlerUnitTest {
                                 "DEBUG Failed while establishing secure connection, cause: the client does not trust ZAP's Root CA Certificate.")));
     }
 
-    @Test
-    void shouldLogGenerationExceptionAsWarn() throws Exception {
+    @ParameterizedTest
+    @MethodSource("exceptionsSource")
+    void shouldLogGenerationExceptionAsWarnWithMessage(UnaryOperator<Exception> source)
+            throws Exception {
         // Given
+        logEvents = registerLogEvents(Level.INFO);
         Exception cause = new GenerationException(new Exception("Cause"));
-        Exception exception = new DecoderException(cause);
+        Exception exception = source.apply(cause);
         // When
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
@@ -147,6 +164,25 @@ class ServerExceptionHandlerUnitTest {
                 hasItem(
                         startsWith(
                                 "WARN Failed while creating certificate, cause: java.lang.Exception: Cause")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionsSource")
+    void shouldLogGenerationExceptionAsDebugWithException(UnaryOperator<Exception> source)
+            throws Exception {
+        // Given
+        Exception cause = new GenerationException(new Exception("Cause"));
+        Exception exception = source.apply(cause);
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(
+                logEvents,
+                hasItem(
+                        allOf(
+                                startsWith(
+                                        "DEBUG Failed while creating certificate, cause: java.lang.Exception: Cause"),
+                                containsString("Caused by: java.lang.Exception: Cause"))));
     }
 
     @Test
@@ -207,13 +243,17 @@ class ServerExceptionHandlerUnitTest {
     }
 
     private static List<String> registerLogEvents() {
+        return registerLogEvents(Level.ALL);
+    }
+
+    private static List<String> registerLogEvents(Level level) {
         List<String> logEvents = new ArrayList<>();
         TestLogAppender logAppender = new TestLogAppender("%p %m%n", logEvents::add);
         LoggerContext context = LoggerContext.getContext();
         LoggerConfig rootLoggerconfig = context.getConfiguration().getRootLogger();
         rootLoggerconfig.getAppenders().values().forEach(context.getRootLogger()::removeAppender);
         rootLoggerconfig.addAppender(logAppender, null, null);
-        rootLoggerconfig.setLevel(Level.ALL);
+        rootLoggerconfig.setLevel(level);
         context.updateLoggers();
         return logEvents;
     }


### PR DESCRIPTION
Check `SSLException` before `IOException` and check for internal error, in newer JREs the exception might not be wrapped.
Include cause's message when throwing `GenerationException` to make it easier to know what the root problem is, also, log the stacktrace when debug.