### PR TITLE
Validate and update commonlib alert tag URLs

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update reference to avoid redirects.
 
 ## [83] - 2026-06-26
 ### Changed

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -249,7 +249,7 @@ ascanrules.traceaxd.soln = Consider whether or not Trace Viewer is actually requ
 
 ascanrules.useragent.desc = Check for differences in response based on fuzzed User Agent (eg. mobile sites, access as a Search Engine Crawler). Compares the response statuscode and the hashcode of the response body with the original response.
 ascanrules.useragent.name = User Agent Fuzzer
-ascanrules.useragent.refs = https://owasp.org/wstg
+ascanrules.useragent.refs = https://owasp.org/www-project-web-security-testing-guide/
 ascanrules.useragent.useragentparmname = Header User-Agent
 
 ascanrules.xpathinjection.name = XPath Injection

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/EnvFileScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/EnvFileScanRuleUnitTest.java
@@ -40,6 +40,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.AbstractAppFilePluginUnitTest;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.PolicyTag;
+import org.zaproxy.zap.testutils.UrlValidationError.Cause;
 
 /** Unit test for {@link EnvFileScanRule}. */
 class EnvFileScanRuleUnitTest extends AbstractAppFilePluginUnitTest<EnvFileScanRule> {
@@ -77,6 +78,11 @@ class EnvFileScanRuleUnitTest extends AbstractAppFilePluginUnitTest<EnvFileScanR
     @Override
     protected void setUpMessages() {
         mockMessages(new ExtensionAscanRules());
+    }
+
+    @Override
+    public boolean isAllowedUrlValidationError(Cause cause, String reference, Object detail) {
+        return cause == Cause.META_REFRESH && reference.startsWith("https://www.google.com/search");
     }
 
     @Override

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Update references to avoid redirects.
 
 ## [66] - 2026-05-06
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -145,7 +145,7 @@ ascanbeta.sessionfixation.alert.url.extrainfo = A likely session value has appea
 ascanbeta.sessionfixation.alert.url.extrainfo.loginpage = The url on which the issue was discovered was flagged as a logon page.
 ascanbeta.sessionfixation.desc = Session Fixation may be possible. If this issue occurs with a login URL (where the user authenticates themselves to the application), then the URL may be given by an attacker, along with a fixed session id, to a victim, in order to later assume the identity of the victim using the given session id. If the issue occurs with a non-login page, the URL and fixed session id may only be used by an attacker to track an unauthenticated user's actions. If the vulnerability occurs on a cookie field or a form field (POST parameter) rather than on a URL (GET) parameter, then some other vulnerability may also be required in order to set the cookie field on the victim's browser, to allow the vulnerability to be exploited.
 ascanbeta.sessionfixation.name = Session Fixation
-ascanbeta.sessionfixation.refs = https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication\nhttps://owasp.org/www-community/attacks/Session_fixation\nhttps://acrossecurity.com/papers/session_fixation.pdf\nhttps://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+ascanbeta.sessionfixation.refs = https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication.html\nhttps://owasp.org/www-community/attacks/Session_fixation\nhttps://acrossecurity.com/papers/session_fixation.pdf\nhttps://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
 ascanbeta.sessionfixation.soln = 1) Prevent the attacker from gaining a session id by enforcing strict session ids, and by only allocating session ids upon successful authentication to the application.\n2) The server should always create a new session id upon authentication, regardless of whether a session is already in place.\n3) Bind the session id to some identifiable client attribute combination, such as IP address, SSL client certificate.\n4) Sessions, when destroyed, must be destroyed on the server, as well as on the client.\n5) Implement a logout mechanism which will destroy all previous sessions for the client.\n6) Implement absolute session timeouts.\n7)Switch from a URL based to a cookie or form based session id implementation, as the latter typically require additional vulnerabilities, in order to be exploitable by an attacker.
 
 ascanbeta.sessionidaccessiblebyjavascript.alert.attack = {0} field: [{1}]
@@ -179,7 +179,7 @@ ascanbeta.sessionidexposedinurl.desc = A session id is exposed in the URL. By sh
 #Exposed Session Id messages
 ascanbeta.sessionidexposedinurl.name = Exposed Session ID
 #these refs cannot be referenced, but we leave it here in the hope that it can be in the future..
-ascanbeta.sessionidexposedinurl.refs = https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication
+ascanbeta.sessionidexposedinurl.refs = https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication.html
 ascanbeta.sessionidexposedinurl.soln = Use a more secure session management implementation, such as one that uses session cookies, which are not as easily shared inadvertently, and which do not typically appear in server log files or web browser bookmarks.
 
 ascanbeta.sessionidsentinsecurely.alert.attack = {0} field: [{1}]
@@ -190,7 +190,7 @@ ascanbeta.sessionidsentinsecurely.desc = A session id may be sent via an insecur
 #Session Id Cookie not sent securely
 ascanbeta.sessionidsentinsecurely.name = Session ID Transmitted Insecurely
 #these refs cannot be referenced, but we leave it here in the hope that it can be in the future..
-ascanbeta.sessionidsentinsecurely.refs = https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication
+ascanbeta.sessionidsentinsecurely.refs = https://owasp.org/www-project-top-ten/2017/A2_2017-Broken_Authentication.html
 ascanbeta.sessionidsentinsecurely.soln = 1) Use the latest available version of SSL/TLS (for HTTPS) for all pages where a session id is communicated between the browser and the web server.\n2) Do not allow the communication to be forced down to the unencrypted HTTP protocol.\n3) Use the 'secure' flag when setting a cookie containing a session id, to prevent its subsequent transmission by an insecure mechanism.\n4) Forward non-secure HTTP page requests to the secure HTTPS equivalent page.
 
 ascanbeta.sourcecodedisclosure.desc = The source code for the current page was disclosed by the web server.

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRuleUnitTest.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.PolicyTag;
 import org.zaproxy.addon.network.common.ZapSocketTimeoutException;
-import org.zaproxy.zap.testutils.AlertReferenceError;
+import org.zaproxy.zap.testutils.UrlValidationError;
 
 class CrossDomainScanRuleUnitTest extends ActiveScannerTest<CrossDomainScanRule> {
 
@@ -40,8 +40,8 @@ class CrossDomainScanRuleUnitTest extends ActiveScannerTest<CrossDomainScanRule>
     }
 
     @Override
-    public boolean isAllowedReferenceError(
-            AlertReferenceError.Cause cause, String reference, Object detail) {
+    public boolean isAllowedUrlValidationError(
+            UrlValidationError.Cause cause, String reference, Object detail) {
         if (reference.startsWith("https://www.adobe.com/")
                 && detail instanceof ZapSocketTimeoutException) {
             // Reference behind CDN which times out when accessed through CI.

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update alert tag URLs to avoid redirects.
 
 ## [1.43.0] - 2026-07-14
 ### Added

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
@@ -52,29 +52,29 @@ public enum CommonAlertTag {
 
     // OWASP Top 10 2021
     OWASP_2021_A01_BROKEN_AC(
-            "OWASP_2021_A01", "https://owasp.org/Top10/A01_2021-Broken_Access_Control/"),
+            "OWASP_2021_A01", "https://owasp.org/Top10/2021/A01_2021-Broken_Access_Control/"),
     OWASP_2021_A02_CRYPO_FAIL(
-            "OWASP_2021_A02", "https://owasp.org/Top10/A02_2021-Cryptographic_Failures/"),
-    OWASP_2021_A03_INJECTION("OWASP_2021_A03", "https://owasp.org/Top10/A03_2021-Injection/"),
+            "OWASP_2021_A02", "https://owasp.org/Top10/2021/A02_2021-Cryptographic_Failures/"),
+    OWASP_2021_A03_INJECTION("OWASP_2021_A03", "https://owasp.org/Top10/2021/A03_2021-Injection/"),
     OWASP_2021_A04_INSECURE_DESIGN(
-            "OWASP_2021_A04", "https://owasp.org/Top10/A04_2021-Insecure_Design/"),
+            "OWASP_2021_A04", "https://owasp.org/Top10/2021/A04_2021-Insecure_Design/"),
     OWASP_2021_A05_SEC_MISCONFIG(
-            "OWASP_2021_A05", "https://owasp.org/Top10/A05_2021-Security_Misconfiguration/"),
+            "OWASP_2021_A05", "https://owasp.org/Top10/2021/A05_2021-Security_Misconfiguration/"),
     OWASP_2021_A06_VULN_COMP(
             "OWASP_2021_A06",
-            "https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/"),
+            "https://owasp.org/Top10/2021/A06_2021-Vulnerable_and_Outdated_Components/"),
     OWASP_2021_A07_AUTH_FAIL(
             "OWASP_2021_A07",
-            "https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/"),
+            "https://owasp.org/Top10/2021/A07_2021-Identification_and_Authentication_Failures/"),
     OWASP_2021_A08_INTEGRITY_FAIL(
             "OWASP_2021_A08",
-            "https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/"),
+            "https://owasp.org/Top10/2021/A08_2021-Software_and_Data_Integrity_Failures/"),
     OWASP_2021_A09_LOGGING_FAIL(
             "OWASP_2021_A09",
-            "https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/"),
+            "https://owasp.org/Top10/2021/A09_2021-Security_Logging_and_Monitoring_Failures/"),
     OWASP_2021_A10_SSRF(
             "OWASP_2021_A10",
-            "https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/"),
+            "https://owasp.org/Top10/2021/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/"),
 
     // OWASP Top 10 2017
     OWASP_2017_A01_INJECTION(

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CommonAlertTagUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CommonAlertTagUnitTest.java
@@ -25,10 +25,14 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.testutils.UrlTests;
 
-class CommonAlertTagUnitTest {
+class CommonAlertTagUnitTest implements UrlTests {
 
     private static final Map<String, String> BASE_TAGS =
             CommonAlertTag.toMap(
@@ -85,5 +89,26 @@ class CommonAlertTagUnitTest {
         assertTrue(allTags.containsKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
         assertTrue(allTags.containsKey(cve));
         assertThat(link, is(equalTo("https://nvd.nist.gov/vuln/detail/CVE-2020-1234")));
+    }
+
+    @Test
+    void shouldHaveValidTagUrls() {
+        // Given
+        List<String> urls =
+                Stream.of(CommonAlertTag.values())
+                        .map(CommonAlertTag::getValue)
+                        .filter(Predicate.not(String::isBlank))
+                        .toList();
+        // When / Then
+        shouldHaveValidUrls(urls);
+    }
+
+    @Test
+    void shouldHaveValidCveUrl() {
+        // Given
+        Map<String, String> tags = new HashMap<>();
+        CommonAlertTag.putCve(tags, "CVE-2020-1234");
+        // When / Then
+        shouldHaveValidUrls(List.of(tags.get("CVE-2020-1234")));
     }
 }

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/ActiveDefaultTemplateGraalJsScriptTest.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/ActiveDefaultTemplateGraalJsScriptTest.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
-import org.zaproxy.zap.testutils.AlertReferenceError;
+import org.zaproxy.zap.testutils.UrlValidationError;
 
 class ActiveDefaultTemplateGraalJsScriptTest extends GraalJsActiveScriptScanRuleTestUtils {
     @Override
@@ -45,8 +45,8 @@ class ActiveDefaultTemplateGraalJsScriptTest extends GraalJsActiveScriptScanRule
     }
 
     @Override
-    public boolean isAllowedReferenceError(
-            AlertReferenceError.Cause cause, String reference, Object detail) {
+    public boolean isAllowedUrlValidationError(
+            UrlValidationError.Cause cause, String reference, Object detail) {
         // These are example.org references.
         return true;
     }

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PassiveDefaultTemplateGraalJsScriptTest.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PassiveDefaultTemplateGraalJsScriptTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.testutils.AlertReferenceError;
+import org.zaproxy.zap.testutils.UrlValidationError;
 
 class PassiveDefaultTemplateGraalJsScriptTest extends GraalJsPassiveScriptScanRuleTestUtils {
     @Override
@@ -43,8 +43,8 @@ class PassiveDefaultTemplateGraalJsScriptTest extends GraalJsPassiveScriptScanRu
     }
 
     @Override
-    public boolean isAllowedReferenceError(
-            AlertReferenceError.Cause cause, String reference, Object detail) {
+    public boolean isAllowedUrlValidationError(
+            UrlValidationError.Cause cause, String reference, Object detail) {
         // These are example.org references.
         return true;
     }

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update reference to avoid redirects.
 
 ## [0.62.0] - 2026-07-16
 ### Changed

--- a/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources/Messages.properties
+++ b/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources/Messages.properties
@@ -8,5 +8,5 @@ retire.rule.desc = The identified library appears to be vulnerable.
 retire.rule.name = Vulnerable JS Library (Powered by Retire.js)
 retire.rule.otherinfo = The identified library {0}, version {1} is vulnerable.\n
 retire.rule.otherinfo.hash = The library matched the known vulnerable hash {0}.
-retire.rule.references = https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/
+retire.rule.references = https://owasp.org/Top10/2021/A06_2021-Vulnerable_and_Outdated_Components/
 retire.rule.soln = Upgrade to the latest version of the affected library.

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -296,7 +296,7 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
                 alert.getReference(),
                 is(
                         equalTo(
-                                "https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/")));
+                                "https://owasp.org/Top10/2021/A06_2021-Vulnerable_and_Outdated_Components/")));
     }
 
     private static HttpMessage createMessage(String url, String body) {

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ScanRuleTests.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ScanRuleTests.java
@@ -24,10 +24,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assumptions.assumingThat;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,20 +36,13 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
-import org.parosproxy.paros.network.HttpHeader;
-import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpSender;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
-import org.zaproxy.zap.network.HttpRequestConfig;
-import org.zaproxy.zap.testutils.AlertReferenceError.Cause;
 
-interface ScanRuleTests {
+interface ScanRuleTests extends UrlTests {
 
     Object getScanRule();
 
@@ -106,83 +97,7 @@ interface ScanRuleTests {
     }
 
     default void shouldHaveValidReferences() {
-        // Given / When
-        Set<String> references = getAllReferences(getScanRule());
-        // Then
-        if (references.isEmpty()) {
-            return;
-        }
-
-        List<AlertReferenceError> errors = new ArrayList<>();
-        for (String reference : references) {
-            if (!reference.startsWith(HttpHeader.HTTP)) {
-                errors.add(AlertReferenceError.Cause.NOT_LINK.create(reference, ""));
-                continue;
-            }
-
-            URI uri;
-            try {
-                uri = new URI(reference, true);
-            } catch (Exception e) {
-                errors.add(AlertReferenceError.Cause.INVALID_URI.create(reference, e));
-                continue;
-            }
-
-            if (!HttpHeader.HTTPS.equals(uri.getScheme())) {
-                errors.add(AlertReferenceError.Cause.NOT_HTTPS.create(reference, ""));
-            } else {
-                assumingThat(
-                        "1".equals(System.getenv("ZAP_REMOTE_TESTS")),
-                        () -> fetchUrl(uri, reference, errors));
-            }
-        }
-
-        assertThat(errors.toString(), errors, is(empty()));
-    }
-
-    default boolean isAllowedReferenceError(
-            AlertReferenceError.Cause cause, String reference, Object detail) {
-        return false;
-    }
-
-    private void fetchUrl(URI uri, String reference, List<AlertReferenceError> errors) {
-        try {
-            HttpMessage message = new HttpMessage(uri);
-            List<URI> redirections = new ArrayList<>();
-            new HttpSender(0)
-                    .sendAndReceive(
-                            message,
-                            HttpRequestConfig.builder()
-                                    .setRedirectionValidator(redirections::add)
-                                    .build());
-            var responseHeader = message.getResponseHeader();
-            int statusCode = responseHeader.getStatusCode();
-            if (statusCode == 429) {
-                // Assume exists.
-            } else if (statusCode != HttpStatusCode.OK) {
-                addErrorIfNotAllowed(
-                        errors,
-                        AlertReferenceError.Cause.UNEXPECTED_STATUS_CODE,
-                        reference,
-                        statusCode);
-            } else if (!redirections.isEmpty()) {
-                addErrorIfNotAllowed(
-                        errors,
-                        AlertReferenceError.Cause.REDIRECTED,
-                        reference,
-                        redirections.get(redirections.size() - 1));
-            }
-        } catch (IOException e) {
-            addErrorIfNotAllowed(errors, AlertReferenceError.Cause.IO_EXCEPTION, reference, e);
-        }
-    }
-
-    private void addErrorIfNotAllowed(
-            List<AlertReferenceError> errors, Cause cause, String reference, Object detail) {
-        if (isAllowedReferenceError(cause, reference, detail)) {
-            return;
-        }
-        errors.add(cause.create(reference, detail));
+        shouldHaveValidUrls(getAllReferences(getScanRule()));
     }
 
     private static Set<String> getAllReferences(Object scanRule) {

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/UrlTests.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/UrlTests.java
@@ -1,0 +1,149 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.testutils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assumptions.assumingThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.htmlparser.jericho.HTMLElementName;
+import net.htmlparser.jericho.Source;
+import org.apache.commons.httpclient.URI;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.testutils.UrlValidationError.Cause;
+
+public interface UrlTests {
+
+    Pattern META_REFRESH_PATTERN = Pattern.compile("url\\s*=\\s*[\"']?([^'\"]*)[\"']?");
+
+    default void shouldHaveValidUrls(Collection<String> urls) {
+        if (urls.isEmpty()) {
+            return;
+        }
+
+        List<UrlValidationError> errors = new ArrayList<>();
+        for (String url : urls) {
+            if (!url.startsWith(HttpHeader.HTTP)) {
+                errors.add(UrlValidationError.Cause.NOT_LINK.create(url, ""));
+                continue;
+            }
+
+            URI uri;
+            try {
+                uri = new URI(url, true);
+            } catch (Exception e) {
+                errors.add(UrlValidationError.Cause.INVALID_URI.create(url, e));
+                continue;
+            }
+
+            if (!HttpHeader.HTTPS.equals(uri.getScheme())) {
+                errors.add(UrlValidationError.Cause.NOT_HTTPS.create(url, ""));
+            } else {
+                assumingThat(
+                        "1".equals(System.getenv("ZAP_REMOTE_TESTS")),
+                        () -> fetchUrl(uri, url, errors));
+            }
+        }
+
+        assertThat(errors.toString(), errors, is(empty()));
+    }
+
+    default boolean isAllowedUrlValidationError(
+            UrlValidationError.Cause cause, String reference, Object detail) {
+        return false;
+    }
+
+    private void fetchUrl(URI uri, String reference, List<UrlValidationError> errors) {
+        try {
+            HttpMessage message = new HttpMessage(uri);
+            List<URI> redirections = new ArrayList<>();
+            new HttpSender(0)
+                    .sendAndReceive(
+                            message,
+                            HttpRequestConfig.builder()
+                                    .setRedirectionValidator(redirections::add)
+                                    .build());
+            var responseHeader = message.getResponseHeader();
+            int statusCode = responseHeader.getStatusCode();
+            if (statusCode == 429) {
+                // Assume exists.
+            } else if (statusCode != HttpStatusCode.OK) {
+                addErrorIfNotAllowed(
+                        errors,
+                        UrlValidationError.Cause.UNEXPECTED_STATUS_CODE,
+                        reference,
+                        statusCode);
+            } else if (!redirections.isEmpty()) {
+                addErrorIfNotAllowed(
+                        errors,
+                        UrlValidationError.Cause.REDIRECTED,
+                        reference,
+                        redirections.get(redirections.size() - 1));
+            } else {
+                String metaRefreshUrl = getMetaRefreshUrl(message.getResponseBody().toString());
+                if (metaRefreshUrl != null) {
+                    addErrorIfNotAllowed(
+                            errors,
+                            UrlValidationError.Cause.META_REFRESH,
+                            reference,
+                            metaRefreshUrl);
+                }
+            }
+        } catch (IOException e) {
+            addErrorIfNotAllowed(errors, UrlValidationError.Cause.IO_EXCEPTION, reference, e);
+        }
+    }
+
+    private static String getMetaRefreshUrl(String responseBody) {
+        Source htmlSource = new Source(responseBody);
+        for (var element : htmlSource.getAllElements(HTMLElementName.META)) {
+            String httpEquiv = element.getAttributeValue("http-equiv");
+            if ("refresh".equalsIgnoreCase(httpEquiv)) {
+                String content = element.getAttributeValue("content");
+                if (content != null) {
+                    Matcher matcher = META_REFRESH_PATTERN.matcher(content);
+                    if (matcher.find()) {
+                        return matcher.group(1);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void addErrorIfNotAllowed(
+            List<UrlValidationError> errors, Cause cause, String reference, Object detail) {
+        if (isAllowedUrlValidationError(cause, reference, detail)) {
+            return;
+        }
+        errors.add(cause.create(reference, detail));
+    }
+}

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/UrlValidationError.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/UrlValidationError.java
@@ -21,7 +21,7 @@ package org.zaproxy.zap.testutils;
 
 import java.util.function.Function;
 
-public class AlertReferenceError {
+public class UrlValidationError {
 
     public enum Cause {
         INVALID_URI(e -> "Invalid URI: '" + e.reference + "'. Reason: " + e.detail),
@@ -30,19 +30,20 @@ public class AlertReferenceError {
         UNEXPECTED_STATUS_CODE(
                 e -> "Unexpected status code, 200 != " + e.detail + ", for: " + e.reference),
         REDIRECTED(e -> "Redirected from " + e.reference + " to: " + e.detail),
+        META_REFRESH(e -> "Meta refresh in " + e.reference + " has url: " + e.detail),
         IO_EXCEPTION(e -> "I/O exception: " + e.detail + ", for: " + e.reference);
 
-        private final Function<AlertReferenceError, String> toString;
+        private final Function<UrlValidationError, String> toString;
 
-        private Cause(Function<AlertReferenceError, String> toString) {
+        private Cause(Function<UrlValidationError, String> toString) {
             this.toString = toString;
         }
 
-        AlertReferenceError create(String reference, Object detail) {
-            return new AlertReferenceError(this, reference, detail);
+        UrlValidationError create(String reference, Object detail) {
+            return new UrlValidationError(this, reference, detail);
         }
 
-        private String toString(AlertReferenceError error) {
+        private String toString(UrlValidationError error) {
             return toString.apply(error);
         }
     }
@@ -51,7 +52,7 @@ public class AlertReferenceError {
     private final String reference;
     private final Object detail;
 
-    private AlertReferenceError(Cause cause, String reference, Object detail) {
+    private UrlValidationError(Cause cause, String reference, Object detail) {
         this.cause = cause;
         this.reference = reference;
         this.detail = detail;


### PR DESCRIPTION
Extract URL test code to be used by scan rule and the commonlib tests, also, check for redirects using meta refresh.
Validate the URLs used in the commonlib alert tags (default and CVE).
Change scan rule references that were redirecting with meta refresh.