### PR TITLE
postman: Max Messsages GUI & API

### DIFF
--- a/addOns/postman/CHANGELOG.md
+++ b/addOns/postman/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- Allow Automation Framework users to limit the number of Postman messages to import (`maxMessages`). Ex: If testing authentication, access, etc.
+- Allow users to limit the number of Postman messages to import (`maxMessages`). Ex: If testing authentication, access, etc.
 
 ### Changed
 - Maintenance changes.

--- a/addOns/postman/CHANGELOG.md
+++ b/addOns/postman/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- Allow Automation Framework users to limit the number of Postman messages to import (`maxMessages`). Ex: If testing authentication, access, etc.
+- Allow users to limit the number of Postman messages to import (`maxMessages`) via the Automation Framework, Import dialogue, and API. Ex: If testing authentication, access, etc.
 
 ### Changed
 - Maintenance changes.

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/ImportDialog.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/ImportDialog.java
@@ -43,6 +43,7 @@ import org.zaproxy.addon.commonlib.ZapUriException;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.utils.ZapHtmlLabel;
+import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.view.LayoutHelper;
 
 public class ImportDialog extends AbstractDialog {
@@ -52,6 +53,7 @@ public class ImportDialog extends AbstractDialog {
     private JTextField fieldCollection;
     private JTextField fieldTarget;
     private JTextField fieldVariables;
+    private ZapNumberSpinner fieldMaxMessages;
     private JButton buttonChooseFile;
     private JButton buttonCancel;
     private JButton buttonImport;
@@ -98,6 +100,13 @@ public class ImportDialog extends AbstractDialog {
         fieldsPanel.add(
                 getVariablesField(),
                 LayoutHelper.getGBC(1, fieldsRow, 2, 0.5, new Insets(4, 4, 4, 0)));
+        fieldsRow++;
+        fieldsPanel.add(
+                new JLabel(Constant.messages.getString("postman.importDialog.labelMaxMessages")),
+                LayoutHelper.getGBC(0, fieldsRow, 1, 0.5, new Insets(4, 0, 0, 4)));
+        fieldsPanel.add(
+                getMaxMessagesField(),
+                LayoutHelper.getGBC(1, fieldsRow, 2, 0.5, new Insets(4, 4, 0, 0)));
 
         int row = 0;
         add(fieldsPanel, LayoutHelper.getGBC(0, row, 2, 1.0, new Insets(8, 8, 4, 8)));
@@ -142,6 +151,13 @@ public class ImportDialog extends AbstractDialog {
             setContextMenu(fieldVariables);
         }
         return fieldVariables;
+    }
+
+    private ZapNumberSpinner getMaxMessagesField() {
+        if (fieldMaxMessages == null) {
+            fieldMaxMessages = new ZapNumberSpinner(0, 0, Integer.MAX_VALUE);
+        }
+        return fieldMaxMessages;
     }
 
     private static void setContextMenu(JTextField field) {
@@ -234,12 +250,16 @@ public class ImportDialog extends AbstractDialog {
 
         PostmanParser parser = new PostmanParser();
         boolean importedWithoutErrors = false;
+        int maxMessages = getMaxMessagesField().getValue();
 
         try {
             UriUtils.isValid(collectionLocation);
             importedWithoutErrors =
                     parser.importFromUrl(
-                            getCollectionField().getText(), getVariablesField().getText(), true);
+                            getCollectionField().getText(),
+                            getVariablesField().getText(),
+                            true,
+                            maxMessages);
         } catch (ZapUriException e1) {
             // Not a valid URI, try to import as a file
             var file = new File(collectionLocation);
@@ -256,7 +276,8 @@ public class ImportDialog extends AbstractDialog {
                         parser.importFromFile(
                                 getCollectionField().getText(),
                                 getVariablesField().getText(),
-                                true);
+                                true,
+                                maxMessages);
             } catch (IOException e2) {
                 handleParseException(e2);
                 return false;
@@ -301,6 +322,7 @@ public class ImportDialog extends AbstractDialog {
         getCollectionField().setEnabled(!show);
         getTargetField().setEnabled(!show);
         getVariablesField().setEditable(!show);
+        getMaxMessagesField().setEnabled(!show);
         getChooseFileButton().setEnabled(!show);
     }
 
@@ -348,5 +370,6 @@ public class ImportDialog extends AbstractDialog {
         getCollectionField().setText("");
         getTargetField().setText("");
         getVariablesField().setText("");
+        getMaxMessagesField().changeToDefaultValue();
     }
 }

--- a/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanApi.java
+++ b/addOns/postman/src/main/java/org/zaproxy/addon/postman/PostmanApi.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiResponse;
 import org.zaproxy.zap.extension.api.ApiResponseElement;
+import org.zaproxy.zap.utils.ApiUtils;
 
 public class PostmanApi extends ApiImplementor {
     private static final String PREFIX = "postman";
@@ -34,10 +35,14 @@ public class PostmanApi extends ApiImplementor {
     private static final String ACTION_IMPORT_URL = "importUrl";
     private static final String PARAM_URL = "url";
     private static final String PARAM_FILE = "file";
+    private static final String PARAM_MAX_MESSAGES = "maxMessages";
 
     public PostmanApi() {
-        this.addApiAction(new ApiAction(ACTION_IMPORT_FILE, List.of(PARAM_FILE), List.of()));
-        this.addApiAction(new ApiAction(ACTION_IMPORT_URL, List.of(PARAM_URL), List.of()));
+        this.addApiAction(
+                new ApiAction(
+                        ACTION_IMPORT_FILE, List.of(PARAM_FILE), List.of(PARAM_MAX_MESSAGES)));
+        this.addApiAction(
+                new ApiAction(ACTION_IMPORT_URL, List.of(PARAM_URL), List.of(PARAM_MAX_MESSAGES)));
     }
 
     @Override
@@ -47,19 +52,24 @@ public class PostmanApi extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        PostmanParser parser = new PostmanParser();
-
         switch (name) {
             case ACTION_IMPORT_FILE:
                 try {
-                    parser.importFromFile(params.getString(PARAM_FILE), "", false);
+                    new PostmanParser()
+                            .importFromFile(
+                                    params.getString(PARAM_FILE),
+                                    "",
+                                    false,
+                                    getMaxMessages(params));
                 } catch (IllegalArgumentException | IOException e) {
                     throw new ApiException(ApiException.Type.BAD_EXTERNAL_DATA);
                 }
                 break;
             case ACTION_IMPORT_URL:
                 try {
-                    parser.importFromUrl(params.getString(PARAM_URL), "", false);
+                    new PostmanParser()
+                            .importFromUrl(
+                                    params.getString(PARAM_URL), "", false, getMaxMessages(params));
                 } catch (IllegalArgumentException | IOException e) {
                     throw new ApiException(ApiException.Type.BAD_EXTERNAL_DATA);
                 }
@@ -70,5 +80,17 @@ public class PostmanApi extends ApiImplementor {
         }
 
         return ApiResponseElement.OK;
+    }
+
+    private static int getMaxMessages(JSONObject params) throws ApiException {
+        if (!params.containsKey(PARAM_MAX_MESSAGES)
+                || params.getString(PARAM_MAX_MESSAGES).isEmpty()) {
+            return 0;
+        }
+        int maxMessages = ApiUtils.getIntParam(params, PARAM_MAX_MESSAGES);
+        if (maxMessages < 0) {
+            throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_MAX_MESSAGES);
+        }
+        return maxMessages;
     }
 }

--- a/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/postman.html
+++ b/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/postman.html
@@ -18,13 +18,19 @@ A menu item is added to the Import menu:
 </ul>
 Any variables defined in the collection will be replaced with their values. Additionally, the dialog allows providing a comma-separated list of variables as key-value pairs in the format <code>key1=value1,key2=value2,...</code>, these variables will have precedence over the collection ones.
 
+<H3>Max Messages</H3>
+The dialogue also allows limiting the number of messages imported via the Max Messages field.
+A value of <code>0</code> (the default) imports all messages.
+Note that redirects are followed when importing, so this is a soft limit and the number of messages stored may exceed the value set.
+
 <H2>API</H2>
 The following operations are added to the API:
 
 <ul>
-<li>ACTION importFile (file)</li>
-<li>ACTION importUrl (url)</li>
+<li>ACTION importFile (file, maxMessages)</li>
+<li>ACTION importUrl (url, maxMessages)</li>
 </ul>
+The optional <code>maxMessages</code> parameter limits the number of messages imported; omit or use <code>0</code> to import all.
 
 <H2>Command Line</H2>
 The following Command Line options are added:

--- a/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/postman.html
+++ b/addOns/postman/src/main/javahelp/org/zaproxy/addon/postman/resources/help/contents/postman.html
@@ -18,13 +18,19 @@ A menu item is added to the Import menu:
 </ul>
 Any variables defined in the collection will be replaced with their values. Additionally, the dialog allows providing a comma-separated list of variables as key-value pairs in the format <code>key1=value1,key2=value2,...</code>, these variables will have precedence over the collection ones.
 
+<H3>Max Messages</H3>
+The dialogue allows users to limit the number of messages imported.
+A value of <code>0</code> (the default) imports all messages.
+Note that redirects are followed when importing, so this is a soft limit and the number of messages stored may exceed the value set.
+
 <H2>API</H2>
 The following operations are added to the API:
 
 <ul>
-<li>ACTION importFile (file)</li>
-<li>ACTION importUrl (url)</li>
+<li>ACTION importFile (file, maxMessages)</li>
+<li>ACTION importUrl (url, maxMessages)</li>
 </ul>
+The optional <code>maxMessages</code> parameter limits the number of messages imported; omit or use <code>0</code> to import all.
 
 <H2>Command Line</H2>
 The following Command Line options are added:

--- a/addOns/postman/src/main/resources/org/zaproxy/addon/postman/resources/Messages.properties
+++ b/addOns/postman/src/main/resources/org/zaproxy/addon/postman/resources/Messages.properties
@@ -1,6 +1,8 @@
 postman.api.action.importFile = Imports a Postman collection from a file.
 postman.api.action.importFile.param.file = The path to the file to be imported.
+postman.api.action.importFile.param.maxMessages = The maximum number of messages to import. Defaults to 0 (import all).
 postman.api.action.importUrl = Imports a Postman collection from a URL.
+postman.api.action.importUrl.param.maxMessages = The maximum number of messages to import. Defaults to 0 (import all).
 postman.api.action.importUrl.param.url = The URL from which to retrieve the collection to be imported.
 postman.api.desc = Functionality for importing Postman collections.
 
@@ -42,6 +44,7 @@ postman.importDialog.chooseFileButton = Choose File
 postman.importDialog.error.missingCollection = A Postman Collection file or URL must be specified.
 postman.importDialog.importButton = Import
 postman.importDialog.labelCollection = Collection File or URL
+postman.importDialog.labelMaxMessages = Max Messages (0 is unlimited)
 postman.importDialog.labelTarget = Target URL
 postman.importDialog.labelVariables = Variables
 postman.importDialog.pasteAction = Paste

--- a/addOns/postman/src/test/java/org/zaproxy/addon/postman/PostmanApiUnitTest.java
+++ b/addOns/postman/src/test/java/org/zaproxy/addon/postman/PostmanApiUnitTest.java
@@ -20,18 +20,25 @@
 package org.zaproxy.addon.postman;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
+import net.sf.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.api.ApiElement;
+import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiParameter;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -53,6 +60,38 @@ class PostmanApiUnitTest extends TestUtils {
         String prefix = api.getPrefix();
         // Then
         assertThat(prefix, is(equalTo("postman")));
+    }
+
+    @Test
+    void shouldThrowApiExceptionIfMaxMessagesNegative() {
+        // Given
+        JSONObject params = new JSONObject();
+        params.put("url", "http://example.com");
+        params.put("maxMessages", "-1");
+        try (MockedConstruction<PostmanParser> mocked = mockConstruction(PostmanParser.class)) {
+            // When / Then
+            ApiException exception =
+                    assertThrows(
+                            ApiException.class, () -> api.handleApiAction("importUrl", params));
+            assertThat(exception.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
+            assertThat(exception.toString(), containsString("(illegal_parameter): maxMessages"));
+            assertThat(mocked.constructed(), is(not(empty())));
+        }
+    }
+
+    @Test
+    void shouldPassMaxMessagesForFile() throws Exception {
+        // Given
+        JSONObject params = new JSONObject();
+        params.put("file", "/tmp/collection.json");
+        params.put("maxMessages", "1");
+        try (MockedConstruction<PostmanParser> mocked = mockConstruction(PostmanParser.class)) {
+            // When
+            api.handleApiAction("importFile", params);
+            // Then
+            verify(mocked.constructed().get(0))
+                    .importFromFile("/tmp/collection.json", "", false, 1);
+        }
     }
 
     @Test

--- a/addOns/postman/src/test/java/org/zaproxy/addon/postman/PostmanApiUnitTest.java
+++ b/addOns/postman/src/test/java/org/zaproxy/addon/postman/PostmanApiUnitTest.java
@@ -20,18 +20,25 @@
 package org.zaproxy.addon.postman;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
+import net.sf.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.api.ApiElement;
+import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiParameter;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -53,6 +60,62 @@ class PostmanApiUnitTest extends TestUtils {
         String prefix = api.getPrefix();
         // Then
         assertThat(prefix, is(equalTo("postman")));
+    }
+
+    @Test
+    void shouldThrowApiExceptionIfMaxMessagesNegativeForUrl() {
+        // Given
+        JSONObject params = new JSONObject();
+        params.put("url", "http://example.com");
+        params.put("maxMessages", "-1");
+        // When / Then
+        ApiException exception =
+                assertThrows(ApiException.class, () -> api.handleApiAction("importUrl", params));
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
+        assertThat(exception.toString(), containsString("(illegal_parameter): maxMessages"));
+    }
+
+    @Test
+    void shouldThrowApiExceptionIfMaxMessagesNegativeForFile() {
+        // Given
+        JSONObject params = new JSONObject();
+        params.put("file", "/tmp/collection.json");
+        params.put("maxMessages", "-1");
+        // When / Then
+        ApiException exception =
+                assertThrows(ApiException.class, () -> api.handleApiAction("importFile", params));
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
+        assertThat(exception.toString(), containsString("(illegal_parameter): maxMessages"));
+    }
+
+    @Test
+    void shouldPassMaxMessagesForUrl() throws Exception {
+        // Given
+        JSONObject params = new JSONObject();
+        params.put("url", "http://example.com/collection.json");
+        params.put("maxMessages", "2");
+        try (MockedConstruction<PostmanParser> mocked = mockConstruction(PostmanParser.class)) {
+            // When
+            api.handleApiAction("importUrl", params);
+            // Then
+            verify(mocked.constructed().get(0))
+                    .importFromUrl("http://example.com/collection.json", "", false, 2);
+        }
+    }
+
+    @Test
+    void shouldPassMaxMessagesForFile() throws Exception {
+        // Given
+        JSONObject params = new JSONObject();
+        params.put("file", "/tmp/collection.json");
+        params.put("maxMessages", "1");
+        try (MockedConstruction<PostmanParser> mocked = mockConstruction(PostmanParser.class)) {
+            // When
+            api.handleApiAction("importFile", params);
+            // Then
+            verify(mocked.constructed().get(0))
+                    .importFromFile("/tmp/collection.json", "", false, 1);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Overview
Extend "Max Messages" parameter to the standard import dialog and web api.

## Related Issues
- https://github.com/zaproxy/zap-extensions/pull/7571
