### PR TITLE
invoke: Use title caps for Run Application

### DIFF
--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Changed
-- Use title capitalization for the Run Application menu.
+- Use title capitalization for the Run Application menu (Issue 2000).
 
 ## [17] - 2025-12-15
 ### Changed

--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Use title capitalization for the Run Application menu.
 
 ## [17] - 2025-12-15
 ### Changed

--- a/addOns/invoke/invoke.gradle.kts
+++ b/addOns/invoke/invoke.gradle.kts
@@ -21,4 +21,6 @@ zapAddOn {
 
 dependencies {
     zapAddOn("commonlib")
+
+    testImplementation(project(":testutils"))
 }

--- a/addOns/invoke/src/main/javahelp/org/zaproxy/zap/extension/invoke/resources/help/contents/concepts.html
+++ b/addOns/invoke/src/main/javahelp/org/zaproxy/zap/extension/invoke/resources/help/contents/concepts.html
@@ -21,12 +21,12 @@
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 			<td><i>Sites tab</i></td>
-			<td>'Run application' right click menu item</td>
+			<td>'Run Application' right click menu item</td>
 		</tr>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 			<td><i>History tab</i></td>
-			<td>'Run application' right click menu item</td>
+			<td>'Run Application' right click menu item</td>
 		</tr>
 	</table>
 

--- a/addOns/invoke/src/main/resources/org/zaproxy/zap/extension/invoke/resources/Messages.properties
+++ b/addOns/invoke/src/main/resources/org/zaproxy/zap/extension/invoke/resources/Messages.properties
@@ -31,4 +31,4 @@ invoke.options.table.header.output = Output
 invoke.options.table.header.parameters = Parameters
 invoke.options.table.header.toNote = To Note
 invoke.options.title = Applications
-invoke.site.popup = Run application
+invoke.site.popup = Run Application

--- a/addOns/invoke/src/test/java/org/zaproxy/zap/extension/invoke/PopupMenuInvokersUnitTest.java
+++ b/addOns/invoke/src/test/java/org/zaproxy/zap/extension/invoke/PopupMenuInvokersUnitTest.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.invoke;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import javax.swing.JMenuItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class PopupMenuInvokersUnitTest extends TestUtils {
+
+    private PopupMenuInvokers popupMenu;
+
+    @BeforeEach
+    void setUp() {
+        mockMessages(new ExtensionInvoke());
+        popupMenu = new PopupMenuInvokers();
+    }
+
+    @Test
+    void shouldUseTitleCapitalizationForMenuLabel() {
+        assertThat(popupMenu.getText(), is("Run Application"));
+    }
+
+    @Test
+    void shouldPreserveConfiguredApplicationNameCapitalization() {
+        // Given
+        InvokableApp app = new InvokableApp();
+        app.setDisplayName("my custom application");
+
+        // When
+        popupMenu.setApps(List.of(app));
+
+        // Then
+        JMenuItem applicationMenuItem = (JMenuItem) popupMenu.getMenuComponent(0);
+        assertThat(applicationMenuItem.getText(), is("my custom application"));
+    }
+}


### PR DESCRIPTION
## Summary

- Use title capitalization for the Invoke Applications right-click menu.
- Keep the English help and add-on changelog aligned with the visible label.
- Add regression coverage for the menu label and for preserving user-configured application-name casing.

## Why

The Invoke Applications popup displayed “Run application”, which did not follow ZAP’s title-capitalization convention for menu items.

## Impact

Users now see “Run Application” in the Sites and History context menus. Runtime behavior and configured application names are unchanged.

Related to zaproxy/zaproxy#2000.

## Validation

- `./gradlew :addOns:invoke:spotlessApply`
  - Passed.
- `./gradlew :addOns:invoke:test --tests org.zaproxy.zap.extension.invoke.PopupMenuInvokersUnitTest --rerun-tasks --no-build-cache`
  - 2 tests passed; 0 failures, 0 errors, 0 skipped.
- `./gradlew :addOns:invoke:build :addOns:invoke:jacocoTestCoverageVerification --rerun-tasks --no-build-cache`
  - Build and coverage verification passed.
  - 82 tasks executed.
  - 2 tests passed; 0 failures, 0 errors, 0 skipped.
- Inspected `invoke-beta-18.zap`
  - Confirmed the manifest changelog, packaged `Messages.properties`, and packaged English help contain “Run Application”.
- Live UI smoke test with a fresh ZAP home
  - Loaded Invoke Applications 18.0.0 and Common Library 1.44.0.
  - Proxied a request to `http://example.com/`.
  - Confirmed the History context menu displays “Run Application”.
  - Shut down ZAP cleanly through the API.
