### PR TITLE
soap: Resolve attribute refs when importing WSDLs

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Resolve `xs:attribute` elements that use `ref` when importing WSDLs so referenced attributes are included in generated requests.
+
 ## [31] - 2026-06-12
 ### Changed
 - Update dependency.

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- WSDL attribute references are now resolved robustly, with proper XSD compliance for prohibited attributes, correct value precedence, and graceful handling of unresolvable references.
 
 ## [32] - 2026-08-12
 ### Added

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -474,18 +474,55 @@ public class WSDLCustomParser {
         }
         List<Attribute> attrs = ct.getAllAttributes();
         if (attrs != null) {
+            java.util.Set<String> prohibitedNames = new java.util.HashSet<>();
             for (Attribute attr : attrs) {
-                String attrName = attr.getName();
-                if (attrName == null) {
+                if ("prohibited".equals(attr.getUse())) {
+                    Attribute resolved = resolveAttribute(attr);
+                    if (resolved != null && resolved.getName() != null) {
+                        prohibitedNames.add(resolved.getName());
+                    }
+                }
+            }
+            for (Attribute attr : attrs) {
+                if ("prohibited".equals(attr.getUse())) {
                     continue;
                 }
-                String attrType = attr.getType() != null ? attr.getType().getLocalPart() : "string";
-                String attrValue = resolveAttributeValue(attr);
+                Attribute resolved = resolveAttribute(attr);
+                if (resolved == null) {
+                    continue;
+                }
+                String attrName = resolved.getName();
+                if (prohibitedNames.contains(attrName)) {
+                    continue;
+                }
+                String attrType =
+                        resolved.getType() != null ? resolved.getType().getLocalPart() : "string";
+                String attrValue = resolveAttributeValue(attr, resolved);
                 formParams.putAll(
                         addParameter(xpath + "/@" + attrName, attrType, attrName, attrValue));
             }
         }
         return formParams;
+    }
+
+    private static Attribute resolveAttribute(Attribute attr) {
+        if (attr.getName() != null) {
+            return attr;
+        }
+        if (attr.getRef() == null) {
+            return null;
+        }
+        try {
+            Attribute resolved = attr.getSchema().getAttribute(attr.getRef());
+            if (resolved == null || resolved.getName() == null) {
+                LOGGER.warn("Could not resolve ref attribute {} from WSDL file.", attr.getRef());
+                return null;
+            }
+            return resolved;
+        } catch (ModelAccessException e) {
+            LOGGER.warn("Could not resolve ref attribute {} from WSDL file.", attr.getRef(), e);
+            return null;
+        }
     }
 
     private Map<String, String> fillFromSequence(Sequence seq, String xpath) {
@@ -536,11 +573,14 @@ public class WSDLCustomParser {
         return addParameter(xpath, "string", element.getName(), null);
     }
 
-    private static String resolveAttributeValue(Attribute attr) {
-        if (attr.getFixedValue() != null) {
-            return attr.getFixedValue();
+    private static String resolveAttributeValue(Attribute original, Attribute resolved) {
+        if (original.getFixedValue() != null) {
+            return original.getFixedValue();
         }
-        SimpleType st = attr.getSimpleType();
+        if (resolved.getFixedValue() != null) {
+            return resolved.getFixedValue();
+        }
+        SimpleType st = resolved.getSimpleType();
         if (st != null) {
             BaseRestriction br = st.getRestriction();
             if (br != null) {

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -475,17 +475,34 @@ public class WSDLCustomParser {
         List<Attribute> attrs = ct.getAllAttributes();
         if (attrs != null) {
             for (Attribute attr : attrs) {
-                String attrName = attr.getName();
-                if (attrName == null) {
+                Attribute resolved = resolveAttribute(attr);
+                if (resolved == null) {
                     continue;
                 }
-                String attrType = attr.getType() != null ? attr.getType().getLocalPart() : "string";
-                String attrValue = resolveAttributeValue(attr);
+                String attrName = resolved.getName();
+                String attrType =
+                        resolved.getType() != null ? resolved.getType().getLocalPart() : "string";
+                String attrValue = resolveAttributeValue(resolved);
                 formParams.putAll(
                         addParameter(xpath + "/@" + attrName, attrType, attrName, attrValue));
             }
         }
         return formParams;
+    }
+
+    private static Attribute resolveAttribute(Attribute attr) {
+        if (attr.getName() != null) {
+            return attr;
+        }
+        if (attr.getRef() == null) {
+            return null;
+        }
+        Attribute resolved = attr.getSchema().getAttribute(attr.getRef());
+        if (resolved == null || resolved.getName() == null) {
+            LOGGER.warn("Could not resolve ref attribute {} from WSDL file.", attr.getRef());
+            return null;
+        }
+        return resolved;
     }
 
     private Map<String, String> fillFromSequence(Sequence seq, String xpath) {

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -397,13 +397,102 @@ class WSDLCustomParserTestCase extends TestUtils {
     }
 
     @Test
-    void shouldSkipAttributeDeclaredByRefWithNullName() throws Exception {
+    void shouldPopulateAttributeDeclaredByRef() throws Exception {
         // Given / When – valid XSD uses <xs:attribute ref="tns:globalRefKey"/>; predic8 leaves
-        // Attribute.getName() null until resolved, and fillFromComplexType skips it
+        // Attribute.getName() null until the ref is resolved
         Map<String, String> params = parseWsdlParams();
         // Then
         assertThat(params, hasEntry("xpath:/Request/attrRefWrapper/@inlineKey", MOCK_FILL_VALUE));
-        assertThat(params, not(hasKey("xpath:/Request/attrRefWrapper/@globalRefKey")));
+        assertThat(
+                params, hasEntry("xpath:/Request/attrRefWrapper/@globalRefKey", MOCK_FILL_VALUE));
+    }
+
+    @Test
+    void shouldUseLocalFixedValueWhenAttributeRefHasOwnFixed() throws Exception {
+        // Given / When – attribute ref use can specify its own fixed value, which is used
+        // instead of the global declaration's default:
+        // <xs:attribute ref="tns:globalRefKeyWithDefault" fixed="LOCAL-FIXED-VAL"/>
+        Map<String, String> params = parseWsdlParams();
+        // Then – local fixed value is used, not the global default
+        assertThat(
+                params,
+                hasEntry(
+                        "xpath:/Request/attrRefLocalFixedWrapper/@globalRefKeyWithDefault",
+                        "LOCAL-FIXED-VAL"));
+        assertThat(
+                params,
+                hasEntry("xpath:/Request/attrRefLocalFixedWrapper/@siblingKey", MOCK_FILL_VALUE));
+    }
+
+    @Test
+    void shouldContinueWhenAttributeRefCannotBeResolved() throws Exception {
+        // Given / When – an unresolvable attribute ref should not stop processing sibling
+        // attributes or elements, just like unresolvable element refs don't
+        Map<String, String> params = parseWsdlParams(DEGRADED_PARAMETERS_WSDL);
+        // Then
+        assertThat(params, hasEntry("xpath:/Request/controlField", MOCK_FILL_VALUE));
+        assertThat(params, hasEntry("xpath:/Request/badAttrRefOuter/innerField", MOCK_FILL_VALUE));
+        assertThat(
+                params,
+                hasEntry("xpath:/Request/badAttrRefOuter/@attrSiblingField", MOCK_FILL_VALUE));
+        assertThat(params, not(hasKey("xpath:/Request/badAttrRefOuter/@missingAttr")));
+    }
+
+    @Test
+    void shouldSkipProhibitedAttributes() throws Exception {
+        // Given / When – XSD attributes can be marked use="prohibited" to exclude them;
+        // the parser must skip prohibited attributes and continue with other fields
+        Map<String, String> params = parseWsdlParams(DEGRADED_PARAMETERS_WSDL);
+        // Then – normal attributes are populated but prohibited ones are skipped
+        assertThat(params, hasEntry("xpath:/Request/prohibitedAttrOuter/field", MOCK_FILL_VALUE));
+        assertThat(
+                params,
+                hasEntry("xpath:/Request/prohibitedAttrOuter/@normalAttr", MOCK_FILL_VALUE));
+        assertThat(params, not(hasKey("xpath:/Request/prohibitedAttrOuter/@prohibitedAttr")));
+    }
+
+    @Test
+    void shouldUseGlobalFixedValueFromResolvedAttribute() throws Exception {
+        // Given / When – when an attribute ref targets a global declaration with a fixed value,
+        // resolveAttributeValue should use the global fixed value as fallback
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(
+                params,
+                hasEntry(
+                        "xpath:/Request/attrRefGlobalFixedWrapper/@globalRefKeyWithFixed",
+                        "GLOBAL-FIXED-VAL"));
+    }
+
+    @Test
+    void shouldUseGlobalEnumValueFromResolvedAttribute() throws Exception {
+        // Given / When – when an attribute ref targets a global declaration with an enumerated
+        // simple type, resolveAttributeValue should use the first enumeration value as fallback
+        Map<String, String> params = parseWsdlParams();
+        // Then
+        assertThat(
+                params,
+                hasEntry(
+                        "xpath:/Request/attrRefGlobalEnumWrapper/@globalRefKeyWithEnum",
+                        "ENUM-VAL-1"));
+    }
+
+    @Test
+    void shouldMaskProhibitedAttributesAcrossMultipleEntries() throws Exception {
+        // Given / When – a complex type has multiple prohibited attributes mixed with normal ones;
+        // the parser must collect all prohibited names and filter them out consistently
+        Map<String, String> params = parseWsdlParams(DEGRADED_PARAMETERS_WSDL);
+        // Then – normal attributes are populated but all prohibited ones are excluded
+        assertThat(
+                params, hasEntry("xpath:/Request/multiProhibitedAttrOuter/field", MOCK_FILL_VALUE));
+        assertThat(
+                params,
+                hasEntry("xpath:/Request/multiProhibitedAttrOuter/@attr1", MOCK_FILL_VALUE));
+        assertThat(
+                params,
+                hasEntry("xpath:/Request/multiProhibitedAttrOuter/@attr2", MOCK_FILL_VALUE));
+        assertThat(params, not(hasKey("xpath:/Request/multiProhibitedAttrOuter/@prohibitedAttr1")));
+        assertThat(params, not(hasKey("xpath:/Request/multiProhibitedAttrOuter/@prohibitedAttr2")));
     }
 
     private Map<String, String> parseWsdlParams() throws Exception {

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -397,13 +397,14 @@ class WSDLCustomParserTestCase extends TestUtils {
     }
 
     @Test
-    void shouldSkipAttributeDeclaredByRefWithNullName() throws Exception {
+    void shouldPopulateAttributeDeclaredByRef() throws Exception {
         // Given / When – valid XSD uses <xs:attribute ref="tns:globalRefKey"/>; predic8 leaves
-        // Attribute.getName() null until resolved, and fillFromComplexType skips it
+        // Attribute.getName() null until the ref is resolved
         Map<String, String> params = parseWsdlParams();
         // Then
         assertThat(params, hasEntry("xpath:/Request/attrRefWrapper/@inlineKey", MOCK_FILL_VALUE));
-        assertThat(params, not(hasKey("xpath:/Request/attrRefWrapper/@globalRefKey")));
+        assertThat(
+                params, hasEntry("xpath:/Request/attrRefWrapper/@globalRefKey", MOCK_FILL_VALUE));
     }
 
     private Map<String, String> parseWsdlParams() throws Exception {

--- a/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/degraded-parameters.wsdl
+++ b/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/degraded-parameters.wsdl
@@ -50,6 +50,20 @@
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
+
+            <xs:element name="badAttrRefOuter" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="innerField" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                </xs:sequence>
+                <xs:attribute xmlns:data="http://example.org/data" ref="data:missingAttr"/>
+                <xs:attribute name="attrSiblingField" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="prohibitedAttrOuter" type="tns:ProhibitedAttrType" minOccurs="0" maxOccurs="1"/>
+
+            <xs:element name="multiProhibitedAttrOuter" type="tns:MultiProhibitedAttrType" minOccurs="0" maxOccurs="1"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -57,6 +71,24 @@
       <xs:simpleType name="SimpleBase">
         <xs:restriction base="xs:string"/>
       </xs:simpleType>
+
+      <xs:complexType name="ProhibitedAttrType">
+        <xs:sequence>
+          <xs:element name="field" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="normalAttr" type="xs:string"/>
+        <xs:attribute name="prohibitedAttr" type="xs:string" use="prohibited"/>
+      </xs:complexType>
+
+      <xs:complexType name="MultiProhibitedAttrType">
+        <xs:sequence>
+          <xs:element name="field" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="attr1" type="xs:string"/>
+        <xs:attribute name="prohibitedAttr1" type="xs:string" use="prohibited"/>
+        <xs:attribute name="attr2" type="xs:string"/>
+        <xs:attribute name="prohibitedAttr2" type="xs:string" use="prohibited"/>
+      </xs:complexType>
 
       <!--
         Intentionally-invalid XSD construct for degradation-path tests:

--- a/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/fill-parameters.wsdl
+++ b/addOns/soap/src/test/resources/org/zaproxy/zap/extension/soap/resources/fill-parameters.wsdl
@@ -34,6 +34,16 @@
       </xs:complexType>
 
       <xs:attribute name="globalRefKey" type="xs:string"/>
+      <xs:attribute name="globalRefKeyWithDefault" type="xs:string" default="GLOBAL-DEFAULT-VAL"/>
+      <xs:attribute name="globalRefKeyWithFixed" type="xs:string" fixed="GLOBAL-FIXED-VAL"/>
+      <xs:attribute name="globalRefKeyWithEnum">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="ENUM-VAL-1"/>
+            <xs:enumeration value="ENUM-VAL-2"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
 
       <xs:element name="Request">
         <xs:complexType>
@@ -174,6 +184,25 @@
               <xs:complexType>
                 <xs:attribute ref="tns:globalRefKey"/>
                 <xs:attribute name="inlineKey" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="attrRefLocalFixedWrapper" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute ref="tns:globalRefKeyWithDefault" fixed="LOCAL-FIXED-VAL"/>
+                <xs:attribute name="siblingKey" type="xs:string"/>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="attrRefGlobalFixedWrapper" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute ref="tns:globalRefKeyWithFixed"/>
+              </xs:complexType>
+            </xs:element>
+
+            <xs:element name="attrRefGlobalEnumWrapper" minOccurs="0" maxOccurs="1">
+              <xs:complexType>
+                <xs:attribute ref="tns:globalRefKeyWithEnum"/>
               </xs:complexType>
             </xs:element>
 


### PR DESCRIPTION
## Overview
`<xs:attribute ref="…"/>` is valid (without a name). However, the predic8 library ends up with a null name which ZAP skips today. This fixes that situation.

## Related Issues
- Fixes an issue identified while working on zaproxy/zap-extensions#7440
