### PR TITLE
pscanrules: CSP scan rule use updated htmlunit-csp

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Content Security Policy scan rule analyzes all active CSP headers and META policies together using browser-style intersection (Issue 9403).
 - Update dependency.
 - Updated help entries for the following scan rules, clarifying the data used to supplement their alerts for credit card related findings:
   - Information Disclosure: Referrer
   - PII Disclosure
+
+### Removed
+- CSP "Header & Meta" alert (10055-12) is no longer raised.
 
 ## [75] - 2026-07-06
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -39,7 +40,9 @@ import org.apache.logging.log4j.Logger;
 import org.htmlunit.csp.FetchDirectiveKind;
 import org.htmlunit.csp.Policy;
 import org.htmlunit.csp.Policy.PolicyErrorConsumer;
-import org.htmlunit.csp.PolicyInOrigin;
+import org.htmlunit.csp.Policy.PolicyListErrorConsumer;
+import org.htmlunit.csp.PolicyList;
+import org.htmlunit.csp.PolicyListInOrigin;
 import org.htmlunit.csp.directive.SourceExpressionDirective;
 import org.htmlunit.csp.url.URI;
 import org.htmlunit.csp.url.URLWithScheme;
@@ -101,8 +104,6 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        boolean cspHeaderFound = false;
-
         LOGGER.debug("Start {} : {}", id, msg.getRequestHeader().getURI());
 
         long start = System.currentTimeMillis();
@@ -117,140 +118,103 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         // Safari 7+, Edge but not Internet Explorer
         List<String> cspOptions =
                 msg.getResponseHeader().getHeaderValues(HttpFieldsNames.CONTENT_SECURITY_POLICY);
-        if (!cspOptions.isEmpty()) {
-            cspHeaderFound = true;
-        }
+        boolean cspHeaderFound = !cspOptions.isEmpty();
 
         checkXcsp(msg, cspHeaderFound);
         checkXWebkitCsp(msg, cspHeaderFound);
 
-        if (cspHeaderFound) {
+        List<Policy> enforcedPolicies = new ArrayList<>();
+        List<String> enforcedPolicyTexts = new ArrayList<>();
+
+        for (String csp : cspOptions) {
             List<PolicyError> observedErrors = new ArrayList<>();
-            PolicyErrorConsumer consumer =
-                    (severity, message, directiveIndex, valueIndex) -> {
-                        observedErrors.add(
-                                new PolicyError(severity, message, directiveIndex, valueIndex));
-                    };
-
-            for (String csp : cspOptions) {
-                Policy policy = parsePolicy(csp, consumer, msg, id);
-                if (policy == null) {
-                    continue;
-                }
-
-                if (!observedErrors.isEmpty()) {
-                    checkObservedErrors(observedErrors, msg, csp, false);
-                }
-
-                List<String> allowedWildcardSources = getAllowedWildcardSources(csp);
-                if (!allowedWildcardSources.isEmpty()) {
-                    checkWildcardSources(allowedWildcardSources, msg, csp, false);
-                }
-
-                PolicyInOrigin p = new PolicyInOrigin(policy, URI.parseURI(RAND_FQDN).orElse(null));
-                if (p.allowsUnsafeInlineScript()) {
-                    buildScriptUnsafeInlineAlert(
-                                    getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY)
-                                            .get(0),
-                                    csp)
-                            .raise();
-                }
-
-                if (p.allowsUnsafeInlineStyle()) {
-                    buildStyleUnsafeInlineAlert(
-                                    getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY)
-                                            .get(0),
-                                    csp)
-                            .raise();
-                }
-
-                if (allowsUnsafeHashes(policy, FetchDirectiveKind.ScriptSrc)) {
-                    buildScriptUnsafeHashAlert(
-                                    getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY)
-                                            .get(0),
-                                    csp)
-                            .raise();
-                }
-
-                if (allowsUnsafeHashes(policy, FetchDirectiveKind.StyleSrc)) {
-                    buildStyleUnsafeHashAlert(
-                                    getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY)
-                                            .get(0),
-                                    csp)
-                            .raise();
-                }
-
-                if (allowsUnsafeEval(policy, FetchDirectiveKind.ScriptSrc)) {
-                    buildScriptUnsafeEvalAlert(
-                                    getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY)
-                                            .get(0),
-                                    csp)
-                            .raise();
-                }
+            PolicyListErrorConsumer consumer =
+                    (severity, message, policyIndex, directiveIndex, valueIndex) ->
+                            observedErrors.add(
+                                    new PolicyError(severity, message, directiveIndex, valueIndex));
+            PolicyList parsed = parsePolicyList(csp, consumer, msg, id);
+            if (parsed == null) {
+                continue;
+            }
+            if (!observedErrors.isEmpty()) {
+                checkObservedErrors(observedErrors, msg, csp, false);
+            }
+            if (!parsed.getPolicies().isEmpty()) {
+                enforcedPolicies.addAll(parsed.getPolicies());
+                enforcedPolicyTexts.add(csp);
             }
         }
-        if (CspUtils.hasMetaCsp(source)) {
-            checkMetaPolicy(msg, id, source, cspHeaderFound);
+
+        for (Element element : getMetaPolicies(source)) {
+            String metaField = element.getAttributeValue("http-equiv");
+            String metaPolicy = element.getAttributeValue("content");
+            if (!HttpFieldsNames.CONTENT_SECURITY_POLICY.equalsIgnoreCase(metaField)
+                    || StringUtils.isBlank(metaPolicy)) {
+                continue;
+            }
+            List<PolicyError> metaObservedErrors = new ArrayList<>();
+            PolicyErrorConsumer metaConsumer =
+                    (severity, message, directiveIndex, valueIndex) ->
+                            metaObservedErrors.add(
+                                    new PolicyError(severity, message, directiveIndex, valueIndex));
+            Policy parsedMetaPolicy = parsePolicy(metaPolicy, metaConsumer, true, msg, id);
+            if (parsedMetaPolicy == null) {
+                continue;
+            }
+            checkObservedErrors(metaObservedErrors, msg, metaPolicy, true);
+            if (parsedMetaPolicy.sandbox().isPresent()
+                    || parsedMetaPolicy.frameAncestors().isPresent()
+                    || parsedMetaPolicy.reportUri().isPresent()) {
+                buildBadMetaAlert(metaField, metaPolicy).raise();
+            }
+            enforcedPolicies.add(parsedMetaPolicy);
+            enforcedPolicyTexts.add(metaPolicy);
+        }
+
+        if (!enforcedPolicies.isEmpty()) {
+            checkEffectivePolicies(msg, enforcedPolicies, enforcedPolicyTexts, cspHeaderFound);
         }
 
         LOGGER.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
     }
 
-    private void checkMetaPolicy(HttpMessage msg, int id, Source source, boolean hasHeader) {
-        List<Element> cspMetaElements = getMetaPolicies(source);
-        if (cspMetaElements.isEmpty()) {
-            return;
+    private void checkEffectivePolicies(
+            HttpMessage msg,
+            List<Policy> enforcedPolicies,
+            List<String> enforcedPolicyTexts,
+            boolean cspHeaderFound) {
+        PolicyList policyList = new PolicyList(enforcedPolicies);
+        PolicyListInOrigin bound = new PolicyListInOrigin(policyList, HTTP_URI.get());
+        String evidence = enforcedPolicyTexts.get(0);
+        String param =
+                cspHeaderFound
+                        ? getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY).get(0)
+                        : HttpFieldsNames.CONTENT_SECURITY_POLICY;
+        String multiPolicyInfo =
+                buildMultiPolicyOtherInfo(enforcedPolicies.size(), enforcedPolicyTexts);
+
+        List<String> allowedWildcardSources = getAllowedWildcardSources(policyList);
+        checkWildcardSources(allowedWildcardSources, param, evidence, multiPolicyInfo);
+
+        if (bound.allowsUnsafeInlineScript()) {
+            buildScriptUnsafeInlineAlert(param, evidence, multiPolicyInfo).raise();
         }
-        for (Element element : cspMetaElements) {
-            String metaField = element.getAttributeValue("http-equiv");
-            String metaPolicy = element.getAttributeValue("content");
-            if (HttpFieldsNames.CONTENT_SECURITY_POLICY.equalsIgnoreCase(metaField)
-                    && !StringUtils.isBlank(metaPolicy)) {
-                List<PolicyError> metaObservedErrors = new ArrayList<>();
-                PolicyErrorConsumer metaConsumer =
-                        (severity, message, directiveIndex, valueIndex) -> {
-                            metaObservedErrors.add(
-                                    new PolicyError(severity, message, directiveIndex, valueIndex));
-                        };
-                Policy parsedMetaPolicy = parsePolicy(metaPolicy, metaConsumer, msg, id);
-                if (parsedMetaPolicy == null) {
-                    continue;
-                }
-                checkObservedErrors(metaObservedErrors, msg, metaPolicy, true);
-                List<String> metaWildcardSources = getAllowedWildcardSources(metaPolicy);
-                // frame-ancestors isn't applicable in META
-                metaWildcardSources.remove(FRAME_ANCESTORS);
-                checkWildcardSources(metaWildcardSources, msg, metaPolicy, true);
-                PolicyInOrigin pol =
-                        new PolicyInOrigin(parsedMetaPolicy, URI.parseURI(RAND_FQDN).orElse(null));
-                if (pol.allowsUnsafeInlineScript()) {
-                    buildScriptUnsafeInlineAlert(metaField, metaPolicy).raise();
-                }
-
-                if (pol.allowsUnsafeInlineStyle()) {
-                    buildStyleUnsafeInlineAlert(metaField, metaPolicy).raise();
-                }
-
-                if (allowsUnsafeHashes(parsedMetaPolicy, FetchDirectiveKind.ScriptSrc)) {
-                    buildScriptUnsafeHashAlert(metaField, metaPolicy).raise();
-                }
-
-                if (allowsUnsafeHashes(parsedMetaPolicy, FetchDirectiveKind.StyleSrc)) {
-                    buildStyleUnsafeHashAlert(metaField, metaPolicy).raise();
-                }
-                if (parsedMetaPolicy.sandbox().isPresent()
-                        || parsedMetaPolicy.frameAncestors().isPresent()
-                        || parsedMetaPolicy.reportUri().isPresent()) {
-                    buildBadMetaAlert(metaField, metaPolicy).raise();
-                }
-                if (allowsUnsafeEval(parsedMetaPolicy, FetchDirectiveKind.ScriptSrc)) {
-                    buildScriptUnsafeEvalAlert(HttpFieldsNames.CONTENT_SECURITY_POLICY, metaPolicy)
-                            .raise();
-                }
-            }
-            if (hasHeader) {
-                buildBothAlert().raise();
-            }
+        if (bound.allowsUnsafeInlineStyle()) {
+            buildStyleUnsafeInlineAlert(param, evidence, multiPolicyInfo).raise();
+        }
+        if (isUnsafeKeywordAllowed(
+                policyList,
+                FetchDirectiveKind.ScriptSrc,
+                SourceExpressionDirective::unsafeHashes)) {
+            buildScriptUnsafeHashAlert(param, evidence, multiPolicyInfo).raise();
+        }
+        if (isUnsafeKeywordAllowed(
+                policyList, FetchDirectiveKind.StyleSrc, SourceExpressionDirective::unsafeHashes)) {
+            buildStyleUnsafeHashAlert(param, evidence, multiPolicyInfo).raise();
+        }
+        if (isUnsafeKeywordAllowed(
+                policyList, FetchDirectiveKind.ScriptSrc, SourceExpressionDirective::unsafeEval)) {
+            buildScriptUnsafeEvalAlert(param, evidence, multiPolicyInfo).raise();
         }
     }
 
@@ -280,25 +244,46 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         }
     }
 
-    private Policy parsePolicy(String csp, PolicyErrorConsumer consumer, HttpMessage msg, int id) {
+    private PolicyList parsePolicyList(
+            String csp, PolicyListErrorConsumer consumer, HttpMessage msg, int id) {
         try {
-            return Policy.parseSerializedCSP(csp, consumer);
+            return Policy.parseSerializedCSPList(csp, consumer);
         } catch (IllegalArgumentException iae) {
-            boolean warn = true;
-            if (iae.getMessage().contains("not ascii")) {
-                buildMalformedAlert(
-                                getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY).get(0),
-                                csp,
-                                getNonasciiCharacters(csp))
-                        .raise();
-                warn = false;
-            }
-
-            if (warn) {
-                LOGGER.warn("CSP Found but not fully parsed, in message {}.", id);
-            }
+            handleParseException(iae, csp, msg, id);
         }
         return null;
+    }
+
+    private Policy parsePolicy(
+            String csp,
+            PolicyErrorConsumer consumer,
+            boolean deliveredViaMeta,
+            HttpMessage msg,
+            int id) {
+        try {
+            return Policy.parseSerializedCSP(csp, consumer, deliveredViaMeta);
+        } catch (IllegalArgumentException iae) {
+            handleParseException(iae, csp, msg, id);
+        }
+        return null;
+    }
+
+    private void handleParseException(
+            IllegalArgumentException iae, String csp, HttpMessage msg, int id) {
+        boolean warn = true;
+        if (iae.getMessage().contains("not ascii")) {
+            List<String> headerField = getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY);
+            String param =
+                    headerField.isEmpty()
+                            ? HttpFieldsNames.CONTENT_SECURITY_POLICY
+                            : headerField.get(0);
+            buildMalformedAlert(param, csp, getNonasciiCharacters(csp)).raise();
+            warn = false;
+        }
+
+        if (warn) {
+            LOGGER.warn("CSP Found but not fully parsed, in message {}.", id);
+        }
     }
 
     private void checkObservedErrors(
@@ -328,7 +313,10 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
     }
 
     private void checkWildcardSources(
-            List<String> allowedWildcardSources, HttpMessage msg, String csp, boolean isMeta) {
+            List<String> allowedWildcardSources,
+            String param,
+            String evidence,
+            String multiPolicyInfo) {
         if (allowedWildcardSources.isEmpty()) {
             return;
         }
@@ -339,47 +327,32 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                         .toList();
         allowedWildcardSources.removeAll(DIRECTIVES_WITHOUT_FALLBACK);
         if (!allowedDirectivesWithoutFallback.isEmpty()) {
-            buildNofallbackAlert(
-                            isMeta
-                                    ? HttpFieldsNames.CONTENT_SECURITY_POLICY
-                                    : getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY)
-                                            .get(0),
-                            csp,
-                            allowedDirectivesWithoutFallback)
+            buildNofallbackAlert(param, evidence, allowedDirectivesWithoutFallback, multiPolicyInfo)
                     .raise();
         }
         if (!allowedWildcardSources.isEmpty()) {
             String allowedWildcardSrcs = String.join(", ", allowedWildcardSources);
             String wildcardSrcOtherInfo =
-                    Constant.messages.getString(
-                            MESSAGE_PREFIX + "wildcard.otherinfo", allowedWildcardSrcs);
-            buildWildcardAlert(
-                            isMeta
-                                    ? HttpFieldsNames.CONTENT_SECURITY_POLICY
-                                    : getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY)
-                                            .get(0),
-                            csp,
-                            wildcardSrcOtherInfo)
-                    .raise();
+                    appendMultiPolicyInfo(
+                            Constant.messages.getString(
+                                    MESSAGE_PREFIX + "wildcard.otherinfo", allowedWildcardSrcs),
+                            multiPolicyInfo);
+            buildWildcardAlert(param, evidence, wildcardSrcOtherInfo).raise();
         }
     }
 
-    private static boolean allowsUnsafeHashes(Policy policy, FetchDirectiveKind source) {
-        Optional<SourceExpressionDirective> fetchDirective = policy.getFetchDirective(source);
-        if (fetchDirective.isPresent()) {
-            SourceExpressionDirective kind = fetchDirective.get();
-            return kind.unsafeHashes();
-        }
-        return false;
-    }
-
-    private static boolean allowsUnsafeEval(Policy policy, FetchDirectiveKind source) {
-        Optional<SourceExpressionDirective> fetchDirective = policy.getFetchDirective(source);
-        if (fetchDirective.isPresent()) {
-            SourceExpressionDirective kind = fetchDirective.get();
-            return kind.unsafeEval();
-        }
-        return false;
+    private static boolean isUnsafeKeywordAllowed(
+            PolicyList policyList,
+            FetchDirectiveKind source,
+            Predicate<SourceExpressionDirective> hasKeyword) {
+        List<Policy> policies = policyList.getPolicies();
+        return !policies.isEmpty()
+                && policies.stream()
+                        .allMatch(
+                                policy ->
+                                        policy.getFetchDirective(source)
+                                                .map(hasKeyword::test)
+                                                .orElse(false));
     }
 
     private static String getCspNoticesString(List<PolicyError> notices) {
@@ -452,45 +425,44 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         return matchedHeaders;
     }
 
-    private static List<String> getAllowedWildcardSources(String policyText) {
+    private static List<String> getAllowedWildcardSources(PolicyList policyList) {
 
         List<String> allowedSources = new ArrayList<>();
-        Policy pol = Policy.parseSerializedCSP(policyText, PolicyErrorConsumer.ignored);
 
-        if (checkPolicy(pol::allowsExternalScript)) {
+        if (checkPolicy(policyList::allowsExternalScript)) {
             allowedSources.add("script-src");
         }
-        if (checkPolicy(pol::allowsExternalStyle)) {
+        if (checkPolicy(policyList::allowsExternalStyle)) {
             allowedSources.add("style-src");
         }
-        if (checkPolicy(pol::allowsImage)) {
+        if (checkPolicy(policyList::allowsImage)) {
             allowedSources.add("img-src");
         }
-        if (checkPolicy(pol::allowsConnection)) {
+        if (checkPolicy(policyList::allowsConnection)) {
             allowedSources.add("connect-src");
         }
-        if (checkPolicy(pol::allowsFrame)) {
+        if (checkPolicy(policyList::allowsFrame)) {
             allowedSources.add("frame-src");
         }
-        if (checkPolicy(pol::allowsFrameAncestor)) {
+        if (checkPolicy(policyList::allowsFrameAncestor)) {
             allowedSources.add(FRAME_ANCESTORS);
         }
-        if (checkPolicy(pol::allowsFont)) {
+        if (checkPolicy(policyList::allowsFont)) {
             allowedSources.add("font-src");
         }
-        if (checkPolicy(pol::allowsMedia)) {
+        if (checkPolicy(policyList::allowsMedia)) {
             allowedSources.add("media-src");
         }
-        if (checkPolicy(pol::allowsObject)) {
+        if (checkPolicy(policyList::allowsObject)) {
             allowedSources.add("object-src");
         }
-        if (checkPolicy(pol::allowsApplicationManifest)) {
+        if (checkPolicy(policyList::allowsApplicationManifest)) {
             allowedSources.add("manifest-src");
         }
-        if (checkPolicy(pol::allowsWorker)) {
+        if (checkPolicy(policyList::allowsWorker)) {
             allowedSources.add("worker-src");
         }
-        if (checkPolicy(pol::allowsFormAction)) {
+        if (checkPolicy(policyList::allowsFormAction)) {
             allowedSources.add("form-action");
         }
 
@@ -501,6 +473,26 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         return source.getAllElements(HTMLElementName.META).stream()
                 .filter(element -> !StringUtils.isBlank(element.getAttributeValue("http-equiv")))
                 .collect(Collectors.toList());
+    }
+
+    private static String buildMultiPolicyOtherInfo(int policyCount, List<String> policyTexts) {
+        if (policyCount <= 1) {
+            return "";
+        }
+        return Constant.messages.getString(
+                MESSAGE_PREFIX + "multipolicy.otherinfo",
+                policyCount,
+                String.join("\n", policyTexts));
+    }
+
+    private static String appendMultiPolicyInfo(String otherInfo, String multiPolicyInfo) {
+        if (StringUtils.isBlank(multiPolicyInfo)) {
+            return otherInfo;
+        }
+        if (StringUtils.isBlank(otherInfo)) {
+            return multiPolicyInfo;
+        }
+        return otherInfo + "\n" + multiPolicyInfo;
     }
 
     private static boolean checkPolicy(AllowsFormActionCheck function) {
@@ -607,26 +599,35 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                 .setOtherInfo(otherinfo);
     }
 
-    private AlertBuilder buildScriptUnsafeInlineAlert(String param, String evidence) {
+    private AlertBuilder buildScriptUnsafeInlineAlert(
+            String param, String evidence, String multiPolicyInfo) {
         return getBuilder(
                         Constant.messages.getString(MESSAGE_PREFIX + "scriptsrc.unsafe.name"), "5")
                 .setRisk(Alert.RISK_MEDIUM)
                 .setParam(param)
                 .setEvidence(evidence)
                 .setOtherInfo(
-                        Constant.messages.getString(MESSAGE_PREFIX + "scriptsrc.unsafe.otherinfo"));
+                        appendMultiPolicyInfo(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "scriptsrc.unsafe.otherinfo"),
+                                multiPolicyInfo));
     }
 
-    private AlertBuilder buildStyleUnsafeInlineAlert(String param, String evidence) {
+    private AlertBuilder buildStyleUnsafeInlineAlert(
+            String param, String evidence, String multiPolicyInfo) {
         return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "stylesrc.unsafe.name"), "6")
                 .setRisk(Alert.RISK_MEDIUM)
                 .setParam(param)
                 .setEvidence(evidence)
                 .setOtherInfo(
-                        Constant.messages.getString(MESSAGE_PREFIX + "stylesrc.unsafe.otherinfo"));
+                        appendMultiPolicyInfo(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "stylesrc.unsafe.otherinfo"),
+                                multiPolicyInfo));
     }
 
-    private AlertBuilder buildScriptUnsafeHashAlert(String param, String evidence) {
+    private AlertBuilder buildScriptUnsafeHashAlert(
+            String param, String evidence, String multiPolicyInfo) {
         return getBuilder(
                         Constant.messages.getString(
                                 MESSAGE_PREFIX + "scriptsrc.unsafe.hashes.name"),
@@ -635,14 +636,17 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                 .setParam(param)
                 .setEvidence(evidence)
                 .setOtherInfo(
-                        Constant.messages.getString(
-                                MESSAGE_PREFIX + "scriptsrc.unsafe.hashes.otherinfo"))
+                        appendMultiPolicyInfo(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "scriptsrc.unsafe.hashes.otherinfo"),
+                                multiPolicyInfo))
                 .setReference(
                         Constant.messages.getString(
                                 MESSAGE_PREFIX + "scriptsrc.unsafe.hashes.refs"));
     }
 
-    private AlertBuilder buildStyleUnsafeHashAlert(String param, String evidence) {
+    private AlertBuilder buildStyleUnsafeHashAlert(
+            String param, String evidence, String multiPolicyInfo) {
         return getBuilder(
                         Constant.messages.getString(MESSAGE_PREFIX + "stylesrc.unsafe.hashes.name"),
                         "8")
@@ -650,8 +654,10 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                 .setParam(param)
                 .setEvidence(evidence)
                 .setOtherInfo(
-                        Constant.messages.getString(
-                                MESSAGE_PREFIX + "stylesrc.unsafe.hashes.otherinfo"))
+                        appendMultiPolicyInfo(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "stylesrc.unsafe.hashes.otherinfo"),
+                                multiPolicyInfo))
                 .setReference(
                         Constant.messages.getString(
                                 MESSAGE_PREFIX + "stylesrc.unsafe.hashes.refs"));
@@ -667,7 +673,8 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                                 MESSAGE_PREFIX + "malformed.otherinfo", badChars));
     }
 
-    private AlertBuilder buildScriptUnsafeEvalAlert(String param, String evidence) {
+    private AlertBuilder buildScriptUnsafeEvalAlert(
+            String param, String evidence, String multiPolicyInfo) {
         return getBuilder(
                         Constant.messages.getString(MESSAGE_PREFIX + "scriptsrc.unsafe.eval.name"),
                         "10")
@@ -675,8 +682,10 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                 .setParam(param)
                 .setEvidence(evidence)
                 .setOtherInfo(
-                        Constant.messages.getString(
-                                MESSAGE_PREFIX + "scriptsrc.unsafe.eval.otherinfo"));
+                        appendMultiPolicyInfo(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "scriptsrc.unsafe.eval.otherinfo"),
+                                multiPolicyInfo));
     }
 
     private AlertBuilder buildBadMetaAlert(String param, String evidence) {
@@ -690,23 +699,21 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                         Constant.messages.getString(MESSAGE_PREFIX + "meta.bad.directive.desc"));
     }
 
-    private AlertBuilder buildBothAlert() {
-        return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "both.name"), "12")
-                .setRisk(Alert.RISK_INFO)
-                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "both.desc"));
-    }
+    // Alert ref 10055-12 ("Header & Meta") is retired/deprecated and should not be reused.
 
     private AlertBuilder buildNofallbackAlert(
-            String param, String evidence, List<String> directives) {
+            String param, String evidence, List<String> directives, String multiPolicyInfo) {
         return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "nofallback.name"), "13")
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "nofallback.desc"))
                 .setRisk(Alert.RISK_MEDIUM)
                 .setParam(param)
                 .setEvidence(evidence)
                 .setOtherInfo(
-                        Constant.messages.getString(
-                                MESSAGE_PREFIX + "nofallback.otherinfo",
-                                String.join(", ", directives)));
+                        appendMultiPolicyInfo(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "nofallback.otherinfo",
+                                        String.join(", ", directives)),
+                                multiPolicyInfo));
     }
 
     @Override
@@ -733,22 +740,26 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         alerts.add(
                 buildScriptUnsafeInlineAlert(
                                 HttpFieldsNames.CONTENT_SECURITY_POLICY,
-                                "script-src 'unsafe-inline'")
+                                "script-src 'unsafe-inline'",
+                                "")
                         .build());
         alerts.add(
                 buildStyleUnsafeInlineAlert(
                                 HttpFieldsNames.CONTENT_SECURITY_POLICY,
-                                "style-src 'unsafe-inline'")
+                                "style-src 'unsafe-inline'",
+                                "")
                         .build());
         alerts.add(
                 buildScriptUnsafeHashAlert(
                                 HttpFieldsNames.CONTENT_SECURITY_POLICY,
-                                "default-src 'self'; script-src 'unsafe-hashes' 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='")
+                                "default-src 'self'; script-src 'unsafe-hashes' 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='",
+                                "")
                         .build());
         alerts.add(
                 buildStyleUnsafeHashAlert(
                                 HttpFieldsNames.CONTENT_SECURITY_POLICY,
-                                "default-src 'self'; style-src 'unsafe-hashes' 'sha256-xyz4zkCjuC3lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ='")
+                                "default-src 'self'; style-src 'unsafe-hashes' 'sha256-xyz4zkCjuC3lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ='",
+                                "")
                         .build());
         alerts.add(
                 buildMalformedAlert(
@@ -759,7 +770,8 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         alerts.add(
                 buildScriptUnsafeEvalAlert(
                                 HttpFieldsNames.CONTENT_SECURITY_POLICY,
-                                "default-src 'self'; script-src 'unsafe-eval'")
+                                "default-src 'self'; script-src 'unsafe-eval'",
+                                "")
                         .build());
         alerts.add(
                 buildBadMetaAlert(
@@ -769,12 +781,12 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                                         + "style-src 'self' *.googleapis.com; font-src 'self' data: *.googleapis.com "
                                         + "fonts.gstatic.com; frame-ancestors 'none'; worker-src 'self'; form-action 'none'")
                         .build());
-        alerts.add(buildBothAlert().build());
         alerts.add(
                 buildNofallbackAlert(
                                 HttpFieldsNames.CONTENT_SECURITY_POLICY,
                                 "connect-src *; default-src 'self'; form-action 'none'",
-                                List.of(FRAME_ANCESTORS))
+                                List.of(FRAME_ANCESTORS),
+                                "")
                         .build());
         return alerts;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -22,10 +22,12 @@ package org.zaproxy.zap.extension.pscanrules;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -46,6 +48,7 @@ import org.htmlunit.csp.PolicyListInOrigin;
 import org.htmlunit.csp.directive.SourceExpressionDirective;
 import org.htmlunit.csp.url.URI;
 import org.htmlunit.csp.url.URLWithScheme;
+import org.htmlunit.csp.value.Hash;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -125,6 +128,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
 
         List<Policy> enforcedPolicies = new ArrayList<>();
         List<String> enforcedPolicyTexts = new ArrayList<>();
+        boolean headerContributedPolicy = false;
 
         for (String csp : cspOptions) {
             List<PolicyError> observedErrors = new ArrayList<>();
@@ -142,6 +146,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
             if (!parsed.getPolicies().isEmpty()) {
                 enforcedPolicies.addAll(parsed.getPolicies());
                 enforcedPolicyTexts.add(csp);
+                headerContributedPolicy = true;
             }
         }
 
@@ -172,7 +177,8 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         }
 
         if (!enforcedPolicies.isEmpty()) {
-            checkEffectivePolicies(msg, enforcedPolicies, enforcedPolicyTexts, cspHeaderFound);
+            checkEffectivePolicies(
+                    msg, enforcedPolicies, enforcedPolicyTexts, headerContributedPolicy);
         }
 
         LOGGER.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
@@ -182,12 +188,12 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
             HttpMessage msg,
             List<Policy> enforcedPolicies,
             List<String> enforcedPolicyTexts,
-            boolean cspHeaderFound) {
+            boolean headerContributedPolicy) {
         PolicyList policyList = new PolicyList(enforcedPolicies);
         PolicyListInOrigin bound = new PolicyListInOrigin(policyList, HTTP_URI.get());
         String evidence = enforcedPolicyTexts.get(0);
         String param =
-                cspHeaderFound
+                headerContributedPolicy
                         ? getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY).get(0)
                         : HttpFieldsNames.CONTENT_SECURITY_POLICY;
         String multiPolicyInfo =
@@ -202,17 +208,13 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         if (bound.allowsUnsafeInlineStyle()) {
             buildStyleUnsafeInlineAlert(param, evidence, multiPolicyInfo).raise();
         }
-        if (isUnsafeKeywordAllowed(
-                policyList,
-                FetchDirectiveKind.ScriptSrc,
-                SourceExpressionDirective::unsafeHashes)) {
+        if (isUnsafeHashesEffectivelyAllowed(policyList, FetchDirectiveKind.ScriptSrc)) {
             buildScriptUnsafeHashAlert(param, evidence, multiPolicyInfo).raise();
         }
-        if (isUnsafeKeywordAllowed(
-                policyList, FetchDirectiveKind.StyleSrc, SourceExpressionDirective::unsafeHashes)) {
+        if (isUnsafeHashesEffectivelyAllowed(policyList, FetchDirectiveKind.StyleSrc)) {
             buildStyleUnsafeHashAlert(param, evidence, multiPolicyInfo).raise();
         }
-        if (isUnsafeKeywordAllowed(
+        if (isEffectiveKeywordAllowed(
                 policyList, FetchDirectiveKind.ScriptSrc, SourceExpressionDirective::unsafeEval)) {
             buildScriptUnsafeEvalAlert(param, evidence, multiPolicyInfo).raise();
         }
@@ -341,18 +343,54 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         }
     }
 
-    private static boolean isUnsafeKeywordAllowed(
+    /**
+     * Determines whether every policy effectively allows the given keyword for the given fetch
+     * directive, resolving each policy's governing directive via the CSP fallback chain (e.g.
+     * {@code script-src} falling back to {@code default-src}). A policy with no governing directive
+     * in the chain is unrestricted and does not block the keyword. At least one policy must
+     * actually declare the keyword, otherwise there is nothing to alert on.
+     */
+    private static boolean isEffectiveKeywordAllowed(
             PolicyList policyList,
             FetchDirectiveKind source,
             Predicate<SourceExpressionDirective> hasKeyword) {
-        List<Policy> policies = policyList.getPolicies();
-        return !policies.isEmpty()
-                && policies.stream()
-                        .allMatch(
-                                policy ->
-                                        policy.getFetchDirective(source)
-                                                .map(hasKeyword::test)
-                                                .orElse(false));
+        List<Optional<SourceExpressionDirective>> effectiveDirectives =
+                policyList.getPolicies().stream()
+                        .map(policy -> policy.getGoverningDirectiveForEffectiveDirective(source))
+                        .toList();
+        return effectiveDirectives.stream().anyMatch(d -> d.filter(hasKeyword).isPresent())
+                && effectiveDirectives.stream().allMatch(d -> d.map(hasKeyword::test).orElse(true));
+    }
+
+    /**
+     * Determines whether {@code 'unsafe-hashes'} is effectively allowed for the given fetch
+     * directive across all policies: every restricted policy (per the CSP fallback chain) must
+     * declare {@code 'unsafe-hashes'} and their hash sets must intersect, since a hash blocked by
+     * any one policy is blocked overall.
+     */
+    private static boolean isUnsafeHashesEffectivelyAllowed(
+            PolicyList policyList, FetchDirectiveKind source) {
+        Set<Hash> commonHashes = null;
+        for (Policy policy : policyList.getPolicies()) {
+            Optional<SourceExpressionDirective> effective =
+                    policy.getGoverningDirectiveForEffectiveDirective(source);
+            if (effective.isEmpty()) {
+                continue;
+            }
+            SourceExpressionDirective directive = effective.get();
+            if (!directive.unsafeHashes() || directive.getHashes().isEmpty()) {
+                return false;
+            }
+            if (commonHashes == null) {
+                commonHashes = new HashSet<>(directive.getHashes());
+            } else {
+                commonHashes.retainAll(directive.getHashes());
+            }
+            if (commonHashes.isEmpty()) {
+                return false;
+            }
+        }
+        return commonHashes != null;
     }
 
     private static String getCspNoticesString(List<PolicyError> notices) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -136,7 +137,9 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                     (severity, message, policyIndex, directiveIndex, valueIndex) ->
                             observedErrors.add(
                                     new PolicyError(severity, message, directiveIndex, valueIndex));
-            PolicyList parsed = parsePolicyList(csp, consumer, msg, id);
+            PolicyList parsed =
+                    parseWithErrorHandling(
+                            () -> Policy.parseSerializedCSPList(csp, consumer), csp, msg, id);
             if (parsed == null) {
                 continue;
             }
@@ -150,7 +153,10 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
             }
         }
 
-        for (Element element : getMetaPolicies(source)) {
+        for (Element element :
+                source.getAllElements(HTMLElementName.META).stream()
+                        .filter(e -> !StringUtils.isBlank(e.getAttributeValue("http-equiv")))
+                        .toList()) {
             String metaField = element.getAttributeValue("http-equiv");
             String metaPolicy = element.getAttributeValue("content");
             if (!HttpFieldsNames.CONTENT_SECURITY_POLICY.equalsIgnoreCase(metaField)
@@ -162,7 +168,12 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                     (severity, message, directiveIndex, valueIndex) ->
                             metaObservedErrors.add(
                                     new PolicyError(severity, message, directiveIndex, valueIndex));
-            Policy parsedMetaPolicy = parsePolicy(metaPolicy, metaConsumer, true, msg, id);
+            Policy parsedMetaPolicy =
+                    parseWithErrorHandling(
+                            () -> Policy.parseSerializedCSP(metaPolicy, metaConsumer, true),
+                            metaPolicy,
+                            msg,
+                            id);
             if (parsedMetaPolicy == null) {
                 continue;
             }
@@ -195,9 +206,14 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         String param =
                 headerContributedPolicy
                         ? getHeaderField(msg, HttpFieldsNames.CONTENT_SECURITY_POLICY).get(0)
-                        : HttpFieldsNames.CONTENT_SECURITY_POLICY;
+                        : "";
         String multiPolicyInfo =
-                buildMultiPolicyOtherInfo(enforcedPolicies.size(), enforcedPolicyTexts);
+                enforcedPolicies.size() <= 1
+                        ? ""
+                        : Constant.messages.getString(
+                                MESSAGE_PREFIX + "multipolicy.otherinfo",
+                                enforcedPolicies.size(),
+                                String.join("\n", enforcedPolicyTexts));
 
         List<String> allowedWildcardSources = getAllowedWildcardSources(policyList);
         checkWildcardSources(allowedWildcardSources, param, evidence, multiPolicyInfo);
@@ -246,24 +262,9 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         }
     }
 
-    private PolicyList parsePolicyList(
-            String csp, PolicyListErrorConsumer consumer, HttpMessage msg, int id) {
+    private <T> T parseWithErrorHandling(Supplier<T> parser, String csp, HttpMessage msg, int id) {
         try {
-            return Policy.parseSerializedCSPList(csp, consumer);
-        } catch (IllegalArgumentException iae) {
-            handleParseException(iae, csp, msg, id);
-        }
-        return null;
-    }
-
-    private Policy parsePolicy(
-            String csp,
-            PolicyErrorConsumer consumer,
-            boolean deliveredViaMeta,
-            HttpMessage msg,
-            int id) {
-        try {
-            return Policy.parseSerializedCSP(csp, consumer, deliveredViaMeta);
+            return parser.get();
         } catch (IllegalArgumentException iae) {
             handleParseException(iae, csp, msg, id);
         }
@@ -356,7 +357,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
             Predicate<SourceExpressionDirective> hasKeyword) {
         List<Optional<SourceExpressionDirective>> effectiveDirectives =
                 policyList.getPolicies().stream()
-                        .map(policy -> policy.getGoverningDirectiveForEffectiveDirective(source))
+                        .map(pol -> pol.getGoverningDirectiveForEffectiveDirective(source))
                         .toList();
         return effectiveDirectives.stream().anyMatch(d -> d.filter(hasKeyword).isPresent())
                 && effectiveDirectives.stream().allMatch(d -> d.map(hasKeyword::test).orElse(true));
@@ -371,9 +372,9 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
     private static boolean isUnsafeHashesEffectivelyAllowed(
             PolicyList policyList, FetchDirectiveKind source) {
         Set<Hash> commonHashes = null;
-        for (Policy policy : policyList.getPolicies()) {
+        for (Policy pol : policyList.getPolicies()) {
             Optional<SourceExpressionDirective> effective =
-                    policy.getGoverningDirectiveForEffectiveDirective(source);
+                    pol.getGoverningDirectiveForEffectiveDirective(source);
             if (effective.isEmpty()) {
                 continue;
             }
@@ -463,64 +464,48 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         return matchedHeaders;
     }
 
-    private static List<String> getAllowedWildcardSources(PolicyList policyList) {
+    private static List<String> getAllowedWildcardSources(PolicyList pol) {
 
         List<String> allowedSources = new ArrayList<>();
 
-        if (checkPolicy(policyList::allowsExternalScript)) {
+        if (checkPolicy(pol::allowsExternalScript)) {
             allowedSources.add("script-src");
         }
-        if (checkPolicy(policyList::allowsExternalStyle)) {
+        if (checkPolicy(pol::allowsExternalStyle)) {
             allowedSources.add("style-src");
         }
-        if (checkPolicy(policyList::allowsImage)) {
+        if (checkPolicy(pol::allowsImage)) {
             allowedSources.add("img-src");
         }
-        if (checkPolicy(policyList::allowsConnection)) {
+        if (checkPolicy(pol::allowsConnection)) {
             allowedSources.add("connect-src");
         }
-        if (checkPolicy(policyList::allowsFrame)) {
+        if (checkPolicy(pol::allowsFrame)) {
             allowedSources.add("frame-src");
         }
-        if (checkPolicy(policyList::allowsFrameAncestor)) {
+        if (checkPolicy(pol::allowsFrameAncestor)) {
             allowedSources.add(FRAME_ANCESTORS);
         }
-        if (checkPolicy(policyList::allowsFont)) {
+        if (checkPolicy(pol::allowsFont)) {
             allowedSources.add("font-src");
         }
-        if (checkPolicy(policyList::allowsMedia)) {
+        if (checkPolicy(pol::allowsMedia)) {
             allowedSources.add("media-src");
         }
-        if (checkPolicy(policyList::allowsObject)) {
+        if (checkPolicy(pol::allowsObject)) {
             allowedSources.add("object-src");
         }
-        if (checkPolicy(policyList::allowsApplicationManifest)) {
+        if (checkPolicy(pol::allowsApplicationManifest)) {
             allowedSources.add("manifest-src");
         }
-        if (checkPolicy(policyList::allowsWorker)) {
+        if (checkPolicy(pol::allowsWorker)) {
             allowedSources.add("worker-src");
         }
-        if (checkPolicy(policyList::allowsFormAction)) {
+        if (checkPolicy(pol::allowsFormAction)) {
             allowedSources.add("form-action");
         }
 
         return allowedSources;
-    }
-
-    private static List<Element> getMetaPolicies(Source source) {
-        return source.getAllElements(HTMLElementName.META).stream()
-                .filter(element -> !StringUtils.isBlank(element.getAttributeValue("http-equiv")))
-                .collect(Collectors.toList());
-    }
-
-    private static String buildMultiPolicyOtherInfo(int policyCount, List<String> policyTexts) {
-        if (policyCount <= 1) {
-            return "";
-        }
-        return Constant.messages.getString(
-                MESSAGE_PREFIX + "multipolicy.otherinfo",
-                policyCount,
-                String.join("\n", policyTexts));
     }
 
     private static String appendMultiPolicyInfo(String otherInfo, String multiPolicyInfo) {
@@ -604,64 +589,89 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
                 .setAlertRef(PLUGIN_ID + "-" + alertRef);
     }
 
+    private AlertBuilder getBuilder(
+            String name, String alertRef, String param, String evidence, int risk) {
+        return getBuilder(name, alertRef).setRisk(risk).setParam(param).setEvidence(evidence);
+    }
+
+    private AlertBuilder getBuilder(
+            String name,
+            String alertRef,
+            String param,
+            String evidence,
+            int risk,
+            String otherInfoKey,
+            String multiPolicyInfo) {
+        return getBuilder(name, alertRef, param, evidence, risk)
+                .setOtherInfo(
+                        appendMultiPolicyInfo(
+                                Constant.messages.getString(MESSAGE_PREFIX + otherInfoKey),
+                                multiPolicyInfo));
+    }
+
     private AlertBuilder buildXcspAlert(int risk, String param, String evidence) {
-        return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "xcsp.name"), "1")
-                .setRisk(risk)
-                .setParam(param)
-                .setEvidence(evidence)
+        return getBuilder(
+                        Constant.messages.getString(MESSAGE_PREFIX + "xcsp.name"),
+                        "1",
+                        param,
+                        evidence,
+                        risk)
                 .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "xcsp.otherinfo"));
     }
 
     private AlertBuilder buildWebkitCspAlert(int risk, String param, String evidence) {
-        return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "xwkcsp.name"), "2")
-                .setRisk(risk)
-                .setParam(param)
-                .setEvidence(evidence)
+        return getBuilder(
+                        Constant.messages.getString(MESSAGE_PREFIX + "xwkcsp.name"),
+                        "2",
+                        param,
+                        evidence,
+                        risk)
                 .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "xwkcsp.otherinfo"));
     }
 
     private AlertBuilder buildNoticesAlert(
             int risk, String param, String evidence, String otherinfo) {
-        return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "notices.name"), "3")
-                .setRisk(risk)
-                .setParam(param)
-                .setEvidence(evidence)
+        return getBuilder(
+                        Constant.messages.getString(MESSAGE_PREFIX + "notices.name"),
+                        "3",
+                        param,
+                        evidence,
+                        risk)
                 .setOtherInfo(otherinfo);
     }
 
     private AlertBuilder buildWildcardAlert(String param, String evidence, String otherinfo) {
-        return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "wildcard.name"), "4")
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
+        return getBuilder(
+                        Constant.messages.getString(MESSAGE_PREFIX + "wildcard.name"),
+                        "4",
+                        param,
+                        evidence,
+                        Alert.RISK_MEDIUM)
                 .setOtherInfo(otherinfo);
     }
 
     private AlertBuilder buildScriptUnsafeInlineAlert(
             String param, String evidence, String multiPolicyInfo) {
         return getBuilder(
-                        Constant.messages.getString(MESSAGE_PREFIX + "scriptsrc.unsafe.name"), "5")
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
-                .setOtherInfo(
-                        appendMultiPolicyInfo(
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "scriptsrc.unsafe.otherinfo"),
-                                multiPolicyInfo));
+                Constant.messages.getString(MESSAGE_PREFIX + "scriptsrc.unsafe.name"),
+                "5",
+                param,
+                evidence,
+                Alert.RISK_MEDIUM,
+                "scriptsrc.unsafe.otherinfo",
+                multiPolicyInfo);
     }
 
     private AlertBuilder buildStyleUnsafeInlineAlert(
             String param, String evidence, String multiPolicyInfo) {
-        return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "stylesrc.unsafe.name"), "6")
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
-                .setOtherInfo(
-                        appendMultiPolicyInfo(
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "stylesrc.unsafe.otherinfo"),
-                                multiPolicyInfo));
+        return getBuilder(
+                Constant.messages.getString(MESSAGE_PREFIX + "stylesrc.unsafe.name"),
+                "6",
+                param,
+                evidence,
+                Alert.RISK_MEDIUM,
+                "stylesrc.unsafe.otherinfo",
+                multiPolicyInfo);
     }
 
     private AlertBuilder buildScriptUnsafeHashAlert(
@@ -669,15 +679,12 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
         return getBuilder(
                         Constant.messages.getString(
                                 MESSAGE_PREFIX + "scriptsrc.unsafe.hashes.name"),
-                        "7")
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
-                .setOtherInfo(
-                        appendMultiPolicyInfo(
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "scriptsrc.unsafe.hashes.otherinfo"),
-                                multiPolicyInfo))
+                        "7",
+                        param,
+                        evidence,
+                        Alert.RISK_MEDIUM,
+                        "scriptsrc.unsafe.hashes.otherinfo",
+                        multiPolicyInfo)
                 .setReference(
                         Constant.messages.getString(
                                 MESSAGE_PREFIX + "scriptsrc.unsafe.hashes.refs"));
@@ -687,25 +694,24 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
             String param, String evidence, String multiPolicyInfo) {
         return getBuilder(
                         Constant.messages.getString(MESSAGE_PREFIX + "stylesrc.unsafe.hashes.name"),
-                        "8")
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
-                .setOtherInfo(
-                        appendMultiPolicyInfo(
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "stylesrc.unsafe.hashes.otherinfo"),
-                                multiPolicyInfo))
+                        "8",
+                        param,
+                        evidence,
+                        Alert.RISK_MEDIUM,
+                        "stylesrc.unsafe.hashes.otherinfo",
+                        multiPolicyInfo)
                 .setReference(
                         Constant.messages.getString(
                                 MESSAGE_PREFIX + "stylesrc.unsafe.hashes.refs"));
     }
 
     private AlertBuilder buildMalformedAlert(String param, String evidence, String badChars) {
-        return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "malformed.name"), "9")
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
+        return getBuilder(
+                        Constant.messages.getString(MESSAGE_PREFIX + "malformed.name"),
+                        "9",
+                        param,
+                        evidence,
+                        Alert.RISK_MEDIUM)
                 .setOtherInfo(
                         Constant.messages.getString(
                                 MESSAGE_PREFIX + "malformed.otherinfo", badChars));
@@ -714,25 +720,22 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
     private AlertBuilder buildScriptUnsafeEvalAlert(
             String param, String evidence, String multiPolicyInfo) {
         return getBuilder(
-                        Constant.messages.getString(MESSAGE_PREFIX + "scriptsrc.unsafe.eval.name"),
-                        "10")
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
-                .setOtherInfo(
-                        appendMultiPolicyInfo(
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "scriptsrc.unsafe.eval.otherinfo"),
-                                multiPolicyInfo));
+                Constant.messages.getString(MESSAGE_PREFIX + "scriptsrc.unsafe.eval.name"),
+                "10",
+                param,
+                evidence,
+                Alert.RISK_MEDIUM,
+                "scriptsrc.unsafe.eval.otherinfo",
+                multiPolicyInfo);
     }
 
     private AlertBuilder buildBadMetaAlert(String param, String evidence) {
         return getBuilder(
                         Constant.messages.getString(MESSAGE_PREFIX + "meta.bad.directive.name"),
-                        "11")
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
+                        "11",
+                        param,
+                        evidence,
+                        Alert.RISK_MEDIUM)
                 .setDescription(
                         Constant.messages.getString(MESSAGE_PREFIX + "meta.bad.directive.desc"));
     }
@@ -741,11 +744,13 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner
 
     private AlertBuilder buildNofallbackAlert(
             String param, String evidence, List<String> directives, String multiPolicyInfo) {
-        return getBuilder(Constant.messages.getString(MESSAGE_PREFIX + "nofallback.name"), "13")
+        return getBuilder(
+                        Constant.messages.getString(MESSAGE_PREFIX + "nofallback.name"),
+                        "13",
+                        param,
+                        evidence,
+                        Alert.RISK_MEDIUM)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "nofallback.desc"))
-                .setRisk(Alert.RISK_MEDIUM)
-                .setParam(param)
-                .setEvidence(evidence)
                 .setOtherInfo(
                         appendMultiPolicyInfo(
                                 Constant.messages.getString(

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -196,7 +196,7 @@ The Content Security Policy (CSP) passive scan rule parses and analyzes CSP head
 or weakness. This rule leverages HtmlUnit's <a href="https://github.com/HtmlUnit/htmlunit-csp">htmlunit-csp</a> 
 library to perform it's parsing and assessment of CSPs.
 <p>
-If a response has multiple CSPs they are analyzed individually, as there is no sure way to intersect/merge the policies and further different browsers have varying levels of CSP support and enforcement.
+If a response has multiple Content-Security-Policy headers or CSP META definitions, they are analyzed together using browser-style intersection: a resource is allowed only if every policy allows it.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java">ContentSecurityPolicyScanRule.java</a>
 <br>

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -105,13 +105,12 @@ pscanrules.crossdomainscriptinclusion.desc = The page includes one or more scrip
 pscanrules.crossdomainscriptinclusion.name = Cross-Domain JavaScript Source File Inclusion
 pscanrules.crossdomainscriptinclusion.soln = Ensure JavaScript source files are loaded from only trusted sources, and the sources can't be controlled by end users of the application.
 
-pscanrules.csp.both.desc = The message contained both CSP specified via header and via Meta tag. It was not possible to union these policies in order to perform an analysis. Therefore, they have been evaluated individually.
-pscanrules.csp.both.name = Header & Meta
 pscanrules.csp.desc = Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks. Including (but not limited to) Cross Site Scripting (XSS), and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page — covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.
 pscanrules.csp.malformed.name = Malformed Policy (Non-ASCII)
 pscanrules.csp.malformed.otherinfo = A non-ASCII character was encountered while attempting to parse the policy, thus rendering it invalid (no further evaluation occurred). The following invalid characters were collected: {0}
 pscanrules.csp.meta.bad.directive.desc = The policy specified via meta element contains either or both the sandbox or frame-ancestors directive, which are not permitted inside meta CSP definitions.
 pscanrules.csp.meta.bad.directive.name = Meta Policy Invalid Directive
+pscanrules.csp.multipolicy.otherinfo = The response contained {0} Content-Security-Policy policies (header and/or meta). They were analyzed together using browser-style intersection (a resource is allowed only if every policy allows it):\n{1}
 pscanrules.csp.name = CSP
 pscanrules.csp.nofallback.desc = The Content Security Policy fails to define one of the directives that has no fallback. Missing/excluding them is the same as allowing anything.
 pscanrules.csp.nofallback.name = Failure to Define Directive with No Fallback

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -27,7 +27,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -59,6 +61,21 @@ class ContentSecurityPolicyScanRuleUnitTest
     @Override
     protected ContentSecurityPolicyScanRule createScanner() {
         return new ContentSecurityPolicyScanRule();
+    }
+
+    @Override
+    public void shouldHaveExpectedAlertRefsInExampleAlerts() {
+        // Given / When
+        List<String> alertRefs = rule.getExampleAlerts().stream().map(Alert::getAlertRef).toList();
+        // Then
+        assertThat(
+                alertRefs,
+                equalTo(
+                        IntStream.rangeClosed(1, 13)
+                                // 10055-12 retired; skip contiguous check.
+                                .filter(i -> i != 12)
+                                .mapToObj(i -> "10055-" + i)
+                                .toList()));
     }
 
     @Test
@@ -98,10 +115,6 @@ class ContentSecurityPolicyScanRuleUnitTest
     void shouldReturnExpectedExampleAlerts() {
         // Given / When
         int count = rule.getExampleAlerts().size();
-        long countInfos =
-                rule.getExampleAlerts().stream()
-                        .filter(alert -> Alert.RISK_INFO == alert.getRisk())
-                        .count();
         long countLows =
                 rule.getExampleAlerts().stream()
                         .filter(alert -> Alert.RISK_LOW == alert.getRisk())
@@ -111,8 +124,7 @@ class ContentSecurityPolicyScanRuleUnitTest
                         .filter(alert -> Alert.RISK_MEDIUM == alert.getRisk())
                         .count();
         // Then
-        assertThat(count, is(equalTo(13)));
-        assertThat(countInfos, is(equalTo(1L)));
+        assertThat(count, is(equalTo(12)));
         assertThat(countLows, is(equalTo(3L)));
         assertThat(countMediums, is(equalTo(9L)));
     }
@@ -284,11 +296,12 @@ class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    void shouldNotAlertOnReasonableMetaCsp() {
-        // Given
+    void shouldAlertOnReasonableMetaCspWithoutFrameAncestors() {
+        // Given — meta CSPs cannot enforce frame-ancestors, so a otherwise-reasonable meta
+        // policy still leaves framing unrestricted at the effective PolicyList layer
         HttpMessage msg = createHttpMessage();
         msg.setResponseBody(
-                "<html><head><<meta http-equiv=\""
+                "<html><head><meta http-equiv=\""
                         + HttpFieldsNames.CONTENT_SECURITY_POLICY
                         + "\" content=\""
                         + REASONABLE_META_POLICY
@@ -297,7 +310,12 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(0));
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(
+                alertsRaised.get(0).getName(),
+                equalTo("CSP: Failure to Define Directive with No Fallback"));
+        assertThat(alertsRaised.get(0).getOtherInfo(), containsString("frame-ancestors"));
+        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-13"));
     }
 
     @Test
@@ -305,7 +323,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // Given
         HttpMessage msg = createHttpMessage();
         msg.setResponseBody(
-                "<html><head><<meta http-equiv=\""
+                "<html><head><meta http-equiv=\""
                         + HttpFieldsNames.CONTENT_SECURITY_POLICY
                         + "\" content=\""
                         // The comma here causes the parsing to fail and return null
@@ -317,27 +335,6 @@ class ContentSecurityPolicyScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(0));
-    }
-
-    @Test
-    void shouldAlertOnMetaCspWithPrefetch() {
-        // Given
-        HttpMessage msg = createHttpMessage();
-        msg.setResponseBody(
-                "<html><head><<meta http-equiv=\""
-                        + HttpFieldsNames.CONTENT_SECURITY_POLICY
-                        + "\" content=\""
-                        + REASONABLE_META_POLICY
-                        + "; prefetch-src *"
-                        + "\"></head></html>");
-        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(alertsRaised.size(), equalTo(1));
-        assertThat(
-                alertsRaised.get(0).getOtherInfo(),
-                is("Warnings:\n" + "The prefetch-src directive has been deprecated\n"));
     }
 
     @Test
@@ -357,12 +354,12 @@ class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    void shouldAlertWhenHeaderAndMetaBothPresent() {
-        // Given
+    void shouldNotAlertWhenHeaderAndMetaBothPresentAndReasonable() {
+        // Given — header provides frame-ancestors; meta is AND'd rather than flagged separately
         HttpMessage msg =
                 createHttpMessageWithReasonableCsp(HttpFieldsNames.CONTENT_SECURITY_POLICY);
         msg.setResponseBody(
-                "<html><head><<meta http-equiv=\""
+                "<html><head><meta http-equiv=\""
                         + HttpFieldsNames.CONTENT_SECURITY_POLICY
                         + "\" content=\""
                         + REASONABLE_META_POLICY
@@ -371,31 +368,205 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(1));
-        Alert alert = alertsRaised.get(0);
-        assertThat(alert.getName(), equalTo("CSP: Header & Meta"));
-        assertThat(alert.getAlertRef(), equalTo("10055-12"));
+        assertThat(alertsRaised.size(), equalTo(0));
     }
 
     @Test
-    void shouldAlertOnMetaPolicyWithInvalidDirective() {
-        // Given
-        HttpMessage msg = createHttpMessage();
+    void shouldNotAlertOnFrameAncestorsWhenHeaderRestrictsAndMetaHasWildcard() {
+        // Given — meta FA is ignored for enforce queries; header FA still restricts via AND
+        HttpMessage msg =
+                createHttpMessageWithReasonableCsp(HttpFieldsNames.CONTENT_SECURITY_POLICY);
         msg.setResponseBody(
-                "<html><head><<meta http-equiv=\""
+                "<html><head><meta http-equiv=\""
                         + HttpFieldsNames.CONTENT_SECURITY_POLICY
                         + "\" content=\""
                         + REASONABLE_META_POLICY
-                        + "; sandbox allow-forms"
+                        + "; frame-ancestors *"
+                        + "\"></head></html>");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then — Notices + Meta Policy Invalid Directive; no FA nofallback
+        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.get(0).getName(), equalTo("CSP: Notices"));
+        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-11"));
+        assertThat(
+                alertsRaised.stream().noneMatch(a -> "10055-13".equals(a.getAlertRef())),
+                is(equalTo(true)));
+    }
+
+    @Test
+    void shouldAlertWhenAllEnforcePoliciesAllowUnsafeInline() {
+        // Given — intersection still weak when every policy allows unsafe-inline
+        HttpMessage msg =
+                createHttpMessage(
+                        "script-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'");
+        msg.getResponseHeader()
+                .addHeader(
+                        HttpFieldsNames.CONTENT_SECURITY_POLICY,
+                        "script-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(
+                alertsRaised.stream().anyMatch(a -> "10055-5".equals(a.getAlertRef())),
+                is(equalTo(true)));
+    }
+
+    @Test
+    void shouldIncludeMultiPolicyOtherInfoAndUseFirstPolicyAsEvidence() {
+        // Given
+        String first = "script-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'";
+        String second = "default-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'";
+        HttpMessage msg = createHttpMessage(first);
+        msg.getResponseHeader().addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, second);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        Alert unsafeInline =
+                alertsRaised.stream()
+                        .filter(a -> "10055-5".equals(a.getAlertRef()))
+                        .findFirst()
+                        .orElseThrow();
+        assertThat(unsafeInline.getEvidence(), equalTo(first));
+        assertThat(
+                unsafeInline.getOtherInfo(),
+                containsString("The response contained 2 Content-Security-Policy policies"));
+        assertThat(unsafeInline.getOtherInfo(), containsString(first));
+        assertThat(unsafeInline.getOtherInfo(), containsString(second));
+    }
+
+    @Test
+    void shouldAndCommaSeparatedPoliciesInSingleHeader() {
+        // Given — one header field value is a serialized CSP list
+        HttpMessage msg = createHttpMessage(REASONABLE_POLICY + ", script-src 'unsafe-inline'");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then — reasonable half blocks unsafe-inline via AND
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    void shouldReportParsedPolicyCountForCommaSeparatedCspList() {
+        // Given — one header text, two parsed policies, both allow unsafe-inline
+        String cspList =
+                "script-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none', "
+                        + "default-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'";
+        HttpMessage msg = createHttpMessage(cspList);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        Alert unsafeInline =
+                alertsRaised.stream()
+                        .filter(a -> "10055-5".equals(a.getAlertRef()))
+                        .findFirst()
+                        .orElseThrow();
+        assertThat(
+                unsafeInline.getOtherInfo(),
+                containsString("The response contained 2 Content-Security-Policy policies"));
+        assertThat(unsafeInline.getOtherInfo(), containsString(cspList));
+    }
+
+    @Test
+    void shouldNotAlertOnWildcardWhenSiblingPolicyRestrictsConnectSrc() {
+        // Given
+        HttpMessage msg =
+                createHttpMessage(
+                        "connect-src *; default-src 'self'; form-action 'none'; frame-ancestors 'self'");
+        msg.getResponseHeader()
+                .addHeader(
+                        HttpFieldsNames.CONTENT_SECURITY_POLICY,
+                        "connect-src 'self'; default-src 'self'; form-action 'none'; frame-ancestors 'self'");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    void shouldAlertOnWildcardWhenAllPoliciesAllowWildcardConnectSrc() {
+        // Given
+        String policy =
+                "connect-src *; default-src 'self'; form-action 'none'; frame-ancestors 'self'";
+        HttpMessage msg = createHttpMessage(policy);
+        msg.getResponseHeader().addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, policy);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-4"));
+        assertThat(alertsRaised.get(0).getOtherInfo(), containsString("connect-src"));
+        assertThat(
+                alertsRaised.get(0).getOtherInfo(),
+                containsString("The response contained 2 Content-Security-Policy policies"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"; sandbox allow-forms", "; frame-ancestors 'none'", "; report-uri /csp"})
+    void shouldAlertOnMetaPolicyWithInvalidDirective(String invalidDirective) {
+        // Given
+        HttpMessage msg = createHttpMessage();
+        msg.setResponseBody(
+                "<html><head><meta http-equiv=\""
+                        + HttpFieldsNames.CONTENT_SECURITY_POLICY
+                        + "\" content=\""
+                        + REASONABLE_META_POLICY
+                        + invalidDirective
                         + "\"></head></html>");
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
         // When
         scanHttpResponseReceive(msg);
         // Then
+        assertThat(
+                alertsRaised.stream().anyMatch(a -> "10055-11".equals(a.getAlertRef())),
+                is(equalTo(true)));
+        assertThat(
+                alertsRaised.stream()
+                        .filter(a -> "10055-3".equals(a.getAlertRef()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getOtherInfo(),
+                containsString("ignored when delivered via a meta element"));
+    }
+
+    @Test
+    void shouldNotAlertOnUnsafeHashesWhenSiblingPolicyLacksThem() {
+        // Given
+        HttpMessage msg =
+                createHttpMessage(
+                        "default-src 'self'; script-src 'unsafe-hashes'"
+                                + " 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=';"
+                                + " form-action 'none'; frame-ancestors 'none'");
+        msg.getResponseHeader()
+                .addHeader(
+                        HttpFieldsNames.CONTENT_SECURITY_POLICY,
+                        "default-src 'self'; script-src 'self'; form-action 'none';"
+                                + " frame-ancestors 'none'");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(
+                alertsRaised.stream().noneMatch(a -> "10055-7".equals(a.getAlertRef())),
+                is(equalTo(true)));
+    }
+
+    @Test
+    void shouldAlertNoticesOnlyForHeaderWithSyntaxIssues() {
+        // Given
+        HttpMessage msg =
+                createHttpMessageWithReasonableCsp(HttpFieldsNames.CONTENT_SECURITY_POLICY);
+        String noisy = "default-src none; form-action 'none'; frame-ancestors 'none'";
+        msg.getResponseHeader().addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, noisy);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
         assertThat(alertsRaised.size(), equalTo(1));
-        Alert alert = alertsRaised.get(0);
-        assertThat(alert.getName(), equalTo("CSP: Meta Policy Invalid Directive"));
-        assertThat(alert.getAlertRef(), equalTo("10055-11"));
+        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-3"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo(noisy));
+        assertThat(
+                alertsRaised.get(0).getOtherInfo(),
+                containsString("missing the required quotes: 'none'"));
     }
 
     @ParameterizedTest
@@ -511,28 +682,18 @@ class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    void shouldRaiseAlertWhenCspIncludesStyleUnsafeInline() {
-        // Given
-        HttpMessage msg = createHttpMessage("style-src 'unsafe-inline'");
+    void shouldNotAlertOnScriptUnsafeInlineWhenStrictDynamicPresent() {
+        // Given — 'strict-dynamic' disables 'unsafe-inline' for scripts per CSP3
+        HttpMessage msg =
+                createHttpMessage(
+                        "script-src 'strict-dynamic' 'unsafe-inline'; form-action 'none';"
+                                + " frame-ancestors 'none'");
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(4));
-        // Verify the specific alerts
         assertThat(
-                alertsRaised.get(0).getName(),
-                equalTo("CSP: Failure to Define Directive with No Fallback"));
-        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-13"));
-
-        assertThat(alertsRaised.get(1).getName(), equalTo("CSP: Wildcard Directive"));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-4"));
-
-        assertThat(alertsRaised.get(2).getName(), equalTo("CSP: script-src unsafe-inline"));
-        assertThat(alertsRaised.get(2).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(alertsRaised.get(2).getAlertRef(), equalTo("10055-5"));
-
-        assertThat(alertsRaised.get(3).getName(), equalTo("CSP: style-src unsafe-inline"));
+                alertsRaised.stream().noneMatch(a -> "10055-5".equals(a.getAlertRef())),
+                is(equalTo(true)));
     }
 
     @Test
@@ -551,8 +712,8 @@ class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    void shouldRaiseAlertOnSecondCspHasIssueFirstDoesNot() {
-        // Given
+    void shouldNotAlertWhenSecondCspHasIssueButFirstIsReasonable() {
+        // Given — browser AND: the reasonable policy blocks what the loose policy would allow
         HttpMessage msg =
                 createHttpMessageWithReasonableCsp(HttpFieldsNames.CONTENT_SECURITY_POLICY);
         msg.getResponseHeader()
@@ -560,64 +721,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(4));
-        // Verify the specific alerts
-        assertThat(
-                alertsRaised.get(0).getName(),
-                equalTo("CSP: Failure to Define Directive with No Fallback"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("style-src 'unsafe-inline'"));
-        assertThat(
-                alertsRaised.get(0).getOtherInfo(),
-                equalTo(
-                        "The directive(s): frame-ancestors, form-action is/are among the directives that do not fallback to default-src."));
-        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-13"));
-
-        assertThat(alertsRaised.get(1).getName(), equalTo("CSP: Wildcard Directive"));
-        assertThat(alertsRaised.get(1).getEvidence(), equalTo("style-src 'unsafe-inline'"));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-4"));
-
-        assertThat(alertsRaised.get(2).getName(), equalTo("CSP: script-src unsafe-inline"));
-        assertThat(alertsRaised.get(2).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(alertsRaised.get(2).getEvidence(), equalTo("style-src 'unsafe-inline'"));
-        assertThat(alertsRaised.get(2).getAlertRef(), equalTo("10055-5"));
-
-        assertThat(alertsRaised.get(3).getName(), equalTo("CSP: style-src unsafe-inline"));
-        assertThat(alertsRaised.get(3).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(3).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(alertsRaised.get(3).getEvidence(), equalTo("style-src 'unsafe-inline'"));
-        assertThat(alertsRaised.get(3).getAlertRef(), equalTo("10055-6"));
-    }
-
-    @Test
-    void shouldRaiseAlertOnUnsafeInDefaultSrc() {
-        // Given
-        HttpMessage msg =
-                createHttpMessageWithReasonableCsp(HttpFieldsNames.CONTENT_SECURITY_POLICY);
-        msg.getResponseHeader()
-                .addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, "default-src 'unsafe-inline'");
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(alertsRaised.size(), equalTo(3));
-        // Verify the specific alerts
-        assertThat(
-                alertsRaised.get(0).getName(),
-                equalTo("CSP: Failure to Define Directive with No Fallback"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("default-src 'unsafe-inline'"));
-        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-13"));
-
-        assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
-        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(alertsRaised.get(1).getEvidence(), equalTo("default-src 'unsafe-inline'"));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
-
-        assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
-        assertThat(alertsRaised.get(2).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(alertsRaised.get(2).getEvidence(), equalTo("default-src 'unsafe-inline'"));
-        assertThat(alertsRaised.get(2).getAlertRef(), equalTo("10055-6"));
+        assertThat(alertsRaised.size(), equalTo(0));
     }
 
     @Test
@@ -694,7 +798,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), is(equalTo(1)));
+        assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getOtherInfo(),
                 is(equalTo("Warnings:\nThe prefetch-src directive has been deprecated\n")));
@@ -720,7 +824,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), is(equalTo(1)));
+        assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getDescription(),
                 is(

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -297,8 +297,8 @@ class ContentSecurityPolicyScanRuleUnitTest
 
     @Test
     void shouldAlertOnReasonableMetaCspWithoutFrameAncestors() {
-        // Given — meta CSPs cannot enforce frame-ancestors, so a otherwise-reasonable meta
-        // policy still leaves framing unrestricted at the effective PolicyList layer
+        // Given — meta CSPs cannot enforce frame-ancestors, so an otherwise-reasonable
+        // meta policy still leaves framing unrestricted at the effective PolicyList layer
         HttpMessage msg = createHttpMessage();
         msg.setResponseBody(
                 "<html><head><meta http-equiv=\""
@@ -792,13 +792,33 @@ class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
+    void shouldUseGenericParamWhenHeaderUnparseableAndMetaProvidesEffectivePolicy() {
+        // Given — header is present but unparseable (non-ASCII), so it never contributes to
+        // enforcedPolicyTexts; only the meta policy is actually evaluated. The effective-policy
+        // alerts' param must reflect that the header was unused, not point at the header itself.
+        HttpMessage msg = createHttpMessage();
+        msg.getResponseHeader().addHeader("Content-Security-Policy", "default-src ‘self’");
+        msg.setResponseBody(
+                "<html><head><meta http-equiv=\""
+                        + HttpFieldsNames.CONTENT_SECURITY_POLICY
+                        + "\" content=\"script-src 'unsafe-inline'\"></head></html>");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        Alert unsafeInline = findAlert("10055-5");
+        assertThat(unsafeInline.getParam(), equalTo(HttpFieldsNames.CONTENT_SECURITY_POLICY));
+        assertThat(unsafeInline.getEvidence(), equalTo("script-src 'unsafe-inline'"));
+    }
+
+    @Test
     void shouldAlertOnReasonableCspWhichIncludesPrefetchsrc() {
         // Given
         HttpMessage msg = createHttpMessage("", REASONABLE_POLICY + "; prefetch-src *");
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.size(), is(equalTo(1)));
         assertThat(
                 alertsRaised.get(0).getOtherInfo(),
                 is(equalTo("Warnings:\nThe prefetch-src directive has been deprecated\n")));
@@ -824,7 +844,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.size(), is(equalTo(1)));
         assertThat(
                 alertsRaised.get(0).getDescription(),
                 is(
@@ -834,6 +854,130 @@ class ContentSecurityPolicyScanRuleUnitTest
         assertThat(
                 alertsRaised.get(0).getName(),
                 equalTo("CSP: Failure to Define Directive with No Fallback"));
+    }
+
+    @Test
+    void shouldAlertOnUnsafeEvalWhenAllowedOnlyViaDefaultSrcFallback() {
+        // Given — script-src omitted; default-src carries 'unsafe-eval', which governs via
+        // the CSP fallback chain (Policy.getGoverningDirectiveForEffectiveDirective).
+        String policy = "default-src 'unsafe-eval'; form-action 'none'; frame-ancestors 'none'";
+        HttpMessage msg = createHttpMessage(policy);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        Alert evalAlert = findAlert("10055-10");
+        assertThat(evalAlert.getName(), equalTo("CSP: script-src unsafe-eval"));
+        assertThat(evalAlert.getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(evalAlert.getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
+        assertThat(evalAlert.getEvidence(), equalTo(policy));
+    }
+
+    @Test
+    void shouldAlertOnUnsafeEvalWhenIntersectionReliesOnDefaultSrcFallback() {
+        // Given — one policy names script-src, the other only default-src; intersection
+        // still allows eval (PolicyList.allowsEval() == true).
+        String first = "script-src 'unsafe-eval'; form-action 'none'; frame-ancestors 'none'";
+        String second = "default-src 'unsafe-eval'; form-action 'none'; frame-ancestors 'none'";
+        HttpMessage msg = createHttpMessage(first);
+        msg.getResponseHeader().addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, second);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        Alert evalAlert = findAlert("10055-10");
+        assertThat(evalAlert.getName(), equalTo("CSP: script-src unsafe-eval"));
+        assertThat(evalAlert.getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(evalAlert.getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
+        assertThat(evalAlert.getEvidence(), equalTo(first));
+    }
+
+    @Test
+    void shouldAlertOnUnsafeHashesWhenAllowedOnlyViaDefaultSrcFallback() {
+        // Given — same fallback issue for 'unsafe-hashes' / 10055-7
+        String policy =
+                "default-src 'unsafe-hashes' 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='; "
+                        + "form-action 'none'; frame-ancestors 'none'";
+        HttpMessage msg = createHttpMessage(policy);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        Alert hashesAlert = findAlert("10055-7");
+        assertThat(hashesAlert.getName(), equalTo("CSP: script-src unsafe-hashes"));
+        assertThat(hashesAlert.getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(hashesAlert.getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
+        assertThat(hashesAlert.getEvidence(), equalTo(policy));
+    }
+
+    @Test
+    void shouldNotAlertOnUnsafeHashesWhenPoliciesHaveDisjointHashSets() {
+        // Given — both policies contain 'unsafe-hashes' but list different hashes.
+        // No concrete handler is allowed by every policy, so the intersection does not
+        // effectively allow unsafe-hashes.
+        String hashA = "sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=";
+        String hashB = "sha256-xyz4zkCjuC3lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ=";
+        HttpMessage msg = createHttpMessage(hashPolicy("script-src", hashA));
+        msg.getResponseHeader()
+                .addHeader(
+                        HttpFieldsNames.CONTENT_SECURITY_POLICY, hashPolicy("script-src", hashB));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(
+                alertsRaised.stream().filter(a -> "10055-7".equals(a.getAlertRef())).count(),
+                equalTo(0L));
+    }
+
+    @Test
+    void shouldNotAlertOnStyleUnsafeHashesWhenPoliciesHaveDisjointHashSets() {
+        // Given — same disjoint-hash-set scenario for style-src / 10055-8
+        String hashA = "sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=";
+        String hashB = "sha256-xyz4zkCjuC3lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ=";
+        HttpMessage msg = createHttpMessage(hashPolicy("style-src", hashA));
+        msg.getResponseHeader()
+                .addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, hashPolicy("style-src", hashB));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(
+                alertsRaised.stream().filter(a -> "10055-8".equals(a.getAlertRef())).count(),
+                equalTo(0L));
+    }
+
+    @Test
+    void shouldAlertOnUnsafeHashesWhenIntersectingHashSetsAllowThem() {
+        // Given — shared hash + keyword in every policy → intersection still permits
+        // unsafe-hashes for that hash; 10055-7 is appropriate.
+        String sharedHash = "sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=";
+        String extraHash = "sha256-xyz4zkCjuC3lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ=";
+        String first = hashPolicy("script-src", sharedHash);
+        String second = hashPolicy("script-src", sharedHash, extraHash);
+        HttpMessage msg = createHttpMessage(first);
+        msg.getResponseHeader().addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, second);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        Alert hashesAlert = findAlert("10055-7");
+        assertThat(hashesAlert.getName(), equalTo("CSP: script-src unsafe-hashes"));
+        assertThat(hashesAlert.getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(hashesAlert.getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
+        assertThat(hashesAlert.getEvidence(), equalTo(first));
+    }
+
+    private Alert findAlert(String alertRef) {
+        return alertsRaised.stream()
+                .filter(a -> alertRef.equals(a.getAlertRef()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected " + alertRef + " alert"));
+    }
+
+    private static String hashPolicy(String directive, String... hashes) {
+        StringBuilder sb =
+                new StringBuilder("default-src 'self'; ")
+                        .append(directive)
+                        .append(" 'unsafe-hashes'");
+        for (String hash : hashes) {
+            sb.append(" '").append(hash).append('\'');
+        }
+        return sb.append("; form-action 'none'; frame-ancestors 'none'").toString();
     }
 
     private static HttpMessage createHttpMessageWithReasonableCsp(String cspHeaderName) {

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -20,16 +20,14 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.IntStream;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -64,18 +62,9 @@ class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Override
-    public void shouldHaveExpectedAlertRefsInExampleAlerts() {
-        // Given / When
-        List<String> alertRefs = rule.getExampleAlerts().stream().map(Alert::getAlertRef).toList();
-        // Then
-        assertThat(
-                alertRefs,
-                equalTo(
-                        IntStream.rangeClosed(1, 13)
-                                // 10055-12 retired; skip contiguous check.
-                                .filter(i -> i != 12)
-                                .mapToObj(i -> "10055-" + i)
-                                .toList()));
+    public Set<Integer> getSkippedAlertRefs() {
+        // 10055-12 retired; skip contiguous check.
+        return Set.of(12);
     }
 
     @Test
@@ -151,63 +140,6 @@ class ContentSecurityPolicyScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(5));
-    }
-
-    @Test
-    void shouldAlertWhenCspContainsSyntaxIssues() {
-        // Given
-        HttpMessage msg = createHttpMessage("default-src: 'none'; report_uri /__cspreport__");
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(alertsRaised.size(), equalTo(5));
-
-        assertThat(alertsRaised.get(0).getName(), equalTo("CSP: Notices"));
-        assertThat(
-                alertsRaised.get(0).getOtherInfo(),
-                equalTo(
-                        "Errors:\nDirective name default-src: contains characters outside the range ALPHA / DIGIT / \"-\"\nDirective name report_uri contains characters outside the range ALPHA / DIGIT / \"-\"\n"));
-        assertThat(
-                alertsRaised.get(0).getEvidence(),
-                equalTo("default-src: 'none'; report_uri /__cspreport__"));
-        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
-        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-
-        assertThat(
-                alertsRaised.get(1).getName(),
-                equalTo("CSP: Failure to Define Directive with No Fallback"));
-        assertThat(
-                alertsRaised.get(1).getOtherInfo(),
-                equalTo(
-                        "The directive(s): frame-ancestors, form-action is/are among the directives that do not fallback to default-src."));
-        assertThat(
-                alertsRaised.get(1).getEvidence(),
-                equalTo("default-src: 'none'; report_uri /__cspreport__"));
-        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-13"));
-    }
-
-    @Test
-    void shouldNotAlertOnValidSyntaxWhenCspContainsSyntaxIssues() {
-        // Given
-        HttpMessage msg =
-                createHttpMessage(
-                        "default-src: 'none'; report_uri /__cspreport__; frame-ancestors 'none'");
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(alertsRaised.size(), equalTo(5));
-        assertThat(
-                alertsRaised.get(1).getName(),
-                equalTo("CSP: Failure to Define Directive with No Fallback"));
-        assertThat(alertsRaised.get(1).getOtherInfo(), not(containsString("frame-ancestors")));
-        assertThat(
-                alertsRaised.get(1).getEvidence(),
-                equalTo("default-src: 'none'; report_uri /__cspreport__; frame-ancestors 'none'"));
-        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-13"));
     }
 
     @Test
@@ -390,21 +322,14 @@ class ContentSecurityPolicyScanRuleUnitTest
         assertThat(alertsRaised.size(), equalTo(2));
         assertThat(alertsRaised.get(0).getName(), equalTo("CSP: Notices"));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-11"));
-        assertThat(
-                alertsRaised.stream().noneMatch(a -> "10055-13".equals(a.getAlertRef())),
-                is(equalTo(true)));
     }
 
     @Test
     void shouldAlertWhenAllEnforcePoliciesAllowUnsafeInline() {
         // Given — intersection still weak when every policy allows unsafe-inline
-        HttpMessage msg =
-                createHttpMessage(
-                        "script-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'");
-        msg.getResponseHeader()
-                .addHeader(
-                        HttpFieldsNames.CONTENT_SECURITY_POLICY,
-                        "script-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'");
+        String policy = "script-src 'unsafe-inline'; form-action 'none'; frame-ancestors 'none'";
+        HttpMessage msg = createHttpMessage(policy);
+        msg.getResponseHeader().addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, policy);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -431,9 +356,10 @@ class ContentSecurityPolicyScanRuleUnitTest
         assertThat(unsafeInline.getEvidence(), equalTo(first));
         assertThat(
                 unsafeInline.getOtherInfo(),
-                containsString("The response contained 2 Content-Security-Policy policies"));
-        assertThat(unsafeInline.getOtherInfo(), containsString(first));
-        assertThat(unsafeInline.getOtherInfo(), containsString(second));
+                allOf(
+                        containsString("The response contained 2 Content-Security-Policy policies"),
+                        containsString(first),
+                        containsString(second)));
     }
 
     @Test
@@ -464,19 +390,18 @@ class ContentSecurityPolicyScanRuleUnitTest
         assertThat(
                 unsafeInline.getOtherInfo(),
                 containsString("The response contained 2 Content-Security-Policy policies"));
-        assertThat(unsafeInline.getOtherInfo(), containsString(cspList));
     }
 
     @Test
     void shouldNotAlertOnWildcardWhenSiblingPolicyRestrictsConnectSrc() {
         // Given
-        HttpMessage msg =
-                createHttpMessage(
-                        "connect-src *; default-src 'self'; form-action 'none'; frame-ancestors 'self'");
+        String permissivePolicy =
+                "connect-src *; default-src 'self'; form-action 'none'; frame-ancestors 'self'";
+        String restrictivePolicy =
+                "connect-src 'self'; default-src 'self'; form-action 'none'; frame-ancestors 'self'";
+        HttpMessage msg = createHttpMessage(permissivePolicy);
         msg.getResponseHeader()
-                .addHeader(
-                        HttpFieldsNames.CONTENT_SECURITY_POLICY,
-                        "connect-src 'self'; default-src 'self'; form-action 'none'; frame-ancestors 'self'");
+                .addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, restrictivePolicy);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -501,35 +426,6 @@ class ContentSecurityPolicyScanRuleUnitTest
                 containsString("The response contained 2 Content-Security-Policy policies"));
     }
 
-    @ParameterizedTest
-    @ValueSource(
-            strings = {"; sandbox allow-forms", "; frame-ancestors 'none'", "; report-uri /csp"})
-    void shouldAlertOnMetaPolicyWithInvalidDirective(String invalidDirective) {
-        // Given
-        HttpMessage msg = createHttpMessage();
-        msg.setResponseBody(
-                "<html><head><meta http-equiv=\""
-                        + HttpFieldsNames.CONTENT_SECURITY_POLICY
-                        + "\" content=\""
-                        + REASONABLE_META_POLICY
-                        + invalidDirective
-                        + "\"></head></html>");
-        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(
-                alertsRaised.stream().anyMatch(a -> "10055-11".equals(a.getAlertRef())),
-                is(equalTo(true)));
-        assertThat(
-                alertsRaised.stream()
-                        .filter(a -> "10055-3".equals(a.getAlertRef()))
-                        .findFirst()
-                        .orElseThrow()
-                        .getOtherInfo(),
-                containsString("ignored when delivered via a meta element"));
-    }
-
     @Test
     void shouldNotAlertOnUnsafeHashesWhenSiblingPolicyLacksThem() {
         // Given
@@ -548,7 +444,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // Then
         assertThat(
                 alertsRaised.stream().noneMatch(a -> "10055-7".equals(a.getAlertRef())),
-                is(equalTo(true)));
+                equalTo(true));
     }
 
     @Test
@@ -624,21 +520,6 @@ class ContentSecurityPolicyScanRuleUnitTest
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-3"));
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-            value = {
-                "default-src 'self'; frame-ancestors 'none'; form-action 'none'; trusted-types myPolicy 'allow-duplicates'",
-                "default-src 'self'; frame-ancestors 'none'; form-action 'none'; trusted-types policy1 policy2 policy3"
-            })
-    void shouldNotAlertOnValidTrustedTypesPolicies(String policy) {
-        // Given
-        HttpMessage msg = createHttpMessage(policy);
-        // When
-        scanHttpResponseReceive(msg);
-        // Then - no alerts
-        assertThat(alertsRaised, is(empty()));
     }
 
     @ParameterizedTest
@@ -773,31 +654,12 @@ class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    void shouldRaiseAlertWhenPolicyContainsNonasciiCharacters() {
-        // Given
-        String policy = "\"default-src ‘self’ 'unsafe-eval' 'unsafe-inline' www.example.net;\"";
-        HttpMessage msg = createHttpMessage(policy);
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(alertsRaised.size(), equalTo(1));
-        // Verify the specific alerts
-        assertThat(alertsRaised.get(0).getName(), equalTo("CSP: Malformed Policy (Non-ASCII)"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo(policy));
-        assertThat(
-                alertsRaised.get(0).getOtherInfo(),
-                equalTo(
-                        "A non-ASCII character was encountered while attempting to parse the policy, thus rendering it invalid (no further evaluation occurred). The following invalid characters were collected: ‘’"));
-        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-9"));
-    }
-
-    @Test
     void shouldUseGenericParamWhenHeaderUnparseableAndMetaProvidesEffectivePolicy() {
         // Given — header is present but unparseable (non-ASCII), so it never contributes to
         // enforcedPolicyTexts; only the meta policy is actually evaluated. The effective-policy
-        // alerts' param must reflect that the header was unused, not point at the header itself.
+        // alerts’ param must reflect that the header was unused, not point at the header itself.
         HttpMessage msg = createHttpMessage();
-        msg.getResponseHeader().addHeader("Content-Security-Policy", "default-src ‘self’");
+        msg.getResponseHeader().addHeader("Content-Security-Policy", "default-src ‘self’ “");
         msg.setResponseBody(
                 "<html><head><meta http-equiv=\""
                         + HttpFieldsNames.CONTENT_SECURITY_POLICY
@@ -807,7 +669,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         Alert unsafeInline = findAlert("10055-5");
-        assertThat(unsafeInline.getParam(), equalTo(HttpFieldsNames.CONTENT_SECURITY_POLICY));
+        assertThat(unsafeInline.getParam(), equalTo(""));
         assertThat(unsafeInline.getEvidence(), equalTo("script-src 'unsafe-inline'"));
     }
 
@@ -856,128 +718,11 @@ class ContentSecurityPolicyScanRuleUnitTest
                 equalTo("CSP: Failure to Define Directive with No Fallback"));
     }
 
-    @Test
-    void shouldAlertOnUnsafeEvalWhenAllowedOnlyViaDefaultSrcFallback() {
-        // Given — script-src omitted; default-src carries 'unsafe-eval', which governs via
-        // the CSP fallback chain (Policy.getGoverningDirectiveForEffectiveDirective).
-        String policy = "default-src 'unsafe-eval'; form-action 'none'; frame-ancestors 'none'";
-        HttpMessage msg = createHttpMessage(policy);
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        Alert evalAlert = findAlert("10055-10");
-        assertThat(evalAlert.getName(), equalTo("CSP: script-src unsafe-eval"));
-        assertThat(evalAlert.getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(evalAlert.getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(evalAlert.getEvidence(), equalTo(policy));
-    }
-
-    @Test
-    void shouldAlertOnUnsafeEvalWhenIntersectionReliesOnDefaultSrcFallback() {
-        // Given — one policy names script-src, the other only default-src; intersection
-        // still allows eval (PolicyList.allowsEval() == true).
-        String first = "script-src 'unsafe-eval'; form-action 'none'; frame-ancestors 'none'";
-        String second = "default-src 'unsafe-eval'; form-action 'none'; frame-ancestors 'none'";
-        HttpMessage msg = createHttpMessage(first);
-        msg.getResponseHeader().addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, second);
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        Alert evalAlert = findAlert("10055-10");
-        assertThat(evalAlert.getName(), equalTo("CSP: script-src unsafe-eval"));
-        assertThat(evalAlert.getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(evalAlert.getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(evalAlert.getEvidence(), equalTo(first));
-    }
-
-    @Test
-    void shouldAlertOnUnsafeHashesWhenAllowedOnlyViaDefaultSrcFallback() {
-        // Given — same fallback issue for 'unsafe-hashes' / 10055-7
-        String policy =
-                "default-src 'unsafe-hashes' 'sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY='; "
-                        + "form-action 'none'; frame-ancestors 'none'";
-        HttpMessage msg = createHttpMessage(policy);
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        Alert hashesAlert = findAlert("10055-7");
-        assertThat(hashesAlert.getName(), equalTo("CSP: script-src unsafe-hashes"));
-        assertThat(hashesAlert.getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(hashesAlert.getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(hashesAlert.getEvidence(), equalTo(policy));
-    }
-
-    @Test
-    void shouldNotAlertOnUnsafeHashesWhenPoliciesHaveDisjointHashSets() {
-        // Given — both policies contain 'unsafe-hashes' but list different hashes.
-        // No concrete handler is allowed by every policy, so the intersection does not
-        // effectively allow unsafe-hashes.
-        String hashA = "sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=";
-        String hashB = "sha256-xyz4zkCjuC3lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ=";
-        HttpMessage msg = createHttpMessage(hashPolicy("script-src", hashA));
-        msg.getResponseHeader()
-                .addHeader(
-                        HttpFieldsNames.CONTENT_SECURITY_POLICY, hashPolicy("script-src", hashB));
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(
-                alertsRaised.stream().filter(a -> "10055-7".equals(a.getAlertRef())).count(),
-                equalTo(0L));
-    }
-
-    @Test
-    void shouldNotAlertOnStyleUnsafeHashesWhenPoliciesHaveDisjointHashSets() {
-        // Given — same disjoint-hash-set scenario for style-src / 10055-8
-        String hashA = "sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=";
-        String hashB = "sha256-xyz4zkCjuC3lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ=";
-        HttpMessage msg = createHttpMessage(hashPolicy("style-src", hashA));
-        msg.getResponseHeader()
-                .addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, hashPolicy("style-src", hashB));
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(
-                alertsRaised.stream().filter(a -> "10055-8".equals(a.getAlertRef())).count(),
-                equalTo(0L));
-    }
-
-    @Test
-    void shouldAlertOnUnsafeHashesWhenIntersectingHashSetsAllowThem() {
-        // Given — shared hash + keyword in every policy → intersection still permits
-        // unsafe-hashes for that hash; 10055-7 is appropriate.
-        String sharedHash = "sha256-jzgBGA4UWFFmpOBq0JpdsySukE1FrEN5bUpoK8Z29fY=";
-        String extraHash = "sha256-xyz4zkCjuC3lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ=";
-        String first = hashPolicy("script-src", sharedHash);
-        String second = hashPolicy("script-src", sharedHash, extraHash);
-        HttpMessage msg = createHttpMessage(first);
-        msg.getResponseHeader().addHeader(HttpFieldsNames.CONTENT_SECURITY_POLICY, second);
-        // When
-        scanHttpResponseReceive(msg);
-        // Then
-        Alert hashesAlert = findAlert("10055-7");
-        assertThat(hashesAlert.getName(), equalTo("CSP: script-src unsafe-hashes"));
-        assertThat(hashesAlert.getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(hashesAlert.getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
-        assertThat(hashesAlert.getEvidence(), equalTo(first));
-    }
-
     private Alert findAlert(String alertRef) {
         return alertsRaised.stream()
                 .filter(a -> alertRef.equals(a.getAlertRef()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Expected " + alertRef + " alert"));
-    }
-
-    private static String hashPolicy(String directive, String... hashes) {
-        StringBuilder sb =
-                new StringBuilder("default-src 'self'; ")
-                        .append(directive)
-                        .append(" 'unsafe-hashes'");
-        for (String hash : hashes) {
-            sb.append(" '").append(hash).append('\'');
-        }
-        return sb.append("; form-action 'none'; frame-ancestors 'none'").toString();
     }
 
     private static HttpMessage createHttpMessageWithReasonableCsp(String cspHeaderName) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,7 @@ openapi-swagger-compatSpecParser = "io.swagger:swagger-compat-spec-parser:1.0.76
 openapi-swagger-parser = "io.swagger.parser.v3:swagger-parser:2.1.45"
 pscanrules-antlr = { module = "org.antlr:antlr4", version.ref = "antlr" }
 pscanrules-antlr-runtime = { module = "org.antlr:antlr4-runtime", version.ref = "antlr" }
-pscanrules-htmlunit-csp = "org.htmlunit:htmlunit-csp:5.3.0"
+pscanrules-htmlunit-csp = "org.htmlunit:htmlunit-csp:5.4.0"
 pscanrules-re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }
 pscanrulesAlpha-re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }
 reports-flyingSaucerPdf = "org.xhtmlrenderer:flying-saucer-pdf:9.13.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,7 @@ openapi-swagger-compatSpecParser = "io.swagger:swagger-compat-spec-parser:1.0.76
 openapi-swagger-parser = "io.swagger.parser.v3:swagger-parser:2.1.48"
 pscanrules-antlr = { module = "org.antlr:antlr4", version.ref = "antlr" }
 pscanrules-antlr-runtime = { module = "org.antlr:antlr4-runtime", version.ref = "antlr" }
-pscanrules-htmlunit-csp = "org.htmlunit:htmlunit-csp:5.3.0"
+pscanrules-htmlunit-csp = "org.htmlunit:htmlunit-csp:5.4.0"
 pscanrules-re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }
 pscanrulesAlpha-re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }
 reports-flyingSaucerPdf = "org.xhtmlrenderer:flying-saucer-pdf:9.13.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,7 @@ openapi-swagger-compatSpecParser = "io.swagger:swagger-compat-spec-parser:1.0.76
 openapi-swagger-parser = "io.swagger.parser.v3:swagger-parser:2.1.48"
 pscanrules-antlr = { module = "org.antlr:antlr4", version.ref = "antlr" }
 pscanrules-antlr-runtime = { module = "org.antlr:antlr4-runtime", version.ref = "antlr" }
-pscanrules-htmlunit-csp = "org.htmlunit:htmlunit-csp:5.4.0"
+pscanrules-htmlunit-csp = "org.htmlunit:htmlunit-csp:5.5.0"
 pscanrules-re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }
 pscanrulesAlpha-re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }
 reports-flyingSaucerPdf = "org.xhtmlrenderer:flying-saucer-pdf:9.13.3"

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ScanRuleTests.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ScanRuleTests.java
@@ -66,6 +66,16 @@ interface ScanRuleTests extends UrlTests {
                         .anyMatch(str -> str.equals(name)));
     }
 
+    /**
+     * Returns the (1-based) alert ref indices to skip when checking example alerts are contiguous,
+     * e.g. for a retired alert ref that leaves a gap in the numbering.
+     *
+     * @return the indices to skip, or empty for no skips
+     */
+    default Set<Integer> getSkippedAlertRefs() {
+        return Set.of();
+    }
+
     default void shouldHaveExpectedAlertRefsInExampleAlerts() {
         // Given / When
         List<Alert> alerts = getExampleAlerts(getScanRule());
@@ -74,10 +84,14 @@ interface ScanRuleTests extends UrlTests {
             return;
         }
 
+        Set<Integer> skipped = getSkippedAlertRefs();
         List<String> errors = new ArrayList<>();
         int i = 0;
         for (Alert alert : alerts) {
             ++i;
+            while (skipped.contains(i)) {
+                ++i;
+            }
             String alertRef = alert.getPluginId() + "-" + i;
             if (!alertRef.equals(alert.getAlertRef())) {
                 errors.add(


### PR DESCRIPTION
## Overview

- Content Security Policy scan rule analyzes all active CSP headers and META policies together using browser-style intersection (Issue 9403).
- CSP "Header & Meta" alert (10055-12) is no longer raised.

## Related Issues

- zaproxy/zaproxy#9403
