### PR TITLE
authhelper: tag diag messages with ID

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Tag diagnostic HTTP messages with an internal ID, to make it easier to cross reference them.
 
 ## [0.41.0] - 2026-08-07
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ui/diags/AllDiagnosticsPanel.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/internal/ui/diags/AllDiagnosticsPanel.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import javax.jdo.PersistenceManager;
 import javax.jdo.PersistenceManagerFactory;
@@ -373,6 +374,7 @@ public class AllDiagnosticsPanel extends AbstractPanel {
                 return;
             }
 
+            AtomicInteger messageCount = new AtomicInteger();
             for (Map<String, Object> diagnosticData : diagnostics) {
                 Diagnostic diagnostic = new Diagnostic();
 
@@ -401,7 +403,9 @@ public class AllDiagnosticsPanel extends AbstractPanel {
                             readWebElement((Map<String, Object>) stepData.get("webElement")));
                     readScreenshot(diagnosticStep, (String) stepData.get("screenshot"));
                     readMessages(
-                            diagnosticStep, (List<Map<String, Object>>) stepData.get("messages"));
+                            messageCount,
+                            diagnosticStep,
+                            (List<Map<String, Object>>) stepData.get("messages"));
                     readWebElements(
                             diagnosticStep,
                             (List<Map<String, Object>>) stepData.get("webElements"));
@@ -533,7 +537,9 @@ public class AllDiagnosticsPanel extends AbstractPanel {
     }
 
     private void readMessages(
-            DiagnosticStep diagnosticStep, List<Map<String, Object>> messagesData) {
+            AtomicInteger messageCount,
+            DiagnosticStep diagnosticStep,
+            List<Map<String, Object>> messagesData) {
         if (messagesData == null) {
             return;
         }
@@ -568,7 +574,10 @@ public class AllDiagnosticsPanel extends AbstractPanel {
                 ref.setTags(
                         List.of(
                                 Constant.messages.getString(
-                                        "authhelper.authdiags.message.tag.initiator", initiator)));
+                                        "authhelper.authdiags.message.tag.initiator", initiator),
+                                Constant.messages.getString(
+                                        "authhelper.authdiags.message.tag.id",
+                                        messageCount.incrementAndGet())));
 
                 if (extensionHistory != null) {
                     EventQueue.invokeLater(

--- a/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
+++ b/addOns/authhelper/src/main/resources/org/zaproxy/addon/authhelper/resources/Messages.properties
@@ -143,6 +143,7 @@ authhelper.authdiags.manager.import.error.clipboard = Failed to process the clip
 authhelper.authdiags.manager.import.error.parse = Failed to parse the Authentication Report.
 authhelper.authdiags.manager.import.error.title = Error Importing Authentication Report
 authhelper.authdiags.manager.import.nodiagnostics = The Authentication Report does not contain any diagnostics.
+authhelper.authdiags.message.tag.id = ID: {0}
 
 authhelper.authdiags.message.tag.initiator = Initiator: {0}
 authhelper.authdiags.panel.all.title = Diagnostics


### PR DESCRIPTION
Tag diagnostic HTTP messages with an internal ID, to make it easier to cross reference them.