### PR TITLE
scripts: show script output/errors asynchronously

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Move script types from core (Issue 8027).
 
+### Changed
+- Show script output/errors asynchronously in the GUI to not block the running script.
+
 ## [45.20.0] - 2026-07-13
 ### Added
 - GUI support for Zest script chains and failure level in the Automation Framework Script job dialog (via the Use Script Chain checkbox, and Chains tab).

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -797,15 +797,13 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     @Override
     public void scriptError(ScriptWrapper script) {
         if (hasView()) {
-            if (script.getLastException() != null) {
-                getView()
-                        .getOutputPanel()
-                        .append(
-                                extractScriptExceptionMessage(script.getLastException()),
-                                script.getName());
-            } else {
-                getView().getOutputPanel().append(script.getLastErrorDetails(), script.getName());
-            }
+            getView()
+                    .getOutputPanel()
+                    .appendAsync(
+                            script.getLastException() != null
+                                    ? extractScriptExceptionMessage(script.getLastException())
+                                    : script.getLastErrorDetails(),
+                            script.getName());
         }
     }
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanelWriter.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanelWriter.java
@@ -51,7 +51,7 @@ public class OutputPanelWriter extends Writer {
 
     @Override
     public void flush() {
-        outputPanel.append(buffer.toString(), sourceName);
+        outputPanel.appendAsync(buffer.toString(), sourceName);
         buffer.setLength(0);
     }
 


### PR DESCRIPTION
Do not block the running thread just to show the script output/errors in the GUI.