### PR TITLE
authhelper: handle interrupts in auth diags

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Tag diagnostic HTTP messages with an internal ID, to make it easier to cross reference them.
+- Obtain the minimal authentication diagnostics when aborting the authentication.
 
 ## [0.41.0] - 2026-08-07
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -199,6 +199,7 @@ return getSelector(arguments[0], document)
     private HttpSenderListener listener;
     private DiagnosticStep currentStep;
     private ScriptKey elementSelectorScriptKey;
+    private boolean interrupted;
 
     public AuthenticationDiagnostics(
             boolean enabled, String authenticationMethod, String context, String user) {
@@ -357,19 +358,41 @@ return getSelector(arguments[0], document)
         try {
             Thread.sleep(150);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            interrupted = true;
         }
 
         currentStep.setCreateTimestamp(Instant.now());
-        currentStep.setUrl(wd.getCurrentUrl());
+        currentStep.setUrl(withInterruptHandled(wd::getCurrentUrl));
         currentStep.setDescription(description);
 
         if (wd instanceof TakesScreenshot ts) {
             DiagnosticScreenshot screenshot = new DiagnosticScreenshot();
-            screenshot.setData(ts.getScreenshotAs(OutputType.BASE64));
+            screenshot.setData(withInterruptHandled(() -> ts.getScreenshotAs(OutputType.BASE64)));
             screenshot.setCreateTimestamp(Instant.now());
             screenshot.setStep(currentStep);
             currentStep.setScreenshot(screenshot);
+        }
+
+        try {
+            recordElements(wd, element);
+            recordStorage(wd);
+        } catch (WebDriverException e) {
+            if (!(e.getCause() instanceof InterruptedException)) {
+                throw e;
+            }
+            interrupted = true;
+        }
+
+        createStep();
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void recordElements(WebDriver wd, WebElement element) {
+        if (interrupted) {
+            return;
         }
 
         List<WebElement> foundElements =
@@ -384,14 +407,35 @@ return getSelector(arguments[0], document)
                 currentStep.getWebElements().add(field);
             }
         }
+    }
+
+    private void recordStorage(WebDriver wd) {
+        if (interrupted) {
+            return;
+        }
 
         if (wd instanceof JavascriptExecutor je) {
             for (var type : DiagnosticBrowserStorageItem.Type.values()) {
                 processStorage(je, type);
             }
         }
+    }
 
-        createStep();
+    private <T> T withInterruptHandled(Supplier<T> function) {
+        interrupted |= Thread.interrupted();
+
+        try {
+            return function.get();
+        } catch (WebDriverException e) {
+            if (!(e.getCause() instanceof InterruptedException)) {
+                throw e;
+            }
+
+            // Retry again with interruption cleared.
+            interrupted |= Thread.interrupted();
+
+            return function.get();
+        }
     }
 
     /**
@@ -550,6 +594,8 @@ return getSelector(arguments[0], document)
                     }
                 });
 
+        interrupted |= Thread.interrupted();
+
         PersistenceManager pm = TableJdo.getPmf().getPersistenceManager();
         Transaction tx = pm.currentTransaction();
         try {
@@ -563,6 +609,11 @@ return getSelector(arguments[0], document)
                 tx.rollback();
             }
             pm.close();
+
+            // JDO/DataNucleus does not restore the interruption.
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 


### PR DESCRIPTION
Get the URL and a screenshot even when interrupted to provide the minimum.
Skip collection of elements and storage when interrupted.