### PR TITLE
graphql: Report schema import request failures

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 
+### Fixed
+
+- Report failures that occur while sending requests during schema imports (Issue 9407).
 
 ## [0.34.0] - 2026-08-12
 ### Added

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlFingerprinter.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlFingerprinter.java
@@ -114,6 +114,9 @@ public class GraphQlFingerprinter {
             } catch (Exception e) {
                 LOGGER.warn("Failed to fingerprint GraphQL engine: {}", fingerprinter.getKey(), e);
             }
+            if (requestor.hasRequestFailed()) {
+                break;
+            }
         }
         queryCache.clear();
     }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -172,7 +172,7 @@ public class GraphQlParser {
         }
     }
 
-    public void parse(String sdl) {
+    public void parse(String sdl) throws IOException {
         GraphQLSchema schema =
                 UnExecutableSchemaGenerator.makeUnExecutableSchema(new SchemaParser().parse(sdl));
         var generator =
@@ -185,11 +185,13 @@ public class GraphQlParser {
         if (syncParse) {
             if (maxMessages <= 0) {
                 fingerprint();
+                requestor.throwIfRequestFailed();
             }
             detectCycles(schema, generator);
             if (param.getQueryGenEnabled()) {
                 generate(generator);
             }
+            requestor.throwIfRequestFailed();
             return;
         }
         ParserThread t =

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ImportDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ImportDialog.java
@@ -194,7 +194,7 @@ public class ImportDialog extends AbstractDialog {
         try {
             parser =
                     new GraphQlParser(
-                            fieldEndpoint.getText(), HttpSender.MANUAL_REQUEST_INITIATOR, false);
+                            fieldEndpoint.getText(), HttpSender.MANUAL_REQUEST_INITIATOR, true);
             parser.setMaxMessages(getMaxMessagesField().getValue());
             parser.addRequesterListener(new HistoryPersister());
             return true;

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/Requestor.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/Requestor.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.graphql;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,6 +38,7 @@ public class Requestor {
     private List<RequesterListener> listeners = new ArrayList<>();
     private HttpSender sender;
     private final HttpRequestConfig requestConfig;
+    private final AtomicReference<IOException> requestFailure = new AtomicReference<>();
     private static final Logger LOGGER = LogManager.getLogger(Requestor.class);
 
     public Requestor(GraphQlQueryMessageBuilder queryMsgBuilder, int initiator) {
@@ -53,14 +55,29 @@ public class Requestor {
 
     public HttpMessage sendQuery(
             String query, String variables, GraphQlParam.RequestMethodOption method) {
+        if (requestFailure.get() != null) {
+            return null;
+        }
         try {
             HttpMessage message = queryMsgBuilder.buildQueryMessage(query, variables, method);
             send(message);
             return message;
         } catch (IOException e) {
+            requestFailure.compareAndSet(null, e);
             LOGGER.warn(e.getMessage(), e);
         }
         return null;
+    }
+
+    void throwIfRequestFailed() throws IOException {
+        IOException failure = requestFailure.get();
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    boolean hasRequestFailed() {
+        return requestFailure.get() != null;
     }
 
     public void send(HttpMessage message) throws IOException {

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
@@ -432,6 +432,58 @@ class GraphQlJobUnitTest extends TestUtils {
         assertThat(progress.getErrors().get(0), is(equalTo("!graphql.automation.error!")));
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void shouldFailIfEndpointCannotBeReached(int maxMessages, @TempDir Path dir)
+            throws IOException {
+        // Given
+        when(extGraphQl.getParam()).thenReturn(defaultGraphQlParam());
+        String endpoint = serverWithGraphQl();
+        stopServer();
+        Path schemaFile = dir.resolve("schema.graphql");
+        Files.writeString(schemaFile, "type Query { name: String }", StandardCharsets.UTF_8);
+        GraphQlJob job =
+                createGraphQlJob(
+                        "parameters:\n"
+                                + "  endpoint: "
+                                + endpoint
+                                + "\n"
+                                + "  schemaFile: "
+                                + schemaFile
+                                + "\n"
+                                + "  maxMessages: "
+                                + maxMessages);
+        AutomationPlan plan = new AutomationPlan();
+        AutomationProgress progress = plan.getProgress();
+        AutomationEnvironment env = plan.getEnv();
+        job.setPlan(plan);
+        env.setPlan(plan);
+        job.verifyParameters(progress);
+
+        // When
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!graphql.automation.error!")));
+    }
+
+    private static GraphQlParam defaultGraphQlParam() {
+        return new GraphQlParam(
+                GraphQlParam.DEFAULT_QUERY_GEN_ENABLED,
+                GraphQlParam.DEFAULT_MAX_QUERY_DEPTH,
+                GraphQlParam.DEFAULT_LENIENT_MAX_QUERY_DEPTH,
+                GraphQlParam.DEFAULT_MAX_ADDITIONAL_QUERY_DEPTH,
+                GraphQlParam.DEFAULT_MAX_ARGS_DEPTH,
+                GraphQlParam.DEFAULT_OPTIONAL_ARGS,
+                GraphQlParam.DEFAULT_ARGS_TYPE,
+                GraphQlParam.DEFAULT_QUERY_SPLIT_TYPE,
+                GraphQlParam.DEFAULT_REQUEST_METHOD,
+                GraphQlParam.DEFAULT_CYCLE_DETECTION_MODE,
+                GraphQlParam.DEFAULT_MAX_CYCLE_DETECTION_ALERTS);
+    }
+
     private String serverWithGraphQl() throws IOException {
         startServer();
         nano.addHandler(graphQlServer);


### PR DESCRIPTION
## Summary

- preserve and propagate the first I/O failure encountered while importing a GraphQL schema
- stop fingerprinting after a request failure so the import does not emit misleading follow-on warnings
- run GUI parsing synchronously inside the dialog's existing worker thread so failures reach the warning dialog
- cover imports both with and without generated operation requests

This fixes the silent failure path in automation, API/CLI, and GUI imports. The GUI remains responsive because `ImportDialog` already performs the import on its dedicated `ZAP-GraphQL-UI-Import` worker.

Fixes zaproxy/zaproxy#9407.

## Validation

```console
JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew --no-daemon --no-build-cache --rerun-tasks :addOns:graphql:spotlessCheck :addOns:graphql:build :addOns:graphql:jacocoTestCoverageVerification
```

- BUILD SUCCESSFUL; 118 tasks executed
- 197 tests, 0 failures, 0 errors, 0 skipped
- packaged `graphql-alpha-0.35.0.zap`
- Automation Framework smoke test with a fresh ZAP home and an unreachable endpoint: the GraphQL job reported the connection refusal and the plan exited with the expected failure status
- GUI smoke test with a fresh ZAP home: the import warning displayed the connection refusal, preserved the entered schema/endpoint, and left the Import action enabled for retry
- runtime log contained one request warning and no follow-on fingerprint warnings
