### PR TITLE
oast: Decrypt Interactsh interactions with AES-CTR instead of AES-CFB

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -10,6 +10,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Maintenance changes.
 - Formatted JavaScript files for consistency.
 
+### Fixed
+- Decrypt Interactsh interactions using AES-CTR, to support Interactsh server 1.3.0 and later (which changed the cipher from AES-CFB). Older servers are no longer supported.
+
 ## [0.24.0] - 2025-12-15
 ### Changed
 - Update minimum ZAP version to 2.17.0.

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
@@ -451,7 +451,7 @@ public class InteractshService extends OastService implements OptionsChangedList
             byte[] decodedDecryptedKey = decryptionCipher.doFinal(decodedEncryptedKey);
 
             byte[] decodedEncryptedMsg = Base64.getDecoder().decode(encodedEncryptedMsg);
-            decryptionCipher = Cipher.getInstance("AES/CFB/NoPadding");
+            decryptionCipher = Cipher.getInstance("AES/CTR/NoPadding");
             SecretKey aesKey = new SecretKeySpec(decodedDecryptedKey, "AES");
             IvParameterSpec iv =
                     new IvParameterSpec(

--- a/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/services/interactsh/interactsh.html
+++ b/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/services/interactsh/interactsh.html
@@ -9,6 +9,10 @@
 <p>
     Interactsh is an open-source solution for out-of-band data extraction.
 </p>
+<p>
+    This add-on requires an Interactsh server running version 1.3.0 or later, which
+    encrypts interactions using AES-CTR; earlier servers (AES-CFB) are not supported.
+</p>
 
 <h3>Features</h3>
 <ul>

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/interactsh/InteractshServiceUnitTests.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/interactsh/InteractshServiceUnitTests.java
@@ -186,12 +186,12 @@ class InteractshServiceUnitTests extends TestUtils {
 
         // Generate AES key and encrypt event with it
         KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
-        keyGenerator.init(128);
+        keyGenerator.init(256);
         SecretKey key = keyGenerator.generateKey();
         byte[] ivBytes = new byte[16];
         new SecureRandom().nextBytes(ivBytes);
         IvParameterSpec iv = new IvParameterSpec(ivBytes);
-        Cipher eventEncryptor = Cipher.getInstance("AES/CFB/NoPadding");
+        Cipher eventEncryptor = Cipher.getInstance("AES/CTR/NoPadding");
         eventEncryptor.init(Cipher.ENCRYPT_MODE, key, iv);
         byte[] encryptedEvent = eventEncryptor.doFinal(event.getBytes());
 


### PR DESCRIPTION
## Overview

Interactsh server `v1.3.0` changed the interaction cypher from AES-CFB to AES-CTR, so the OAST add-on could no longer decrypt interactions from current servers: the decrypted output was garbled, the client could not parse the interaction, and out-of-band findings are silently missed. 
The change shipped without a release note and was diagnosed upstream in [projectdiscovery/interactsh#1333](https://github.com/projectdiscovery/interactsh/issues/1333).

Switch the AES cipher mode to CTR to match the current server. The wire format is unchanged (a 16-byte IV prepended to the ciphertext), so this is a mode-only change. Interactsh servers older than 1.3.0 use AES-CFB and are no longer supported.

## Related Issues

- Interactsh's PR that changes from AES-CFB to AES-CTR: https://github.com/projectdiscovery/interactsh/pull/1192
- [Full list of Interactsh's v1.3.0 commits that included 1192](https://github.com/projectdiscovery/interactsh/compare/v1.2.4...v1.3.0): 
<img width="1735" height="455" alt="Screenshot 2026-08-18 at 7 42 48 am" src="https://github.com/user-attachments/assets/a3e95e80-5846-4daf-8265-d54c8a3458db" />
