### PR TITLE
exim: Tweak AF support HTML title

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.22.0] - 2026-08-12
 ### Added

--- a/addOns/exim/src/main/javahelp/help/contents/automation.html
+++ b/addOns/exim/src/main/javahelp/help/contents/automation.html
@@ -3,7 +3,7 @@
 <HEAD>
     <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
     <TITLE>
-        Automation Framework Support
+        Import/Export Automation Framework Support
     </TITLE>
 </HEAD>
 <BODY>


### PR DESCRIPTION
Update the title of exim's af help page, so that it's easier to find on the website.

Had to scroll down and find it:
<img width="344" height="78" alt="image" src="https://github.com/user-attachments/assets/05a17899-3d16-4ade-a7f1-04c463e62701" />

Doesn't show in filter:
<img width="336" height="328" alt="image" src="https://github.com/user-attachments/assets/4867925c-6ec8-413d-a995-2aa0f3b47f63" />

Others do:
<img width="337" height="214" alt="image" src="https://github.com/user-attachments/assets/78732390-3ab8-4be7-8eef-e95f488f47eb" />

<img width="318" height="216" alt="image" src="https://github.com/user-attachments/assets/1dd88dac-b2d1-4674-a3d2-1f3dc6d32385" />

