### PR TITLE
authhelper: do not wait for screenshot element

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Obtain the minimal authentication diagnostics when aborting the authentication.
 - Authentication report: include summary with connection success and failure counts.
 
+### Fixed
+- Do not wait when getting the element for a screenshot diagnostic step to not add unnecessary delays.
+
 ## [0.41.0] - 2026-08-07
 ### Added
 - Automation Framework `diagnostics` job to start and stop plan-level recording of authentication related diagnostics.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -653,10 +653,14 @@ return getSelector(arguments[0], document)
             return resetWait(
                     wd,
                     () -> {
+                        int waitForMsec = element.getWaitForMsec();
                         try {
+                            element.setWaitForMsec(0);
                             return element.getWebElement(runtime);
                         } catch (ZestClientFailException e) {
                             return null;
+                        } finally {
+                            element.setWaitForMsec(waitForMsec);
                         }
                     },
                     () -> null);


### PR DESCRIPTION
Set the wait to zero when getting the element for the screenshot step, the element might no longer be present which would add unnecessary delay.