### PR TITLE
Include common headers in verification requests

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - A toolbar button to the Authentication Diagnostics screenshots tab, to toggle screenshots between full size and scaled to fit the window.
 
 ### Changed
+- Depend on newer Common Library add-on.
 - Tag diagnostic HTTP messages with an internal ID, to make it easier to cross reference them.
 - Obtain the minimal authentication diagnostics when aborting the authentication.
 - Authentication report: include summary with connection success and failure counts.
+- Include Accept, Accept-Language, Connection, and User-Agent headers when doing authentication verification.
 
 ### Fixed
 - Do not wait when getting the element for a screenshot diagnostic step to not add unnecessary delays.

--- a/addOns/authhelper/authhelper.gradle.kts
+++ b/addOns/authhelper/authhelper.gradle.kts
@@ -69,7 +69,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.35.0 & < 2.0.0")
+                    version.set(">= 1.44.0 & < 2.0.0")
                 }
                 register("database") {
                     version.set(">=0.8.0 & < 1.0.0")

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationDetectionProcessor.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/VerificationDetectionProcessor.java
@@ -20,10 +20,10 @@
 package org.zaproxy.addon.authhelper;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpSender;
@@ -39,6 +39,17 @@ public class VerificationDetectionProcessor implements Runnable {
     private static final VerificationComparator COMPARATOR =
             VerificationRequestDetails.getComparator();
     private static final Logger LOGGER = LogManager.getLogger(VerificationDetectionProcessor.class);
+
+    private static final List<String> DEFAULT_VERIFICATION_HEADERS =
+            // These are ordered based on likely browser order, not alphabetically.
+            List.of(
+                    HttpFieldsNames.USER_AGENT,
+                    HttpFieldsNames.ACCEPT,
+                    HttpFieldsNames.ACCEPT_LANGUAGE,
+                    HttpFieldsNames.CONTENT_TYPE,
+                    HttpFieldsNames.REFERER,
+                    HttpFieldsNames.ORIGIN,
+                    HttpFieldsNames.CONNECTION);
 
     private final Context context;
     private final VerificationDetectionScanRule rule;
@@ -143,9 +154,8 @@ public class VerificationDetectionProcessor implements Runnable {
         authMethod.setPollData(details.getMsg().getRequestBody().toString());
 
         StringBuilder sb = new StringBuilder();
-        appendHeader(sb, details.getMsg().getRequestHeader(), HttpHeader.CONTENT_TYPE);
-        appendHeader(sb, details.getMsg().getRequestHeader(), HttpHeader.REFERER);
-        appendHeader(sb, details.getMsg().getRequestHeader(), HttpFieldsNames.ORIGIN);
+        DEFAULT_VERIFICATION_HEADERS.forEach(
+                e -> appendHeader(sb, details.getMsg().getRequestHeader(), e));
         if (!sb.isEmpty()) {
             authMethod.setPollHeaders(sb.toString());
         }
@@ -176,18 +186,8 @@ public class VerificationDetectionProcessor implements Runnable {
                                     origReqHeader.getMethod(),
                                     origReqHeader.getURI(),
                                     origReqHeader.getVersion()));
-            msg.getRequestHeader()
-                    .setHeader(
-                            HttpRequestHeader.CONTENT_TYPE,
-                            origReqHeader.getHeader(HttpRequestHeader.CONTENT_TYPE));
-            msg.getRequestHeader()
-                    .setHeader(
-                            HttpRequestHeader.REFERER,
-                            origReqHeader.getHeader(HttpRequestHeader.REFERER));
-            msg.getRequestHeader()
-                    .setHeader(
-                            HttpFieldsNames.ORIGIN,
-                            origReqHeader.getHeader(HttpFieldsNames.ORIGIN));
+            DEFAULT_VERIFICATION_HEADERS.forEach(
+                    e -> msg.getRequestHeader().setHeader(e, origReqHeader.getHeader(e)));
 
             msg.getRequestBody().setBody(vrd.getMsg().getRequestBody().getBytes());
             msg.getRequestHeader().setContentLength(msg.getRequestBody().length());

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/VerificationDetectionProcessorUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/VerificationDetectionProcessorUnitTest.java
@@ -153,6 +153,10 @@ class VerificationDetectionProcessorUnitTest extends TestUtils {
 
     @ParameterizedTest
     @CsvSource({
+        "user-agent, my agent",
+        "accept, application/json",
+        "accept-language, en",
+        "connection, keep-alive",
         "content-type, application/json",
         "referer, https://example.com",
         "origin, https://example.com"

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add standard header for other add-ons to use.
+
 ### Changed
 - Update alert tag URLs to avoid redirects.
 

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/HttpFieldsNames.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/HttpFieldsNames.java
@@ -27,6 +27,12 @@ package org.zaproxy.addon.commonlib.http;
 public final class HttpFieldsNames {
 
     public static final String ACCEPT = "accept";
+
+    /**
+     * @since 1.44.0
+     */
+    public static final String ACCEPT_LANGUAGE = "accept-language";
+
     public static final String ACCEPT_ENCODING = "accept-encoding";
     public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS =
             "access-control-allow-credentials";


### PR DESCRIPTION
Change authhelper to include the user-agent, accept, accept-language, and connection headers when checking the verification since some targets might need them.
Add accept-language to commonlib.