### PR TITLE
authhelper: skip disabled Zest stmts in diags

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Obtain the minimal authentication diagnostics when aborting the authentication.
 - Authentication report: include summary with connection success and failure counts.
 - Include Accept, Accept-Language, Connection, and User-Agent headers when doing authentication verification.
+- Ignore commented Zest statements when collecting authentication diagnostics.
 
 ### Fixed
 - Do not wait when getting the element for a screenshot diagnostic step to not add unnecessary delays.

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthenticationDiagnostics.java
@@ -305,7 +305,7 @@ return getSelector(arguments[0], document)
 
         for (int i = 0; i < zestScript.getStatements().size(); i++) {
             ZestStatement stmt = zestScript.getStatements().get(i);
-            if (stmt instanceof ZestClientElementClear) {
+            if (stmt instanceof ZestClientElementClear || !stmt.isEnabled()) {
                 continue;
             }
 


### PR DESCRIPTION
Those disabled statements will just add noise steps since they don't do anything.