### PR TITLE
mcp: Allow security key to be copied

### DIFF
--- a/addOns/mcp/CHANGELOG.md
+++ b/addOns/mcp/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Allow MCP security key to be copied (Issue #9432)
 
 ## [0.3.0] - 2026-08-07
 

--- a/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/McpOptionsPanel.java
+++ b/addOns/mcp/src/main/java/org/zaproxy/addon/mcp/McpOptionsPanel.java
@@ -160,6 +160,7 @@ public class McpOptionsPanel extends AbstractParamPanel {
     private JPasswordField getSecurityKeyField() {
         if (securityKeyField == null) {
             securityKeyField = new JPasswordField(32);
+            securityKeyField.putClientProperty("JPasswordField.cutCopyAllowed", true);
         }
         return securityKeyField;
     }


### PR DESCRIPTION
Fixes https://github.com/zaproxy/zaproxy/issues/9432
