### PR TITLE
spiderAjax: clarify AF job parameter behaviour

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Include cause of invalid URL in error message of Ajax Spider job.
+- Clarify Automation Framework job behaviour when `clickDefaultElems` is false and no `elements` provided.
 
 ## [23.32.0] - 2026-07-06
 ### Changed

--- a/addOns/spiderAjax/src/main/javahelp/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/automation.html
+++ b/addOns/spiderAjax/src/main/javahelp/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/automation.html
@@ -38,7 +38,7 @@ This job supports monitor tests.
       reloadWait:                      # Int: The time in milliseconds to wait after the URL is loaded, default: 1000
       scopeCheck:                      # String: The scope check, either Flexible or Strict, default: Strict
       logoutAvoidance:                 # Bool: When enabled, the spider will avoid clicking common logout elements, default: false
-      elements:                        # A list of HTML elements to click - will be ignored unless clickDefaultElems is false
+      elements:                        # A list of HTML elements to click; ignored unless clickDefaultElems is false, if not provided the default elements 'a', 'input', and 'button' will be used
       - "a"
       - "button"
       - "input"

--- a/addOns/spiderAjax/src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/spiderAjax-max.yaml
+++ b/addOns/spiderAjax/src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/spiderAjax-max.yaml
@@ -16,7 +16,7 @@
       maxCrawlStates:                  # Int: The maximum number of crawl states the crawler should crawl, default: 0 unlimited
       randomInputs:                    # Bool: When enabled random values will be entered into input element, default: true
       reloadWait:                      # Int: The time in milliseconds to wait after the URL is loaded, default: 1000
-      elements:                        # A list of HTML elements to click - will be ignored unless clickDefaultElems is false
+      elements:                        # A list of HTML elements to click; ignored unless clickDefaultElems is false, if not provided the default elements 'a', 'input', and 'button' will be used
       excludedElements:                # A list of HTML elements to exclude from click.
       scopeCheck:                      # String: How the scope is checked, either 'Strict' or 'Flexible', default: 'Strict'
       logoutAvoidance:                 # Bool: When enabled, the spider will avoid clicking common logout elements, default: false


### PR DESCRIPTION
Mention the usage of default elements when none provided.