### PR TITLE
quickstart: Default to firefox headless for modern spider

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Default modern spider browser to Firefox headless.
 
+### Fixed
+- Persist the default browsers by ID instead of by (translatable) name, so the setting is restored correctly when ZAP is not running in English.
 
 ## [59] - 2026-07-13
 ### Added

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/BrowserSelector.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/BrowserSelector.java
@@ -28,7 +28,5 @@ public interface BrowserSelector {
 
     String getSelectedBrowserId();
 
-    String getSelectedBrowserName();
-
-    void restoreSelection(String savedBrowserName);
+    void restoreSelection(String savedBrowserId);
 }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ModernSpiderPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ModernSpiderPanel.java
@@ -155,7 +155,7 @@ public class ModernSpiderPanel implements PlugableSpider {
         QuickStartParam qsParam = extension.getQuickStartParam();
         qsParam.setAjaxSpiderSelection(((Select) selectComboBox.getSelectedItem()).name());
         if (browserSelector != null) {
-            qsParam.setAjaxSpiderDefaultBrowser(browserSelector.getSelectedBrowserName());
+            qsParam.setAjaxSpiderDefaultBrowser(browserSelector.getSelectedBrowserId());
         }
         ModernSpiderOption selected = (ModernSpiderOption) getTypeComboBox().getSelectedItem();
         if (selected != null) {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartParam.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartParam.java
@@ -27,6 +27,8 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
+import org.zaproxy.zap.extension.selenium.Browser;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 
 public class QuickStartParam extends VersionedAbstractParam {
 
@@ -50,7 +52,10 @@ public class QuickStartParam extends VersionedAbstractParam {
 
     private static final String BLANK_START_PAGE = "BLANK";
 
-    private static final String DEFAULT_BROWSER = "Firefox"; // The default default ;)
+    // The default default ;)
+    private static final String DEFAULT_BROWSER_ID = Browser.FIREFOX.getId();
+
+    private static final String DEFAULT_SPIDER_BROWSER_ID = Browser.FIREFOX_HEADLESS.getId();
 
     private static final String PARAM_AJAX_BASE_KEY = PARAM_BASE_KEY + ".ajax";
 
@@ -78,7 +83,7 @@ public class QuickStartParam extends VersionedAbstractParam {
      * @see #CONFIG_VERSION_KEY
      * @see #updateConfigsImpl(int)
      */
-    private static final int CURRENT_CONFIG_VERSION = 2;
+    private static final int CURRENT_CONFIG_VERSION = 3;
 
     /**
      * The configuration key to read/write the version of the configurations.
@@ -91,7 +96,7 @@ public class QuickStartParam extends VersionedAbstractParam {
     private List<Object> recentUrls = new ArrayList<>(0);
     private int maxRecentUrls;
     private String launchStartPage;
-    private String launchDefaultBrowser = DEFAULT_BROWSER;
+    private String launchDefaultBrowser = DEFAULT_BROWSER_ID;
 
     private String ajaxSpiderSelection;
     private String ajaxSpiderDefaultBrowser;
@@ -122,7 +127,7 @@ public class QuickStartParam extends VersionedAbstractParam {
             LOGGER.error("Failed to load the \"Start Page\" configuration", e);
         }
         try {
-            launchDefaultBrowser = getConfig().getString(PARAM_DEFAULT_BROWSER, DEFAULT_BROWSER);
+            launchDefaultBrowser = getConfig().getString(PARAM_DEFAULT_BROWSER, DEFAULT_BROWSER_ID);
         } catch (Exception e) {
             LOGGER.error("Failed to load the \"Default Browser\" configuration", e);
         }
@@ -137,7 +142,9 @@ public class QuickStartParam extends VersionedAbstractParam {
         }
         try {
             ajaxSpiderDefaultBrowser =
-                    getConfig().getString(PARAM_AJAX_SPIDER_DEFAULT_BROWSER, DEFAULT_BROWSER);
+                    getConfig()
+                            .getString(
+                                    PARAM_AJAX_SPIDER_DEFAULT_BROWSER, DEFAULT_SPIDER_BROWSER_ID);
         } catch (Exception e) {
             LOGGER.error("Failed to load the Ajax \"Default Browser\" configuration", e);
         }
@@ -176,6 +183,7 @@ public class QuickStartParam extends VersionedAbstractParam {
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     protected void updateConfigsImpl(int fileVersion) {
         switch (fileVersion) {
             case -1:
@@ -188,9 +196,32 @@ public class QuickStartParam extends VersionedAbstractParam {
                                 PARAM_MODERN_SPIDER_TYPE,
                                 Constant.messages.getString(
                                         "quickstart.modern.option.clientspider"));
+            // $FALL-THROUGH$
+            case 2:
+                migrateBrowserNameToId(PARAM_DEFAULT_BROWSER);
+                migrateBrowserNameToId(PARAM_AJAX_SPIDER_DEFAULT_BROWSER);
                 break;
             default:
         }
+    }
+
+    private void migrateBrowserNameToId(String configKey) {
+        String value = getConfig().getString(configKey, null);
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        for (Browser browser : Browser.values()) {
+            if (value.equals(browser.getId())) {
+                return;
+            }
+        }
+        for (Browser browser : Browser.values()) {
+            if (value.equals(ExtensionSelenium.getName(browser))) {
+                getConfig().setProperty(configKey, browser.getId());
+                return;
+            }
+        }
+        getConfig().clearProperty(configKey);
     }
 
     public String getLaunchStartPage() {
@@ -226,10 +257,16 @@ public class QuickStartParam extends VersionedAbstractParam {
         getConfig().setProperty(PARAM_START_PAGE, str);
     }
 
+    /**
+     * @return the id of the default browser for Manual Explore.
+     */
     public String getLaunchDefaultBrowser() {
         return launchDefaultBrowser;
     }
 
+    /**
+     * @param defaultBrowser the id of the default browser.
+     */
     public void setLaunchDefaultBrowser(String defaultBrowser) {
         this.launchDefaultBrowser = defaultBrowser;
         getConfig().setProperty(PARAM_DEFAULT_BROWSER, defaultBrowser);
@@ -255,10 +292,16 @@ public class QuickStartParam extends VersionedAbstractParam {
         QuickStartHelper.raiseOptionsChangedEvent();
     }
 
+    /**
+     * @return the id of the default browser for the Ajax/Client Spider.
+     */
     public String getAjaxSpiderDefaultBrowser() {
         return ajaxSpiderDefaultBrowser;
     }
 
+    /**
+     * @param ajaxSpiderDefaultBrowser the id of the default browser.
+     */
     public void setAjaxSpiderDefaultBrowser(String ajaxSpiderDefaultBrowser) {
         this.ajaxSpiderDefaultBrowser = ajaxSpiderDefaultBrowser;
         getConfig().setProperty(PARAM_AJAX_SPIDER_DEFAULT_BROWSER, ajaxSpiderDefaultBrowser);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/SeleniumBrowserSelector.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/SeleniumBrowserSelector.java
@@ -30,16 +30,19 @@ import org.zaproxy.zap.extension.selenium.ProvidedBrowsersComboBoxModel;
 public class SeleniumBrowserSelector implements BrowserSelector {
 
     private final JComboBox<ProvidedBrowserUI> combo;
+    private final ProvidedBrowsersComboBoxModel model;
 
     public SeleniumBrowserSelector() {
         combo = new JComboBox<>();
         ExtensionSelenium extSelenium =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
         if (extSelenium != null) {
-            ProvidedBrowsersComboBoxModel model = extSelenium.createProvidedBrowsersComboBoxModel();
+            model = extSelenium.createProvidedBrowsersComboBoxModel();
             model.setIncludeUnconfigured(false);
             model.setSelectedBrowser(Browser.FIREFOX_HEADLESS.getId());
             combo.setModel(model);
+        } else {
+            model = null;
         }
     }
 
@@ -55,22 +58,10 @@ public class SeleniumBrowserSelector implements BrowserSelector {
     }
 
     @Override
-    public String getSelectedBrowserName() {
-        Object item = combo.getSelectedItem();
-        return item != null ? item.toString() : null;
-    }
-
-    @Override
-    public void restoreSelection(String savedBrowserName) {
-        if (savedBrowserName == null || savedBrowserName.isEmpty()) {
+    public void restoreSelection(String savedBrowserId) {
+        if (model == null || savedBrowserId == null || savedBrowserId.isEmpty()) {
             return;
         }
-        for (int i = 0; i < combo.getModel().getSize(); i++) {
-            ProvidedBrowserUI el = combo.getModel().getElementAt(i);
-            if (el.getName().equals(savedBrowserName)) {
-                combo.setSelectedItem(el);
-                break;
-            }
-        }
+        model.setSelectedBrowser(savedBrowserId);
     }
 }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -211,14 +211,14 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
 
         for (int i = 0; i < model.getSize(); i++) {
             ProvidedBrowserUI browser = model.getElementAt(i);
-            String browserName = browser.getName();
-            JRadioButtonMenuItem item =
-                    new JRadioButtonMenuItem(browserName, browser.equals(selected));
+            String browserId = browser.getBrowser().getId();
+            BrowserMenuItem item =
+                    new BrowserMenuItem(browser.getName(), browser.equals(selected), browserId);
             item.setIcon(browser.getBrowser().getIcon());
             item.addActionListener(
                     e -> {
-                        launchPanel.selectBrowser(browserName);
-                        setToolbarButtonIcon(browserName);
+                        launchPanel.selectBrowser(browserId);
+                        setToolbarButtonIcon(browserId);
                         launchPanel.launchBrowser();
                         Stats.incCounter(
                                 "stats.ui.maintoolbar.button.quickstart.browserlaunch.menu");
@@ -234,14 +234,14 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
         populateBrowserMenuItems();
     }
 
-    protected void setToolbarButtonIcon(String browserName) {
-        launchToolbarButton.setIcon(getIconForBrowser(browserName));
+    protected void setToolbarButtonIcon(String browserId) {
+        launchToolbarButton.setIcon(getIconForBrowser(browserId));
 
         if (browserPopupMenu != null) {
             for (Iterator<AbstractButton> it = browsersButtonGroup.getElements().asIterator();
                     it.hasNext(); ) {
-                AbstractButton button = it.next();
-                if (button.getText().equals(browserName)) {
+                BrowserMenuItem button = (BrowserMenuItem) it.next();
+                if (button.getBrowserId().equals(browserId)) {
                     browsersButtonGroup.setSelected(button.getModel(), true);
                     break;
                 }
@@ -249,15 +249,14 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
         }
     }
 
-    private Icon getIconForBrowser(String browserName) {
+    private Icon getIconForBrowser(String browserId) {
         if (launchPanel == null) {
             return null;
         }
         ProvidedBrowsersComboBoxModel model = launchPanel.getActiveBrowserModel();
         for (int i = 0; i < model.getSize(); i++) {
             ProvidedBrowserUI bui = model.getElementAt(i);
-            if (bui.getName().equalsIgnoreCase(browserName)
-                    || bui.getBrowser().getId().equalsIgnoreCase(browserName)) {
+            if (bui.getBrowser().getId().equalsIgnoreCase(browserId)) {
                 return bui.getBrowser().getIcon();
             }
         }
@@ -287,27 +286,25 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
         return Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
     }
 
-    protected void launchBrowser(String browserName, String url) {
+    protected void launchBrowser(String browserId, String url) {
         new Thread(
                         () -> {
                             try {
-                                WebDriver wd =
-                                        getExtSelenium().getProxiedBrowserByName(browserName);
+                                WebDriver wd = getExtSelenium().getProxiedBrowser(browserId);
                                 if (wd != null) {
                                     QuickStartParam params =
                                             getExtQuickStart().getQuickStartParam();
                                     accessUrl(wd, params, url);
                                     // Use the same browser next time, as long
                                     // as it worked
-                                    params.setLaunchDefaultBrowser(browserName);
+                                    params.setLaunchDefaultBrowser(browserId);
                                     params.getConfig().save();
                                 }
                             } catch (Exception e1) {
                                 ExtensionSelenium extSel = getExtSelenium();
                                 View.getSingleton()
                                         .showWarningDialog(
-                                                extSel.getWarnMessageFailedToStart(
-                                                        browserName, e1));
+                                                extSel.getWarnMessageFailedToStart(browserId, e1));
                                 LOGGER.error(e1.getMessage(), e1);
                             }
                         },
@@ -356,6 +353,20 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
                 && hasView()
                 && statusUpdate.getAddOn().getId().equals("hud")) {
             this.launchPanel.hudAddOnUninstalled();
+        }
+    }
+
+    private static class BrowserMenuItem extends JRadioButtonMenuItem {
+        private static final long serialVersionUID = 1L;
+        private String browserId;
+
+        public BrowserMenuItem(String text, boolean selected, String browserId) {
+            super(text, selected);
+            this.browserId = browserId;
+        }
+
+        public String getBrowserId() {
+            return browserId;
         }
     }
 }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import javax.swing.ComboBoxModel;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -267,7 +266,7 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
         if (addToRecentList) {
             getExtQuickStart().getQuickStartParam().addRecentUrl(url);
         }
-        extLaunch.launchBrowser(getSelectedBrowser(), url);
+        extLaunch.launchBrowser(getSelectedBrowserId(), url);
     }
 
     /**
@@ -287,14 +286,7 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
             // no default
             return;
         }
-        ComboBoxModel<ProvidedBrowserUI> model = this.getBrowserComboBox().getModel();
-        for (int idx = 0; idx < model.getSize(); idx++) {
-            ProvidedBrowserUI el = model.getElementAt(idx);
-            if (el.getName().equals(def)) {
-                model.setSelectedItem(el);
-                break;
-            }
-        }
+        getActiveBrowserModel().setSelectedBrowser(def);
 
         JPanel hudPanel = new QuickStartBackgroundPanel();
         hudPanel.add(getHudCheckbox(), LayoutHelper.getGBC(0, 0, 1, 0));
@@ -319,23 +311,16 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
         }
     }
 
-    private String getSelectedBrowser() {
-        return getBrowserComboBox().getSelectedItem().toString();
+    private String getSelectedBrowserId() {
+        return ((ProvidedBrowserUI) getBrowserComboBox().getSelectedItem()).getBrowser().getId();
     }
 
     public ProvidedBrowsersComboBoxModel getActiveBrowserModel() {
         return (ProvidedBrowsersComboBoxModel) getBrowserComboBox().getModel();
     }
 
-    public void selectBrowser(String browserName) {
-        ProvidedBrowsersComboBoxModel model = getActiveBrowserModel();
-        for (int i = 0; i < model.getSize(); i++) {
-            ProvidedBrowserUI browser = model.getElementAt(i);
-            if (browser.getName().equals(browserName)) {
-                model.setSelectedItem(browser);
-                break;
-            }
-        }
+    public void selectBrowser(String browserId) {
+        getActiveBrowserModel().setSelectedBrowser(browserId);
     }
 
     private String getUrlValue() {
@@ -363,30 +348,30 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
             allBrowserModel.setIncludeUnconfigured(false);
             browserComboBox.setModel(allBrowserModel);
             browserComboBox.addActionListener(
-                    e ->
-                            extLaunch.setToolbarButtonIcon(
-                                    browserComboBox.getSelectedItem().toString()));
+                    e -> extLaunch.setToolbarButtonIcon(getSelectedBrowserId()));
         }
         return browserComboBox;
     }
 
     private void setBrowserOptions(boolean hudEnabled) {
         if (hudBrowserModel != null) {
-            Object selected = browserComboBox.getModel().getSelectedItem();
+            ProvidedBrowserUI selected =
+                    (ProvidedBrowserUI) browserComboBox.getModel().getSelectedItem();
+            String selectedId = selected != null ? selected.getBrowser().getId() : null;
             if (hudEnabled) {
                 browserComboBox.setModel(hudBrowserModel);
                 if (getExtQuickStart()
                         .getHudProvider()
                         .getSupportedBrowserIds()
-                        .contains(selected)) {
-                    browserComboBox.getModel().setSelectedItem(selected);
+                        .contains(selected.getBrowser().getProviderId())) {
+                    hudBrowserModel.setSelectedBrowser(selectedId);
                 } else {
                     hudBrowserModel.setSelectedBrowser(DEFAULT_BROWSER_ID);
                 }
             } else {
                 browserComboBox.setModel(allBrowserModel);
                 // New model will be a superset
-                browserComboBox.getModel().setSelectedItem(selected);
+                allBrowserModel.setSelectedBrowser(selectedId);
             }
         }
     }

--- a/addOns/quickstart/src/test/java/org/zaproxy/zap/extension/quickstart/QuickStartParamUnitTest.java
+++ b/addOns/quickstart/src/test/java/org/zaproxy/zap/extension/quickstart/QuickStartParamUnitTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -36,8 +37,8 @@ class QuickStartParamUnitTest extends TestUtils {
 
     @BeforeEach
     void setUp() throws Exception {
-        mockMessages(new ExtensionQuickStart());
         setUpZap();
+        mockMessages(new ExtensionQuickStart(), new ExtensionSelenium());
         param = new QuickStartParam();
         configuration = new ZapXmlConfiguration();
         param.load(configuration);
@@ -97,14 +98,14 @@ class QuickStartParamUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldDefaultAjaxSpiderDefaultBrowserToFirefox() {
-        assertThat(param.getAjaxSpiderDefaultBrowser(), is(equalTo("Firefox")));
+    void shouldDefaultAjaxSpiderDefaultBrowserToFirefoxHeadless() {
+        assertThat(param.getAjaxSpiderDefaultBrowser(), is(equalTo("firefox-headless")));
     }
 
     @Test
     void shouldSaveAjaxSpiderDefaultBrowser() {
         // Given
-        String browser = "Chrome";
+        String browser = "chrome";
         // When
         param.setAjaxSpiderDefaultBrowser(browser);
         // Then
@@ -114,11 +115,44 @@ class QuickStartParamUnitTest extends TestUtils {
     @Test
     void shouldLoadAjaxSpiderDefaultBrowserFromConfig() {
         // Given
-        configuration.setProperty("quickstart.ajax.browser", "Safari");
+        configuration.setProperty("quickstart.ajax.browser", "safari");
         // When
         param.load(configuration);
         // Then
-        assertThat(param.getAjaxSpiderDefaultBrowser(), is(equalTo("Safari")));
+        assertThat(param.getAjaxSpiderDefaultBrowser(), is(equalTo("safari")));
+    }
+
+    @Test
+    void shouldMigrateAjaxSpiderDefaultBrowserNameToIdWhenMigratingFromVersion2() {
+        // Given
+        configuration.setProperty("quickstart[@version]", 2);
+        configuration.setProperty("quickstart.ajax.browser", "Chrome");
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getAjaxSpiderDefaultBrowser(), is(equalTo("chrome")));
+    }
+
+    @Test
+    void shouldMigrateLaunchDefaultBrowserNameToIdWhenMigratingFromVersion2() {
+        // Given
+        configuration.setProperty("quickstart[@version]", 2);
+        configuration.setProperty("quickstart.launch.defaultBrowser", "Firefox Headless");
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getLaunchDefaultBrowser(), is(equalTo("firefox-headless")));
+    }
+
+    @Test
+    void shouldResetUnrecognisedAjaxSpiderDefaultBrowserNameToDefaultIdWhenMigratingFromVersion2() {
+        // Given
+        configuration.setProperty("quickstart[@version]", 2);
+        configuration.setProperty("quickstart.ajax.browser", "Some Unknown Browser");
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getAjaxSpiderDefaultBrowser(), is(equalTo("firefox-headless")));
     }
 
     @Test


### PR DESCRIPTION
Also changed the configs to use browser IDs rather than the i18n browser names.
