### PR TITLE
client: change completed scan action title capitalization

### DIFF
--- a/addOns/client/CHANGELOG.md
+++ b/addOns/client/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated Chrome and Firefox full extensions to v0.2.3.
+- Update the Client Spider clear action title capitalization (Issue 2000).
 
 ## [0.31.0] - 2026-08-14
 ### Changed

--- a/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
+++ b/addOns/client/src/main/resources/org/zaproxy/addon/client/resources/Messages.properties
@@ -238,7 +238,7 @@ client.spider.task.stats.stopped = Stopped
 
 client.spider.toolbar.added.label = Nodes Added:
 client.spider.toolbar.ascans.label = Current Scans:
-client.spider.toolbar.button.clear = Clean completed scans
+client.spider.toolbar.button.clear = Clean Completed Scans
 client.spider.toolbar.button.new = New Scan
 client.spider.toolbar.button.options = Client Options
 client.spider.toolbar.button.pause = Pause Spider


### PR DESCRIPTION
## Overview

Update the Client Spider toolbar action from “Clean completed scans” to “Clean Completed Scans” so it follows the title-capitalization guidance and matches the surrounding actions. Record the change in the Client add-on changelog.

Only the base English resource bundle and add-on changelog change; translated bundles remain managed through Crowdin.

## Impact

The Client Spider toolbar now presents the clear action consistently. There is no behavior or configuration change.

## Related issue

Part of zaproxy/zaproxy#2000.

## Validation

- After merging current upstream main and resolving its concurrent Client changelog update:
  - `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew --no-daemon --no-build-cache :addOns:client:cleanTest :addOns:client:spotlessCheck :addOns:client:test`
  - BUILD SUCCESSFUL in 3m 1s; 484 tests, 0 failures, 0 errors, 0 skips.
- Final full-suite and coverage gate before the changelog-only follow-up:
  - `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew --no-daemon --no-build-cache :addOns:client:cleanTest :addOns:client:test :addOns:client:jacocoTestCoverageVerification`
  - BUILD SUCCESSFUL; 484 tests, 0 failures, 0 errors, 0 skips; JaCoCo verification passed.
- Complete affected-module gate:
  - `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew --no-daemon --no-build-cache :addOns:client:spotlessCheck :addOns:client:build :addOns:client:jacocoTestCoverageVerification`
  - BUILD SUCCESSFUL; 128 tasks up-to-date from the final clean compilation, package, test, and coverage runs.
- Packaging check: `client-alpha-0.32.0.zap` contains the exact value “Clean Completed Scans”.
- PR diff whitespace check against current upstream main passed.
- Fresh runtime smoke: loaded Client 0.32.0 and its dependencies in ZAP 2.18.0-SNAPSHOT; `ExtensionClientIntegration` initialized, the Client Spider options API returned `MaxScansInUi=5`, and the installed package exposed the corrected resource. Firefox/geckodriver was unavailable in the local smoke environment, so browser launch was not exercised.

The earlier Windows CI run hit an unrelated timing-test failure: `AdaptiveWaitStrategyUnitTest.shouldResetPageLoadHintAtStartOfEachWait()` measured 125 ms against a 100 ms threshold. The same 484-test Client suite passed locally both before and after merging current upstream, and all Linux CI jobs passed.
