### PR TITLE
encoder: Support inline/chaining encoder operations in any Swing JTextComponent 

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- In-place encode/decode/hash/convert operations in the right-click context menu, with submenus for Encode, Decode, Hash, and Utility operations that apply directly to selected text in JTextComponent fields.
+
 ### Changed
 - Maintenance changes.
 - Formatted JavaScript files for consistency.

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/ExtensionEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/ExtensionEncoder.java
@@ -136,10 +136,9 @@ public class ExtensionEncoder extends ExtensionAdaptor {
 
     private PopupEncoderMenu getPopupMenuEncode() {
         if (popupEncodeMenu == null) {
-            popupEncodeMenu = new PopupEncoderMenu();
-            popupEncodeMenu.setText(Constant.messages.getString("encoder.popup.title"));
-            popupEncodeMenu.addActionListener(
-                    e -> showEncodeDecodeDialog(popupEncodeMenu.getLastInvoker()));
+            popupEncodeMenu =
+                    new PopupEncoderMenu(
+                            () -> showEncodeDecodeDialog(popupEncodeMenu.getLastInvoker()));
         }
         return popupEncodeMenu;
     }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2018 The ZAP Development Team
+ * Copyright 2026 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,15 @@
 package org.zaproxy.addon.encoder;
 
 import java.awt.Component;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.text.JTextComponent;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.addon.commonlib.MenuWeights;
 import org.zaproxy.addon.encoder.popup.EncoderOperationMenuItem;
 import org.zaproxy.addon.encoder.popup.EncoderSubMenu;
+import org.zaproxy.addon.encoder.processors.Category;
 import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessorItem;
 import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessors;
 import org.zaproxy.zap.extension.ExtensionPopupMenu;
@@ -36,51 +36,13 @@ import org.zaproxy.zap.view.popup.PopupMenuUtils;
 
 /**
  * The "Encode/Decode/Hash..." right-click popup menu. Hovering shows the in-place Encode, Decode,
- * Hash, and Utility submenus. Clicking the menu opens the Encode/Decode/Hash dialog.
+ * Hash, and Utility submenus. The "Encode/Decode/Hash..." child item opens the Encode/Decode/Hash
+ * dialog.
  */
 @SuppressWarnings("serial")
 public class PopupEncoderMenu extends ExtensionPopupMenu {
 
     private static final long serialVersionUID = 1L;
-
-    private static final String[] ENCODE_IDS = {
-        "base64encode",
-        "base64urlencode",
-        "urlencode",
-        "fullurlencode",
-        "hexencode",
-        "htmlencode",
-        "fullhtmlencode",
-        "javascriptencode",
-        "unicodeencode",
-        "powershellencode",
-        "morsecodeencode"
-    };
-
-    private static final String[] DECODE_IDS = {
-        "base64decode",
-        "base64urldecode",
-        "urldecode",
-        "fullurldecode",
-        "hexdecode",
-        "htmldecode",
-        "javascriptdecode",
-        "unicodedecode",
-        "morsecodedecode"
-    };
-
-    private static final String[] HASH_IDS = {"md5hash", "sha1hash", "sha256hash"};
-
-    private static final String[] UTILITY_IDS = {
-        "removewhitespace",
-        "reverse",
-        "lowercase",
-        "uppercase",
-        "ascify",
-        "illegalutf8with2byteencoder",
-        "illegalutf8with3byteencoder",
-        "illegalutf8with4byteencoder"
-    };
 
     private volatile JTextComponent lastInvoker = null;
 
@@ -88,18 +50,30 @@ public class PopupEncoderMenu extends ExtensionPopupMenu {
         super(Constant.messages.getString("encoder.tools.menu.encdec"));
         setWeight(MenuWeights.MENU_ENCODE_WEIGHT);
 
-        addMouseListener(
-                new MouseAdapter() {
-                    @Override
-                    public void mouseClicked(MouseEvent e) {
-                        dialogAction.run();
-                    }
-                });
+        ExtensionPopupMenuItem openDialogItem =
+                new ExtensionPopupMenuItem(msg("encoder.popup.title")) {
+                    private static final long serialVersionUID = 1L;
 
-        add(new EncoderSubMenu(msg("encoder.popup.menu.encode"), buildItems(ENCODE_IDS)));
-        add(new EncoderSubMenu(msg("encoder.popup.menu.decode"), buildItems(DECODE_IDS)));
-        add(new EncoderSubMenu(msg("encoder.popup.menu.hash"), buildItems(HASH_IDS)));
-        add(new EncoderSubMenu(msg("encoder.popup.menu.utility"), buildItems(UTILITY_IDS)));
+                    @Override
+                    public boolean isSafe() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isEnableForComponent(Component invoker) {
+                        return invoker instanceof JTextComponent
+                                && !isInvokerFromEncodeDecode(invoker);
+                    }
+                };
+        openDialogItem.addActionListener(e -> dialogAction.run());
+        add(openDialogItem);
+
+        for (Category category : Category.values()) {
+            List<EncoderOperationMenuItem> items = buildItems(category);
+            if (!items.isEmpty()) {
+                add(new EncoderSubMenu(msg(category.getI18nKey()), items));
+            }
+        }
     }
 
     private static String msg(String key) {
@@ -148,22 +122,11 @@ public class PopupEncoderMenu extends ExtensionPopupMenu {
         return MenuWeights.MENU_ENCODE_WEIGHT;
     }
 
-    private static List<EncoderOperationMenuItem> buildItems(String[] processorIds) {
+    private static List<EncoderOperationMenuItem> buildItems(Category category) {
         List<EncoderOperationMenuItem> items = new ArrayList<>();
-        for (String id : processorIds) {
-            EncodeDecodeProcessorItem item =
-                    EncodeDecodeProcessors.getPredefinedProcessors().stream()
-                            .filter(
-                                    p ->
-                                            p.getId()
-                                                    .equals(
-                                                            EncodeDecodeProcessors.PREDEFINED_PREFIX
-                                                                    + id))
-                            .findFirst()
-                            .orElse(null);
-            if (item != null) {
-                items.add(new EncoderOperationMenuItem(item.getName(), item.getProcessor()));
-            }
+        for (EncodeDecodeProcessorItem item :
+                EncodeDecodeProcessors.getPredefinedItemsByCategory(category)) {
+            items.add(new EncoderOperationMenuItem(item.getName(), item.getProcessor()));
         }
         return items;
     }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
@@ -20,18 +20,90 @@
 package org.zaproxy.addon.encoder;
 
 import java.awt.Component;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
 import javax.swing.text.JTextComponent;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.addon.commonlib.MenuWeights;
+import org.zaproxy.addon.encoder.popup.EncoderOperationMenuItem;
+import org.zaproxy.addon.encoder.popup.EncoderSubMenu;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessorItem;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessors;
+import org.zaproxy.zap.extension.ExtensionPopupMenu;
+import org.zaproxy.zap.view.popup.PopupMenuUtils;
 
-public class PopupEncoderMenu extends ExtensionPopupMenuItem {
+/**
+ * The "Encode/Decode/Hash..." right-click popup menu. Hovering shows the in-place Encode, Decode,
+ * Hash, and Utility submenus. Clicking the menu opens the Encode/Decode/Hash dialog.
+ */
+@SuppressWarnings("serial")
+public class PopupEncoderMenu extends ExtensionPopupMenu {
 
     private static final long serialVersionUID = 1L;
-    private JTextComponent lastInvoker = null;
 
-    public PopupEncoderMenu() {
+    private static final String[] ENCODE_IDS = {
+        "base64encode",
+        "base64urlencode",
+        "urlencode",
+        "fullurlencode",
+        "hexencode",
+        "htmlencode",
+        "fullhtmlencode",
+        "javascriptencode",
+        "unicodeencode",
+        "powershellencode",
+        "morsecodeencode"
+    };
+
+    private static final String[] DECODE_IDS = {
+        "base64decode",
+        "base64urldecode",
+        "urldecode",
+        "fullurldecode",
+        "hexdecode",
+        "htmldecode",
+        "javascriptdecode",
+        "unicodedecode",
+        "morsecodedecode"
+    };
+
+    private static final String[] HASH_IDS = {"md5hash", "sha1hash", "sha256hash"};
+
+    private static final String[] UTILITY_IDS = {
+        "removewhitespace",
+        "reverse",
+        "lowercase",
+        "uppercase",
+        "ascify",
+        "illegalutf8with2byteencoder",
+        "illegalutf8with3byteencoder",
+        "illegalutf8with4byteencoder"
+    };
+
+    private volatile JTextComponent lastInvoker = null;
+
+    public PopupEncoderMenu(Runnable dialogAction) {
         super(Constant.messages.getString("encoder.tools.menu.encdec"));
+        setWeight(MenuWeights.MENU_ENCODE_WEIGHT);
+
+        addMouseListener(
+                new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        dialogAction.run();
+                    }
+                });
+
+        add(new EncoderSubMenu(msg("encoder.popup.menu.encode"), buildItems(ENCODE_IDS)));
+        add(new EncoderSubMenu(msg("encoder.popup.menu.decode"), buildItems(DECODE_IDS)));
+        add(new EncoderSubMenu(msg("encoder.popup.menu.hash"), buildItems(HASH_IDS)));
+        add(new EncoderSubMenu(msg("encoder.popup.menu.utility"), buildItems(UTILITY_IDS)));
+    }
+
+    private static String msg(String key) {
+        return Constant.messages.getString(key);
     }
 
     /**
@@ -51,12 +123,11 @@ public class PopupEncoderMenu extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker instanceof JTextComponent && !isInvokerFromEncodeDecode(invoker)) {
-
             JTextComponent txt = (JTextComponent) invoker;
             String sel = txt.getSelectedText();
             this.setEnabled(!(sel == null || sel.length() == 0));
-
             setLastInvoker((JTextComponent) invoker);
+            processExtensionPopupChildren(PopupMenuUtils.getPopupMenuInvokerWrapper(invoker));
             return true;
         }
 
@@ -64,11 +135,10 @@ public class PopupEncoderMenu extends ExtensionPopupMenuItem {
         return false;
     }
 
-    private boolean isInvokerFromEncodeDecode(Component invoker) {
+    private static boolean isInvokerFromEncodeDecode(Component invoker) {
         if (invoker.getName() == null) {
             return false;
         }
-
         return invoker.getName().equals(EncodeDecodeDialog.ENCODE_DECODE_FIELD)
                 || invoker.getName().equals(EncodeDecodeDialog.ENCODE_DECODE_RESULTFIELD);
     }
@@ -76,5 +146,25 @@ public class PopupEncoderMenu extends ExtensionPopupMenuItem {
     @Override
     public int getWeight() {
         return MenuWeights.MENU_ENCODE_WEIGHT;
+    }
+
+    private static List<EncoderOperationMenuItem> buildItems(String[] processorIds) {
+        List<EncoderOperationMenuItem> items = new ArrayList<>();
+        for (String id : processorIds) {
+            EncodeDecodeProcessorItem item =
+                    EncodeDecodeProcessors.getPredefinedProcessors().stream()
+                            .filter(
+                                    p ->
+                                            p.getId()
+                                                    .equals(
+                                                            EncodeDecodeProcessors.PREDEFINED_PREFIX
+                                                                    + id))
+                            .findFirst()
+                            .orElse(null);
+            if (item != null) {
+                items.add(new EncoderOperationMenuItem(item.getName(), item.getProcessor()));
+            }
+        }
+        return items;
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
@@ -110,11 +110,8 @@ public class PopupEncoderMenu extends ExtensionPopupMenu {
     }
 
     private static boolean isInvokerFromEncodeDecode(Component invoker) {
-        if (invoker.getName() == null) {
-            return false;
-        }
-        return invoker.getName().equals(EncodeDecodeDialog.ENCODE_DECODE_FIELD)
-                || invoker.getName().equals(EncodeDecodeDialog.ENCODE_DECODE_RESULTFIELD);
+        return EncodeDecodeDialog.ENCODE_DECODE_FIELD.equals(invoker.getName())
+                || EncodeDecodeDialog.ENCODE_DECODE_RESULTFIELD.equals(invoker.getName());
     }
 
     @Override

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/PopupEncoderMenu.java
@@ -101,11 +101,13 @@ public class PopupEncoderMenu extends ExtensionPopupMenu {
             String sel = txt.getSelectedText();
             this.setEnabled(!(sel == null || sel.length() == 0));
             setLastInvoker((JTextComponent) invoker);
+            EncoderOperationMenuItem.setCurrentInvoker((JTextComponent) invoker);
             processExtensionPopupChildren(PopupMenuUtils.getPopupMenuInvokerWrapper(invoker));
             return true;
         }
 
         setLastInvoker(null);
+        EncoderOperationMenuItem.setCurrentInvoker(null);
         return false;
     }
 

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
@@ -20,7 +20,6 @@
 package org.zaproxy.addon.encoder.popup;
 
 import java.awt.Component;
-import java.awt.KeyboardFocusManager;
 import javax.swing.SwingUtilities;
 import javax.swing.text.JTextComponent;
 import org.apache.logging.log4j.LogManager;
@@ -42,12 +41,18 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
 
     private static final Logger LOGGER = LogManager.getLogger(EncoderOperationMenuItem.class);
 
+    private static volatile JTextComponent currentInvoker;
+
     private final EncodeDecodeProcessor processor;
 
     public EncoderOperationMenuItem(String label, EncodeDecodeProcessor processor) {
         super(label);
         this.processor = processor;
         addActionListener(e -> performAction());
+    }
+
+    public static void setCurrentInvoker(JTextComponent invoker) {
+        currentInvoker = invoker;
     }
 
     @Override
@@ -83,17 +88,8 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
         return true;
     }
 
-    private static JTextComponent findInvoker() {
-        Component focusOwner =
-                KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
-        if (focusOwner instanceof JTextComponent) {
-            return (JTextComponent) focusOwner;
-        }
-        return null;
-    }
-
     void performAction() {
-        JTextComponent invoker = findInvoker();
+        JTextComponent invoker = currentInvoker;
         if (invoker == null) {
             return;
         }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
@@ -20,11 +20,13 @@
 package org.zaproxy.addon.encoder.popup;
 
 import java.awt.Component;
+import javax.swing.SwingUtilities;
 import javax.swing.text.JTextComponent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessor;
 import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
 import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
@@ -108,7 +110,7 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
                                 if (result.hasError()) {
                                     showErrorDialog(new Exception(newText));
                                 } else {
-                                    javax.swing.SwingUtilities.invokeLater(
+                                    SwingUtilities.invokeLater(
                                             () ->
                                                     replaceSelectionIfUnchanged(
                                                             invoker,
@@ -154,9 +156,9 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
     }
 
     private void showErrorDialog(Exception e) {
-        javax.swing.SwingUtilities.invokeLater(
+        SwingUtilities.invokeLater(
                 () ->
-                        org.parosproxy.paros.view.View.getSingleton()
+                        View.getSingleton()
                                 .showWarningDialog(
                                         Constant.messages.getString(
                                                 "encoder.popup.operation.error",

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
@@ -1,0 +1,149 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.popup;
+
+import java.awt.Component;
+import javax.swing.text.JTextComponent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessor;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
+import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
+
+/**
+ * A leaf popup menu item that applies an {@link EncodeDecodeProcessor} to the currently selected
+ * text of the invoking {@code JTextComponent} and replaces the selection with the result, keeping
+ * the new text selected so that multiple operations can be chained.
+ */
+@SuppressWarnings("serial")
+public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
+
+    private static final Logger LOGGER = LogManager.getLogger(EncoderOperationMenuItem.class);
+
+    private final EncodeDecodeProcessor processor;
+    private JTextComponent lastInvoker;
+
+    public EncoderOperationMenuItem(String label, EncodeDecodeProcessor processor) {
+        super(label);
+        this.processor = processor;
+        addActionListener(e -> performAction());
+    }
+
+    @Override
+    public boolean isEnableForComponent(Component invoker) {
+        if (isInResponseView(invoker)) {
+            lastInvoker = null;
+            return false;
+        }
+        if (invoker instanceof JTextComponent) {
+            JTextComponent textComponent = (JTextComponent) invoker;
+            String selectedText = textComponent.getSelectedText();
+            boolean hasSelection = selectedText != null && !selectedText.isEmpty();
+            setEnabled(hasSelection);
+            if (hasSelection) {
+                lastInvoker = textComponent;
+            }
+            return true;
+        }
+
+        lastInvoker = null;
+        return false;
+    }
+
+    private static boolean isInResponseView(Component component) {
+        for (Component c = component; c != null; c = c.getParent()) {
+            if (c instanceof HttpPanelResponse) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+
+    private void performAction() {
+        if (lastInvoker == null) {
+            return;
+        }
+        final JTextComponent invoker = lastInvoker;
+        final String selectedText = invoker.getSelectedText();
+        if (selectedText == null || selectedText.isEmpty()) {
+            return;
+        }
+
+        Thread thread =
+                new Thread(
+                        () -> {
+                            try {
+                                EncodeDecodeResult result = processor.process(selectedText);
+                                String newText = result.getResult();
+                                if (result.hasError()) {
+                                    showErrorDialog(new Exception(newText));
+                                } else {
+                                    javax.swing.SwingUtilities.invokeLater(
+                                            () -> replaceSelection(invoker, newText));
+                                }
+                            } catch (Exception e) {
+                                LOGGER.error(
+                                        "Error performing operation '{}': {}",
+                                        getText(),
+                                        e.getMessage(),
+                                        e);
+                                showErrorDialog(e);
+                            }
+                        },
+                        "EncoderOperation-" + getText());
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static void replaceSelection(JTextComponent textComponent, String newText) {
+        try {
+            int start = textComponent.getSelectionStart();
+            int end = textComponent.getSelectionEnd();
+            if (start == end) {
+                return;
+            }
+            textComponent.replaceSelection(newText);
+            textComponent.setSelectionStart(start);
+            textComponent.setSelectionEnd(start + newText.length());
+        } catch (RuntimeException e) {
+            LOGGER.warn("Could not replace the selected text", e);
+        }
+    }
+
+    private void showErrorDialog(Exception e) {
+        javax.swing.SwingUtilities.invokeLater(
+                () ->
+                        org.parosproxy.paros.view.View.getSingleton()
+                                .showWarningDialog(
+                                        Constant.messages.getString(
+                                                "encoder.popup.operation.error",
+                                                getText(),
+                                                e.getMessage() == null
+                                                        ? e.toString()
+                                                        : e.getMessage())));
+    }
+}

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
@@ -40,7 +40,7 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
     private static final Logger LOGGER = LogManager.getLogger(EncoderOperationMenuItem.class);
 
     private final EncodeDecodeProcessor processor;
-    private JTextComponent lastInvoker;
+    private volatile JTextComponent lastInvoker;
 
     public EncoderOperationMenuItem(String label, EncodeDecodeProcessor processor) {
         super(label);
@@ -87,7 +87,7 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
         return true;
     }
 
-    private void performAction() {
+    void performAction() {
         if (lastInvoker == null) {
             return;
         }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
@@ -20,6 +20,7 @@
 package org.zaproxy.addon.encoder.popup;
 
 import java.awt.Component;
+import java.awt.KeyboardFocusManager;
 import javax.swing.SwingUtilities;
 import javax.swing.text.JTextComponent;
 import org.apache.logging.log4j.LogManager;
@@ -42,7 +43,6 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
     private static final Logger LOGGER = LogManager.getLogger(EncoderOperationMenuItem.class);
 
     private final EncodeDecodeProcessor processor;
-    private volatile JTextComponent lastInvoker;
 
     public EncoderOperationMenuItem(String label, EncodeDecodeProcessor processor) {
         super(label);
@@ -53,25 +53,19 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (isInResponseView(invoker)) {
-            lastInvoker = null;
             return false;
         }
         if (invoker instanceof JTextComponent) {
             JTextComponent textComponent = (JTextComponent) invoker;
             if (!textComponent.isEditable()) {
-                lastInvoker = null;
                 return false;
             }
             String selectedText = textComponent.getSelectedText();
             boolean hasSelection = selectedText != null && !selectedText.isEmpty();
             setEnabled(hasSelection);
-            if (hasSelection) {
-                lastInvoker = textComponent;
-            }
             return true;
         }
 
-        lastInvoker = null;
         return false;
     }
 
@@ -89,11 +83,20 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
         return true;
     }
 
+    private static JTextComponent findInvoker() {
+        Component focusOwner =
+                KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
+        if (focusOwner instanceof JTextComponent) {
+            return (JTextComponent) focusOwner;
+        }
+        return null;
+    }
+
     void performAction() {
-        if (lastInvoker == null) {
+        JTextComponent invoker = findInvoker();
+        if (invoker == null) {
             return;
         }
-        final JTextComponent invoker = lastInvoker;
         final String selectedText = invoker.getSelectedText();
         if (selectedText == null || selectedText.isEmpty()) {
             return;

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItem.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2018 The ZAP Development Team
+ * Copyright 2026 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,10 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
         }
         if (invoker instanceof JTextComponent) {
             JTextComponent textComponent = (JTextComponent) invoker;
+            if (!textComponent.isEditable()) {
+                lastInvoker = null;
+                return false;
+            }
             String selectedText = textComponent.getSelectedText();
             boolean hasSelection = selectedText != null && !selectedText.isEmpty();
             setEnabled(hasSelection);
@@ -92,6 +96,8 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
         if (selectedText == null || selectedText.isEmpty()) {
             return;
         }
+        final int selStart = invoker.getSelectionStart();
+        final int selEnd = invoker.getSelectionEnd();
 
         Thread thread =
                 new Thread(
@@ -103,7 +109,13 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
                                     showErrorDialog(new Exception(newText));
                                 } else {
                                     javax.swing.SwingUtilities.invokeLater(
-                                            () -> replaceSelection(invoker, newText));
+                                            () ->
+                                                    replaceSelectionIfUnchanged(
+                                                            invoker,
+                                                            newText,
+                                                            selStart,
+                                                            selEnd,
+                                                            selectedText));
                                 }
                             } catch (Exception e) {
                                 LOGGER.error(
@@ -119,11 +131,18 @@ public class EncoderOperationMenuItem extends ExtensionPopupMenuItem {
         thread.start();
     }
 
-    private static void replaceSelection(JTextComponent textComponent, String newText) {
+    private static void replaceSelectionIfUnchanged(
+            JTextComponent textComponent,
+            String newText,
+            int expectedStart,
+            int expectedEnd,
+            String expectedText) {
         try {
             int start = textComponent.getSelectionStart();
             int end = textComponent.getSelectionEnd();
-            if (start == end) {
+            if (start != expectedStart
+                    || end != expectedEnd
+                    || !expectedText.equals(textComponent.getSelectedText())) {
                 return;
             }
             textComponent.replaceSelection(newText);

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderSubMenu.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderSubMenu.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2018 The ZAP Development Team
+ * Copyright 2026 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderSubMenu.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderSubMenu.java
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.popup;
+
+import java.awt.Component;
+import java.util.List;
+import org.zaproxy.zap.extension.ExtensionPopupMenu;
+
+/**
+ * A submenu container for the Encoder add-on's in-place operations (e.g. Encode, Decode, Hash,
+ * Utility) containing operation items or further nested submenus.
+ */
+@SuppressWarnings("serial")
+public class EncoderSubMenu extends ExtensionPopupMenu {
+
+    public EncoderSubMenu(String label, List<? extends Component> children) {
+        super(label);
+        children.forEach(this::add);
+    }
+}

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderSubMenu.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/popup/EncoderSubMenu.java
@@ -21,14 +21,14 @@ package org.zaproxy.addon.encoder.popup;
 
 import java.awt.Component;
 import java.util.List;
-import org.zaproxy.zap.extension.ExtensionPopupMenu;
+import javax.swing.JMenu;
 
 /**
  * A submenu container for the Encoder add-on's in-place operations (e.g. Encode, Decode, Hash,
  * Utility) containing operation items or further nested submenus.
  */
 @SuppressWarnings("serial")
-public class EncoderSubMenu extends ExtensionPopupMenu {
+public class EncoderSubMenu extends JMenu {
 
     public EncoderSubMenu(String label, List<? extends Component> children) {
         super(label);

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/Category.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/Category.java
@@ -1,0 +1,39 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors;
+
+/** Categories for classifying encode/decode processors in the popup menu. */
+public enum Category {
+    ENCODE("encoder.popup.menu.encode"),
+    DECODE("encoder.popup.menu.decode"),
+    HASH("encoder.popup.menu.hash"),
+    UTILITY("encoder.popup.menu.utility"),
+    SCRIPT("encoder.popup.menu.script");
+
+    private final String i18nKey;
+
+    Category(String i18nKey) {
+        this.i18nKey = i18nKey;
+    }
+
+    public String getI18nKey() {
+        return i18nKey;
+    }
+}

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessorItem.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessorItem.java
@@ -21,14 +21,21 @@ package org.zaproxy.addon.encoder.processors;
 
 public class EncodeDecodeProcessorItem {
 
-    private String id;
-    private String name;
-    private EncodeDecodeProcessor processor;
+    private final String id;
+    private final String name;
+    private final EncodeDecodeProcessor processor;
+    private final Category category;
 
-    public EncodeDecodeProcessorItem(String id, String name, EncodeDecodeProcessor processor) {
+    public EncodeDecodeProcessorItem(
+            String id, String name, EncodeDecodeProcessor processor, Category category) {
         this.id = id;
         this.name = name;
         this.processor = processor;
+        this.category = category;
+    }
+
+    public EncodeDecodeProcessorItem(String id, String name, EncodeDecodeProcessor processor) {
+        this(id, name, processor, null);
     }
 
     public String getId() {
@@ -41,5 +48,9 @@ public class EncodeDecodeProcessorItem {
 
     public EncodeDecodeProcessor getProcessor() {
         return processor;
+    }
+
+    public Category getCategory() {
+        return category;
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
@@ -68,59 +68,71 @@ public class EncodeDecodeProcessors {
     private static List<EncodeDecodeProcessorItem> predefinedProcessors = new ArrayList<>();
 
     static {
-        addPredefined("base64decode", Base64Decoder.getSingleton());
-        addPredefined("base64encode", Base64Encoder.getSingleton());
+        addPredefined("base64decode", Base64Decoder.getSingleton(), Category.DECODE);
+        addPredefined("base64encode", Base64Encoder.getSingleton(), Category.ENCODE);
 
-        addPredefined("base64urldecode", Base64UrlDecoder.getSingleton());
-        addPredefined("base64urlencode", Base64UrlEncoder.getSingleton());
+        addPredefined("base64urldecode", Base64UrlDecoder.getSingleton(), Category.DECODE);
+        addPredefined("base64urlencode", Base64UrlEncoder.getSingleton(), Category.ENCODE);
 
-        addPredefined("hexdecode", HexStringDecoder.getSingleton());
-        addPredefined("hexencode", HexStringEncoder.getSingleton());
+        addPredefined("hexdecode", HexStringDecoder.getSingleton(), Category.DECODE);
+        addPredefined("hexencode", HexStringEncoder.getSingleton(), Category.ENCODE);
 
-        addPredefined("htmldecode", HtmlStringDecoder.getSingleton());
-        addPredefined("htmlencode", HtmlStringEncoder.getSingleton());
-        addPredefined("fullhtmlencode", FullHtmlStringEncoder.getSingleton());
+        addPredefined("htmldecode", HtmlStringDecoder.getSingleton(), Category.DECODE);
+        addPredefined("htmlencode", HtmlStringEncoder.getSingleton(), Category.ENCODE);
+        addPredefined("fullhtmlencode", FullHtmlStringEncoder.getSingleton(), Category.ENCODE);
 
-        addPredefined("javascriptdecode", JavaScriptStringDecoder.getSingleton());
-        addPredefined("javascriptencode", JavaScriptStringEncoder.getSingleton());
+        addPredefined("javascriptdecode", JavaScriptStringDecoder.getSingleton(), Category.DECODE);
+        addPredefined("javascriptencode", JavaScriptStringEncoder.getSingleton(), Category.ENCODE);
 
-        addPredefined("unicodedecode", UnicodeDecoder.getSingleton());
-        addPredefined("unicodeencode", UnicodeEncoder.getSingleton());
+        addPredefined("unicodedecode", UnicodeDecoder.getSingleton(), Category.DECODE);
+        addPredefined("unicodeencode", UnicodeEncoder.getSingleton(), Category.ENCODE);
 
-        addPredefined("urldecode", UrlDecoder.getSingleton());
-        addPredefined("urlencode", UrlEncoder.getSingleton());
+        addPredefined("urldecode", UrlDecoder.getSingleton(), Category.DECODE);
+        addPredefined("urlencode", UrlEncoder.getSingleton(), Category.ENCODE);
 
-        addPredefined("fullurldecode", FullUrlDecoder.getSingleton());
-        addPredefined("fullurlencode", FullUrlEncoder.getSingleton());
+        addPredefined("fullurldecode", FullUrlDecoder.getSingleton(), Category.DECODE);
+        addPredefined("fullurlencode", FullUrlEncoder.getSingleton(), Category.ENCODE);
 
-        addPredefined("md5hash", Md5Hasher.getSingleton());
-        addPredefined("sha1hash", Sha1Hasher.getSingleton());
-        addPredefined("sha256hash", Sha256Hasher.getSingleton());
+        addPredefined("md5hash", Md5Hasher.getSingleton(), Category.HASH);
+        addPredefined("sha1hash", Sha1Hasher.getSingleton(), Category.HASH);
+        addPredefined("sha256hash", Sha256Hasher.getSingleton(), Category.HASH);
 
-        addPredefined("illegalutf8with2byteencoder", IllegalUTF8With2ByteEncoder.getSingleton());
-        addPredefined("illegalutf8with3byteencoder", IllegalUTF8With3ByteEncoder.getSingleton());
-        addPredefined("illegalutf8with4byteencoder", IllegalUTF8With4ByteEncoder.getSingleton());
+        addPredefined(
+                "illegalutf8with2byteencoder",
+                IllegalUTF8With2ByteEncoder.getSingleton(),
+                Category.UTILITY);
+        addPredefined(
+                "illegalutf8with3byteencoder",
+                IllegalUTF8With3ByteEncoder.getSingleton(),
+                Category.UTILITY);
+        addPredefined(
+                "illegalutf8with4byteencoder",
+                IllegalUTF8With4ByteEncoder.getSingleton(),
+                Category.UTILITY);
 
-        addPredefined("removewhitespace", RemoveWhitespace.getSingleton());
-        addPredefined("reverse", Reverse.getSingleton());
-        addPredefined("lowercase", LowerCase.getSingleton());
-        addPredefined("uppercase", UpperCase.getSingleton());
+        addPredefined("removewhitespace", RemoveWhitespace.getSingleton(), Category.UTILITY);
+        addPredefined("reverse", Reverse.getSingleton(), Category.UTILITY);
+        addPredefined("lowercase", LowerCase.getSingleton(), Category.UTILITY);
+        addPredefined("uppercase", UpperCase.getSingleton(), Category.UTILITY);
 
-        addPredefined("powershellencode", PowerShellEncoder.getSingleton());
-        addPredefined("ascify", Ascify.getSingleton());
-        addPredefined("morsecodeencode", MorseEncoder.getSingleton());
-        addPredefined("morsecodedecode", MorseDecoder.getSingleton());
+        addPredefined("powershellencode", PowerShellEncoder.getSingleton(), Category.ENCODE);
+        addPredefined("ascify", Ascify.getSingleton(), Category.UTILITY);
+        addPredefined("morsecodeencode", MorseEncoder.getSingleton(), Category.ENCODE);
+        addPredefined("morsecodedecode", MorseDecoder.getSingleton(), Category.DECODE);
     }
 
     private Map<String, EncodeDecodeProcessorItem> scriptProcessors = new HashMap<>();
 
-    private static void addPredefined(String id, EncodeDecodeProcessor processor) {
-        addPredefined(PREDEFINED_PREFIX + id, PREDEFINED_PREFIX + id, processor);
+    private static void addPredefined(
+            String id, EncodeDecodeProcessor processor, Category category) {
+        addPredefined(PREDEFINED_PREFIX + id, PREDEFINED_PREFIX + id, processor, category);
     }
 
-    private static void addPredefined(String id, String i18nKey, EncodeDecodeProcessor processor) {
+    private static void addPredefined(
+            String id, String i18nKey, EncodeDecodeProcessor processor, Category category) {
         predefinedProcessors.add(
-                new EncodeDecodeProcessorItem(id, Constant.messages.getString(i18nKey), processor));
+                new EncodeDecodeProcessorItem(
+                        id, Constant.messages.getString(i18nKey), processor, category));
     }
 
     public List<EncodeDecodeProcessorItem> getProcessorItems() {
@@ -145,11 +157,7 @@ public class EncodeDecodeProcessors {
         }
 
         // Delete not existing
-        for (String key : scriptProcessors.keySet()) {
-            if (!encodeDecodeScripts.contains(key)) {
-                scriptProcessors.remove(key);
-            }
-        }
+        scriptProcessors.keySet().removeIf(key -> !encodeDecodeScripts.contains(key));
 
         return scriptProcessors.values().stream().collect(Collectors.toList());
     }
@@ -158,7 +166,7 @@ public class EncodeDecodeProcessors {
         String scriptName = ws.getName();
         ScriptBasedEncodeDecodeProcessor processor =
                 new ScriptBasedEncodeDecodeProcessor(ws.getName());
-        return new EncodeDecodeProcessorItem(scriptName, scriptName, processor);
+        return new EncodeDecodeProcessorItem(scriptName, scriptName, processor, Category.SCRIPT);
     }
 
     public EncodeDecodeProcessorItem findProcessorItemById(String name) {
@@ -172,10 +180,30 @@ public class EncodeDecodeProcessors {
 
     public EncodeDecodeResult process(String processorId, String value) throws Exception {
         EncodeDecodeProcessorItem processor = findProcessorItemById(processorId);
+        if (processor == null) {
+            throw new IllegalArgumentException(
+                    "Processor '" + processorId + "' not found, disabled or an error occurred");
+        }
         return processor.getProcessor().process(value);
     }
 
     public static List<EncodeDecodeProcessorItem> getPredefinedProcessors() {
         return predefinedProcessors;
+    }
+
+    public static List<EncodeDecodeProcessorItem> getPredefinedItemsByCategory(Category category) {
+        return predefinedProcessors.stream()
+                .filter(item -> category.equals(item.getCategory()))
+                .collect(Collectors.toList());
+    }
+
+    public List<EncodeDecodeProcessorItem> getItemsByCategory(Category category) {
+        List<EncodeDecodeProcessorItem> items =
+                new ArrayList<>(getPredefinedItemsByCategory(category));
+        items.addAll(
+                getScriptProcessors().stream()
+                        .filter(item -> category.equals(item.getCategory()))
+                        .collect(Collectors.toList()));
+        return items;
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.encoder.ExtensionEncoder;
 import org.zaproxy.addon.encoder.processors.predefined.Base64Decoder;
@@ -142,7 +141,7 @@ public class EncodeDecodeProcessors {
 
         return processors.stream()
                 .sorted(Comparator.comparing(EncodeDecodeProcessorItem::getName))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private List<EncodeDecodeProcessorItem> getScriptProcessors() {
@@ -159,7 +158,7 @@ public class EncodeDecodeProcessors {
         // Delete not existing
         scriptProcessors.keySet().removeIf(key -> !encodeDecodeScripts.contains(key));
 
-        return scriptProcessors.values().stream().collect(Collectors.toList());
+        return scriptProcessors.values().stream().toList();
     }
 
     private static EncodeDecodeProcessorItem createItemFromScriptWrapper(ScriptWrapper ws) {
@@ -194,7 +193,7 @@ public class EncodeDecodeProcessors {
     public static List<EncodeDecodeProcessorItem> getPredefinedItemsByCategory(Category category) {
         return predefinedProcessors.stream()
                 .filter(item -> category.equals(item.getCategory()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<EncodeDecodeProcessorItem> getItemsByCategory(Category category) {
@@ -203,7 +202,7 @@ public class EncodeDecodeProcessors {
         items.addAll(
                 getScriptProcessors().stream()
                         .filter(item -> category.equals(item.getCategory()))
-                        .collect(Collectors.toList()));
+                        .toList());
         return items;
     }
 }

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -262,5 +262,26 @@ Many text areas such as the Output tab, Scripts console, Request and Response pa
 right click menu item</td></tr>
 </table>
 
+<H2>In-Place Operations</H2>
+
+<p>
+The right-click context menu provides in-place encode, decode, hash, and utility operations that
+apply directly to the selected text in any <code>JTextComponent</code> (e.g. Request panel, Scripts console).
+The menu is not shown in the Response view.
+
+<p>
+When text is selected and you right-click, the <b>Encode/Decode/Hash...</b> menu contains the following submenus:
+
+<ul>
+  <li><b>Encode</b> - Base64, Base64 URL, URL, Full URL, ASCII Hex, HTML, Full HTML, JavaScript, Unicode, PowerShell, Morse Code</li>
+  <li><b>Decode</b> - Base64, Base64 URL, URL, Full URL, ASCII Hex, HTML, JavaScript, Unicode, Morse Code</li>
+  <li><b>Hash</b> - MD5, SHA1, SHA256</li>
+  <li><b>Utility</b> - Remove Whitespace, Reverse, Lowercase, Uppercase, ASCify, Illegal UTF-8 (2/3/4 byte)</li>
+</ul>
+
+<p>
+Selecting an operation replaces the selected text with the result. The result remains selected so that
+multiple operations can be chained without re-selecting.
+
 </BODY>
 </HTML>

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -267,7 +267,7 @@ right click menu item</td></tr>
 <p>
 The right-click context menu provides in-place encode, decode, hash, and utility operations that
 apply directly to the selected text in any <code>JTextComponent</code> (e.g. Request panel, Scripts console).
-The menu is not shown in the Response view.
+The in-place operation submenus are not shown in the Response view.
 
 <p>
 When text is selected and you right-click, the <b>Encode/Decode/Hash...</b> menu contains the following submenus:

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -28,6 +28,12 @@ encoder.optionspanel.hashers.output.lowercase = Always output lower case?
 encoder.optionspanel.name = Encode/Decode
 
 encoder.popup.delete = Delete Output Panel
+encoder.popup.menu.decode = Decode
+encoder.popup.menu.encode = Encode
+encoder.popup.menu.hash = Hash
+encoder.popup.menu.title = Encoder
+encoder.popup.menu.utility = Utility
+encoder.popup.operation.error = Failed to {0} the selected text: {1}
 encoder.popup.replace.input = Replace Input Text
 encoder.popup.title = Encode/Decode/Hash...
 

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -31,6 +31,7 @@ encoder.popup.delete = Delete Output Panel
 encoder.popup.menu.decode = Decode
 encoder.popup.menu.encode = Encode
 encoder.popup.menu.hash = Hash
+encoder.popup.menu.script = Scripts
 encoder.popup.menu.title = Encoder
 encoder.popup.menu.utility = Utility
 encoder.popup.operation.error = Failed to {0} the selected text: {1}

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/PopupEncoderMenuUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/PopupEncoderMenuUnitTest.java
@@ -1,0 +1,134 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import javax.swing.JButton;
+import javax.swing.JPopupMenu;
+import javax.swing.text.JTextComponent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit tests for {@link PopupEncoderMenu}. */
+class PopupEncoderMenuUnitTest extends TestUtils {
+
+    @BeforeAll
+    static void initMessages() {
+        mockMessages(new ExtensionEncoder());
+        Constant.getInstance();
+        Model model = new Model();
+        Model.setSingletonForTesting(model);
+        Control.initSingletonForTesting(model);
+    }
+
+    @Test
+    void shouldNotBeEnabledForNonTextComponent() {
+        // Given
+        PopupEncoderMenu menu = createMenu();
+        JButton button = mock(JButton.class);
+
+        // When
+        boolean result = menu.isEnableForComponent(button);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void shouldBeEnabledForTextComponentWithSelection() {
+        // Given
+        PopupEncoderMenu menu = createMenu();
+        JTextComponent textComponent = mock(JTextComponent.class);
+        given(textComponent.getSelectedText()).willReturn("selected");
+
+        // When
+        boolean result = menu.isEnableForComponent(textComponent);
+
+        // Then
+        assertThat(result, is(true));
+        assertThat(menu.isEnabled(), is(true));
+    }
+
+    @Test
+    void shouldBeEnabledButDisabledForTextComponentWithNoSelection() {
+        // Given
+        PopupEncoderMenu menu = createMenu();
+        JTextComponent textComponent = mock(JTextComponent.class);
+        given(textComponent.getSelectedText()).willReturn(null);
+
+        // When
+        boolean result = menu.isEnableForComponent(textComponent);
+
+        // Then
+        assertThat(result, is(true));
+        assertThat(menu.isEnabled(), is(false));
+    }
+
+    @Test
+    void shouldNotBeEnabledForEncodeDecodeInputField() {
+        // Given
+        PopupEncoderMenu menu = createMenu();
+        JTextComponent textComponent = mock(JTextComponent.class);
+        given(textComponent.getName()).willReturn(EncodeDecodeDialog.ENCODE_DECODE_FIELD);
+
+        // When
+        boolean result = menu.isEnableForComponent(textComponent);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void shouldNotBeEnabledForEncodeDecodeResultField() {
+        // Given
+        PopupEncoderMenu menu = createMenu();
+        JTextComponent textComponent = mock(JTextComponent.class);
+        given(textComponent.getName()).willReturn(EncodeDecodeDialog.ENCODE_DECODE_RESULTFIELD);
+
+        // When
+        boolean result = menu.isEnableForComponent(textComponent);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void shouldBuildSubmenusForAllCategories() {
+        // Given / When
+        PopupEncoderMenu menu = createMenu();
+
+        // Then - should have category submenus (plus the dialog item in the popup)
+        JPopupMenu popupMenu = menu.getPopupMenu();
+        assertThat(popupMenu.getComponentCount(), is(greaterThan(0)));
+    }
+
+    private static PopupEncoderMenu createMenu() {
+        return new PopupEncoderMenu(() -> {});
+    }
+}

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItemUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItemUnitTest.java
@@ -23,8 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
 import javax.swing.JPanel;
@@ -32,9 +30,6 @@ import javax.swing.text.JTextComponent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.quality.Strictness;
-import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.encoder.EncodeDecodeDialog;
 import org.zaproxy.addon.encoder.ExtensionEncoder;
 import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessor;
@@ -48,61 +43,41 @@ class EncoderOperationMenuItemUnitTest extends TestUtils {
     @BeforeAll
     static void initMessages() {
         mockMessages(new ExtensionEncoder());
-        Constant.getInstance();
-        Model model = new Model();
-        Model.setSingletonForTesting(model);
-        Control.initSingletonForTesting(model);
     }
 
     @Test
     void shouldNotBeEnabledForNonEditableTextComponent() {
-        // Given
         EncoderOperationMenuItem menuItem = createMenuItem();
         JTextComponent textComponent =
                 mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
         given(textComponent.isEditable()).willReturn(false);
         given(textComponent.getSelectedText()).willReturn("selected");
 
-        // When
-        boolean result = menuItem.isEnableForComponent(textComponent);
-
-        // Then
-        assertThat(result, is(false));
+        assertThat(menuItem.isEnableForComponent(textComponent), is(false));
     }
 
     @Test
     void shouldNotBeEnabledForEncodeDecodeInputField() {
-        // Given
         EncoderOperationMenuItem menuItem = createMenuItem();
         JTextComponent textComponent =
                 mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
         given(textComponent.getName()).willReturn(EncodeDecodeDialog.ENCODE_DECODE_FIELD);
 
-        // When
-        boolean result = menuItem.isEnableForComponent(textComponent);
-
-        // Then
-        assertThat(result, is(false));
+        assertThat(menuItem.isEnableForComponent(textComponent), is(false));
     }
 
     @Test
     void shouldNotBeEnabledForEncodeDecodeResultField() {
-        // Given
         EncoderOperationMenuItem menuItem = createMenuItem();
         JTextComponent textComponent =
                 mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
         given(textComponent.getName()).willReturn(EncodeDecodeDialog.ENCODE_DECODE_RESULTFIELD);
 
-        // When
-        boolean result = menuItem.isEnableForComponent(textComponent);
-
-        // Then
-        assertThat(result, is(false));
+        assertThat(menuItem.isEnableForComponent(textComponent), is(false));
     }
 
     @Test
     void shouldNotBeEnabledWhenParentIsResponseView() {
-        // Given
         EncoderOperationMenuItem menuItem = createMenuItem();
         JTextComponent textComponent =
                 mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
@@ -111,76 +86,37 @@ class EncoderOperationMenuItemUnitTest extends TestUtils {
         given(textComponent.getParent()).willReturn(parent);
         given(parent.getParent()).willReturn(responsePanel);
 
-        // When
-        boolean result = menuItem.isEnableForComponent(textComponent);
-
-        // Then
-        assertThat(result, is(false));
+        assertThat(menuItem.isEnableForComponent(textComponent), is(false));
     }
 
     @Test
-    void shouldNotApplyResultWhenSelectionChangedDuringProcessing() throws Exception {
-        // Given
-        java.util.concurrent.CountDownLatch processingStarted =
-                new java.util.concurrent.CountDownLatch(1);
-        java.util.concurrent.CountDownLatch continueProcessing =
-                new java.util.concurrent.CountDownLatch(1);
-        EncodeDecodeProcessor processor =
-                value -> {
-                    processingStarted.countDown();
-                    try {
-                        continueProcessing.await();
-                    } catch (InterruptedException ignored) {
-                        Thread.currentThread().interrupt();
-                    }
-                    return new EncodeDecodeResult("processed-" + value);
-                };
-        EncoderOperationMenuItem menuItem = createMenuItem(processor);
-
+    void shouldBeEnabledForEditableTextComponentWithSelection() {
+        EncoderOperationMenuItem menuItem = createMenuItem();
         JTextComponent textComponent =
                 mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
         given(textComponent.isEditable()).willReturn(true);
-        given(textComponent.getSelectedText()).willReturn("hello");
-        given(textComponent.getSelectionStart()).willReturn(0);
-        given(textComponent.getSelectionEnd()).willReturn(5);
-        menuItem.isEnableForComponent(textComponent);
+        given(textComponent.getSelectedText()).willReturn("selected");
 
-        // When - trigger the action, then change selection before processing completes
-        new Thread(() -> menuItem.performAction()).start();
-        processingStarted.await();
-
-        // Simulate: user changes selection before processing completes
-        given(textComponent.getSelectionStart()).willReturn(10);
-        given(textComponent.getSelectionEnd()).willReturn(20);
-        given(textComponent.getSelectedText()).willReturn("different");
-
-        // Let processing complete
-        continueProcessing.countDown();
-
-        // Then - replaceSelection should not have been called
-        verify(textComponent, timeout(1000).times(0))
-                .replaceSelection(org.mockito.ArgumentMatchers.anyString());
+        assertThat(menuItem.isEnableForComponent(textComponent), is(true));
+        assertThat(menuItem.isEnabled(), is(true));
     }
 
     @Test
-    void shouldApplyResultWhenSelectionUnchanged() throws Exception {
-        // Given
-        EncodeDecodeProcessor processor = value -> new EncodeDecodeResult("processed-" + value);
-        EncoderOperationMenuItem menuItem = createMenuItem(processor);
-
+    void shouldBeEnabledButDisabledForTextComponentWithNoSelection() {
+        EncoderOperationMenuItem menuItem = createMenuItem();
         JTextComponent textComponent =
                 mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
         given(textComponent.isEditable()).willReturn(true);
-        given(textComponent.getSelectedText()).willReturn("hello");
-        given(textComponent.getSelectionStart()).willReturn(0);
-        given(textComponent.getSelectionEnd()).willReturn(5);
-        menuItem.isEnableForComponent(textComponent);
+        given(textComponent.getSelectedText()).willReturn(null);
 
-        // When - trigger the action (selection unchanged)
+        assertThat(menuItem.isEnableForComponent(textComponent), is(true));
+        assertThat(menuItem.isEnabled(), is(false));
+    }
+
+    @Test
+    void shouldNotThrowWhenNoFocusOwner() {
+        EncoderOperationMenuItem menuItem = createMenuItem();
         menuItem.performAction();
-
-        // Then - replaceSelection should have been called with processed text
-        verify(textComponent, timeout(1000)).replaceSelection("processed-hello");
     }
 
     private static EncoderOperationMenuItem createMenuItem() {

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItemUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItemUnitTest.java
@@ -1,0 +1,193 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.popup;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import javax.swing.JPanel;
+import javax.swing.text.JTextComponent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.quality.Strictness;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.encoder.EncodeDecodeDialog;
+import org.zaproxy.addon.encoder.ExtensionEncoder;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessor;
+import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
+import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit tests for {@link EncoderOperationMenuItem}. */
+class EncoderOperationMenuItemUnitTest extends TestUtils {
+
+    @BeforeAll
+    static void initMessages() {
+        mockMessages(new ExtensionEncoder());
+        Constant.getInstance();
+        Model model = new Model();
+        Model.setSingletonForTesting(model);
+        Control.initSingletonForTesting(model);
+    }
+
+    @Test
+    void shouldNotBeEnabledForNonEditableTextComponent() {
+        // Given
+        EncoderOperationMenuItem menuItem = createMenuItem();
+        JTextComponent textComponent =
+                mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
+        given(textComponent.isEditable()).willReturn(false);
+        given(textComponent.getSelectedText()).willReturn("selected");
+
+        // When
+        boolean result = menuItem.isEnableForComponent(textComponent);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void shouldNotBeEnabledForEncodeDecodeInputField() {
+        // Given
+        EncoderOperationMenuItem menuItem = createMenuItem();
+        JTextComponent textComponent =
+                mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
+        given(textComponent.getName()).willReturn(EncodeDecodeDialog.ENCODE_DECODE_FIELD);
+
+        // When
+        boolean result = menuItem.isEnableForComponent(textComponent);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void shouldNotBeEnabledForEncodeDecodeResultField() {
+        // Given
+        EncoderOperationMenuItem menuItem = createMenuItem();
+        JTextComponent textComponent =
+                mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
+        given(textComponent.getName()).willReturn(EncodeDecodeDialog.ENCODE_DECODE_RESULTFIELD);
+
+        // When
+        boolean result = menuItem.isEnableForComponent(textComponent);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void shouldNotBeEnabledWhenParentIsResponseView() {
+        // Given
+        EncoderOperationMenuItem menuItem = createMenuItem();
+        JTextComponent textComponent =
+                mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
+        HttpPanelResponse responsePanel = mock(HttpPanelResponse.class);
+        JPanel parent = mock(JPanel.class);
+        given(textComponent.getParent()).willReturn(parent);
+        given(parent.getParent()).willReturn(responsePanel);
+
+        // When
+        boolean result = menuItem.isEnableForComponent(textComponent);
+
+        // Then
+        assertThat(result, is(false));
+    }
+
+    @Test
+    void shouldNotApplyResultWhenSelectionChangedDuringProcessing() throws Exception {
+        // Given
+        java.util.concurrent.CountDownLatch processingStarted =
+                new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch continueProcessing =
+                new java.util.concurrent.CountDownLatch(1);
+        EncodeDecodeProcessor processor =
+                value -> {
+                    processingStarted.countDown();
+                    try {
+                        continueProcessing.await();
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return new EncodeDecodeResult("processed-" + value);
+                };
+        EncoderOperationMenuItem menuItem = createMenuItem(processor);
+
+        JTextComponent textComponent =
+                mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
+        given(textComponent.isEditable()).willReturn(true);
+        given(textComponent.getSelectedText()).willReturn("hello");
+        given(textComponent.getSelectionStart()).willReturn(0);
+        given(textComponent.getSelectionEnd()).willReturn(5);
+        menuItem.isEnableForComponent(textComponent);
+
+        // When - trigger the action, then change selection before processing completes
+        new Thread(() -> menuItem.performAction()).start();
+        processingStarted.await();
+
+        // Simulate: user changes selection before processing completes
+        given(textComponent.getSelectionStart()).willReturn(10);
+        given(textComponent.getSelectionEnd()).willReturn(20);
+        given(textComponent.getSelectedText()).willReturn("different");
+
+        // Let processing complete
+        continueProcessing.countDown();
+
+        // Then - replaceSelection should not have been called
+        verify(textComponent, timeout(1000).times(0))
+                .replaceSelection(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void shouldApplyResultWhenSelectionUnchanged() throws Exception {
+        // Given
+        EncodeDecodeProcessor processor = value -> new EncodeDecodeResult("processed-" + value);
+        EncoderOperationMenuItem menuItem = createMenuItem(processor);
+
+        JTextComponent textComponent =
+                mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
+        given(textComponent.isEditable()).willReturn(true);
+        given(textComponent.getSelectedText()).willReturn("hello");
+        given(textComponent.getSelectionStart()).willReturn(0);
+        given(textComponent.getSelectionEnd()).willReturn(5);
+        menuItem.isEnableForComponent(textComponent);
+
+        // When - trigger the action (selection unchanged)
+        menuItem.performAction();
+
+        // Then - replaceSelection should have been called with processed text
+        verify(textComponent, timeout(1000)).replaceSelection("processed-hello");
+    }
+
+    private static EncoderOperationMenuItem createMenuItem() {
+        return createMenuItem(value -> new EncodeDecodeResult("encoded-" + value));
+    }
+
+    private static EncoderOperationMenuItem createMenuItem(EncodeDecodeProcessor processor) {
+        return new EncoderOperationMenuItem("Test", processor);
+    }
+}

--- a/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItemUnitTest.java
+++ b/addOns/encoder/src/test/java/org/zaproxy/addon/encoder/popup/EncoderOperationMenuItemUnitTest.java
@@ -23,10 +23,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
 import javax.swing.JPanel;
 import javax.swing.text.JTextComponent;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.quality.Strictness;
@@ -43,6 +45,11 @@ class EncoderOperationMenuItemUnitTest extends TestUtils {
     @BeforeAll
     static void initMessages() {
         mockMessages(new ExtensionEncoder());
+    }
+
+    @AfterEach
+    void clearInvoker() {
+        EncoderOperationMenuItem.setCurrentInvoker(null);
     }
 
     @Test
@@ -114,8 +121,31 @@ class EncoderOperationMenuItemUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldNotThrowWhenNoFocusOwner() {
+    void shouldProcessTextViaCurrentInvoker() throws Exception {
+        // Given
+        EncodeDecodeProcessor processor = value -> new EncodeDecodeResult("processed-" + value);
+        EncoderOperationMenuItem menuItem = createMenuItem(processor);
+
+        JTextComponent textComponent =
+                mock(JTextComponent.class, withSettings().strictness(Strictness.LENIENT));
+        given(textComponent.getSelectedText()).willReturn("hello");
+        given(textComponent.getSelectionStart()).willReturn(0);
+        given(textComponent.getSelectionEnd()).willReturn(5);
+
+        EncoderOperationMenuItem.setCurrentInvoker(textComponent);
+
+        // When
+        menuItem.performAction();
+
+        // Then
+        Thread.sleep(1000);
+        verify(textComponent).replaceSelection("processed-hello");
+    }
+
+    @Test
+    void shouldNotThrowWhenNoInvoker() {
         EncoderOperationMenuItem menuItem = createMenuItem();
+        EncoderOperationMenuItem.setCurrentInvoker(null);
         menuItem.performAction();
     }
 


### PR DESCRIPTION
## Overview
Adds in-place encode/decode/hash/utility operations to the right-click context menu. Selecting text in any JTextComponent (Request panel, Scripts console, etc.) and right-clicking shows submenus that apply the encoder's own processors directly to the selection, replacing it in-place. The result remains selected for operation chaining.

## Changes
- **EncoderSubMenu** - Generic submenu container for grouping operations
- **EncoderOperationMenuItem** - Leaf menu item that applies an EncodeDecodeProcessor to selected text, replaces the selection, and re-selects the result. Excludes HttpPanelResponse view. Runs operations on daemon threads.
- **PopupEncoderMenu** - Converted from ExtensionPopupMenuItem to ExtensionPopupMenu containing Encode, Decode, Hash, and Utility submenus built from the encoder's predefined processors. Clicking the menu still opens the dialog.
- **ExtensionEncoder** - Updated to pass dialog action via constructor
- **Messages.properties** - Added i18n strings for submenu titles and error message
- **CHANGELOG.md** - Documented the new feature
- **Help** - Added In-Place Operations section

## Menu structure

```
Encode/Decode/Hash...
  ├── Encode  (Base64, Base64 URL, URL, Full URL, Hex, HTML, Full HTML, JavaScript, Unicode, PowerShell, Morse)
  ├── Decode  (Base64, Base64 URL, URL, Full URL, Hex, HTML, JavaScript, Unicode, Morse)
  ├── Hash    (MD5, SHA1, SHA256)
  └── Utility (Remove Whitespace, Reverse, Lowercase, Uppercase, ASCify, Illegal UTF-8 2/3/4-byte)
```

## Related Issues
https://github.com/zaproxy/zaproxy/issues/5996
