### PR TITLE
soap: Enforce Mode & restrict resolutions

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- When importing a WSDL from a URL, referenced resources are only retrieved over HTTP or HTTPS and requests are subject to the current ZAP Mode. When importing from a local file, local file references remain supported (Issue 9438).
 
 ## [32] - 2026-08-12
 ### Added

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -25,6 +25,7 @@ import com.predic8.schema.ComplexContent;
 import com.predic8.schema.ComplexType;
 import com.predic8.schema.Element;
 import com.predic8.schema.Extension;
+import com.predic8.schema.Include;
 import com.predic8.schema.Sequence;
 import com.predic8.schema.SimpleType;
 import com.predic8.schema.restriction.BaseRestriction;
@@ -35,15 +36,18 @@ import com.predic8.wsdl.AbstractBinding;
 import com.predic8.wsdl.Binding;
 import com.predic8.wsdl.BindingOperation;
 import com.predic8.wsdl.Definitions;
+import com.predic8.wsdl.Import;
 import com.predic8.wsdl.Operation;
 import com.predic8.wsdl.Part;
 import com.predic8.wsdl.Port;
 import com.predic8.wsdl.PortType;
 import com.predic8.wsdl.Service;
 import com.predic8.wsdl.WSDLParser;
+import com.predic8.wsdl.WSDLParserContext;
 import com.predic8.wstool.creator.RequestCreator;
 import com.predic8.wstool.creator.SOARequestCreator;
 import com.predic8.xml.util.ResourceDownloadException;
+import com.predic8.xml.util.ResourceResolver;
 import groovy.xml.MarkupBuilder;
 import java.awt.EventQueue;
 import java.io.ByteArrayInputStream;
@@ -59,6 +63,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -77,7 +83,9 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.commonlib.ValueProvider;
+import org.zaproxy.zap.network.HttpRedirectionValidator;
 import org.zaproxy.zap.network.HttpRequestBody;
+import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.ThreadUtils;
 
@@ -160,7 +168,7 @@ public class WSDLCustomParser {
             return false;
         } else {
             // WSDL parsing.
-            WSDLParser parser = new WSDLParser();
+            WSDLParser parser = createWSDLParser();
             try {
                 InputStream contentI =
                         new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
@@ -171,6 +179,50 @@ public class WSDLCustomParser {
                 return false;
             }
         }
+    }
+
+    private static HttpRequestConfig createRequestConfig(
+            AtomicBoolean requestValid, AtomicReference<URI> effectiveUri) {
+        return HttpRequestConfig.builder()
+                .setRedirectionValidator(
+                        new HttpRedirectionValidator() {
+                            @Override
+                            public void notifyMessageReceived(HttpMessage msg) {
+                                effectiveUri.set(msg.getRequestHeader().getURI());
+                            }
+
+                            @Override
+                            public boolean isValid(URI redirection) {
+                                requestValid.set(isValidForCurrentMode(redirection));
+                                return requestValid.get();
+                            }
+                        })
+                .build();
+    }
+
+    private static boolean send(HttpSender sender, HttpMessage message) throws IOException {
+        return send(sender, message, new AtomicReference<>());
+    }
+
+    private static boolean send(
+            HttpSender sender, HttpMessage message, AtomicReference<URI> effectiveUri)
+            throws IOException {
+        if (!isValidForCurrentMode(message.getRequestHeader().getURI())) {
+            return false;
+        }
+
+        AtomicBoolean requestValid = new AtomicBoolean(true);
+        effectiveUri.set(message.getRequestHeader().getURI());
+        sender.sendAndReceive(message, createRequestConfig(requestValid, effectiveUri));
+        return requestValid.get();
+    }
+
+    private static boolean isValidForCurrentMode(URI uri) {
+        return switch (Control.getSingleton().getMode()) {
+            case safe -> false;
+            case protect -> Model.getSingleton().getSession().isInScope(uri.toString());
+            default -> true;
+        };
     }
 
     /*
@@ -234,8 +286,11 @@ public class WSDLCustomParser {
                 return;
             }
             HttpSender sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
+            AtomicReference<URI> effectiveUri = new AtomicReference<>();
             try {
-                sender.sendAndReceive(httpRequest, true);
+                if (!send(sender, httpRequest, effectiveUri)) {
+                    return;
+                }
             } catch (IOException e) {
                 LOGGER.error("Unable to send WSDL request.", e);
                 return;
@@ -245,7 +300,9 @@ public class WSDLCustomParser {
             if (content.trim().isEmpty()) {
                 LOGGER.debug("Response from WSDL file request has no body content, url: {}", url);
             } else {
-                parseWSDLContent(content, true, maxMessages);
+                String baseDir =
+                        java.net.URI.create(effectiveUri.get().toString()).resolve(".").toString();
+                parseWSDLContent(content, baseDir, true, maxMessages);
             }
         } catch (Exception e) {
             LOGGER.error("There was an error while parsing WSDL from URL. ", e);
@@ -253,15 +310,23 @@ public class WSDLCustomParser {
     }
 
     private boolean parseWSDLContent(String content, boolean sendMessages, int maxMessages) {
+        return parseWSDLContent(content, "", sendMessages, maxMessages);
+    }
+
+    private boolean parseWSDLContent(
+            String content, String baseDir, boolean sendMessages, int maxMessages) {
         if (content == null || content.trim().length() <= 0) {
             return false;
         } else {
             // WSDL parsing.
-            WSDLParser parser = new WSDLParser();
+            WSDLParser parser = createWSDLParser();
             try {
                 InputStream contentI =
                         new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-                Definitions wsdl = parser.parse(contentI);
+                WSDLParserContext context = new WSDLParserContext();
+                context.setInput(contentI);
+                context.setBaseDir(baseDir);
+                Definitions wsdl = parser.parse(context);
                 contentI.close();
                 parseWSDL(wsdl, sendMessages, maxMessages);
                 return true;
@@ -689,9 +754,12 @@ public class WSDLCustomParser {
         HttpSender sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
         /* Send request. */
         try {
-            sender.sendAndReceive(httpRequest, true);
+            if (!send(sender, httpRequest)) {
+                return;
+            }
         } catch (IOException e) {
             LOGGER.error("Unable to communicate with SOAP server. Server may be not available.", e);
+            return;
         }
         persistMessage(httpRequest);
         if (sb != null)
@@ -740,5 +808,73 @@ public class WSDLCustomParser {
 
     SOAPMsgConfig getLastConfig() {
         return lastConfig;
+    }
+
+    private static WSDLParser createWSDLParser() {
+        WSDLParser parser = new WSDLParser();
+        parser.setResourceResolver(
+                new ResourceResolver() {
+                    public Object resolve(Object input, String baseDir) {
+                        if (input instanceof InputStream ipt) {
+                            try {
+                                return fixUtf(ipt);
+                            } catch (IOException e) {
+                                throw new IllegalStateException("Failed to read WSDL resource.", e);
+                            }
+                        }
+
+                        String location;
+                        if (input instanceof Import imp) {
+                            location = imp.getLocation();
+                        } else if (input instanceof com.predic8.schema.Import schImp) {
+                            location = schImp.getSchemaLocation();
+                        } else if (input instanceof Include incl) {
+                            location = incl.getSchemaLocation();
+                        } else if (input instanceof String loc) {
+                            location = loc;
+                        } else {
+                            throw new IllegalArgumentException(
+                                    "Unsupported WSDL resource: " + input);
+                        }
+
+                        if (location == null || location.isBlank()) {
+                            return null;
+                        }
+
+                        java.net.URI resourceUri = java.net.URI.create(location);
+                        if (!resourceUri.isAbsolute()) {
+                            if (baseDir == null || baseDir.isBlank()) {
+                                throw new IllegalArgumentException(
+                                        "Unable to resolve relative WSDL resource: " + location);
+                            }
+                            resourceUri = java.net.URI.create(baseDir).resolve(resourceUri);
+                        }
+
+                        String scheme = resourceUri.getScheme();
+                        if (!HttpHeader.HTTP.equalsIgnoreCase(scheme)
+                                && !HttpHeader.HTTPS.equalsIgnoreCase(scheme)) {
+                            throw new IllegalArgumentException(
+                                    "Unsupported WSDL resource URI: " + resourceUri);
+                        }
+
+                        try {
+                            HttpMessage message =
+                                    new HttpMessage(new URI(resourceUri.toString(), true));
+                            HttpSender sender = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
+
+                            if (!send(sender, message)) {
+                                throw new IllegalStateException(
+                                        "WSDL resource blocked by current mode: " + resourceUri);
+                            }
+
+                            return fixUtf(
+                                    new ByteArrayInputStream(message.getResponseBody().getBytes()));
+                        } catch (IOException e) {
+                            throw new IllegalStateException(
+                                    "Failed to retrieve WSDL resource: " + resourceUri, e);
+                        }
+                    }
+                });
+        return parser;
     }
 }

--- a/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/soap.html
+++ b/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/soap.html
@@ -27,6 +27,7 @@ Operations to import a WSDL file from the local filesystem or from a URL are als
 (<code>importFile</code> / <code>importUrl</code>), including an optional <code>maxMessages</code> parameter.
 <br><br>
 <b>NOTE:</b> As of version 6 of this add-on, only encoded URLs are supported.
+<b>NOTE:</b> When importing a WSDL from a URL, referenced resources are only retrieved over HTTP or HTTPS and requests are subject to the current ZAP Mode. When importing from a local file, local file references remain supported.
 
 <h3>Form Handler Add-on Support</h3>
 The SOAP add-on supports overriding default parameter values based on field names via the Form Handler add-on.

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -31,15 +31,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.lenient;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -48,6 +52,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -56,8 +61,17 @@ import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.quality.Strictness;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.control.Control.Mode;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.extension.option.OptionsParamView;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.ValueProvider;
+import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.testutils.TestUtils;
 
 class WSDLCustomParserTestCase extends TestUtils {
@@ -66,6 +80,9 @@ class WSDLCustomParserTestCase extends TestUtils {
     private static final String FILL_PARAMETERS_WSDL = "fill-parameters.wsdl";
     private static final String DEGRADED_PARAMETERS_WSDL = "degraded-parameters.wsdl";
 
+    private static ExtensionLoader extensionLoader;
+    private static Session session;
+
     private ValueProvider valueProvider;
     private Supplier<Date> dateSupplier;
     private String wsdlContent;
@@ -73,6 +90,28 @@ class WSDLCustomParserTestCase extends TestUtils {
 
     @BeforeEach
     void setUp() throws Exception {
+        setUpZap();
+        startServer();
+
+        Model model = mock(Model.class, withSettings().strictness(Strictness.LENIENT));
+        Model.setSingletonForTesting(model);
+
+        session = mock(Session.class, withSettings().strictness(Strictness.LENIENT));
+        given(model.getSession()).willReturn(session);
+
+        OptionsParam optionsParam =
+                mock(OptionsParam.class, withSettings().strictness(Strictness.LENIENT));
+        OptionsParamView viewParam =
+                mock(OptionsParamView.class, withSettings().strictness(Strictness.LENIENT));
+
+        given(model.getOptionsParam()).willReturn(optionsParam);
+        given(optionsParam.getViewParam()).willReturn(viewParam);
+        given(viewParam.getMode()).willReturn(Mode.standard.name());
+
+        extensionLoader =
+                mock(ExtensionLoader.class, withSettings().strictness(Strictness.LENIENT));
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+
         /* Gets test wsdl file and retrieves its content as String. */
         Path wsdlPath = getResourcePath("resources/test.wsdl");
         wsdlContent = new String(Files.readAllBytes(wsdlPath), StandardCharsets.UTF_8);
@@ -83,6 +122,12 @@ class WSDLCustomParserTestCase extends TestUtils {
                 .thenReturn(MOCK_FILL_VALUE);
         dateSupplier = mockLenientDateSupplier();
         parser = new WSDLCustomParser(() -> valueProvider, null, dateSupplier);
+    }
+
+    @AfterEach
+    void tearDown() {
+        stopServer();
+        Control.getSingleton().setMode(Mode.standard);
     }
 
     @Test
@@ -130,6 +175,96 @@ class WSDLCustomParserTestCase extends TestUtils {
         parser.syncImportWsdlFile(wsdl.toFile(), 1);
 
         assertThat(parser.getLastConfig().getBindOp().getName(), is(equalTo("sayByeWorld")));
+    }
+
+    @Test
+    void shouldNotFetchWsdlInSafeMode() throws Exception {
+        // Given
+        Control.getSingleton().setMode(Mode.safe);
+        // When
+        parser.syncImportWsdlUrl(serverUrl("/service.wsdl"), 0);
+        // Then
+        assertThat(nano.getRequestedUris().isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldNotFetchOutOfScopeWsdlInScopedMode() throws Exception {
+        // Given
+        Control.getSingleton().setMode(Mode.protect);
+        // When
+        parser.syncImportWsdlUrl(serverUrl("/service.wsdl"), 0);
+        // Then
+        assertThat(nano.getRequestedUris().isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldFetchInScopeWsdlInScopedMode() throws Exception {
+        // Given
+        addWsdlHandler("/service.wsdl", simpleWsdl());
+        Control.getSingleton().setMode(Mode.protect);
+        given(session.isInScope(anyString())).willReturn(true);
+        // When
+        parser.syncImportWsdlUrl(serverUrl("/service.wsdl"), 0);
+        // Then
+        assertThat(nano.getRequestedUris(), is(List.of("/service.wsdl")));
+    }
+
+    @Test
+    void shouldFetchRelativeSchemaImportThroughZapHttpSender() throws Exception {
+        // Given
+        addWsdlHandler("/service.wsdl", wsdlWithSchemaImport("schema/types.xsd"));
+        addWsdlHandler("/schema/types.xsd", simpleSchema());
+        // When
+        parser.syncImportWsdlUrl(serverUrl("/service.wsdl"), 0);
+        // Then
+        assertThat(nano.getRequestedUris(), is(List.of("/service.wsdl", "/schema/types.xsd")));
+    }
+
+    @Test
+    void shouldNotFetchImportedSchemaInSafeMode() throws Exception {
+        // Given
+        addWsdlHandler("/service.wsdl", wsdlWithSchemaImport("schema/types.xsd"));
+        addWsdlHandler("/schema/types.xsd", simpleSchema());
+
+        // Safe mode should block the initial WSDL request, so no imported resources are fetched
+        // either.
+        Control.getSingleton().setMode(Mode.safe);
+        // When
+        parser.syncImportWsdlUrl(serverUrl("/service.wsdl"), 0);
+        // Then
+        assertThat(nano.getRequestedUris().isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldNotFetchOutOfScopeImportedSchemaInScopedMode() throws Exception {
+        // Given
+        addWsdlHandler("/service.wsdl", wsdlWithSchemaImport("schema/types.xsd"));
+        addWsdlHandler("/schema/types.xsd", simpleSchema());
+        Control.getSingleton().setMode(Mode.protect);
+        String wsdlUrl = serverUrl("/service.wsdl");
+        // Everything out of scope unless explicitly allowed.
+        given(session.isInScope(anyString())).willReturn(false);
+        given(session.isInScope(wsdlUrl)).willReturn(true);
+        // When
+        parser.syncImportWsdlUrl(wsdlUrl, 0);
+        // Then
+        assertThat(nano.getRequestedUris(), is(List.of("/service.wsdl")));
+    }
+
+    @Test
+    void shouldRejectFileSchemaImport() throws Exception {
+        // Given
+        Path schema = Files.createTempFile("soap-local-schema", ".xsd");
+        Files.writeString(
+                schema,
+                "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><xsd:include schemaLocation=\""
+                        + serverUrl("/unexpected.xsd")
+                        + "\"/></xsd:schema>");
+        addWsdlHandler("/service.wsdl", wsdlWithSchemaImport(schema.toUri().toString()));
+        // When
+        parser.syncImportWsdlUrl(serverUrl("/service.wsdl"), 0);
+        // Then
+        assertThat(nano.getRequestedUris(), is(List.of("/service.wsdl")));
     }
 
     @ParameterizedTest
@@ -404,6 +539,119 @@ class WSDLCustomParserTestCase extends TestUtils {
         // Then
         assertThat(params, hasEntry("xpath:/Request/attrRefWrapper/@inlineKey", MOCK_FILL_VALUE));
         assertThat(params, not(hasKey("xpath:/Request/attrRefWrapper/@globalRefKey")));
+    }
+
+    @Test
+    void shouldFollowInScopeRedirectInScopedMode() throws Exception {
+        // Given
+        addRedirectHandler("/redirect.wsdl", serverUrl("/service.wsdl"));
+        addWsdlHandler("/service.wsdl", simpleWsdl());
+        Control.getSingleton().setMode(Mode.protect);
+        given(session.isInScope(anyString())).willReturn(true);
+        // When
+        parser.syncImportWsdlUrl(serverUrl("/redirect.wsdl"), 0);
+        // Then
+        assertThat(nano.getRequestedUris(), is(List.of("/redirect.wsdl", "/service.wsdl")));
+    }
+
+    @Test
+    void shouldNotFollowOutOfScopeRedirectInScopedMode() throws Exception {
+        // Given
+        String wsdlUrl = serverUrl("/redirect.wsdl");
+        addRedirectHandler("/redirect.wsdl", serverUrl("/out.wsdl"));
+        addWsdlHandler("/out.wsdl", simpleWsdl());
+        Control.getSingleton().setMode(Mode.protect);
+        given(session.isInScope(anyString())).willReturn(false);
+        given(session.isInScope(wsdlUrl)).willReturn(true);
+        // When
+        parser.syncImportWsdlUrl(wsdlUrl, 0);
+        // Then
+        assertThat(nano.getRequestedUris(), is(List.of("/redirect.wsdl")));
+    }
+
+    @Test
+    void shouldResolveRelativeImportAgainstRedirectedWsdlUrl() throws Exception {
+        // Given
+        String initialWsdlUrl = serverUrl("/redirect.wsdl");
+        String redirectedWsdlUrl = serverUrl("/foo/bar/service.wsdl");
+        // When
+        addRedirectHandler("/redirect.wsdl", redirectedWsdlUrl);
+        addWsdlHandler("/foo/bar/service.wsdl", wsdlWithSchemaImport("schema.xsd"));
+        addWsdlHandler("/foo/bar/schema.xsd", simpleSchema());
+        Control.getSingleton().setMode(Mode.standard);
+        parser.syncImportWsdlUrl(initialWsdlUrl, 0);
+        // Then
+        assertThat(
+                nano.getRequestedUris(),
+                is(List.of("/redirect.wsdl", "/foo/bar/service.wsdl", "/foo/bar/schema.xsd")));
+    }
+
+    private String serverUrl(String path) {
+        return "http://localhost:" + nano.getListeningPort() + path;
+    }
+
+    private void addWsdlHandler(String path, String body) {
+        nano.addHandler(
+                new NanoServerHandler(path) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        return NanoHTTPD.newFixedLengthResponse(Status.OK, "text/xml", body);
+                    }
+                });
+    }
+
+    private void addRedirectHandler(String path, String location) {
+        nano.addHandler(
+                new NanoServerHandler(path) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        Response response =
+                                NanoHTTPD.newFixedLengthResponse(
+                                        Status.REDIRECT, NanoHTTPD.MIME_PLAINTEXT, "");
+                        response.addHeader(HttpHeader.LOCATION, location);
+                        return response;
+                    }
+                });
+    }
+
+    private static String simpleWsdl() {
+        return """
+                <?xml version="1.0"?>
+                <wsdl:definitions
+                    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                    targetNamespace="http://example.com/test">
+                </wsdl:definitions>
+                """;
+    }
+
+    private static String wsdlWithSchemaImport(String schemaLocation) {
+        return """
+                <?xml version="1.0"?>
+                <wsdl:definitions
+                    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    targetNamespace="http://example.com/test">
+                  <wsdl:types>
+                    <xsd:schema targetNamespace="http://example.com/test">
+                      <xsd:import
+                          namespace="http://example.com/types"
+                          schemaLocation="%s"/>
+                    </xsd:schema>
+                  </wsdl:types>
+                </wsdl:definitions>
+                """
+                .formatted(schemaLocation);
+    }
+
+    private static String simpleSchema() {
+        return """
+                <?xml version="1.0"?>
+                <xsd:schema
+                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    targetNamespace="http://example.com/types">
+                  <xsd:element name="value" type="xsd:string"/>
+                </xsd:schema>
+                """;
     }
 
     private Map<String, String> parseWsdlParams() throws Exception {


### PR DESCRIPTION
## Overview

- Added ZAP Mode enforcement for WSDL imports and generated SOAP requests.
- Restricted resource resolution for URL-based WSDL imports to HTTP/HTTPS schemes.

Changes are based largely on the existing HAR import handling in the exim add-on.

## Related Issues

- Fixes zaproxy/zaproxy#9438
