### PR TITLE
authhelper: notify auth state in CSA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Notify authentication successes/failures for browser login and error paths in Client Script Based Authentication.
 
 ## [0.42.0] - 2026-08-26
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -27,6 +27,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.httpclient.URI;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -274,6 +275,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
             ZestScript zestScript = getZestScript();
             if (zestScript == null) {
                 LOGGER.warn("No Zest script configured for client script authentication");
+                notifyAuthFailure(null, user);
                 return false;
             }
             try {
@@ -285,12 +287,14 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                 runner.setWebDriver(webDriver);
 
                 executeZestAuthScript(runner, user);
+                AuthenticationHelper.notifyOutputAuthSuccessful(getFirstMessage(zestScript, user));
                 return true;
             } catch (Exception e) {
                 LOGGER.warn(
                         "An error occurred while trying to execute the Client Script Authentication script: {}",
                         e.getMessage(),
                         e);
+                notifyAuthFailure(zestScript, user);
                 return false;
             }
         }
@@ -347,6 +351,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
             ScriptWrapper script = getScript();
             AuthenticationScript authScript = getAuthenticationScript(script);
             if (authScript == null) {
+                notifyAuthFailure(null, user);
                 return null;
             }
             LOGGER.debug("Script class: {}", authScript.getClass().getCanonicalName());
@@ -371,6 +376,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                         ZestScript zestScript = zestRunner.getScript().getZestScript();
                         if (!hasBrowserLaunch(zestScript)) {
                             LOGGER.warn("The script does not have any browser launch.");
+                            notifyAuthFailure(zestScript, user);
                             return null;
                         }
 
@@ -385,6 +391,7 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                         }
                     } else {
                         LOGGER.warn("Expected authScript to be a Zest script");
+                        notifyAuthFailure(null, user);
                         return null;
                     }
 
@@ -403,6 +410,10 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
 
                 } catch (Exception e) {
                     diags.recordErrorStep(getWebDriver(zestRunner));
+
+                    notifyAuthFailure(
+                            zestRunner != null ? zestRunner.getScript().getZestScript() : null,
+                            user);
 
                     // Catch Exception instead of ScriptException and IOException because script
                     // engine
@@ -524,6 +535,37 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                                     });
                     zestRunner.closeProxy();
                 }
+            }
+        }
+
+        private void notifyAuthFailure(ZestScript zestScript, User user) {
+            HttpMessage authMsg = getFirstMessage(zestScript, user);
+            if (authMsg != null) {
+                AuthenticationHelper.notifyOutputAuthFailure(authMsg);
+            }
+        }
+
+        static HttpMessage getFirstMessage(ZestScript zestScript, User user) {
+            String url = null;
+            if (zestScript != null) {
+                url =
+                        zestScript.getStatements().stream()
+                                .filter(ZestClientLaunch.class::isInstance)
+                                .map(ZestClientLaunch.class::cast)
+                                .filter(ZestClientLaunch::isEnabled)
+                                .map(ZestClientLaunch::getUrl)
+                                .findFirst()
+                                .orElse(null);
+            }
+            if (url == null) {
+                LOGGER.warn("Using'unknown URL' for authentication failure of {}", user.getName());
+                url = "https://unknown-auth-url.zap/";
+            }
+
+            try {
+                return new HttpMessage(new URI(url, true));
+            } catch (Exception e) {
+                return null;
             }
         }
 

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodTypeUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodTypeUnitTest.java
@@ -21,21 +21,36 @@ package org.zaproxy.addon.authhelper;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.authhelper.ClientScriptBasedAuthenticationMethodType.ClientScriptBasedAuthenticationMethod;
+import org.zaproxy.zap.authentication.AuthenticationHelper;
+import org.zaproxy.zap.authentication.GenericAuthenticationCredentials;
+import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.session.SessionManagementMethod;
+import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
+import org.zaproxy.zest.core.v1.ZestClientLaunch;
+import org.zaproxy.zest.core.v1.ZestScript;
 
 class ClientScriptBasedAuthenticationMethodTypeUnitTest {
 
@@ -62,5 +77,113 @@ class ClientScriptBasedAuthenticationMethodTypeUnitTest {
         // Then
         assertThat(method1.getLoginPageWait(), is(equalTo(2)));
         assertThat(method1.getMinWaitFor(), is(equalTo(0)));
+    }
+
+    @Test
+    void shouldGetMessageFromFirstEnabledZestClientLaunch() throws Exception {
+        // Given
+        ZestScript script = new ZestScript();
+
+        ZestClientLaunch cl =
+                new ZestClientLaunch(
+                        "window", "firefox", "https://app1.example.com/login", null, true, null);
+        cl.setEnabled(false);
+        script.add(cl);
+        script.add(
+                new ZestClientLaunch(
+                        "w2", "firefox", "https://app2.example.com/login", null, true, null));
+        script.add(
+                new ZestClientLaunch(
+                        "w3", "firefox", "https://app3.example.com/login", null, true, null));
+
+        // When
+        HttpMessage msg = ClientScriptBasedAuthenticationMethod.getFirstMessage(script, mock());
+
+        // Then
+        assertThat(msg, is(notNullValue()));
+        assertThat(
+                msg.getRequestHeader().getURI().toString(),
+                equalTo("https://app2.example.com/login"));
+    }
+
+    @Test
+    void shouldFallbackToUnknownUrlWhenNoZestClientLaunch() throws Exception {
+        // Given
+        ZestScript script = new ZestScript();
+
+        // When
+        HttpMessage msg = ClientScriptBasedAuthenticationMethod.getFirstMessage(script, mock());
+
+        // Then
+        assertThat(msg, is(notNullValue()));
+        assertThat(
+                msg.getRequestHeader().getURI().toString(),
+                equalTo("https://unknown-auth-url.zap/"));
+    }
+
+    @Test
+    void shouldNotifyFailureWhenNoScriptOnWebDriverAuth() {
+        // Given
+        ClientScriptBasedAuthenticationMethod method =
+                spy(new ClientScriptBasedAuthenticationMethodType().createAuthenticationMethod(0));
+        doReturn(null).when(method).getZestScript();
+
+        try (MockedStatic<AuthenticationHelper> authMock = mockStatic()) {
+            // When
+            boolean result = method.authenticate(mock(), mock());
+
+            // Then
+            assertThat(result, is(false));
+            authMock.verify(() -> AuthenticationHelper.notifyOutputAuthFailure(any()));
+        }
+    }
+
+    @Test
+    void shouldNotifyFailureOnExceptionOnWebDriverAuth() {
+        // Given
+        ZestScript script = new ZestScript();
+        script.add(
+                new ZestClientLaunch(
+                        "window", "firefox", "https://app.example.com/login", null, true, null));
+
+        ClientScriptBasedAuthenticationMethod method =
+                spy(new ClientScriptBasedAuthenticationMethodType().createAuthenticationMethod(0));
+        doReturn(script).when(method).getZestScript();
+
+        try (MockedStatic<AuthenticationHelper> authMock = mockStatic()) {
+            // When
+            boolean result = method.authenticate(mock(), mock());
+
+            // Then
+            assertThat(result, is(false));
+            authMock.verify(() -> AuthenticationHelper.notifyOutputAuthFailure(any()));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void shouldNotifyFailureWhenAuthScriptIsNullOnUserAuth() throws Exception {
+        // Given
+        ClientScriptBasedAuthenticationMethod method =
+                new ClientScriptBasedAuthenticationMethodType().createAuthenticationMethod(0);
+
+        ScriptWrapper scriptWrapper = mock();
+        given(scriptWrapper.getName()).willReturn("test_script");
+        method.setScriptWrapper(scriptWrapper);
+
+        User user = mock();
+        SessionManagementMethod sessionMgmt = mock();
+        GenericAuthenticationCredentials credentials = mock();
+
+        try (MockedStatic<ScriptBasedAuthenticationMethodType> ignored = mockStatic();
+                MockedStatic<AuthenticationHelper> authMock = mockStatic()) {
+
+            // When
+            var result = method.authenticate(sessionMgmt, credentials, user);
+
+            // Then
+            assertThat(result, is(nullValue()));
+            authMock.verify(() -> AuthenticationHelper.notifyOutputAuthFailure(any()));
+        }
     }
 }


### PR DESCRIPTION
Ensure browser login (WebDriver) authentication success/failure and non-browser login errors are properly notified so other parts of the code work as expected (e.g. authentication insights).