### PR TITLE
authhelper: notify auth state in BBA

### DIFF
--- a/addOns/authhelper/CHANGELOG.md
+++ b/addOns/authhelper/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Fixed
-- Notify authentication successes/failures for browser login and error paths in Client Script Based Authentication.
+- Notify authentication successes/failures for browser login and error paths in Browser and Client Script Based Authentication.
 
 ## [0.42.0] - 2026-08-26
 ### Added

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/AuthUtils.java
@@ -1751,4 +1751,12 @@ public class AuthUtils {
             }
         }
     }
+
+    static String getFallbackUnknownAuthUrl(String url, User user) {
+        if (url == null || url.isBlank()) {
+            LOGGER.warn("Using'unknown URL' for authentication failure of {}", user.getName());
+            return "https://unknown-auth-url.zap/";
+        }
+        return url;
+    }
 }

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodType.java
@@ -304,16 +304,47 @@ public class BrowserBasedAuthenticationMethodType extends AuthenticationMethodTy
         public boolean authenticate(WebDriver webDriver, User user) {
             if (!isConfigured()) {
                 LOGGER.warn("Login page URL is not configured");
+                notifyAuthFailure(user);
                 return false;
             }
-            return AuthUtils.authenticateAsUser(
-                    diagnostics,
-                    webDriver,
-                    user,
-                    loginPageUrl,
-                    loginPageWait,
-                    stepDelay,
-                    authenticationSteps);
+
+            try {
+                boolean result =
+                        AuthUtils.authenticateAsUser(
+                                diagnostics,
+                                webDriver,
+                                user,
+                                loginPageUrl,
+                                loginPageWait,
+                                stepDelay,
+                                authenticationSteps);
+                if (result) {
+                    AuthenticationHelper.notifyOutputAuthSuccessful(createMessage(user));
+                } else {
+                    notifyAuthFailure(user);
+                }
+                return result;
+            } catch (Exception e) {
+                notifyAuthFailure(user);
+                throw e;
+            }
+        }
+
+        private void notifyAuthFailure(User user) {
+            HttpMessage authMsg = createMessage(user);
+            if (authMsg != null) {
+                AuthenticationHelper.notifyOutputAuthFailure(authMsg);
+            }
+        }
+
+        private HttpMessage createMessage(User user) {
+            String url = AuthUtils.getFallbackUnknownAuthUrl(loginPageUrl, user);
+
+            try {
+                return new HttpMessage(new URI(url, true));
+            } catch (Exception e) {
+                return null;
+            }
         }
 
         @Override

--- a/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
+++ b/addOns/authhelper/src/main/java/org/zaproxy/addon/authhelper/ClientScriptBasedAuthenticationMethodType.java
@@ -557,10 +557,8 @@ public class ClientScriptBasedAuthenticationMethodType extends ScriptBasedAuthen
                                 .findFirst()
                                 .orElse(null);
             }
-            if (url == null) {
-                LOGGER.warn("Using'unknown URL' for authentication failure of {}", user.getName());
-                url = "https://unknown-auth-url.zap/";
-            }
+
+            url = AuthUtils.getFallbackUnknownAuthUrl(url, user);
 
             try {
                 return new HttpMessage(new URI(url, true));

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/AuthUtilsUnitTest.java
@@ -80,6 +80,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openqa.selenium.By;
@@ -1335,6 +1336,26 @@ class AuthUtilsUnitTest extends TestUtils {
         assertThat(el1.getWaitForMsec(), is(equalTo(5000)));
         assertThat(el2.getWaitForMsec(), is(equalTo(5000)));
         assertThat(el3.getWaitForMsec(), is(equalTo(8000)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "  "})
+    void shouldReturnFallbackUrlWhenUrlIsNullOrBlank(String loginUrl) {
+        // Given / When
+        String url = AuthUtils.getFallbackUnknownAuthUrl(loginUrl, mock(User.class));
+        // Then
+        assertThat(url, is(equalTo("https://unknown-auth-url.zap/")));
+    }
+
+    @Test
+    void shouldReturnUrlWhenUrlIsNotBlank() {
+        // Given
+        String loginUrl = "https://example.com/login";
+        // When
+        String url = AuthUtils.getFallbackUnknownAuthUrl(loginUrl, mock(User.class));
+        // Then
+        assertThat(url, is(equalTo(loginUrl)));
     }
 
     static class BrowserTest extends TestUtils {

--- a/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodTypeUnitTest.java
+++ b/addOns/authhelper/src/test/java/org/zaproxy/addon/authhelper/BrowserBasedAuthenticationMethodTypeUnitTest.java
@@ -24,28 +24,38 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import net.sf.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.openqa.selenium.WebDriver;
 import org.parosproxy.paros.db.RecordContext;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.authhelper.BrowserBasedAuthenticationMethodType.BrowserBasedAuthenticationMethod;
+import org.zaproxy.zap.authentication.AuthenticationHelper;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
 import org.zaproxy.zap.extension.api.ApiResponse;
 import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 class BrowserBasedAuthenticationMethodTypeUnitTest {
+
+    private static final String LOGIN_PAGE_URL = "https://example.org/login";
 
     @AfterAll
     static void cleanUp() {
@@ -213,5 +223,126 @@ class BrowserBasedAuthenticationMethodTypeUnitTest {
         assertThat(method2.getLoginPageWait(), is(equalTo(7)));
         assertThat(method2.getBrowserId(), is(equalTo("example")));
         assertThat(method2.getStepDelay(), is(equalTo(2)));
+    }
+
+    @Test
+    void shouldNotifyFailureWhenNotConfiguredOnWebDriverAuth() {
+        // Given
+        BrowserBasedAuthenticationMethod method =
+                new BrowserBasedAuthenticationMethodType().createAuthenticationMethod(0);
+
+        WebDriver wd = mock();
+        User user = mock();
+
+        try (MockedStatic<AuthenticationHelper> authMock = mockStatic()) {
+            // When
+            boolean result = method.authenticate(wd, user);
+            // Then
+            assertThat(result, is(false));
+            authMock.verify(() -> AuthenticationHelper.notifyOutputAuthFailure(any()));
+        }
+    }
+
+    @Test
+    void shouldNotifySuccessWhenAuthSucceedsOnWebDriverAuth() {
+        // Given
+        BrowserBasedAuthenticationMethod method =
+                new BrowserBasedAuthenticationMethodType().createAuthenticationMethod(0);
+        method.setLoginPageUrl(LOGIN_PAGE_URL);
+
+        WebDriver wd = mock();
+        User user = mock();
+
+        try (MockedStatic<AuthUtils> authUtilsMock = mockStatic();
+                MockedStatic<AuthenticationHelper> authMock = mockStatic()) {
+            authUtilsMock
+                    .when(
+                            () ->
+                                    AuthUtils.authenticateAsUser(
+                                            anyBoolean(),
+                                            eq(wd),
+                                            eq(user),
+                                            eq(LOGIN_PAGE_URL),
+                                            anyInt(),
+                                            anyInt(),
+                                            any()))
+                    .thenReturn(true);
+            authUtilsMock
+                    .when(() -> AuthUtils.getFallbackUnknownAuthUrl(LOGIN_PAGE_URL, user))
+                    .thenReturn(LOGIN_PAGE_URL);
+            // When
+            boolean result = method.authenticate(wd, user);
+            // Then
+            assertThat(result, is(true));
+            authMock.verify(() -> AuthenticationHelper.notifyOutputAuthSuccessful(any()));
+        }
+    }
+
+    @Test
+    void shouldNotifyFailureWhenAuthFailsOnWebDriverAuth() {
+        // Given
+        BrowserBasedAuthenticationMethod method =
+                new BrowserBasedAuthenticationMethodType().createAuthenticationMethod(0);
+        method.setLoginPageUrl(LOGIN_PAGE_URL);
+
+        WebDriver wd = mock();
+        User user = mock();
+
+        try (MockedStatic<AuthUtils> authUtilsMock = mockStatic();
+                MockedStatic<AuthenticationHelper> authMock = mockStatic()) {
+            authUtilsMock
+                    .when(
+                            () ->
+                                    AuthUtils.authenticateAsUser(
+                                            anyBoolean(),
+                                            eq(wd),
+                                            eq(user),
+                                            eq(LOGIN_PAGE_URL),
+                                            anyInt(),
+                                            anyInt(),
+                                            any()))
+                    .thenReturn(false);
+            authUtilsMock
+                    .when(() -> AuthUtils.getFallbackUnknownAuthUrl(LOGIN_PAGE_URL, user))
+                    .thenReturn(LOGIN_PAGE_URL);
+            // When
+            boolean result = method.authenticate(wd, user);
+            // Then
+            assertThat(result, is(false));
+            authMock.verify(() -> AuthenticationHelper.notifyOutputAuthFailure(any()));
+        }
+    }
+
+    @Test
+    void shouldNotifyFailureAndRethrowWhenAuthThrowsOnWebDriverAuth() {
+        // Given
+        BrowserBasedAuthenticationMethod method =
+                new BrowserBasedAuthenticationMethodType().createAuthenticationMethod(0);
+        method.setLoginPageUrl(LOGIN_PAGE_URL);
+
+        WebDriver wd = mock();
+        User user = mock();
+
+        try (MockedStatic<AuthUtils> authUtilsMock = mockStatic();
+                MockedStatic<AuthenticationHelper> authMock = mockStatic()) {
+            authUtilsMock
+                    .when(
+                            () ->
+                                    AuthUtils.authenticateAsUser(
+                                            anyBoolean(),
+                                            eq(wd),
+                                            eq(user),
+                                            eq(LOGIN_PAGE_URL),
+                                            anyInt(),
+                                            anyInt(),
+                                            any()))
+                    .thenThrow(new IllegalArgumentException("auth error"));
+            authUtilsMock
+                    .when(() -> AuthUtils.getFallbackUnknownAuthUrl(LOGIN_PAGE_URL, user))
+                    .thenReturn(LOGIN_PAGE_URL);
+            // When / Then
+            assertThrows(IllegalArgumentException.class, () -> method.authenticate(wd, user));
+            authMock.verify(() -> AuthenticationHelper.notifyOutputAuthFailure(any()));
+        }
     }
 }


### PR DESCRIPTION
Ensure browser login (WebDriver) authentication success/failure is properly notified when using Browser Based Authentication.